### PR TITLE
Fix python segfault in Mac OS X.

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -321,5 +321,6 @@ BOOST_PYTHON_MODULE(_caffe) {
   boost::python::class_<vector<CaffeLayer> >("LayerVec")
       .def(vector_indexing_suite<vector<CaffeLayer>, true>());
 
+  Py_Initialize();
   import_array();
 }


### PR DESCRIPTION
In Mac OS X, a segfault occurs when running `import caffe` in Python.  This PR fixes that segfault by initializing Python before attempting to initialize Numpy.
