### PR TITLE
Make net know output blob indices

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -123,6 +123,7 @@ class Net {
   vector<vector<int> > top_id_vecs_;
   // blob indices for the input and the output of the net
   vector<int> net_input_blob_indices_;
+  vector<int> net_output_blob_indices_;
   vector<Blob<Dtype>*> net_input_blobs_;
   vector<Blob<Dtype>*> net_output_blobs_;
   string name_;

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -162,6 +162,7 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
       it != available_blobs.end(); ++it) {
     LOG(INFO) << "This network produces output " << *it;
     net_output_blobs_.push_back(blobs_[blob_name_to_idx[*it]].get());
+    net_output_blob_indices_.push_back(blob_name_to_idx[*it]);
   }
   for (size_t i = 0; i < blob_names_.size(); ++i) {
     blob_names_index_[blob_names_[i]] = i;


### PR DESCRIPTION
To make introspection and automation easier, Net now keeps a vector of its output blob indices just as it keeps a vector of input blob indices.
