### PR TITLE
Add WARPLossLayer and gradient check test cases

### DIFF
--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -464,6 +464,39 @@ class EuclideanLossLayer : public Layer<Dtype> {
   Blob<Dtype> difference_;
 };
 
+/*
+ * Weighted Approximate-Rank Pairwise loss for image retrieval/annotation etc.
+ * References:
+ * [1] Yunchao Gong, Yangqing Jia, Sergey Ioffe, Alexander Toshev, Thomas
+ *     Leung. Deep Convolutional Ranking for Multilabel Image Annotation.
+ *     arXiv:1312.4894 [cs.CV]
+ * [2] Jason Weston, Samy Bengio, and Nicolas Usunier. Wsabie: Scaling up
+ *     to large vocabulary image annotation. In IJCAI, 2011.
+ */
+template <typename Dtype>
+class WARPLossLayer : public Layer<Dtype> {
+ public:
+  explicit WARPLossLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void SetUp(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual Dtype Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const bool propagate_down, vector<Blob<Dtype>*>* bottom);
+  virtual Dtype Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const bool propagate_down, vector<Blob<Dtype>*>* bottom);
+  // In image retrieval or annotations, results or labels form ranked list
+  //   based on their scores.
+  // Weighted Approximate-Rank Pairwise loss uses a function to
+  //   set weight for different ranks, e.g. 1 / j for the j-th rank.
+  Blob<Dtype> rank_weights_;
+};
+
 
 template <typename Dtype>
 class AccuracyLayer : public Layer<Dtype> {

--- a/src/caffe/layers/warp_loss_layer.cpp
+++ b/src/caffe/layers/warp_loss_layer.cpp
@@ -1,0 +1,109 @@
+// Copyright 2014 kloudkl@github
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/vision_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template<typename Dtype>
+void WARPLossLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
+                                 vector<Blob<Dtype>*>* top) {
+  CHECK_EQ(bottom.size(), 2)<<
+  "WARPLossLayer takes two blobs data and bottom_labels as input.";
+  CHECK_EQ(top->size(), 0) << "WARPLossLayer takes no output.";
+  CHECK_EQ(bottom[0]->num(), bottom[1]->num()) <<
+  "The data and bottom_labels should have the same number.";
+  CHECK_EQ(bottom[0]->count(), bottom[1]->count()) <<
+  "The data and bottom_labels should have the same count.";
+  int dim = bottom[0]->count() / bottom[0]->num();
+  rank_weights_.Reshape(1, dim, 1, 1);
+  Dtype* rank_weights_data = rank_weights_.mutable_cpu_data();
+  rank_weights_data[0] = 1. / (1 + 0);
+  for (int i = 1; i < dim; ++i) {
+    rank_weights_data[i] = rank_weights_data[i - 1] + 1. / (1 + i);
+  }
+};
+
+template<typename Dtype>
+void WARPLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+                                       vector<Blob<Dtype>*>* top) {
+}
+
+template<typename Dtype>
+void WARPLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+                                       vector<Blob<Dtype>*>* top) {
+}
+
+template<typename Dtype>
+Dtype WARPLossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+                                         const bool propagate_down,
+                                         vector<Blob<Dtype>*>* bottom) {
+  const Dtype* bottom_data = (*bottom)[0]->cpu_data();
+  const Dtype* bottom_labels = (*bottom)[1]->cpu_data();
+  const Dtype* rank_weights_data = rank_weights_.cpu_data();
+  const int num_data = (*bottom)[0]->num();
+  const int dim = (*bottom)[0]->count() / (*bottom)[0]->num();
+  const int num_bottom_labels = dim;
+  const int max_num_trials = num_bottom_labels - 1;
+  Dtype* bottom_diff = (*bottom)[0]->mutable_cpu_diff();
+  memset(bottom_diff, 0, sizeof(Dtype) * (*bottom)[0]->count());
+  Dtype loss = 0;
+  Dtype score_margin;
+  int random_label;
+  int estimated_rank;
+  int num_trials;
+  Dtype rank_weight;
+  for (int i = 0; i < num_data; ++i) {
+    for (int j = 0; j < num_bottom_labels; ++j) {
+      if (bottom_labels[j] == 1) {
+        // Since the real rank is too costly to compute when number of labels is large,
+        //   bottom_labels j's rank is estimated based on the score margin violation
+        //   which is defined as 1 - bottom_data[j] + bottom_data[a_negative_label] > 0.
+        num_trials = 0;
+        do {
+          do { // sample with replacement, TODO: without replacement
+            // TODO: more precise uniform random int generator
+            random_label = rand()
+                % (num_bottom_labels - 1/* num bottom_labels except j */);
+            if (random_label >= j) {
+              ++random_label;  // shift one to get skip j
+            }
+          } while (bottom_labels[random_label] == 1);  // sample until a negative bottom_labels is found
+          ++num_trials;
+          score_margin = 1 - bottom_data[j] + bottom_data[random_label];
+        } while (score_margin <= 0 & num_trials < max_num_trials);
+        estimated_rank = floor(max_num_trials / num_trials);
+        rank_weight = rank_weights_data[estimated_rank];
+//        LOG(ERROR)<< "rank_weight " << rank_weight;
+        for (int k = 0; k < num_bottom_labels; ++k) {
+          if (bottom_labels[k] == 0) {
+            score_margin = 1 - bottom_data[j] + bottom_data[k];
+//            LOG(ERROR)<< "score margin " << score_margin << ", loss " << (loss + rank_weight * score_margin);
+            if (score_margin > 0) {
+              loss += rank_weight * score_margin;
+              bottom_diff[i * dim + j] -= rank_weight;
+              bottom_diff[i * dim + k] += rank_weight;
+            }
+          }
+        }  // for (int k = 0; k < num_bottom_labels; ++k) {
+      }  // if (bottom_labels[j] == 1) {
+    }  // for (int j = 0; j < num_bottom_labels; ++j) {
+  }  //  for (int i = 0; i < num_data; ++i) {
+  caffe_scal((*bottom)[0]->count(), Dtype(1) / num_data, bottom_diff);
+  return loss / num_data;
+}
+
+template<typename Dtype>
+Dtype WARPLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+                                         const bool propagate_down,
+                                         vector<Blob<Dtype>*>* bottom) {
+  // TODO: implement the GPU version
+  return Backward_cpu(top, propagate_down, bottom);
+}
+
+INSTANTIATE_CLASS(WARPLossLayer);
+
+}  // namespace caffe

