### PR TITLE
Document BLAS install, tailor Makefile and Makefile.config to platform

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -10,7 +10,9 @@ CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
 		-gencode arch=compute_30,code=sm_30 \
 		-gencode arch=compute_35,code=sm_35
 
-# MKL switch: set to 1 for MKL
+# MKL switch:
+# 0 for ATLAS BLAS (default)
+# 1 for MKL BLAS
 USE_MKL := 0
 # MKL directory contains include/ and lib/ directions that we need.
 MKL_DIR := /opt/intel/mkl
@@ -23,21 +25,15 @@ MATLAB_DIR := /usr/local
 # NOTE: this is required only if you will compile the python interface.
 # We need to be able to find Python.h and numpy/arrayobject.h.
 PYTHON_INCLUDES := /usr/include/python2.7 \
-    /usr/local/lib/python2.7/dist-packages/numpy/core/include
+		/usr/local/lib/python2.7/dist-packages/numpy/core/include
 # Anaconda Python distribution is quite popular. Include path:
 # PYTHON_INCLUDES := $(HOME)/anaconda/include \
-    # $(HOME)/anaconda/include/python2.7 \
-    # $(HOME)/anaconda/lib/python2.7/site-packages/numpy/core/include
+		# $(HOME)/anaconda/include/python2.7 \
+		# $(HOME)/anaconda/lib/python2.7/site-packages/numpy/core/include
 
 # We need to be able to find libpythonX.X.so or .dylib.
 PYTHON_LIB := /usr/local/lib
 # PYTHON_LIB := $(HOME)/anaconda/lib
-
-CXX := /usr/bin/g++
-# For OS X, use clang++.
-# CXX := /usr/bin/clang++
-# For OS X 10.9, use libstdc++ instead of libc++ for CUDA compatibility.
-# CXXFLAGS := -stdlib=libstdc++
 
 # Whatever else you find you need goes here.
 INCLUDE_DIRS := $(PYTHON_INCLUDES) /usr/local/include

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -152,7 +152,6 @@ Here are the relevant parts of the Makefile.config after all this:
     MKL_DIR := /opt/intel/mkl  # only needed for MKL
     PYTHON_INCLUDES := /path/to/anaconda/include /path/to/anaconda/include/python2.7 /path/to/anaconda/lib/python2.7/site-packages/numpy/core/include
     PYTHON_LIB := /path/to/anaconda/lib
-    CXX=/usr/bin/clang++
 
 Don't forget to set `PATH` and `LD_LIBRARY_PATH`:
 


### PR DESCRIPTION
This documents BLAS choices, fixes the ATLAS BLAS / non-MKL build configuration, and otherwise eases installation by automatically configuring the build according to the platform.
- [x] document BLAS choices (ATLAS and MKL supported, OpenBLAS for the adventurous)
- [x] include commands for ATLAS installation
- [x] detect platform in Makefile by `uname` 
- [x] correct cblas/atlas linking on OS X (needs `-framework vecLib` and other details)
- [ ] ~~possibly split Makefile.config into Makefile.config.linux and Makefile.config.osx (as once suggested by @sguada)~~ No need, given that the `Makefile` now makes the proper choices.
