### PR TITLE
Resolves #105

### DIFF
--- a/python/caffe/convert.py
+++ b/python/caffe/convert.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """This script converts blobproto instances to numpy arrays.
 """
 

--- a/python/caffe/detection/detector.py
+++ b/python/caffe/detection/detector.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Do windowed detection by classifying a number of images/crops at once,
 optionally using the selective search window proposal method.

--- a/python/caffe/drawnet.py
+++ b/python/caffe/drawnet.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Functions to draw a caffe NetParameter protobuffer.
 """
 

--- a/python/caffe/pycaffe.cpp
+++ b/python/caffe/pycaffe.cpp
@@ -13,6 +13,7 @@
 // Temporary solution for numpy < 1.7 versions: old macro.
 #ifndef NPY_ARRAY_C_CONTIGUOUS
 #define NPY_ARRAY_C_CONTIGUOUS NPY_C_CONTIGUOUS
+#define PyArray_SetBaseObject(arr, x) (PyArray_BASE(arr) = (x))
 #endif
 
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 Cython>=0.19.2
-h5py==2.2.0
+h5py>=2.2.0
 ipython==1.1.0
 leveldb>=0.191
 matplotlib>=1.3.1
@@ -8,7 +8,6 @@ nose>=1.3.0
 numpy>=1.7.1
 pandas>=0.12.0
 protobuf>=2.5.0
-python-gflags>=2.0
 scikit-image>=0.9.3
 scikit-learn>=0.14.1
 scipy>=0.13.2

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+python-gflags>=2.0


### PR DESCRIPTION
script/resize_and_crop_images.py uses gflags to pass the arguments to mincepie which depends on gflags. For compatibility with mincepie, it will not be changed.

Add shebang at the beginning of python files to run them directly rather than by "python caffe/*.py".

Patch python/caffe/pycaffe.cpp per @longjon's [comment](https://github.com/BVLC/caffe/issues/44#issuecomment-32832810) in #44.

pip cannot find h5py 2.2.0.

Fixes issue: #105
