### PR TITLE
Comment out MATLAB by default in Makefile.config

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -17,7 +17,7 @@ MKL_DIR := /opt/intel/mkl
 
 # This is required only if you will compile the matlab interface.
 # MATLAB directory should contain the mex binary in /bin.
-MATLAB_DIR := /usr/local
+# MATLAB_DIR := /usr/local
 # MATLAB_DIR := /Applications/MATLAB_R2012b.app
 
 # NOTE: this is required only if you will compile the python interface.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,7 +68,7 @@ Now that you have the prerequisites, edit your `Makefile.config` to change the p
 
 With the prerequisites installed, do `make all` to compile Caffe.
 
-To compile the python and MATLAB wrappers do `make pycaffe` and `make matcaffe` respectively.
+To compile the python and MATLAB wrappers do `make pycaffe` and `make matcaffe` respectively. Be sure to set your MATLAB and python paths in `Makefile.config` first!
 
 *Distribution*: run `make distribute` to create a `distribute` directory with all the Caffe headers, compiled libraries, binaries, etc. needed for distribution to other machines.
 


### PR DESCRIPTION
Otherwise the Makefile tries to determine the MATLAB SO extension even if
MATLAB doesn't exist, breaking `make`.
