### PR TITLE
Seed Boost RNG with cluster_seedgen by default

### DIFF
--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -121,7 +121,9 @@ class Caffe::RNG::Generator {
 };
 
 Caffe::RNG::RNG()
-: generator_(new Generator) { }
+: generator_(new Generator) {
+  generator_->rng = caffe::rng_t(cluster_seedgen());
+}
 
 Caffe::RNG::RNG(unsigned int seed)
 : generator_(new Generator) {


### PR DESCRIPTION
As discussed with @sguada, since the switch to Boost, results were deterministic by default since Boost uses a fixed seed by default.  This fixes that.  I think it's useful to be able to have results be deterministic though, so I'll follow up with another PR that allows one to specify a fixed seed in the SolverParameter.
