### PR TITLE
Python interface to blobs and blob data through boost::python

### DIFF
--- a/python/caffe/pycaffe.cpp
+++ b/python/caffe/pycaffe.cpp
@@ -220,6 +220,8 @@ struct CaffeNet
       return vector<CaffeBlob>(net_->blobs().begin(), net_->blobs().end());
   }
 
+  vector<CaffeBlob> params() {
+      return vector<CaffeBlob>(net_->params().begin(), net_->params().end());
   }
 
   // The pointer to the internal caffe::Net instant.
@@ -242,6 +244,7 @@ BOOST_PYTHON_MODULE(pycaffe)
       .def("set_phase_test",  &CaffeNet::set_phase_test)
       .def("set_device",      &CaffeNet::set_device)
       .def("blobs",           &CaffeNet::blobs)
+      .def("params",          &CaffeNet::params)
   ;
 
   boost::python::class_<CaffeBlob, CaffeBlobWrap>(


### PR DESCRIPTION
This is the Python blob interface as it stands. If you'd rather not touch blob.hpp (which I think is reasonable), I think that can be accomplished by switching from inheritance to composition for CaffeBlob, and writing a few more wrappers.
