### PR TITLE
Extract Iteration from log instead of computing it from parameters

### DIFF
--- a/scripts/parselog.sh
+++ b/scripts/parselog.sh
@@ -9,9 +9,9 @@ echo "Usage parselog.sh /path_to/caffe.log"
 fi
 LOG=`basename $1`
 grep -B 2 'Test ' $1 > aux.txt
-grep 'Iteration ' aux.txt | awk -F ',| ' '{print $7}' > aux0.txt
+grep 'Iteration ' aux.txt | sed  's/.*Iteration \([[:digit:]]*\).*/\1/g' > aux0.txt
 grep 'Test score #0' aux.txt | awk '{print $8}' > aux1.txt
 grep 'Test score #1' aux.txt | awk '{print $8}' > aux2.txt
 grep ' loss =' $1 | awk '{print $6,$9}' | sed 's/,//g' | column -t > $LOG.loss 
 paste aux0.txt aux1.txt aux2.txt | column -t > $LOG.test
-rm aux0.txt aux1.txt aux2.txt
+rm aux.txt aux0.txt aux1.txt aux2.txt


### PR DESCRIPTION
Removed parameters [init_iter=0] [test_interval=1000]
Not needed anymore, now it extracts that info from the log
