### PR TITLE
modify im2col.cpp into a multi-thread version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ LIBRARY_DIRS += $(BLAS_LIB)
 
 # Complete build flags.
 COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
-CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS)
+CXXFLAGS += -pthread -fPIC -D THREADS=$(PHTREAD_NUM) $(COMMON_FLAGS)
 NVCCFLAGS := -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS)
 LDFLAGS += $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir)) \
 		$(foreach library,$(LIBRARIES),-l$(library))

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -51,3 +51,6 @@ DISTRIBUTE_DIR := distribute
 
 # The ID of the GPU that 'make runtest' will use to run unit tests.
 TEST_GPUID := 0
+
+#The number of the pthreads
+PTHREAD_NUM := 4

--- a/src/caffe/util/im2col.cpp
+++ b/src/caffe/util/im2col.cpp
@@ -10,7 +10,12 @@
 
 #include "caffe/layer.hpp"
 #include "caffe/util/im2col.hpp"
-#define THREAD_NUM 4
+
+#ifdef THREADS
+#define THREAD_NUM THREADS
+#else 
+#define THREAD_NUM 1
+#endif
 
 template <typename Dtype>
 struct im2col_data

--- a/src/caffe/util/im2col.cpp
+++ b/src/caffe/util/im2col.cpp
@@ -1,39 +1,94 @@
-// Copyright 2014 BVLC and contributors.
+// Copyright 2013 Yangqing Jia
 
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <pthread.h>
+#include <algorithm>
+#include <cstdio>
+#include <unistd.h>
 
+#include "caffe/layer.hpp"
 #include "caffe/util/im2col.hpp"
