### PR TITLE
Python wrapper fixes and re-arrangement

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -287,7 +287,7 @@ struct CaffeNet {
 // The boost python module definition.
 BOOST_PYTHON_MODULE(_caffe) {
   boost::python::class_<CaffeNet>(
-      "CaffeNet", boost::python::init<string, string>())
+      "Net", boost::python::init<string, string>())
       .def("Forward",          &CaffeNet::Forward)
       .def("ForwardPrefilled", &CaffeNet::ForwardPrefilled)
       .def("Backward",         &CaffeNet::Backward)
@@ -296,11 +296,12 @@ BOOST_PYTHON_MODULE(_caffe) {
       .def("set_phase_train",  &CaffeNet::set_phase_train)
       .def("set_phase_test",   &CaffeNet::set_phase_test)
       .def("set_device",       &CaffeNet::set_device)
-      .add_property("blobs",   &CaffeNet::blobs)
+      // rename blobs here since the pycaffe.py wrapper will replace it
+      .add_property("_blobs",  &CaffeNet::blobs)
       .add_property("layers",  &CaffeNet::layers);
 
   boost::python::class_<CaffeBlob, CaffeBlobWrap>(
-      "CaffeBlob", boost::python::no_init)
+      "Blob", boost::python::no_init)
       .add_property("name",     &CaffeBlob::name)
       .add_property("num",      &CaffeBlob::num)
       .add_property("channels", &CaffeBlob::channels)
@@ -311,7 +312,7 @@ BOOST_PYTHON_MODULE(_caffe) {
       .add_property("diff",     &CaffeBlobWrap::get_diff);
 
   boost::python::class_<CaffeLayer>(
-      "CaffeLayer", boost::python::no_init)
+      "Layer", boost::python::no_init)
       .add_property("name",  &CaffeLayer::name)
       .add_property("blobs", &CaffeLayer::blobs);
 

--- a/python/caffe/pycaffe.py
+++ b/python/caffe/pycaffe.py
@@ -6,23 +6,28 @@ interface.
 from ._caffe import CaffeNet
 from collections import OrderedDict
 
-class Net(CaffeNet):
-    """
-    The direct Python interface to caffe, exposing Forward and Backward
-    passes, data, gradients, and layer parameters
-    """
-    def __init__(self, param_file, pretrained_param_file):
-        super(Net, self).__init__(param_file, pretrained_param_file)
-        self._blobs = OrderedDict([(bl.name, bl)
-                                   for bl in super(Net, self).blobs])
-        self.params = OrderedDict([(lr.name, lr.blobs)
-                                   for lr in super(Net, self).layers
-                                   if len(lr.blobs) > 0])
+# we directly update methods from Net here (rather than using composition or
+# inheritance) so that nets created by caffe (e.g., by SGDSolver) will
+# automatically have the improved interface
 
-    @property
-    def blobs(self):
-        """
-        An OrderedDict (bottom to top, i.e., input to output) of network
-        blobs indexed by name
-        """
-        return self._blobs
+@property
+def _Net_blobs(self):
+    """
+    An OrderedDict (bottom to top, i.e., input to output) of network
+    blobs indexed by name
+    """
+    return OrderedDict([(bl.name, bl) for bl in self._blobs])
+
+Net.blobs = _Net_blobs
+
+@property
+def _Net_params(self):
+    """
+    An OrderedDict (bottom to top, i.e., input to output) of network
+    parameters indexed by name; each is a list of multiple blobs (e.g.,
+    weights and biases)
+    """
+    return OrderedDict([(lr.name, lr.blobs) for lr in self.layers
+                                            if len(lr.blobs) > 0])
+
+Net.params = _Net_params


### PR DESCRIPTION
N.B. this PR is against `master` to address users' current problems, and reduce the number of issues raised that are better solved by examples and documentation.

This is a placeholder to let everyone know I'm working on (list in progress):
- formatting helpers to convert images to Caffe format for deployment, or convert Caffe images back to normal images for viewing
- batching helper for feeding inputs to the net with padding as needed
- python exceptions instead of library crashes 
- a more complete wrapper example that shows how image formatting, computing the forward pass,
  and reading off predictions works
- properly separate responsibilities between the pycaffe wrapper, the wrapper example (wrapper.py) and detection example (detector.py)
