### PR TITLE
Fix Makefile header dependency bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ STATIC_NAME := $(LIB_BUILD_DIR)/lib$(PROJECT).a
 # CXX_SRCS are the source files excluding the test ones.
 CXX_SRCS := $(shell find src/$(PROJECT) ! -name "test_*.cpp" -name "*.cpp")
 # HXX_SRCS are the header files
-HXX_SRCS := $(shell find include/$(PROJECT) ! -name "*.hpp")
+HXX_SRCS := $(shell find include/$(PROJECT) -name "*.hpp")
 # CU_SRCS are the cuda source files
 CU_SRCS := $(shell find src/$(PROJECT) -name "*.cu")
 # TEST_SRCS are the test source files


### PR DESCRIPTION
The `HXX_SRCS` variable in the Makefile was being set to "files not ending with `.hpp` in the `include/` directory", instead of files that do end in `.hpp` as intended (at least I assume).  Hence targets that depended on `HXX_SRCS` header files were depending on the `include` directory, any other directories under it, and any non-*.hpp files you may have put under the `include` directory for whatever reason.

I discovered this because I was frustrated by the fact that almost everything was recompiling whenever I'd open a Caffe header file in vim and didn't change anything in it.  I looked at the output of `make -d` (to show debug info) and saw that it was recompiling due to my `include/caffe` directory and `include/caffe/.layer.hpp.swp` file (if I'd opened `include/caffe/layer.hpp` in vim) being newer than the target.  The `.swp` file is created by vim when you open a file to backup unsaved work, so if you always used vim (or another editor that does something similar), the previous buggy setting of `HXX_SRCS` was actually safe in the sense that it would always recompile upon changing a header file (due to the created `.swp` file), but recompiled far more often than necessary.  If you used an editor that doesn't create such a file, or modified header files by means other than an editor (for example, by doing `git checkout` or `git merge`*), this was unsafe -- i.e., possibly not recompiling when header files had changed. 

I'm going to merge this myself because it's a two character change, and I'm pretty sure it's correct.   PRing just for the sake of announcement.

*note: did not actually test that `git checkout`/`merge` weren't causing recompiles, just speculating
