### PR TITLE
Make CheckGradientExhaustive fail for topless layers

### DIFF
--- a/src/caffe/test/test_gradient_check_util.hpp
+++ b/src/caffe/test/test_gradient_check_util.hpp
@@ -135,6 +135,7 @@ template <typename Dtype>
 void GradientChecker<Dtype>::CheckGradientExhaustive(Layer<Dtype>* layer,
     vector<Blob<Dtype>*>* bottom, vector<Blob<Dtype>*>* top, int check_bottom) {
   layer->SetUp(*bottom, top);
+  CHECK_GT(top->size(), 0) << "Exhaustive mode requires at least one top blob.";
   // LOG(ERROR) << "Exhaustive Mode.";
   for (int i = 0; i < top->size(); ++i) {
     // LOG(ERROR) << "Exhaustive: blob " << i << " size " << top[i]->count();


### PR DESCRIPTION
Without this commit, it is possible to mistakenly call CheckGradientExhaustive on a layer with no top blobs (i.e., a loss layer), causing the gradient check to silently succeed while doing nothing. With this commit, doing so will cause the test to fail.

All existing tests continue to pass.

See, e.g., @aravindhm's comment in #258.
