### PR TITLE
Boosteigencompilewithboost146

### DIFF
--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -401,9 +401,12 @@ void caffe_vRngUniform(const int n, Dtype* r,
   boost::uniform_real<Dtype> random_distribution(
       a, caffe_nextafter<Dtype>(b));
   Caffe::random_generator_t &generator = Caffe::vsl_stream();
+  boost::variate_generator<Caffe::random_generator_t,
+      boost::uniform_real<Dtype> > variate_generator(
+      generator, random_distribution);
 
-  for(int i = 0; i < n; i += 1) {
-    r[i] = random_distribution(generator);
+  for (int i = 0; i < n; ++i) {
+    r[i] = variate_generator();
   }
 }
 
@@ -435,7 +438,7 @@ void caffe_vRngGaussian(const int n, Dtype* r, const Dtype a,
       boost::normal_distribution<Dtype> > variate_generator(
       generator, random_distribution);
 
-  for(int i = 0; i < n; ++i) {
+  for (int i = 0; i < n; ++i) {
     r[i] = variate_generator();
   }
 }
@@ -457,9 +460,12 @@ void caffe_vRngBernoulli(const int n, Dtype* r, const double p) {
     // FIXME check if parameters are handled in the same way ?
   boost::bernoulli_distribution<Dtype> random_distribution(p);
   Caffe::random_generator_t &generator = Caffe::vsl_stream();
+  boost::variate_generator<Caffe::random_generator_t,
+      boost::bernoulli_distribution<Dtype> > variate_generator(
+      generator, random_distribution);
 
-  for(int i = 0; i < n; i += 1) {
-    r[i] = random_distribution(generator);
+  for (int i = 0; i < n; ++i) {
+    r[i] = variate_generator();
   }
 }
 


### PR DESCRIPTION
Actually, I wasn't _quite_ able to compile using Boost 1.46 with the previous pull request (whoops) -- had to change boost::random::uniform_real_distribution to boost::uniform_real.  When I did compile successfully, I had a bunch of tests failing with 1.46 due to vRngGaussian generating all NaNs.  I changed all RNGs to use Boost's "variate_generator" (I think this is the Right Way based on https://svn.boost.org/trac/boost/ticket/904) and this was fixed (compiles and passes all tests in both 1.46 and 1.54).
