### PR TITLE
add Share{Data,Diff} methods to blobs to enable "virtual" copies

### DIFF
--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -73,8 +73,13 @@ class Blob {
   void FromProto(const BlobProto& proto);
   void ToProto(BlobProto* proto, bool write_diff = false) const;
 
-  void AdoptData(const Blob& other);
-  void AdoptDiff(const Blob& other);
+  // Set the data_/diff_ shared_ptr to point to the SyncedMemory holding the
+  // data_/diff_ of Blob other -- useful in layers which simply perform a copy
+  // in their forward or backward pass.
+  // This deallocates the SyncedMemory holding this blob's data/diff, as
+  // shared_ptr calls its destructor when reset with the = operator.
+  void ShareData(const Blob& other);
+  void ShareDiff(const Blob& other);
 
  protected:
   shared_ptr<SyncedMemory> data_;

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -86,13 +86,13 @@ Dtype* Blob<Dtype>::mutable_gpu_diff() {
 }
 
 template <typename Dtype>
-void Blob<Dtype>::AdoptData(const Blob& other) {
+void Blob<Dtype>::ShareData(const Blob& other) {
   CHECK_EQ(count_, other.count());
   data_ = other.data();
 }
 
 template <typename Dtype>
-void Blob<Dtype>::AdoptDiff(const Blob& other) {
+void Blob<Dtype>::ShareDiff(const Blob& other) {
   CHECK_EQ(count_, other.count());
   diff_ = other.diff();
 }

--- a/src/caffe/layers/flatten_layer.cpp
+++ b/src/caffe/layers/flatten_layer.cpp
@@ -24,14 +24,14 @@ void FlattenLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 Dtype FlattenLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       vector<Blob<Dtype>*>* top) {
-  (*top)[0]->AdoptData(*bottom[0]);
+  (*top)[0]->ShareData(*bottom[0]);
   return Dtype(0.);
 }
 
 template <typename Dtype>
 void FlattenLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const bool propagate_down, vector<Blob<Dtype>*>* bottom) {
-  (*bottom)[0]->AdoptDiff(*top[0]);
+  (*bottom)[0]->ShareDiff(*top[0]);
 }
 
 INSTANTIATE_CLASS(FlattenLayer);

--- a/src/caffe/layers/flatten_layer.cu
+++ b/src/caffe/layers/flatten_layer.cu
@@ -11,14 +11,14 @@ namespace caffe {
 template <typename Dtype>
 Dtype FlattenLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       vector<Blob<Dtype>*>* top) {
-  (*top)[0]->AdoptData(*bottom[0]);
+  (*top)[0]->ShareData(*bottom[0]);
   return Dtype(0.);
 }
 
 template <typename Dtype>
 void FlattenLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
       const bool propagate_down, vector<Blob<Dtype>*>* bottom) {
-  (*bottom)[0]->AdoptDiff(*top[0]);
+  (*bottom)[0]->ShareDiff(*top[0]);
 }
 
 INSTANTIATE_CLASS(FlattenLayer);

--- a/src/caffe/layers/split_layer.cpp
+++ b/src/caffe/layers/split_layer.cpp
@@ -31,7 +31,7 @@ template <typename Dtype>
 Dtype SplitLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       vector<Blob<Dtype>*>* top) {
   for (int i = 0; i < top->size(); ++i) {
-    (*top)[i]->AdoptData(*bottom[0]);
+    (*top)[i]->ShareData(*bottom[0]);
   }
   return Dtype(0.);
 }
@@ -40,7 +40,7 @@ template <typename Dtype>
 void SplitLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const bool propagate_down, vector<Blob<Dtype>*>* bottom) {
   if (propagate_down) {
-    (*bottom)[0]->AdoptDiff(*top[0]);
+    (*bottom)[0]->ShareDiff(*top[0]);
     // Add remaining top blob diffs.
     Dtype* bottom_diff = (*bottom)[0]->mutable_cpu_diff();
     for (int i = 1; i < top.size(); ++i) {

--- a/src/caffe/layers/split_layer.cu
+++ b/src/caffe/layers/split_layer.cu
@@ -12,7 +12,7 @@ template <typename Dtype>
 Dtype SplitLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       vector<Blob<Dtype>*>* top) {
   for (int i = 0; i < top->size(); ++i) {
-    (*top)[i]->AdoptData(*bottom[0]);
+    (*top)[i]->ShareData(*bottom[0]);
   }
   return Dtype(0.);
 }
@@ -21,7 +21,7 @@ template <typename Dtype>
 void SplitLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
       const bool propagate_down, vector<Blob<Dtype>*>* bottom) {
   if (propagate_down) {
-    (*bottom)[0]->AdoptDiff(*top[0]);
+    (*bottom)[0]->ShareDiff(*top[0]);
     // Add remaining top blob diffs.
     Dtype* bottom_diff = (*bottom)[0]->mutable_gpu_diff();
     for (int i = 1; i < top.size(); ++i) {


### PR DESCRIPTION
This PR adds methods `ShareData` and `ShareDiff` so that explicit O(N) copies by value can be replaced with O(1) copies by reference using the `=` operator on `shared_ptr<SyncedMem>`s which hold the blob data.

This makes `FlattenLayer`s essentially free and `SplitLayer`s substantially cheaper -- only needing to do an `axpy` in the backward pass (which is mathematically necessary).

On my machine, this speeds up `FlattenLayerTest` from ~20s to ~12s_, with the vast majority of the speedup due to TestGPUGradient since FlattenLayer no longer actually does any GPU computation.  The `SplitLayerTest` timing does not change much because the copies in the unit test are so small to begin with, but when I do the test on a somewhat realistic input size (change `test_split_layer` line 27 to `blob_bottom_(new Blob<Dtype>(1000, 3, 200, 200))` instead of `(2, 3, 6, 5)`) and run using `./build/test/test_split_layer.testbin --gtest_filter="-_Gradient*"` (suppresses gradient checking tests because they become absurdly slow with this blob size), I see a speedup from ~176s to ~171s.  Not huge, but basically a free improvement.

*These unit tests (which I wrote) are way too slow even with this improvement, but that's a problem to address in another PR...