+#define THREAD_NUM 4
+
+template <typename Dtype>
+struct im2col_data
+{
+	const Dtype* data_im;
+	Dtype *data_col;
+	int channels,height,width,ksize,pad,stride;
+	int thread_tid;
+};
+
+template <typename Dtype>
+struct col2im_data
+{
+	Dtype* data_im;
+	const Dtype *data_col;
+	int channels,height,width,ksize,pad,stride;
+	int thread_tid;
+};
 
 namespace caffe {
+
+template <typename Dtype>
+void* im2col_cpu_pthread(void* parameter) {
+	struct im2col_data<Dtype>* param = reinterpret_cast<struct im2col_data<Dtype>*>(parameter);
+
+    int height_col = (param->height + 2 * param->pad - param->ksize) / param->stride + 1;
+    int width_col = (param->width + 2 * param->pad - param->ksize) / param->stride + 1;
+    int channels_col = param->channels * param->ksize * param->ksize;
+    
+    for (int c = param->thread_tid; c < channels_col; c=c+THREAD_NUM) {
+		int w_offset = c % param->ksize;
+		int h_offset = (c / param->ksize) % param->ksize;
+		int c_im = c / param->ksize / param->ksize;
+		int h_pad = h_offset- param->pad;
+		int w_pad = w_offset- param->pad;
+	
+		for (int h = 0; h < height_col; ++h) {
+			for (int w = 0; w < width_col; ++w) {
+			h_pad+=param->stride;
+			w_pad+=param->stride;
+			if (h_pad >= 0 && h_pad < param->height && w_pad >= 0 && w_pad < param->width)
+			  param->data_col[(c * height_col + h) * width_col + w] =
+				param->data_im[(c_im * param->height + h_pad) * param->width + w_pad];
+			else
+			  param->data_col[(c * height_col + h) * width_col + w] = 0;
+		  }
+		}
+	}
+}
 
 template <typename Dtype>
 void im2col_cpu(const Dtype* data_im, const int channels,
     const int height, const int width, const int ksize, const int pad,
     const int stride, Dtype* data_col) {
-  int height_col = (height + 2 * pad - ksize) / stride + 1;
-  int width_col = (width + 2 * pad - ksize) / stride + 1;
-  int channels_col = channels * ksize * ksize;
-  for (int c = 0; c < channels_col; ++c) {
-    int w_offset = c % ksize;
-    int h_offset = (c / ksize) % ksize;
-    int c_im = c / ksize / ksize;
-    for (int h = 0; h < height_col; ++h) {
-      for (int w = 0; w < width_col; ++w) {
-        int h_pad = h * stride - pad + h_offset;
-        int w_pad = w * stride - pad + w_offset;
-        if (h_pad >= 0 && h_pad < height && w_pad >= 0 && w_pad < width)
-          data_col[(c * height_col + h) * width_col + w] =
-            data_im[(c_im * height + h_pad) * width + w_pad];
-        else
-          data_col[(c * height_col + h) * width_col + w] = 0;
-      }
-    }
+  
+  pthread_t thread_[THREAD_NUM];
+  struct im2col_data<Dtype>* param=(struct im2col_data<Dtype>*)malloc(sizeof(struct im2col_data<Dtype>));
+  param->data_im=data_im;
+  param->data_col=data_col;
+  param->channels=channels;
+  param->height=height;
+  param->width=width;
+  param->ksize=ksize;
+  param->pad=pad;
+  param->stride=stride;
+
+  for(int i=0; i<THREAD_NUM; i++)
+  {
+	  param->thread_tid=i; 
+	  CHECK(!pthread_create(&thread_[i], NULL,im2col_cpu_pthread<Dtype>,(void*)param)) << "Pthread execution failed.";
   }
+  for(int i=0; i<THREAD_NUM; i++)
+	  CHECK(!pthread_join(thread_[i], NULL)) << "Pthread joining failed.";
 }
 
 // Explicit instantiation
+template void* im2col_cpu_pthread<float>(void* parameter);
+template void* im2col_cpu_pthread<double>(void* parameter);
 template void im2col_cpu<float>(const float* data_im, const int channels,
     const int height, const int width, const int ksize, const int pad,
     const int stride, float* data_col);
@@ -42,30 +97,60 @@ template void im2col_cpu<double>(const double* data_im, const int channels,
     const int stride, double* data_col);
 
 template <typename Dtype>
+void* col2im_cpu_pthread(void* parameter) {
+	struct col2im_data<Dtype>* param = reinterpret_cast<struct col2im_data<Dtype>*>(parameter);
+
+    int height_col = (param->height + 2 * param->pad - param->ksize) / param->stride + 1;
+    int width_col = (param->width + 2 * param->pad - param->ksize) / param->stride + 1;
+    int channels_col = param->channels * param->ksize * param->ksize;
+
+    for (int c = param->thread_tid; c < channels_col; c=c+THREAD_NUM) {
+		int w_offset = c % param->ksize;
+		int h_offset = (c / param->ksize) % param->ksize;
+		int c_im = c / param->ksize / param->ksize;
+		int h_pad = h_offset- param->pad;
+		int w_pad = w_offset- param->pad;
+
+		for (int h = 0; h < height_col; ++h) {
+			for (int w = 0; w < width_col; ++w) {
+			h_pad+=param->stride;
+			w_pad+=param->stride;
+			if (h_pad >= 0 && h_pad < param->height && w_pad >= 0 && w_pad < param->width)
+			  param->data_im[(c_im * param->height + h_pad) * param->width + w_pad] +=
+			  param->data_col[(c * height_col + h) * width_col + w];
+		  }
+		}
+	}
+}
+
+template <typename Dtype>
 void col2im_cpu(const Dtype* data_col, const int channels,
     const int height, const int width, const int ksize, const int pad,
     const int stride, Dtype* data_im) {
   memset(data_im, 0, sizeof(Dtype) * height * width * channels);
-  int height_col = (height + 2 * pad - ksize) / stride + 1;
-  int width_col = (width + 2 * pad - ksize) / stride + 1;
-  int channels_col = channels * ksize * ksize;
-  for (int c = 0; c < channels_col; ++c) {
-    int w_offset = c % ksize;
-    int h_offset = (c / ksize) % ksize;
-    int c_im = c / ksize / ksize;
-    for (int h = 0; h < height_col; ++h) {
-      for (int w = 0; w < width_col; ++w) {
-        int h_pad = h * stride - pad + h_offset;
-        int w_pad = w * stride - pad + w_offset;
-        if (h_pad >= 0 && h_pad < height && w_pad >= 0 && w_pad < width)
-          data_im[(c_im * height + h_pad) * width + w_pad] +=
-              data_col[(c * height_col + h) * width_col + w];
-      }
-    }
+  pthread_t thread_[THREAD_NUM];
+  struct col2im_data<Dtype>* param=(struct col2im_data<Dtype>*)malloc(sizeof(struct col2im_data<Dtype>));
+  param->data_im=data_im;
+  param->data_col=data_col;
+  param->channels=channels;
+  param->height=height;
+  param->width=width;
+  param->ksize=ksize;
+  param->pad=pad;
+  param->stride=stride;
+
+  for(int i=0; i<THREAD_NUM; i++)
+  {
+	  param->thread_tid=i; 
+	  CHECK(!pthread_create(&thread_[i], NULL,col2im_cpu_pthread<Dtype>,(void*)param)) << "Pthread execution failed.";
   }
+  for(int i=0; i<THREAD_NUM; i++)
+	  CHECK(!pthread_join(thread_[i], NULL)) << "Pthread joining failed.";
 }
 
 // Explicit instantiation
+template void* col2im_cpu_pthread<float>(void* parameter);
+template void* col2im_cpu_pthread<double>(void* parameter);
 template void col2im_cpu<float>(const float* data_col, const int channels,
     const int height, const int width, const int psize, const int pad,
     const int stride, float* data_im);


### PR DESCRIPTION
When training ImageNet model on CPU, `ConvolutionLayer<Dtype>::Forward_cpu` and `ConvolutionLayer<Dtype>::Backward_cpu` occupy about 80% time, and `im2col_cpu` + `col2im_cpu` occupy 30%~50% time of ConvolutionLayer, thus, we modify im2col.cpp into a multi-thread version.

We test out modified version on our 4-physical-core machine, if we create 4 pthreads, we can decrease 50% time of `im2col_cpu` + `col2im_cpu` . And you can define your **THREAD_NUM** based on the physical core number of your machine.