### PR TITLE
set TRAIN in CommonTest.TestPhase

### DIFF
--- a/src/caffe/test/test_common.cpp
+++ b/src/caffe/test/test_common.cpp
@@ -27,6 +27,7 @@ TEST_F(CommonTest, TestBrewMode) {
 }
 
 TEST_F(CommonTest, TestPhase) {
+  Caffe::set_phase(Caffe::TRAIN);
   EXPECT_EQ(Caffe::phase(), Caffe::TRAIN);
   Caffe::set_phase(Caffe::TEST);
   EXPECT_EQ(Caffe::phase(), Caffe::TEST);


### PR DESCRIPTION
...to avoid effects of test execution order. The original intention was to
check that TRAIN is the default, but it is better to have consistent results.
