### PR TITLE
Add DEBUG option to Makefile/Makefile.config.example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,11 @@ LIBRARIES := cudart cublas curand \
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall
 
-COMMON_FLAGS := -DNDEBUG -O2
+ifdef DEBUG
+	COMMON_FLAGS := -DDEBUG -g -O0
+else
+	COMMON_FLAGS := -DNDEBUG -O2
+endif
 
 # MKL switch (default = non-MKL)
 USE_MKL ?= 0

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -45,3 +45,6 @@ LIBRARY_DIRS := $(PYTHON_LIB) /usr/lib /usr/local/lib
 
 BUILD_DIR := build
 DISTRIBUTE_DIR := distribute
+
+# uncomment for debugging
+#DEBUG := 1


### PR DESCRIPTION
This allows debugging to be toggled without dirtying the tree.
