### PR TITLE
more expressive CUDA error macro. instead of 'cuda error = 2', now we ge...

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -11,13 +11,12 @@
 #include <driver_types.h>
 #include <glog/logging.h>
 #include <mkl_vsl.h>
-#include <stdio.h>
 
 // various checks for different function calls.
-#define CUDA_CHECK(x) do { \
-  cudaError_t res = (x); \
+#define CUDA_CHECK(condition) do { \
+  cudaError_t res = (condition); \
   if(res != cudaSuccess) { \
-    LOG(FATAL) << printf("CUDART: %s = %d (%s) at (%s:%d)\n", #x, res, cudaGetErrorString(res),__FILE__,__LINE__);\
+    LOG(FATAL) << "CUDA: " << #condition << " = " << res << " (" << cudaGetErrorString(res) << ") " << "(" << __FILE__ << ":" << __LINE__ << ")";\
     exit(1); \
   } \
 } while(0)


### PR DESCRIPTION
When CUDA has an error, it throws a number like "2" or "7" or something like that. Previously, Caffe was just printing out the error number, and the user needed to go look up the meaning of the error number. With this addition to the code, CUDA errors are now printed in plaintext (e.g. "out of memory.")

I verified that errors are still caught properly, and that the tests still pass. Still gives the correct ImageNet-val results.
