### PR TITLE
Update installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ Caffe depends on several software packages.
 * [BLAS](http://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms) (provided via ATLAS, MKL, or OpenBLAS).
 * [OpenCV](http://opencv.org/).
 * [Boost](http://www.boost.org/) (we have only tested 1.55)
-* `glog`, `gflags`, `protobuf`, `leveldb`, `snappy`, `hdf5`
+* `glog`, `gflags`, `protobuf` (suggest use 2.4.1), `leveldb`, `snappy`, `hdf5`
 * For the python wrapper
     * `python`, `numpy (>= 1.7)`, Boost-provided `boost.python`
 * For the MATLAB wrapper


### PR DESCRIPTION
When we install Caffe on RedHat cluster system without **sudo** authority, we find protobuf 2.4.1 (updated in 2011) is ok while the current one is failed.
