### PR TITLE
Add libcaffe.a to dependencies for TEST_ALL_BIN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,8 @@ PYTHON_LDFLAGS := $(LDFLAGS) $(foreach library,$(PYTHON_LIBRARIES),-l$(library))
 ##############################
 # Define build targets
 ##############################
-.PHONY: all init test clean linecount lint tools examples py mat distribute py$(PROJECT) mat$(PROJECT) proto
+.PHONY: all init test clean linecount lint tools examples py mat distribute \
+        py$(PROJECT) mat$(PROJECT) proto runtest
 
 all: init $(NAME) $(STATIC_NAME) tools examples
 	@echo $(CXX_OBJS)
@@ -172,7 +173,7 @@ runtest: $(TEST_ALL_BIN)
 $(TEST_BINS): %.testbin : %.o $(GTEST_OBJ) $(STATIC_NAME) $(TEST_HDRS)
 	$(CXX) $(TEST_MAIN_SRC) $< $(GTEST_OBJ) $(STATIC_NAME) -o $@ $(CXXFLAGS) $(LDFLAGS) $(WARNINGS)
 
-$(TEST_ALL_BIN): $(STATIC_NAME) $(TEST_OBJS)
+$(TEST_ALL_BIN): $(GTEST_OBJ) $(STATIC_NAME) $(TEST_OBJS)
 	$(CXX) $(TEST_MAIN_SRC) $(TEST_OBJS) $(GTEST_OBJ) $(STATIC_NAME) -o $(TEST_ALL_BIN) $(CXXFLAGS) $(LDFLAGS) $(WARNINGS)
 
 $(TOOL_BINS): %.bin : %.o $(STATIC_NAME)


### PR DESCRIPTION
Prior to this change, running `make clean && make test` gave the error `g++: error: libcaffe.a: No such file or directory`.  This fixes that.

Edit: `make clean && make runtest` was giving a similar error `g++: error: build/src/gtest/gtest-all.o: No such file or directory`; commit 9251ae7 fixes that as well.
