### PR TITLE
Polish test_net

### DIFF
--- a/tools/test_net.cpp
+++ b/tools/test_net.cpp
@@ -39,9 +39,7 @@ int main(int argc, char** argv) {
   }
 
   Net<float> caffe_test_net(argv[1]);
-  NetParameter trained_net_param;
-  ReadProtoFromBinaryFile(argv[2], &trained_net_param);
-  caffe_test_net.CopyTrainedLayersFrom(trained_net_param);
+  caffe_test_net.CopyTrainedLayersFrom(argv[2]);
 
   int total_iter = atoi(argv[3]);
   LOG(ERROR) << "Running " << total_iter << " iterations.";


### PR DESCRIPTION
`test_net` accepts a device arg (that defaults to device 0) fixing #232 and upgrades V0 parameters if they're encountered (@sguada this fixes the accuracy issue you had with R-CNN). The code was slightly rinsed too.
