### PR TITLE
Wrap up SyncedMem resize from @kloudkl; make train/test nets share data blobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ $(GTEST_OBJ): $(GTEST_SRC) | $(GTEST_BUILD_DIR)
 	$(CXX) $< $(CXXFLAGS) -c -o $@
 	@ echo
 
-$(BUILD_DIR)/src/$(PROJECT)/%.cuo: src/$(PROJECT)/%.cu
+$(OBJ_BUILD_DIR)/%.cuo: src/$(PROJECT)/%.cu | $(OBJ_BUILD_DIR)
 	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@
 	@ echo
 
@@ -353,7 +353,7 @@ $(EXAMPLE_BUILD_DIR)/%.o: examples/%.cpp $(PROTO_GEN_HEADER) \
 	$(CXX) $< $(CXXFLAGS) -c -o $@ $(LDFLAGS)
 	@ echo
 
-$(BUILD_DIR)/src/$(PROJECT)/%.o: src/$(PROJECT)/%.cpp $(HXX_SRCS)
+$(OBJ_BUILD_DIR)/%.o: src/$(PROJECT)/%.cpp $(HXX_SRCS)
 	$(CXX) $< $(CXXFLAGS) -c -o $@
 	@ echo
 

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,10 @@ $(TEST_BIN_DIR)/%.testbin: $(TEST_BUILD_DIR)/%.o $(GTEST_OBJ) $(STATIC_NAME) \
 		-o $@ $(CXXFLAGS) $(LDFLAGS) $(WARNINGS)
 	@ echo
 
+$(GTEST_OBJ): $(GTEST_SRC) | $(GTEST_BUILD_DIR)
+	$(CXX) $< $(CXXFLAGS) -c -o $@
+	@ echo
+
 $(TOOL_BINS): %.bin : %.o $(STATIC_NAME)
 	$(CXX) $< $(STATIC_NAME) -o $@ $(CXXFLAGS) $(LDFLAGS) $(WARNINGS)
 	@ echo
@@ -327,33 +331,29 @@ $(UTIL_BUILD_DIR)/%.o: src/$(PROJECT)/util/%.cpp $(HXX_SRCS) | $(UTIL_BUILD_DIR)
 	$(CXX) $< $(CXXFLAGS) -c -o $@
 	@ echo
 
-$(GTEST_OBJ): $(GTEST_SRC) | $(GTEST_BUILD_DIR)
-	$(CXX) $< $(CXXFLAGS) -c -o $@
-	@ echo
-
-$(OBJ_BUILD_DIR)/%.cuo: src/$(PROJECT)/%.cu | $(OBJ_BUILD_DIR)
-	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@
-	@ echo
-
 $(LAYER_BUILD_DIR)/%.cuo: src/$(PROJECT)/layers/%.cu $(HXX_SRCS) \
 		| $(LAYER_BUILD_DIR)
 	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@
 	@ echo
 
-$(UTIL_BUILD_DIR)/%.cuo: src/$(PROJECT)/util/%.cu | $(UTIL_BUILD_DIR)
+$(UTIL_BUILD_DIR)/%.cuo: src/$(PROJECT)/util/%.cu $(HXX_SRCS) \
+		| $(UTIL_BUILD_DIR)
 	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@
 	@ echo
 
-$(TOOL_BUILD_DIR)/%.o: tools/%.cpp $(PROTO_GEN_HEADER) | $(TOOL_BUILD_DIR)
+$(OBJ_BUILD_DIR)/%.cuo: src/$(PROJECT)/%.cu $(HXX_SRCS) | $(OBJ_BUILD_DIR)
+	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@
+	@ echo
+
+$(TOOL_BUILD_DIR)/%.o: tools/%.cpp $(HXX_SRCS) | $(TOOL_BUILD_DIR)
 	$(CXX) $< $(CXXFLAGS) -c -o $@ $(LDFLAGS)
 	@ echo
 
-$(EXAMPLE_BUILD_DIR)/%.o: examples/%.cpp $(PROTO_GEN_HEADER) \
-		| $(EXAMPLE_BUILD_DIRS)
+$(EXAMPLE_BUILD_DIR)/%.o: examples/%.cpp $(HXX_SRCS) | $(EXAMPLE_BUILD_DIRS)
 	$(CXX) $< $(CXXFLAGS) -c -o $@ $(LDFLAGS)
 	@ echo
 
-$(OBJ_BUILD_DIR)/%.o: src/$(PROJECT)/%.cpp $(HXX_SRCS)
+$(OBJ_BUILD_DIR)/%.o: src/$(PROJECT)/%.cpp $(HXX_SRCS) | $(OBJ_BUILD_DIR)
 	$(CXX) $< $(CXXFLAGS) -c -o $@
 	@ echo
 

--- a/Makefile
+++ b/Makefile
@@ -331,6 +331,10 @@ $(GTEST_OBJ): $(GTEST_SRC) | $(GTEST_BUILD_DIR)
 	$(CXX) $< $(CXXFLAGS) -c -o $@
 	@ echo
 
+$(BUILD_DIR)/src/$(PROJECT)/%.cuo: src/$(PROJECT)/%.cu
+	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@
+	@ echo
+
 $(LAYER_BUILD_DIR)/%.cuo: src/$(PROJECT)/layers/%.cu $(HXX_SRCS) \
 		| $(LAYER_BUILD_DIR)
 	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@

--- a/examples/imagenet/imagenet_solver.prototxt
+++ b/examples/imagenet/imagenet_solver.prototxt
@@ -1,6 +1,6 @@
 train_net: "imagenet_train.prototxt"
 test_net: "imagenet_val.prototxt"
-test_iter: 1000
+test_iter: 200
 test_interval: 1000
 base_lr: 0.01
 lr_policy: "step"

