### PR TITLE
opencv dependency libpng

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ INCLUDE_DIRS += ./src ./include $(CUDA_INCLUDE_DIR) $(MKL_INCLUDE_DIR)
 LIBRARY_DIRS += $(CUDA_LIB_DIR) $(MKL_LIB_DIR)
 LIBRARIES := cudart cublas curand protobuf opencv_core opencv_highgui \
 	glog mkl_rt mkl_intel_thread leveldb snappy pthread boost_system \
-	opencv_imgproc
+	opencv_imgproc png
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall
 


### PR DESCRIPTION
Because opencv_highgui depends on libpng, without linking it I get the following errors:

```
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_strip_alpha@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_get_io_ptr@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_palette_to_rgb@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_swap@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_write_end@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_compression_level@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_write_image@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_destroy_read_struct@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_write_info@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_gray_to_rgb@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_destroy_write_struct@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_get_IHDR@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_read_update_info@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_compression_strategy@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_create_read_struct@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_read_info@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_longjmp_fn@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_read_image@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_create_write_struct@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_bgr@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_create_info_struct@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_write_fn@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_init_io@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_packing@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_error@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_strip_16@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_read_end@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_IHDR@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_read_fn@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_expand_gray_1_2_4_to_8@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_rgb_to_gray@PNG15_0'
/home/domhant/anaconda/lib/libopencv_highgui.so: undefined reference to `png_set_filter@PNG15_0'
```
