### PR TITLE
add ShareTrainedLayersWith method and use for test net in solver

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -54,6 +54,10 @@ class Net {
   // Updates the network weights based on the diff values computed.
   void Update();
 
+  // For an already initialized net, ShareTrainedLayersWith() implicitly copies
+  // (i.e., using no additional memory) the already trained layers from another
+  // Net.
+  void ShareTrainedLayersWith(Net* other);
   // For an already initialized net, CopyTrainedLayersFrom() copies the already
   // trained layers from another net parameter instance.
   void CopyTrainedLayersFrom(const NetParameter& param);

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -95,9 +95,7 @@ void Solver<Dtype>::Solve(const char* resume_file) {
 template <typename Dtype>
 void Solver<Dtype>::Test() {
   LOG(INFO) << "Iteration " << iter_ << ", Testing net";
-  NetParameter net_param;
-  net_->ToProto(&net_param);
-  CHECK_NOTNULL(test_net_.get())->CopyTrainedLayersFrom(net_param);
+  CHECK_NOTNULL(test_net_.get())->ShareTrainedLayersWith(net_.get());
   vector<Dtype> test_score;
   vector<Blob<Dtype>*> bottom_vec;
   Dtype loss = 0;


### PR DESCRIPTION
This PR uses the new `ShareData` method of blobs to implicitly copy parameter blobs (weights/biases) from the train net to the test net.  I tested the imagenet model on GPU to confirm that memory is saved (233 MB, which makes sense as this is roughly the size of the saved imagenet parameters) once the test net is initialized:

```
dev:

before test net initialization: 64% GPU memory use: 3074 MB / 4799 MB
after test net initialization: 74% GPU memory use: 3548 MB / 4799 MB


share-trained-layers:

before test net initialization: 64% GPU memory use: 3074 MB / 4799 MB
after test net initialization: 69% GPU memory use: 3315 MB / 4799 MB
```

Note that the test net initialization still uses extra memory because its data blobs (which store bottom/top inputs/outputs in each layer) are still allocated.
