### PR TITLE
Fix dump network

### DIFF
--- a/tools/dump_network.cpp
+++ b/tools/dump_network.cpp
@@ -28,7 +28,6 @@
 using namespace caffe;  // NOLINT(build/namespaces)
 
 int main(int argc, char** argv) {
-  cudaSetDevice(1);
   Caffe::set_mode(Caffe::GPU);
   Caffe::set_phase(Caffe::TEST);
 


### PR DESCRIPTION
Some errors that were breaking things.

~~The backward pass still does not work (wrong Caffe::phase()), will look at it tomorrow.~~

Backward pass seems to work now (but note I haven't inspected the saved blobs yet).
