### PR TITLE
bugfix regarding #100

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -117,14 +117,18 @@ void Net<Dtype>::Init(const NetParameter& param) {
           << top_vecs_[i][topid]->height() << " "
           << top_vecs_[i][topid]->width();
     }
-    // catch: if a layer param does not specify blobs_lr, we should assume the
-    // learning rate to be 1. Thus we will need to perform backward.
-    if (layers_[i]->layer_param().blobs_lr_size()) {
+    int blobs_lr_size = layers_[i]->layer_param().blobs_lr_size();
+    CHECK(blobs_lr_size == layers_[i]->blobs().size() || blobs_lr_size == 0)
+        << "Incorrect blobs lr size: should be either 0 or the same as "
+           "the number of the layer's parameter blobs.";
+    if (blobs_lr_size) {
       // Check if this layer needs backward operation itself
-      for (int j = 0; j < layers_[i]->layer_param().blobs_lr_size(); ++j) {
+      for (int j = 0; j < blobs_lr_size; ++j) {
         need_backward |= (layers_[i]->layer_param().blobs_lr(j) > 0);
       }
-    } else {
+    } else if (layers_[i]->blobs().size()) {
+      // catch: if a layer param does not specify blobs_lr, we should assume the
+      // learning rate to be 1. Thus we will need to perform backward.
       need_backward = true;
     }
     // Finally, set the backward flag


### PR DESCRIPTION
The bugfix for #100: when checking blobs_lr, also check the size of the parameter's blobs().size(): if size() is nonzero then we need to do backpropagation.

TODO: maybe add a regression test to rule out future bugs. Also the Init() function is growing quite big now.
