### PR TITLE
Fix 'make lint' in OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ NONGEN_CXX_SRCS := $(shell find \
 	matlab/$(PROJECT) \
 	examples \
 	tools \
-	-regex ".*\.\(cpp\|hpp\|cu\|cuh\)")
+	-name "*.cpp" -or -name "*.hpp" -or -name "*.cu" -or -name "*.cuh")
 LINT_REPORT := $(BUILD_DIR)/cpp_lint.log
 FAILED_LINT_REPORT := $(BUILD_DIR)/cpp_lint.error_log
 # PY$(PROJECT)_SRC is the python wrapper for $(PROJECT)


### PR DESCRIPTION
Thanks to @sguada for reporting in the comment thread on #132:

Seems that NONGEN_CXX_SRCS (Makefile variable intended to list all the files we want to include in lint) was empty in OSX due to some disagreement in the regex formatting of 'find'...give up on that and use an ugly but (hopefully?) reliable chain of `-name ... -or -name ...`
