### PR TITLE
Change hdf5 output layer test output file to use tmpnam

### DIFF
--- a/src/caffe/test/test_hdf5_output_layer.cpp
+++ b/src/caffe/test/test_hdf5_output_layer.cpp
@@ -12,9 +12,10 @@
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/test/test_caffe_main.hpp"
 
-namespace caffe {
 using std::string;
 using std::vector;
+
+namespace caffe {
 
 extern cudaDeviceProp CAFFE_TEST_CUDA_PROP;
 
@@ -22,17 +23,14 @@ template <typename Dtype>
 class HDF5OutputLayerTest : public ::testing::Test {
  protected:
   HDF5OutputLayerTest()
-      : output_file_name_("/tmp/test_hdf5_output_layer-sample_data.hdf5"),
+      : output_file_name_(tmpnam(NULL)),
         input_file_name_("src/caffe/test/test_data/sample_data.h5"),
         blob_data_(new Blob<Dtype>()),
         blob_label_(new Blob<Dtype>()),
         num_(5),
         channels_(8),
         height_(5),
-        width_(5) {
-  }
-  virtual void SetUp() {
-  }
+        width_(5) {}
 
   virtual ~HDF5OutputLayerTest() {
     delete blob_data_;


### PR DESCRIPTION
...rather than a hard-coded path, which causes the test to crash if the file exists and you do not have write access to it (e.g. when multiple users on a single machine run the Caffe unit tests).  Please always use tmpnam (or the like) for any temporary files.