--- a/src/caffe/test/test_gradient_check_util.hpp
+++ b/src/caffe/test/test_gradient_check_util.hpp
@@ -82,11 +82,11 @@ void GradientChecker<Dtype>::CheckGradientSingle(Layer<Dtype>& layer,
     blobs_to_check.push_back(bottom[check_bottom]);
   }
   // go through the bottom and parameter blobs
-  // LOG(ERROR) << "Checking " << blobs_to_check.size() << " blobs.";
+   LOG(ERROR) << "Checking " << blobs_to_check.size() << " blobs.";
   for (int blobid = 0; blobid < blobs_to_check.size(); ++blobid) {
     Blob<Dtype>* current_blob = blobs_to_check[blobid];
-    // LOG(ERROR) << "Blob " << blobid << ": checking " << current_blob->count()
-    //     << " parameters.";
+     LOG(ERROR) << "Blob " << blobid << ": checking " << current_blob->count()
+         << " parameters.";
     // go through the values
     for (int feat_id = 0; feat_id < current_blob->count(); ++feat_id) {
       // First, obtain the original data
@@ -95,26 +95,33 @@ void GradientChecker<Dtype>::CheckGradientSingle(Layer<Dtype>& layer,
       Dtype computed_objective = GetObjAndGradient(top, top_id, top_data_id);
       // Get any additional loss from the layer
       computed_objective += layer.Backward(top, true, &bottom);
+      LOG(ERROR) << "computed_objective " << computed_objective;
       Dtype computed_gradient = current_blob->cpu_diff()[feat_id];
+      LOG(ERROR) << "computed_gradient " << computed_gradient;
       // compute score by adding stepsize
       current_blob->mutable_cpu_data()[feat_id] += stepsize_;
       Caffe::set_random_seed(seed_);
       layer.Forward(bottom, &top);
       Dtype positive_objective = GetObjAndGradient(top, top_id, top_data_id);
+      LOG(ERROR) << "positive_objective " << positive_objective;
       positive_objective += layer.Backward(top, true, &bottom);
+      LOG(ERROR) << "positive_objective " << positive_objective;
       // compute score by subtracting stepsize
       current_blob->mutable_cpu_data()[feat_id] -= stepsize_ * 2;
       Caffe::set_random_seed(seed_);
       layer.Forward(bottom, &top);
       Dtype negative_objective = GetObjAndGradient(top, top_id, top_data_id);
+      LOG(ERROR) << "negative_objective " << negative_objective;
       negative_objective += layer.Backward(top, true, &bottom);
+      LOG(ERROR) << "negative_objective " << negative_objective;
       // Recover stepsize
       current_blob->mutable_cpu_data()[feat_id] += stepsize_;
       Dtype estimated_gradient = (positive_objective - negative_objective) /
           stepsize_ / 2.;
+      LOG(ERROR) << "estimated_gradient " << estimated_gradient;
       Dtype feature = current_blob->cpu_data()[feat_id];
-      // LOG(ERROR) << "debug: " << current_blob->cpu_data()[feat_id] << " "
-      //     << current_blob->cpu_diff()[feat_id];
+       LOG(ERROR) << "debug: " << current_blob->cpu_data()[feat_id] << " "
+           << current_blob->cpu_diff()[feat_id];
       if (kink_ - kink_range_ > feature || feature > kink_ + kink_range_) {
         // We check relative accuracy, but for too small values, we threshold
         // the scale factor by 1.

--- a/src/caffe/test/test_warp_loss_layer.cpp
+++ b/src/caffe/test/test_warp_loss_layer.cpp
@@ -1,0 +1,72 @@
+// Copyright 2014 kloudkl@github
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <cuda_runtime.h>
+
+#include "gtest/gtest.h"
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/vision_layers.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+extern cudaDeviceProp CAFFE_TEST_CUDA_PROP;
+
+template <typename Dtype>
+class WARPLossLayerTest : public ::testing::Test {
+ protected:
+  WARPLossLayerTest()
+      : blob_bottom_data_(new Blob<Dtype>(10, 3, 1, 1)),
+        blob_bottom_label_(new Blob<Dtype>(10, 3, 1, 1)) {
+    // fill the values
+    FillerParameter filler_param;
+    filler_param.set_std(10);
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_data_);
+    blob_bottom_vec_.push_back(blob_bottom_data_);
+    for (int i = 0; i < blob_bottom_label_->count(); ++i) {
+      blob_bottom_label_->mutable_cpu_data()[i] = rand() % 2;
+    }
+    blob_bottom_vec_.push_back(blob_bottom_label_);
+  }
+  virtual ~WARPLossLayerTest() {
+    delete blob_bottom_data_;
+    delete blob_bottom_label_;
+  }
+  Blob<Dtype>* const blob_bottom_data_;
+  Blob<Dtype>* const blob_bottom_label_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+typedef ::testing::Types<float, double> Dtypes;
+TYPED_TEST_CASE(WARPLossLayerTest, Dtypes);
+
+
+TYPED_TEST(WARPLossLayerTest, TestGradientCPU) {
+  LayerParameter layer_param;
+  Caffe::set_mode(Caffe::CPU);
+  WARPLossLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, &this->blob_top_vec_);
+  GradientChecker<TypeParam> checker(1e-2, 1e-2, 1701);
+  checker.CheckGradientSingle(layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 0, -1, -1);
+}
+
+TYPED_TEST(WARPLossLayerTest, TestGradientGPU) {
+  LayerParameter layer_param;
+  Caffe::set_mode(Caffe::GPU);
+  WARPLossLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, &this->blob_top_vec_);
+  GradientChecker<TypeParam> checker(1e-2, 1e-2, 1701);
+  checker.CheckGradientSingle(layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 0, -1, -1);
+}
+
+}


### PR DESCRIPTION
This pull request chose to implement the Weighted Approximate Rank Pairwise (WARP) loss layer in response to issue #88 "Implement ranking loss layer". WARP[1] was applied in a similar manner for image annotation[2] and is also useful in image retrieval using text queries.

The only open source implementation of WARP loss that I found is in [the mrec recommender systems Python library from Mendeley](https://github.com/Mendeley/mrec/search?q=warp). WARP was used there to optimize a matrix factorization model and a hybrid ranking model.

Obeying the contributing protocol designed by @shelhamer in #101, I opened this work in progress PR to welcome comments to correct defects as early as possible and to guide my further development. 

References:
[1] Jason Weston, Samy Bengio, and Nicolas Usunier. Wsabie: Scaling up to large vocabulary  image annotation. In IJCAI, 2011.
[2] Yunchao Gong, Yangqing Jia, Sergey Ioffe, Alexander Toshev, Thomas Leung. Deep Convolutional Ranking for Multilabel Image Annotation. arXiv:1312.4894 [cs.CV]