--- a/examples/imagenet/imagenet_val.prototxt
+++ b/examples/imagenet/imagenet_val.prototxt
@@ -7,7 +7,7 @@ layers {
   data_param {
     source: "ilsvrc12_val_leveldb"
     mean_file: "../../data/ilsvrc12/imagenet_mean.binaryproto"
-    batch_size: 50
+    batch_size: 250
     crop_size: 227
     mirror: false
   }

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -23,7 +23,6 @@ class Blob {
   inline int height() const { return height_; }
   inline int width() const { return width_; }
   inline int count() const { return count_; }
-  inline size_t capacity() const { return capacity_; }
   inline int offset(const int n, const int c = 0, const int h = 0,
       const int w = 0) const {
     CHECK_GE(n, 0);
@@ -90,7 +89,6 @@ class Blob {
   int height_;
   int width_;
   int count_;
-  size_t capacity_;
   size_t space_requirement_;
 
   DISABLE_COPY_AND_ASSIGN(Blob);

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -13,9 +13,9 @@ template <typename Dtype>
 class Blob {
  public:
   explicit Blob(const int num = 0, const int channels = 0,
-      const int height = 0, const int width = 0);
-  void Reshape(const int num, const int channels, const int height,
-    const int width);
+                const int height = 0, const int width = 0);
+  void Reshape(const int num, const int channels,
+               const int height, const int width);
   void ReshapeLike(const Blob& other);
   inline int num() const { return num_; }
   inline int channels() const { return channels_; }

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -14,6 +14,7 @@ class Blob {
  public:
   explicit Blob(const int num = 0, const int channels = 0,
                 const int height = 0, const int width = 0);
+  explicit Blob(Blob* memory_share_blob);
   void Reshape(const int num, const int channels,
                const int height, const int width);
   void ReshapeLike(const Blob& other);
@@ -90,6 +91,7 @@ class Blob {
   int width_;
   int count_;
   size_t capacity_;
+  size_t space_requirement_;
 
   DISABLE_COPY_AND_ASSIGN(Blob);
 };  // class Blob

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -12,11 +12,8 @@ namespace caffe {
 template <typename Dtype>
 class Blob {
  public:
-  Blob()
-       : num_(0), channels_(0), height_(0), width_(0), count_(0), data_(),
-       diff_() {}
-  explicit Blob(const int num, const int channels, const int height,
-    const int width);
+  explicit Blob(const int num = 0, const int channels = 0,
+      const int height = 0, const int width = 0);
   void Reshape(const int num, const int channels, const int height,
     const int width);
   void ReshapeLike(const Blob& other);

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -14,7 +14,7 @@ class Blob {
  public:
   explicit Blob(const int num = 0, const int channels = 0,
                 const int height = 0, const int width = 0);
-  explicit Blob(Blob* memory_share_blob);
+  explicit Blob(const Blob& memory_share_blob);
   void Reshape(const int num, const int channels,
                const int height, const int width);
   void ReshapeLike(const Blob& other);
@@ -91,7 +91,7 @@ class Blob {
   int count_;
   size_t space_requirement_;
 
-  DISABLE_COPY_AND_ASSIGN(Blob);
+  DISABLE_ASSIGN(Blob);
 };  // class Blob
 
 }  // namespace caffe

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -24,7 +24,8 @@ class Blob {
   inline int channels() const { return channels_; }
   inline int height() const { return height_; }
   inline int width() const { return width_; }
-  inline int count() const {return count_; }
+  inline int count() const { return count_; }
+  inline size_t capacity() const { return capacity_; }
   inline int offset(const int n, const int c = 0, const int h = 0,
       const int w = 0) const {
     CHECK_GE(n, 0);
@@ -91,6 +92,7 @@ class Blob {
   int height_;
   int width_;
   int count_;
+  size_t capacity_;
 
   DISABLE_COPY_AND_ASSIGN(Blob);
 };  // class Blob

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -16,6 +16,11 @@ private:\
   classname(const classname&);\
   classname& operator=(const classname&)
 
+// Disable just the assignment operator for a class.
+#define DISABLE_ASSIGN(classname) \
+private:\
+  classname& operator=(const classname&)
+
 // Instantiate a class with float and double specifications.
 #define INSTANTIATE_CLASS(classname) \
   template class classname<float>; \

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -22,12 +22,12 @@ namespace caffe {
 template <typename Dtype>
 class Net {
  public:
-  explicit Net(const NetParameter& param);
-  explicit Net(const string& param_file);
+  explicit Net(const NetParameter& param, Net<Dtype>* memory_share_net = NULL);
+  explicit Net(const string& param_file, Net<Dtype>* memory_share_net = NULL);
   virtual ~Net() {}
 
   // Initialize a network with the network parameter.
-  void Init(const NetParameter& param);
+  void Init(const NetParameter& param, Net<Dtype>* memory_share_net = NULL);
 
   // Run forward with the input blobs already fed separately. You can get the
   // input blobs using input_blobs().

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -26,7 +26,11 @@ class Net {
   explicit Net(const string& param_file, Net<Dtype>* memory_share_net = NULL);
   virtual ~Net() {}
 
-  // Initialize a network with the network parameter.
+  // Initialize a network with the network parameter.  If memory_share_net is
+  // non-null, any top/bottom blob in this net with an identically-named blob
+  // in memory_share_net will share its memory location to save on memory, using
+  // memory proportional to max(net_a_blob_size, net_b_blob_size) rather than
+  // (net_a_blob_size + net_b_blob_size).
   void Init(const NetParameter& param, Net<Dtype>* memory_share_net = NULL);
 
   // Run forward with the input blobs already fed separately. You can get the

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -3,6 +3,8 @@
 #ifndef CAFFE_SYNCEDMEM_HPP_
 #define CAFFE_SYNCEDMEM_HPP_
 
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
 #include <cstdlib>
 
 #include "caffe/common.hpp"
@@ -53,8 +55,8 @@ class SyncedMemory {
  private:
   void to_cpu();
   void to_gpu();
-  void* cpu_ptr_;
-  void* gpu_ptr_;
+  thrust::host_vector<uint8_t> cpu_vector_;
+  thrust::device_vector<uint8_t> gpu_vector_;
   size_t size_;
   SyncedHead head_;
   bool own_cpu_data_;

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -55,6 +55,14 @@ class SyncedMemory {
   enum SyncedHead { UNINITIALIZED, HEAD_AT_CPU, HEAD_AT_GPU, SYNCED };
   SyncedHead head() { return head_; }
   inline size_t size() const { return size_; }
+  // set_size sets the "size_" variable.  The current size_ is checked whenever
+  // a data accessor/mutator method (cpu_data, gpu_data, mutable_cpu_data, ...)
+  // is called and if the current CPU or GPU memory is insufficient to hold the
+  // size_, extra space is allocated.  If the current allocation on the device/
+  // host (depending on whether cpu_* or gpu_data was called) is sufficient
+  // (i.e., capacity >= size_), no action is taken as a result of the set_size
+  // call.  Therefore, the actual allocation can only grow, never shrinking
+  // (until the SyncedMemory itself is freed/deleted).
   inline void set_size(const size_t size) { size_ = size; }
   inline size_t cpu_capacity() const { return cpu_capacity_; }
   inline size_t gpu_capacity() const { return gpu_capacity_; }

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -50,7 +50,10 @@ class SyncedMemory {
   void* mutable_gpu_data();
   enum SyncedHead { UNINITIALIZED, HEAD_AT_CPU, HEAD_AT_GPU, SYNCED };
   SyncedHead head() { return head_; }
-  size_t size() { return size_; }
+  inline size_t size() const { return size_; }
+  inline size_t capacity() const { return capacity_; }
+  void resize(const size_t size, const uint8_t default_value = 0);
+  void reserve(const size_t capacity);
 
  private:
   void to_cpu();

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -44,7 +44,8 @@ class SyncedMemory {
  public:
   explicit SyncedMemory(const size_t size = 0)
       : cpu_data_(NULL), gpu_data_(NULL), size_(size),
-        cpu_capacity_(0), gpu_capacity_(0), head_(UNINITIALIZED) {}
+        cpu_capacity_(0), gpu_capacity_(0), head_(UNINITIALIZED),
+        own_cpu_data_(false) {}
   ~SyncedMemory();
   const void* cpu_data();
   void set_cpu_data(void* data);

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -50,30 +50,22 @@ class SyncedMemory {
   enum SyncedHead { UNINITIALIZED, HEAD_AT_CPU, HEAD_AT_GPU, SYNCED };
   SyncedHead head() { return head_; }
   inline size_t size() const { return size_; }
+  inline void set_size(const size_t size) { size_ = size; }
   inline size_t cpu_capacity() const { return cpu_capacity_; }
   inline size_t gpu_capacity() const { return gpu_capacity_; }
-  inline void set_size(const size_t size) { size_ = size; }
 
  private:
-  size_t size_;
-  size_t cpu_capacity_;
-  size_t gpu_capacity_;
-  void* cpu_data_;
-  void* gpu_data_;
   void to_cpu();
   void to_gpu();
+  size_t cpu_resize();
+  size_t gpu_resize();
+  void* cpu_data_;
+  void* gpu_data_;
+  size_t cpu_capacity_;
+  size_t gpu_capacity_;
+  size_t size_;
   SyncedHead head_;
   bool own_cpu_data_;
-
-  // If CPU memory is uninitialized or cpu_capacity_ < size_, allocate
-  // the appropriate amount of additional CPU memory and return true. Otherwise,
-  // do nothing and return false.
-  bool cpu_resize();
-
-  // If GPU memory is uninitialized or gpu_capacity_ < size_, allocate
-  // the appropriate amount of additional GPU memory and return true. Otherwise,
-  // do nothing and return false.
-  bool gpu_resize();
 
   DISABLE_COPY_AND_ASSIGN(SyncedMemory);
 };  // class SyncedMemory

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -3,8 +3,6 @@
 #ifndef CAFFE_SYNCEDMEM_HPP_
 #define CAFFE_SYNCEDMEM_HPP_
 
-#include <thrust/device_vector.h>
-#include <thrust/host_vector.h>
 #include <cstdlib>
 
 #include "caffe/common.hpp"
@@ -29,6 +27,10 @@ inline void CaffeMallocHost(void** ptr, size_t size) {
   *ptr = malloc(size);
 }
 
+inline void CaffeReallocHost(void** ptr, size_t size) {
+  *ptr = realloc(*ptr, size);
+}
+
 inline void CaffeFreeHost(void* ptr) {
   free(ptr);
 }
@@ -36,12 +38,9 @@ inline void CaffeFreeHost(void* ptr) {
 
 class SyncedMemory {
  public:
-  SyncedMemory()
-      : cpu_ptr_(NULL), gpu_ptr_(NULL), size_(0), head_(UNINITIALIZED),
-        own_cpu_data_(false) {}
-  explicit SyncedMemory(size_t size)
-      : cpu_ptr_(NULL), gpu_ptr_(NULL), size_(size), head_(UNINITIALIZED),
-        own_cpu_data_(false) {}
+  explicit SyncedMemory(const size_t size = 0)
+      : cpu_data_(NULL), gpu_data_(NULL), size_(size),
+        cpu_capacity_(0), gpu_capacity_(0), head_(UNINITIALIZED) {}
   ~SyncedMemory();
   const void* cpu_data();
   void set_cpu_data(void* data);
@@ -51,18 +50,18 @@ class SyncedMemory {
   enum SyncedHead { UNINITIALIZED, HEAD_AT_CPU, HEAD_AT_GPU, SYNCED };
   SyncedHead head() { return head_; }
   inline size_t size() const { return size_; }
-  inline size_t capacity() const { return capacity_; }
-  void resize(const size_t size, const uint8_t default_value = 0);
-  void reserve(const size_t capacity);
+  inline void set_size(const size_t size) { size_ = size; }
 
  private:
+  size_t size_;
+  size_t cpu_capacity_;
+  size_t gpu_capacity_;
+  void* cpu_data_;
+  void* gpu_data_;
   void to_cpu();
   void to_gpu();
-  thrust::host_vector<uint8_t> cpu_vector_;
-  thrust::device_vector<uint8_t> gpu_vector_;
-  size_t size_;
-  uint8_t resize_default_value_;
-  size_t capacity_;
+  void cpu_resize();
+  void gpu_resize();
   SyncedHead head_;
   bool own_cpu_data_;
 

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -50,6 +50,8 @@ class SyncedMemory {
   enum SyncedHead { UNINITIALIZED, HEAD_AT_CPU, HEAD_AT_GPU, SYNCED };
   SyncedHead head() { return head_; }
   inline size_t size() const { return size_; }
+  inline size_t cpu_capacity() const { return cpu_capacity_; }
+  inline size_t gpu_capacity() const { return gpu_capacity_; }
   inline void set_size(const size_t size) { size_ = size; }
 
  private:
@@ -60,10 +62,18 @@ class SyncedMemory {
   void* gpu_data_;
   void to_cpu();
   void to_gpu();
-  void cpu_resize();
-  void gpu_resize();
   SyncedHead head_;
   bool own_cpu_data_;
+
+  // If CPU memory is uninitialized or cpu_capacity_ < size_, allocate
+  // the appropriate amount of additional CPU memory and return true. Otherwise,
+  // do nothing and return false.
+  bool cpu_resize();
+
+  // If GPU memory is uninitialized or gpu_capacity_ < size_, allocate
+  // the appropriate amount of additional GPU memory and return true. Otherwise,
+  // do nothing and return false.
+  bool gpu_resize();
 
   DISABLE_COPY_AND_ASSIGN(SyncedMemory);
 };  // class SyncedMemory

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -25,10 +25,14 @@ namespace caffe {
 
 inline void CaffeMallocHost(void** ptr, size_t size) {
   *ptr = malloc(size);
+  CHECK(*ptr) << "malloc failed when attempting to allocate "
+              << size << " bytes of host memory.";
 }
 
 inline void CaffeReallocHost(void** ptr, size_t size) {
   *ptr = realloc(*ptr, size);
+  CHECK(*ptr) << "realloc failed when attempting to allocate "
+              << size << " bytes of host memory.";
 }
 
 inline void CaffeFreeHost(void* ptr) {

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -58,6 +58,8 @@ class SyncedMemory {
   thrust::host_vector<uint8_t> cpu_vector_;
   thrust::device_vector<uint8_t> gpu_vector_;
   size_t size_;
+  uint8_t resize_default_value_;
+  size_t capacity_;
   SyncedHead head_;
   bool own_cpu_data_;
 

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -11,16 +11,14 @@
 namespace caffe {
 
 template <typename Dtype>
-Blob<Dtype>::Blob(const int num, const int channels, const int height,
-    const int width) : data_(), diff_(), num_(num), channels_(channels),
-    height_(height), width_(width), count_(num * channels * height * width),
-    capacity_(count_) {
+Blob<Dtype>::Blob(const int num, const int channels,
+                  const int height, const int width) {
   Reshape(num, channels, height, width);
 }
 
 template <typename Dtype>
-void Blob<Dtype>::Reshape(const int num, const int channels, const int height,
-    const int width) {
+void Blob<Dtype>::Reshape(const int num, const int channels,
+                          const int height, const int width) {
   CHECK_GE(num, 0);
   CHECK_GE(channels, 0);
   CHECK_GE(height, 0);
@@ -60,7 +58,7 @@ Blob<Dtype>::Blob(const int num, const int channels, const int height,
 template <typename Dtype>
 const Dtype* Blob<Dtype>::cpu_data() const {
   CHECK(data_);
-  return (const Dtype*)data_->cpu_data();
+  return static_cast<const Dtype*>(data_->cpu_data());
 }
 
 template <typename Dtype>
@@ -72,43 +70,43 @@ void Blob<Dtype>::set_cpu_data(Dtype* data) {
 template <typename Dtype>
 const Dtype* Blob<Dtype>::gpu_data() const {
   CHECK(data_);
-  return (const Dtype*)data_->gpu_data();
+  return static_cast<const Dtype*>(data_->gpu_data());
 }
 
 template <typename Dtype>
 const Dtype* Blob<Dtype>::cpu_diff() const {
   CHECK(diff_);
-  return (const Dtype*)diff_->cpu_data();
+  return static_cast<const Dtype*>(diff_->cpu_data());
 }
 
 template <typename Dtype>
 const Dtype* Blob<Dtype>::gpu_diff() const {
   CHECK(diff_);
-  return (const Dtype*)diff_->gpu_data();
+  return static_cast<const Dtype*>(diff_->gpu_data());
 }
 
 template <typename Dtype>
 Dtype* Blob<Dtype>::mutable_cpu_data() {
   CHECK(data_);
-  return reinterpret_cast<Dtype*>(data_->mutable_cpu_data());
+  return static_cast<Dtype*>(data_->mutable_cpu_data());
 }
 
 template <typename Dtype>
 Dtype* Blob<Dtype>::mutable_gpu_data() {
   CHECK(data_);
-  return reinterpret_cast<Dtype*>(data_->mutable_gpu_data());
+  return static_cast<Dtype*>(data_->mutable_gpu_data());
 }
 
 template <typename Dtype>
 Dtype* Blob<Dtype>::mutable_cpu_diff() {
   CHECK(diff_);
-  return reinterpret_cast<Dtype*>(diff_->mutable_cpu_data());
+  return static_cast<Dtype*>(diff_->mutable_cpu_data());
 }
 
 template <typename Dtype>
 Dtype* Blob<Dtype>::mutable_gpu_diff() {
   CHECK(diff_);
-  return reinterpret_cast<Dtype*>(diff_->mutable_gpu_data());
+  return static_cast<Dtype*>(diff_->mutable_gpu_data());
 }
 
 template <typename Dtype>
@@ -130,15 +128,15 @@ void Blob<Dtype>::Update() {
   case SyncedMemory::HEAD_AT_CPU:
     // perform computation on CPU
     caffe_axpy<Dtype>(count_, Dtype(-1),
-        reinterpret_cast<const Dtype*>(diff_->cpu_data()),
-        reinterpret_cast<Dtype*>(data_->mutable_cpu_data()));
+        static_cast<const Dtype*>(diff_->cpu_data()),
+        static_cast<Dtype*>(data_->mutable_cpu_data()));
     break;
   case SyncedMemory::HEAD_AT_GPU:
   case SyncedMemory::SYNCED:
     // perform computation on GPU
     caffe_gpu_axpy<Dtype>(count_, Dtype(-1),
-        reinterpret_cast<const Dtype*>(diff_->gpu_data()),
-        reinterpret_cast<Dtype*>(data_->mutable_gpu_data()));
+        static_cast<const Dtype*>(diff_->gpu_data()),
+        static_cast<Dtype*>(data_->mutable_gpu_data()));
     break;
   default:
     LOG(FATAL) << "Syncedmem not initialized.";

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -11,6 +11,14 @@
 namespace caffe {
 
 template <typename Dtype>
+Blob<Dtype>::Blob(const int num, const int channels, const int height,
+    const int width) : data_(), diff_(), num_(num), channels_(channels),
+    height_(height), width_(width), count_(num * channels * height * width),
+    capacity_(count_) {
+  Reshape(num, channels, height, width);
+}
+
+template <typename Dtype>
 void Blob<Dtype>::Reshape(const int num, const int channels, const int height,
     const int width) {
   CHECK_GE(num, 0);

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -12,7 +12,8 @@ namespace caffe {
 
 template <typename Dtype>
 Blob<Dtype>::Blob(const int num, const int channels,
-                  const int height, const int width) {
+                  const int height, const int width) :
+    count_(0), capacity_(0), data_(), diff_() {
   Reshape(num, channels, height, width);
 }
 
@@ -33,12 +34,12 @@ void Blob<Dtype>::Reshape(const int num, const int channels,
   }
   size_t space_requirement = capacity_ * sizeof(Dtype);
   if (data_) {
-    data_->reserve(space_requirement);
+    data_->set_size(space_requirement);
   } else {
     data_.reset(new SyncedMemory(space_requirement));
   }
   if (diff_) {
-    diff_->reserve(space_requirement);
+    diff_->set_size(space_requirement);
   } else {
     diff_.reset(new SyncedMemory(space_requirement));
   }

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -18,10 +18,10 @@ Blob<Dtype>::Blob(const int num, const int channels,
 }
 
 template <typename Dtype>
-Blob<Dtype>::Blob(Blob* memory_share_blob) :
+Blob<Dtype>::Blob(const Blob& memory_share_blob) :
     count_(0), space_requirement_(0), data_(), diff_() {
-  ShareData(*memory_share_blob);
-  ShareDiff(*memory_share_blob);
+  ShareData(memory_share_blob);
+  ShareDiff(memory_share_blob);
 }
 
 template <typename Dtype>

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -55,12 +55,6 @@ void Blob<Dtype>::ReshapeLike(const Blob<Dtype>& other) {
 }
 
 template <typename Dtype>
-Blob<Dtype>::Blob(const int num, const int channels, const int height,
-    const int width) {
-  Reshape(num, channels, height, width);
-}
-
-template <typename Dtype>
 const Dtype* Blob<Dtype>::cpu_data() const {
   CHECK(data_);
   data_->set_size(space_requirement_);

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -22,12 +22,19 @@ void Blob<Dtype>::Reshape(const int num, const int channels, const int height,
   height_ = height;
   width_ = width;
   count_ = num_ * channels_ * height_ * width_;
-  if (count_) {
-    data_.reset(new SyncedMemory(count_ * sizeof(Dtype)));
-    diff_.reset(new SyncedMemory(count_ * sizeof(Dtype)));
+  if (capacity_ < count_) {
+    capacity_ = count_;
+  }
+  size_t space_requirement = capacity_ * sizeof(Dtype);
+  if (data_) {
+    data_->reserve(space_requirement);
   } else {
-    data_.reset(reinterpret_cast<SyncedMemory*>(NULL));
-    diff_.reset(reinterpret_cast<SyncedMemory*>(NULL));
+    data_.reset(new SyncedMemory(space_requirement));
+  }
+  if (diff_) {
+    diff_->reserve(space_requirement);
+  } else {
+    diff_.reset(new SyncedMemory(space_requirement));
   }
 }
 

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -64,6 +64,7 @@ const Dtype* Blob<Dtype>::cpu_data() const {
 template <typename Dtype>
 void Blob<Dtype>::set_cpu_data(Dtype* data) {
   CHECK(data);
+  data_->set_size(space_requirement_);
   data_->set_cpu_data(data);
 }
 

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -114,7 +114,7 @@ void Net<Dtype>::Init(const NetParameter& in_param,
         if (memory_share_net && memory_share_net->has_blob(blob_name)) {
           shared_ptr<Blob<Dtype> > memory_share_blob =
               memory_share_net->blob_by_name(blob_name);
-          blob_pointer.reset(new Blob<Dtype>(memory_share_blob.get()));
+          blob_pointer.reset(new Blob<Dtype>(*memory_share_blob));
         } else {
           blob_pointer.reset(new Blob<Dtype>());
         }

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -42,7 +42,7 @@ void Solver<Dtype>::Init(const SolverParameter& param) {
   net_.reset(new Net<Dtype>(param_.train_net()));
   if (param_.has_test_net()) {
     LOG(INFO) << "Creating testing net.";
-    test_net_.reset(new Net<Dtype>(param_.test_net()));
+    test_net_.reset(new Net<Dtype>(param_.test_net(), net_.get()));
     CHECK_GT(param_.test_iter(), 0);
     CHECK_GT(param_.test_interval(), 0);
   }

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -42,6 +42,8 @@ void Solver<Dtype>::Init(const SolverParameter& param) {
   net_.reset(new Net<Dtype>(param_.train_net()));
   if (param_.has_test_net()) {
     LOG(INFO) << "Creating testing net.";
+    // Instantiate test net with a pointer to the train net (net_.get()) to
+    // reuse memory occupied by correspondingly-named blobs in the train net.
     test_net_.reset(new Net<Dtype>(param_.test_net(), net_.get()));
     CHECK_GT(param_.test_iter(), 0);
     CHECK_GT(param_.test_interval(), 0);

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -91,7 +91,7 @@ inline void SyncedMemory::to_gpu() {
 
 const void* SyncedMemory::cpu_data() {
   to_cpu();
-  return reinterpret_cast<const void*>(thrust::raw_pointer_cast(
+  return static_cast<const void*>(thrust::raw_pointer_cast(
       cpu_vector_.data()));
 }
 
@@ -107,20 +107,20 @@ void SyncedMemory::set_cpu_data(void* data) {
 
 const void* SyncedMemory::gpu_data() {
   to_gpu();
-  return reinterpret_cast<const void*>(thrust::raw_pointer_cast(
+  return static_cast<const void*>(thrust::raw_pointer_cast(
       gpu_vector_.data()));
 }
 
 void* SyncedMemory::mutable_cpu_data() {
   to_cpu();
   head_ = HEAD_AT_CPU;
-  return reinterpret_cast<void*>(thrust::raw_pointer_cast(cpu_vector_.data()));
+  return static_cast<void*>(thrust::raw_pointer_cast(cpu_vector_.data()));
 }
 
 void* SyncedMemory::mutable_gpu_data() {
   to_gpu();
   head_ = HEAD_AT_GPU;
-  return reinterpret_cast<void*>(thrust::raw_pointer_cast(gpu_vector_.data()));
+  return static_cast<void*>(thrust::raw_pointer_cast(gpu_vector_.data()));
 }
 
 

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -18,10 +18,38 @@ SyncedMemory::~SyncedMemory() {
 SyncedMemory::~SyncedMemory() {
 }
 
+/*
+ * http://thrust.github.io/doc/classthrust_1_1host__vector.html
+ * http://thrust.github.io/doc/classthrust_1_1device__vector.html
+ * thrust::host_vector and thrust::device_vector will resize this vector to 
+ *   the specified number of elements. If the number is smaller than this 
+ *   vector's current size this vector is truncated, otherwise this vector 
+ *   is extended and new elements are populated with given data.
+ */
+void SyncedMemory::resize(const size_t size, const uint8_t default_value) {
+  size_ = size;
+  resize_default_value_ = default_value;
+  reserve(size);
+}
+
+/*
+ * http://thrust.github.io/doc/classthrust_1_1host__vector.html
+ * http://thrust.github.io/doc/classthrust_1_1device__vector.html
+ * If n is less than or equal to capacity(), this call has no effect. 
+ * Otherwise, this method is a request for allocation of additional memory. 
+ * If the request is successful, then capacity() is greater than or equal to n;
+ *   otherwise, capacity() is unchanged. In either case, size() is unchanged.
+ */
+void SyncedMemory::reserve(const size_t capacity) {
+  if (capacity_ < capacity) {
+    capacity_ = capacity;
+  }
+}
+
 inline void SyncedMemory::to_cpu() {
   switch (head_) {
   case UNINITIALIZED:
-    cpu_vector_.resize(size_, 0);
+    cpu_vector_.resize(size_, resize_default_value_);
     head_ = HEAD_AT_CPU;
     own_cpu_data_ = true;
     break;
@@ -42,12 +70,15 @@ inline void SyncedMemory::to_cpu() {
 inline void SyncedMemory::to_gpu() {
   switch (head_) {
   case UNINITIALIZED:
-    gpu_vector_.resize(size_, 0);
+    gpu_vector_.resize(size_, resize_default_value_);
     head_ = HEAD_AT_GPU;
     break;
   case HEAD_AT_CPU:
-    if (gpu_vector_.size() < size_) {
-      gpu_vector_.resize(size_, 0);
+    if (cpu_vector_.size() < size_) {
+      cpu_vector_.resize(size_, resize_default_value_);
+    }
+    if (gpu_vector_.capacity() < cpu_vector_.size()) {
+      gpu_vector_.reserve(cpu_vector_.size());
     }
     gpu_vector_ = cpu_vector_;
     head_ = SYNCED;

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -91,7 +91,8 @@ inline void SyncedMemory::to_gpu() {
 
 const void* SyncedMemory::cpu_data() {
   to_cpu();
-  return (const void*)thrust::raw_pointer_cast(cpu_vector_.data());
+  return reinterpret_cast<const void*>(thrust::raw_pointer_cast(
+      cpu_vector_.data()));
 }
 
 void SyncedMemory::set_cpu_data(void* data) {
@@ -106,19 +107,20 @@ void SyncedMemory::set_cpu_data(void* data) {
 
 const void* SyncedMemory::gpu_data() {
   to_gpu();
-  return (const void*)thrust::raw_pointer_cast(gpu_vector_.data());
+  return reinterpret_cast<const void*>(thrust::raw_pointer_cast(
+      gpu_vector_.data()));
 }
 
 void* SyncedMemory::mutable_cpu_data() {
   to_cpu();
   head_ = HEAD_AT_CPU;
-  return (void*)thrust::raw_pointer_cast(cpu_vector_.data());
+  return reinterpret_cast<void*>(thrust::raw_pointer_cast(cpu_vector_.data()));
 }
 
 void* SyncedMemory::mutable_gpu_data() {
   to_gpu();
   head_ = HEAD_AT_GPU;
-  return (void*)thrust::raw_pointer_cast(gpu_vector_.data());
+  return reinterpret_cast<void*>(thrust::raw_pointer_cast(gpu_vector_.data()));
 }
 
 

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -21,9 +21,9 @@ SyncedMemory::~SyncedMemory() {
 /*
  * http://thrust.github.io/doc/classthrust_1_1host__vector.html
  * http://thrust.github.io/doc/classthrust_1_1device__vector.html
- * thrust::host_vector and thrust::device_vector will resize this vector to 
- *   the specified number of elements. If the number is smaller than this 
- *   vector's current size this vector is truncated, otherwise this vector 
+ * thrust::host_vector and thrust::device_vector will resize this vector to
+ *   the specified number of elements. If the number is smaller than this
+ *   vector's current size this vector is truncated, otherwise this vector
  *   is extended and new elements are populated with given data.
  */
 void SyncedMemory::resize(const size_t size, const uint8_t default_value) {
@@ -35,8 +35,8 @@ void SyncedMemory::resize(const size_t size, const uint8_t default_value) {
 /*
  * http://thrust.github.io/doc/classthrust_1_1host__vector.html
  * http://thrust.github.io/doc/classthrust_1_1device__vector.html
- * If n is less than or equal to capacity(), this call has no effect. 
- * Otherwise, this method is a request for allocation of additional memory. 
+ * If n is less than or equal to capacity(), this call has no effect.
+ * Otherwise, this method is a request for allocation of additional memory.
  * If the request is successful, then capacity() is greater than or equal to n;
  *   otherwise, capacity() is unchanged. In either case, size() is unchanged.
  */
@@ -91,8 +91,7 @@ inline void SyncedMemory::to_gpu() {
 
 const void* SyncedMemory::cpu_data() {
   to_cpu();
-  return static_cast<const void*>(thrust::raw_pointer_cast(
-      cpu_vector_.data()));
+  return static_cast<const void*>(thrust::raw_pointer_cast(cpu_vector_.data()));
 }
 
 void SyncedMemory::set_cpu_data(void* data) {
@@ -107,8 +106,7 @@ void SyncedMemory::set_cpu_data(void* data) {
 
 const void* SyncedMemory::gpu_data() {
   to_gpu();
-  return static_cast<const void*>(thrust::raw_pointer_cast(
-      gpu_vector_.data()));
+  return static_cast<const void*>(thrust::raw_pointer_cast(gpu_vector_.data()));
 }
 
 void* SyncedMemory::mutable_cpu_data() {
@@ -125,4 +123,3 @@ void* SyncedMemory::mutable_gpu_data() {
 
 
 }  // namespace caffe
-

--- a/src/caffe/test/test_syncedmem.cpp
+++ b/src/caffe/test/test_syncedmem.cpp
@@ -76,7 +76,7 @@ TEST_F(SyncedMemoryTest, TestGPUWrite) {
   CUDA_CHECK(cudaMemset(gpu_data, 1, mem.size()));
   const void* cpu_data = mem.cpu_data();
   for (int i = 0; i < mem.size(); ++i) {
-    EXPECT_EQ(1, (static_cast<const char*>(cpu_data))[i]);
+    EXPECT_EQ((static_cast<const char*>(cpu_data))[i], 1);
   }
   EXPECT_EQ(mem.head(), SyncedMemory::SYNCED);
 
@@ -85,40 +85,69 @@ TEST_F(SyncedMemoryTest, TestGPUWrite) {
   CUDA_CHECK(cudaMemset(gpu_data, 2, mem.size()));
   cpu_data = mem.cpu_data();
   for (int i = 0; i < mem.size(); ++i) {
-    EXPECT_EQ(2, (static_cast<const char*>(cpu_data))[i]);
+    EXPECT_EQ((static_cast<const char*>(cpu_data))[i], 2);
   }
   EXPECT_EQ(mem.head(), SyncedMemory::SYNCED);
 }
 
 TEST_F(SyncedMemoryTest, TestResize) {
   SyncedMemory mem;
+  EXPECT_EQ(mem.head(), SyncedMemory::UNINITIALIZED);
   EXPECT_EQ(mem.size(), 0);
+  EXPECT_EQ(mem.cpu_capacity(), 0);
+  EXPECT_EQ(mem.gpu_capacity(), 0);
   mem.set_size(20);
   EXPECT_EQ(mem.head(), SyncedMemory::UNINITIALIZED);
   EXPECT_EQ(mem.size(), 20);
+  EXPECT_EQ(mem.cpu_capacity(), 0);
+  EXPECT_EQ(mem.gpu_capacity(), 0);
   mem.set_size(0);
   EXPECT_EQ(mem.head(), SyncedMemory::UNINITIALIZED);
   EXPECT_EQ(mem.size(), 0);
+  EXPECT_EQ(mem.cpu_capacity(), 0);
+  EXPECT_EQ(mem.gpu_capacity(), 0);
   mem.set_size(5);
-  const void* cpu_data = mem.cpu_data();
+  EXPECT_EQ(mem.head(), SyncedMemory::UNINITIALIZED);
+  EXPECT_EQ(mem.size(), 5);
+  EXPECT_EQ(mem.cpu_capacity(), 0);
+  EXPECT_EQ(mem.gpu_capacity(), 0);
+  const uint8_t* cpu_data = static_cast<const uint8_t*>(mem.cpu_data());
   EXPECT_EQ(mem.head(), SyncedMemory::HEAD_AT_CPU);
   EXPECT_EQ(mem.size(), 5);
+  EXPECT_EQ(mem.cpu_capacity(), 5);
+  EXPECT_EQ(mem.gpu_capacity(), 0);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(0, (static_cast<const uint8_t*>(cpu_data))[i]);
+    EXPECT_EQ(cpu_data[i], 0);
+  }
+  uint8_t* mutable_cpu_data = static_cast<uint8_t*>(mem.mutable_cpu_data());
+  EXPECT_EQ(mem.head(), SyncedMemory::HEAD_AT_CPU);
+  EXPECT_EQ(mem.size(), 5);
+  EXPECT_EQ(mem.cpu_capacity(), 5);
+  EXPECT_EQ(mem.gpu_capacity(), 0);
+  for (int i = 0; i < 5; ++i) {
+    mutable_cpu_data[i] = 7;
   }
   mem.set_size(30);
-  const void* gpu_data = mem.gpu_data();
+  const uint8_t* gpu_data = static_cast<const uint8_t*>(mem.gpu_data());
   EXPECT_EQ(mem.head(), SyncedMemory::SYNCED);
   EXPECT_EQ(mem.size(), 30);
+  EXPECT_EQ(mem.cpu_capacity(), 30);
+  EXPECT_EQ(mem.gpu_capacity(), 30);
   uint8_t* recovered_value = new uint8_t[30];
   cudaMemcpy(static_cast<void*>(recovered_value), gpu_data, 30,
              cudaMemcpyDeviceToHost);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(0, (static_cast<const uint8_t*>(recovered_value))[i]);
+    EXPECT_EQ((static_cast<const uint8_t*>(recovered_value))[i], 7);
   }
   for (int i = 5; i < 30; ++i) {
-    EXPECT_EQ(0, (static_cast<const uint8_t*>(recovered_value))[i]);
+    EXPECT_EQ((static_cast<const uint8_t*>(recovered_value))[i], 0);
   }
+  mem.set_size(40);
+  uint8_t* mutable_gpu_data = static_cast<uint8_t*>(mem.mutable_gpu_data());
+  EXPECT_EQ(mem.head(), SyncedMemory::HEAD_AT_GPU);
+  EXPECT_EQ(mem.size(), 40);
+  EXPECT_EQ(mem.cpu_capacity(), 30);
+  EXPECT_EQ(mem.gpu_capacity(), 40);
 }
 
 }  // namespace caffe

--- a/src/caffe/test/test_syncedmem.cpp
+++ b/src/caffe/test/test_syncedmem.cpp
@@ -43,31 +43,31 @@ TEST_F(SyncedMemoryTest, TestCPUWrite) {
   EXPECT_EQ(mem.head(), SyncedMemory::HEAD_AT_CPU);
   memset(cpu_data, 1, mem.size());
   for (int i = 0; i < mem.size(); ++i) {
-    EXPECT_EQ((reinterpret_cast<char*>(cpu_data))[i], 1);
+    EXPECT_EQ((static_cast<char*>(cpu_data))[i], 1);
   }
   const void* gpu_data = mem.gpu_data();
   EXPECT_EQ(mem.head(), SyncedMemory::SYNCED);
   // check if values are the same
   char* recovered_value = new char[10];
-  cudaMemcpy(reinterpret_cast<void*>(recovered_value), gpu_data, 10,
+  cudaMemcpy(static_cast<void*>(recovered_value), gpu_data, 10,
              cudaMemcpyDeviceToHost);
   for (int i = 0; i < mem.size(); ++i) {
-    EXPECT_EQ((reinterpret_cast<char*>(recovered_value))[i], 1);
+    EXPECT_EQ((static_cast<char*>(recovered_value))[i], 1);
   }
   // do another round
   cpu_data = mem.mutable_cpu_data();
   EXPECT_EQ(mem.head(), SyncedMemory::HEAD_AT_CPU);
   memset(cpu_data, 2, mem.size());
   for (int i = 0; i < mem.size(); ++i) {
-    EXPECT_EQ((reinterpret_cast<char*>(cpu_data))[i], 2);
+    EXPECT_EQ((static_cast<char*>(cpu_data))[i], 2);
   }
   gpu_data = mem.gpu_data();
   EXPECT_EQ(mem.head(), SyncedMemory::SYNCED);
   // check if values are the same
-  cudaMemcpy(reinterpret_cast<void*>(recovered_value), gpu_data, 10,
+  cudaMemcpy(static_cast<void*>(recovered_value), gpu_data, 10,
              cudaMemcpyDeviceToHost);
   for (int i = 0; i < mem.size(); ++i) {
-    EXPECT_EQ((reinterpret_cast<char*>(recovered_value))[i], 2);
+    EXPECT_EQ((static_cast<char*>(recovered_value))[i], 2);
   }
   delete[] recovered_value;
 }
@@ -79,7 +79,7 @@ TEST_F(SyncedMemoryTest, TestGPUWrite) {
   CUDA_CHECK(cudaMemset(gpu_data, 1, mem.size()));
   const void* cpu_data = mem.cpu_data();
   for (int i = 0; i < mem.size(); ++i) {
-    EXPECT_EQ((reinterpret_cast<const char*>(cpu_data))[i], 1);
+    EXPECT_EQ((static_cast<const char*>(cpu_data))[i], 1);
   }
   EXPECT_EQ(mem.head(), SyncedMemory::SYNCED);
 
@@ -88,7 +88,7 @@ TEST_F(SyncedMemoryTest, TestGPUWrite) {
   CUDA_CHECK(cudaMemset(gpu_data, 2, mem.size()));
   cpu_data = mem.cpu_data();
   for (int i = 0; i < mem.size(); ++i) {
-    EXPECT_EQ((reinterpret_cast<const char*>(cpu_data))[i], 2);
+    EXPECT_EQ((static_cast<const char*>(cpu_data))[i], 2);
   }
   EXPECT_EQ(mem.head(), SyncedMemory::SYNCED);
 }
@@ -108,7 +108,7 @@ TEST_F(SyncedMemoryTest, TestResize) {
   EXPECT_EQ(mem.head(), SyncedMemory::HEAD_AT_CPU);
   EXPECT_EQ(mem.size(), 5);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(123, (reinterpret_cast<const uint8_t*>(cpu_data))[i]);
+    EXPECT_EQ(123, (static_cast<const uint8_t*>(cpu_data))[i]);
   }
   mem.resize(30, 234);
   const void* gpu_data = mem.gpu_data();
@@ -116,13 +116,13 @@ TEST_F(SyncedMemoryTest, TestResize) {
   EXPECT_EQ(mem.size(), 30);
   EXPECT_EQ(mem.capacity(), 30);
   uint8_t* recovered_value = new uint8_t[30];
-  cudaMemcpy(reinterpret_cast<void*>(recovered_value), gpu_data, 30,
+  cudaMemcpy(static_cast<void*>(recovered_value), gpu_data, 30,
              cudaMemcpyDeviceToHost);
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(123, (reinterpret_cast<const uint8_t*>(recovered_value))[i]);
+    EXPECT_EQ(123, (static_cast<const uint8_t*>(recovered_value))[i]);
   }
   for (int i = 5; i < 30; ++i) {
-    EXPECT_EQ(234, (reinterpret_cast<const uint8_t*>(recovered_value))[i]);
+    EXPECT_EQ(234, (static_cast<const uint8_t*>(recovered_value))[i]);
   }
 }
 
@@ -141,10 +141,10 @@ TEST_F(SyncedMemoryTest, TestReserve) {
   EXPECT_EQ(mem.size(), 10);
   EXPECT_EQ(mem.capacity(), 20);
   uint8_t* recovered_value = new uint8_t[10];
-  cudaMemcpy(reinterpret_cast<void*>(recovered_value), gpu_data, 10,
+  cudaMemcpy(static_cast<void*>(recovered_value), gpu_data, 10,
              cudaMemcpyDeviceToHost);
   for (int i = 0; i < 10; ++i) {
-    EXPECT_EQ(0, (reinterpret_cast<const uint8_t*>(recovered_value))[i]);
+    EXPECT_EQ(0, (static_cast<const uint8_t*>(recovered_value))[i]);
   }
   mem.reserve(30);
   const void* cpu_data = mem.cpu_data();
@@ -152,7 +152,7 @@ TEST_F(SyncedMemoryTest, TestReserve) {
   EXPECT_EQ(mem.size(), 10);
   EXPECT_EQ(mem.capacity(), 30);
   for (int i = 0; i < 10; ++i) {
-    EXPECT_EQ(0, (reinterpret_cast<const uint8_t*>(cpu_data))[i]);
+    EXPECT_EQ(0, (static_cast<const uint8_t*>(cpu_data))[i]);
   }
 }
 


### PR DESCRIPTION
This PR wraps up the SyncedMem changes from @kloudkl in #250 (thanks for doing most of the work on this @kloudkl!).  I ended up removing the thrust host/device_vector dependency as I couldn't get them working at all (almost all tests segfaulted), and instead kept the `void*` pointers that we were already using to store the data (and still syncing using explicit `cudaMemcpy` calls).  I added private fields `cpu_capacity_` and `gpu_capacity_` which keep track of the current space allocation, and methods `cpu_resize()` and `gpu_resize()` allocate additional memory (copying any current memory) if the current allocation is insufficient.

The final commit makes use of this new functionality and my `ShareData` and `ShareDiff` methods from #332 to share all the *data* blobs between the training and test net (#332 only shared weight blobs).  Because of this change I've expanded the imagenet_val batchsize from 50 to 250 (as close to the train batch size of 256 as possible while still evenly dividing 50K...) for slightly faster test time with little memory cost.

I ran some tests of the ImageNet model on a Tesla K40 and found little to no difference in training/test time (not counting the test time improvement due to the expanded batch size), while memory use after the first test iteration improves significantly:

```
test batch size 50:

    @ dev:
    before first test iteration: 3014 MB (GPU memory use based on 'nvidia-smi')
     after first test iteration: 3255 MB
    -> 241 MB additional memory used by test net

    @ capacity-aware-memory:
    before first test iteration: 3014 MB
     after first test iteration: 3053 MB
    -> 39 MB additional memory used by test net, 84% reduction vs. dev


test batch size 250:

    @ dev:
    before first test iteration: 3014 MB
     after first test iteration: 4143 MB
    -> 1129 MB additional memory used by test net

    @ capacity-aware-memory:
    before first test iteration: 3014 MB
     after first test iteration: 3141 MB
    -> 127 MB additional memory used by test net, 89% reduction vs. dev
```

Note that the memory use of the test net is non-zero, because additional memory is still allocated for the test net in at least these three cases:

(1) blobs used inside of layers to store intermediate computations (the solver has no way of knowing about these; would have to change each layer's code to share these),
(2) blobs in the test net which do not share a name with any blob in the train net (e.g. the `accuracy` top blob in the ImageNet test net -- which isn't a great example because it's only 8 bytes, but you get the idea)
(3) blobs in the test net which are larger (in terms of `count`) than correspondingly named blobs in the train net (there aren't any of these cases in any of Caffe's sample models, but it would obviously happen if you, e.g., used a larger batch size in the test net, or did something weird like swapping the names of `conv1` and `conv5` between the train and test net, etc.)