### PR TITLE
Improve includes in util/math_functions.hpp

### DIFF
--- a/include/caffe/util/math_functions.hpp
+++ b/include/caffe/util/math_functions.hpp
@@ -4,8 +4,10 @@
 #define CAFFE_UTIL_MATH_FUNCTIONS_H_
 
 #include <cublas_v2.h>
-#include <math.h>  // for signbit
-#include <cmath>  // for std::fabs
+#include <stdint.h>
+#include <cmath>  // for std::fabs and std::signbit
+
+#include "glog/logging.h"
 
 #include "caffe/util/mkl_alternate.hpp"
 


### PR DESCRIPTION
This PR removes the redundant `<math.h>`, and adds the necessary `<stdint.h>` (for `uint32_t`) and `<glog/logging.h>`. The NOLINT is necessary since cpplint seems to think that `<glog/logging.h>` is a C system header. Passes tests and lint.
