### PR TITLE
add cublas status in cuda 6 to fix warning

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -56,6 +56,10 @@ private:\
 // CUDA: check for error after kernel execution and exit loudly if there is one.
 #define CUDA_POST_KERNEL_CHECK CUDA_CHECK(cudaPeekAtLastError())
 
+// Define not supported status for pre-6.0 compatibility.
+#if CUDA_VERSION < 6000
+#define CUBLAS_STATUS_NOT_SUPPORTED 831486
+#endif
 
 namespace caffe {
 

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -155,6 +155,8 @@ const char* cublasGetErrorString(cublasStatus_t error) {
     return "CUBLAS_STATUS_EXECUTION_FAILED";
   case CUBLAS_STATUS_INTERNAL_ERROR:
     return "CUBLAS_STATUS_INTERNAL_ERROR";
+  case CUBLAS_STATUS_NOT_SUPPORTED:
+    return "CUBLAS_STATUS_NOT_SUPPORTED";
   }
   return "Unknown cublas status";
 }


### PR DESCRIPTION
...and define for older CUDAs to not break the build. Fixes 8368818 and 46e2036 rollback.
