### PR TITLE
setting default power_wrapper batch size to match the imagenet_deploy pr...

### DIFF
--- a/python/caffe/imagenet/power_wrapper.py
+++ b/python/caffe/imagenet/power_wrapper.py
@@ -32,7 +32,7 @@ IMAGE_CENTER = int((IMAGE_DIM - CROPPED_DIM) / 2)
 CROP_MODES = ['center_only', 'corners', 'selective_search']
 
 # NOTE: this must match the setting in the prototxt that is used!
-BATCH_SIZE = 245
+BATCH_SIZE = 10
 
 # Load the imagenet mean file
 IMAGENET_MEAN = np.load(


### PR DESCRIPTION
Setting power_wrapper's batchsize to match imagenet_deploy prototxt. (so that power_wrapper works out of the box on the ipython notebook tutorial.)

[also, my first caffe pull request... making sure all the plumbing works.]
