### PR TITLE
Note the last added layer/params in caffe.proto to prevent conflicts

### DIFF
--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -99,7 +99,7 @@ message SolverState {
 
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available ID: 22
+// LayerParameter next available ID: 22 (last added: power_param)
 message LayerParameter {
   repeated string bottom = 2; // the name of the bottom blobs
   repeated string top = 3; // the name of the top blobs
@@ -110,7 +110,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 29
+  // LayerType next available ID: 29 (last added: HINGE_LOSS)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if


### PR DESCRIPTION
Currently, `caffe.proto` has two comment lines that keep track of field numbers for layers and layer parameters. They are intended to create conflicts when additional layers are added simultaneously, ensuring a unique assignment of numbers. Unfortunately this scheme does not work; three-way merging will happily agree to add two layers with the same number so long as they agree on what the next number should be.

This PR proposes a solution by noting the name of the last added layer.
