### PR TITLE
Added grayscale image processing to io.cpp and convert_imageset.cpp

### DIFF
--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -61,7 +61,7 @@ inline void WriteProtoToBinaryFile(
 }
 
 bool ReadImageToDatum(const string& filename, const int label,
-    const int height, const int width, const bool iscolor, Datum* datum);
+    const int height, const int width, const bool is_color, Datum* datum);
 
 inline bool ReadImageToDatum(const string& filename, const int label,
     const int height, const int width, Datum* datum) {

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -72,9 +72,10 @@ void WriteProtoToBinaryFile(const Message& proto, const char* filename) {
 }
 
 bool ReadImageToDatum(const string& filename, const int label,
-    const int height, const int width, const bool iscolor, Datum* datum) {
+    const int height, const int width, const bool is_color, Datum* datum) {
   cv::Mat cv_img;
-  int cv_read_flag = (iscolor ? CV_LOAD_IMAGE_COLOR : CV_LOAD_IMAGE_GRAYSCALE);
+  int cv_read_flag = (is_color ? CV_LOAD_IMAGE_COLOR :
+    CV_LOAD_IMAGE_GRAYSCALE);
   if (height > 0 && width > 0) {
     cv::Mat cv_img_origin = cv::imread(filename, cv_read_flag);
     cv::resize(cv_img_origin, cv_img, cv::Size(height, width));
@@ -85,7 +86,7 @@ bool ReadImageToDatum(const string& filename, const int label,
     LOG(ERROR) << "Could not open or find file " << filename;
     return false;
   }
-  int num_channels = (iscolor ? 3 : 1);
+  int num_channels = (is_color ? 3 : 1);
   datum->set_channels(num_channels);
   datum->set_height(cv_img.rows);
   datum->set_width(cv_img.cols);
@@ -93,7 +94,7 @@ bool ReadImageToDatum(const string& filename, const int label,
   datum->clear_data();
   datum->clear_float_data();
   string* datum_string = datum->mutable_data();
-  if (iscolor) {
+  if (is_color) {
     for (int c = 0; c < num_channels; ++c) {
       for (int h = 0; h < cv_img.rows; ++h) {
         for (int w = 0; w < cv_img.cols; ++w) {
@@ -102,7 +103,7 @@ bool ReadImageToDatum(const string& filename, const int label,
         }
       }
     }
-  } else {  // Faster than repeatedly testing iscolor for each pixel w/i loop
+  } else {  // Faster than repeatedly testing is_color for each pixel w/i loop
     for (int h = 0; h < cv_img.rows; ++h) {
       for (int w = 0; w < cv_img.cols; ++w) {
         datum_string->push_back(

--- a/tools/convert_imageset.cpp
+++ b/tools/convert_imageset.cpp
@@ -45,8 +45,8 @@ int main(int argc, char** argv) {
   }
 
   // Test whether argv[1] == "-g"
-  bool iscolor= !(string("-g") == string(argv[1]));
-  int  arg_offset = (iscolor ? 0 : 1);
+  bool is_color= !(string("-g") == string(argv[1]));
+  int  arg_offset = (is_color ? 0 : 1);
   std::ifstream infile(argv[arg_offset+2]);
   std::vector<std::pair<string, int> > lines;
   string filename;
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
   bool data_size_initialized = false;
   for (int line_id = 0; line_id < lines.size(); ++line_id) {
     if (!ReadImageToDatum(root_folder + lines[line_id].first,
-         lines[line_id].second, resize_height, resize_width, iscolor, &datum)) {
+        lines[line_id].second, resize_height, resize_width, is_color, &datum)) {
       continue;
     }
     if (!data_size_initialized) {


### PR DESCRIPTION
Added an iscolor flag to io.cpp method ReadImageToDatum to handle
grayscale images and a corresponding commandline flag [-g] to
convert_imageset.cpp.

Specifically, I changed the existing ReadImageToDatum to accept an
iscolor boolean flag that alters the call to OpenCV's imread. The
existing signature and behavior of the method was preserved.

Modified tool convert_imageset.bin to accept (in the first position)
an optional -g flag to indicate that all images should be read as
grayscale. This also preserves the existing usage and behavior of the
executable. Nicely, I think OpenCV's imread also converts color images
to gray when this is given the -g flag. (So no warnings or errors are
generated, for better or worse.)
