### PR TITLE
Matcaffe2

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -125,6 +125,8 @@ class Caffe {
   // Sets the device. Since we have cublas and curand stuff, set device also
   // requires us to reset those values.
   static void SetDevice(const int device_id);
+  // Gets current device_id
+  static int GetDevice();
   // Prints the current GPU status.
   static void DeviceQuery();
 

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -25,6 +25,7 @@ classdef CaffeNet < handle
             if nargin == 0
                 init_net(self,self.model_def_file);
                 load_net(self,self.model_file);
+            end
             if nargin > 0
                 init_net(self,model_def_file);
             end
@@ -49,10 +50,10 @@ classdef CaffeNet < handle
                         self = CaffeNet();
                 end
             else
-                if nargin > 0 & ~isempty(model_def_file)
+                if nargin > 0 && ~isempty(model_def_file)
                     init_net(self,model_def_file);
                 end
-                if nargin > 1 & ~isempty(model_file)
+                if nargin > 1 && ~isempty(model_file)
                     load_net(self,model_file);
                 end
             end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -61,16 +61,22 @@ classdef CaffeNet < handle
     end
     methods
         function weights = get.weights(self)
-            if (self.weights_changed)
-                self.weights_store = caffe('get_weights');
-                self.weights_changed = false;
+            if (is_initialized(self))
+                if (self.weights_changed)
+                    self.weights_store = caffe('get_weights');
+                    self.weights_changed = false;
+                end
+                weights = self.weights_store;
+            else
+                weights = [];
             end
-            weights = self.weights_store;
         end
         function set.weights(self,weights)
-            caffe('set_weights', weights);
-            self.weights_store = weights;
-            self.weights_changed = false;
+            if (is_initialized(self))
+                caffe('set_weights', weights);
+                self.weights_store = weights;
+                self.weights_changed = false;
+            end
         end
         function set.mode(self,mode)
             % mode = {'CPU' 'GPU'}
@@ -105,36 +111,48 @@ classdef CaffeNet < handle
             self.device_id = device_id;
         end
         function set.input_blobs(self, input_blobs)
-            caffe('set_input_blobs', input_blobs);
-            self.input_blobs = input_blobs;
+            if (is_initialized(self))
+                caffe('set_input_blobs', input_blobs);
+                self.input_blobs = input_blobs;
+            end
         end
         function set.output_blobs(self, output_blobs)
-            caffe('set_output_blobs', output_blobs);
-            self.output_blobs = output_blobs;
+            if (is_initialized(self))
+                caffe('set_output_blobs', output_blobs);
+                self.output_blobs = output_blobs;
+            end
         end
     end
     methods
         function res = forward(~,input)
-            if nargin < 2
-                res = caffe('forward');
-            else
-                res = caffe('forward',input);
+            if (is_initialized(self))
+                if nargin < 2
+                    res = caffe('forward');
+                else
+                    res = caffe('forward',input);
+                end
             end
         end
         function res = backward(self,diff)
-            assert(strcmp(self.phase,'TRAIN'),'Network should be in TRAIN phase');
-            if nargin < 2
-                res = caffe('backward');
-            else
-                res = caffe('backward',diff);
+            if (is_initialized(self))
+                assert(strcmp(self.phase,'TRAIN'),'Network should be in TRAIN phase');
+                if nargin < 2
+                    res = caffe('backward');
+                else
+                    res = caffe('backward',diff);
+                end
             end
         end
         function res = forward_prefilled(~)
-            res = caffe('forward_prefilled');
+            if (is_initialized(self))
+                res = caffe('forward_prefilled');
+            end
         end
         function res = backward_prefilled(self)
-            assert(strcmp(self.phase,'TRAIN'),'Network should be in TRAIN phase');
-            res = caffe('backward_prefilled');
+            if (is_initialized(self))
+                assert(strcmp(self.phase,'TRAIN'),'Network should be in TRAIN phase');
+                res = caffe('backward_prefilled');
+            end
         end
         function res = init(self, model_def_file, model_file)
             self.init_key = caffe('init',model_def_file, model_file);
@@ -155,13 +173,17 @@ classdef CaffeNet < handle
             res = self.init_key;
         end
         function res = load_net(self, model_file)
-            self.init_key = caffe('load_net',model_file);
-            self.model_file = model_file;
-            self.weights_changed = true;
-            res = self.init_key;
+            if (is_initialized(self))
+                self.init_key = caffe('load_net',model_file);
+                self.model_file = model_file;
+                self.weights_changed = true;
+                res = self.init_key;
+            end
         end
         function res = save_net(~, model_file)
-            res = caffe('save_net', model_file);
+            if (is_initialized(self))
+                res = caffe('save_net', model_file);
+            end
         end
         function res = is_initialized(~)
             res = caffe('is_initialized');
@@ -182,17 +204,23 @@ classdef CaffeNet < handle
             self.device_id = device_id;
         end
         function res = get_weights(self)
-            res = self.weights;
+            if (is_initialized(self))
+                res = self.weights;
+            end
         end
         function set_weights(self, weights)
             self.weights = weights;
         end
-        function res = get_layer_weights(~, layer_name)
-            res = caffe('get_layer_weights', layer_name);
+        function res = get_layer_weights(self, layer_name)
+            if (is_initialized(self))
+                res = caffe('get_layer_weights', layer_name);
+            end
         end
         function res = set_layer_weights(self, layer_name, weights)
-            res = caffe('set_layer_weights', layer_name, weights);
-            self.weights = caffe('get_weights');
+            if (is_initialized(self))
+                res = caffe('set_layer_weights', layer_name, weights);
+                self.weights = caffe('get_weights');
+            end
         end
         function res = get_layers_info(self)
             res = self.layers_info;
@@ -200,17 +228,25 @@ classdef CaffeNet < handle
         function res = get_blobs_info(self)
             res = self.blobs_info;
         end
-        function res = get_blob_data(~, blob_name)
-            res = caffe('get_blob_data', blob_name);
+        function res = get_blob_data(self, blob_name)
+            if (is_initialized(self))
+                res = caffe('get_blob_data', blob_name);
+            end
         end
-        function res = get_blob_diff(~, blob_name)
-            res = caffe('get_blob_diff', blob_name);
+        function res = get_blob_diff(self, blob_name)
+            if (is_initialized(self))
+                res = caffe('get_blob_diff', blob_name);
+            end
         end
-        function res = get_all_data(~)
-            res = caffe('get_all_data');
+        function res = get_all_data(self)
+            if (is_initialized(self))
+                res = caffe('get_all_data');
+            end
         end
-        function res = get_all_diff(~)
-            res = caffe('get_all_diff');
+        function res = get_all_diff(self)
+            if (is_initialized(self))
+                res = caffe('get_all_diff');
+            end
         end
         function res = get_init_key(self)
             res = caffe('get_init_key');

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -27,6 +27,9 @@ classdef CaffeNet < handle
                 self.init_key = caffe('init', model_def_file, model_file);
                 self.weights_changed  = true;
             end
+            self.mode = caffe('get_mode');
+            self.phase = caffe('get_phase');
+            self.device_id = caffe('get_device');
         end
     end
     methods (Static)
@@ -48,7 +51,7 @@ classdef CaffeNet < handle
     end
     methods
         function weights = get.weights(self)
-            if (weights_changed)
+            if (self.weights_changed)
                 self.getting_weights = true;
                 self.weights = caffe('get_weights');
                 self.getting_weights = false;

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -23,14 +23,13 @@ classdef CaffeNet < handle
     methods (Access=private)
         function self = CaffeNet(model_def_file, model_file)
             if nargin == 0
-                init_net(self,self.model_def_file);
-                load_net(self,self.model_file);
+                init(self, self.model_def_file, self.model_file);
             end
             if nargin > 0
-                init_net(self,model_def_file);
+                init_net(self, model_def_file);
             end
             if nargin > 1
-                load_net(self,model_file);
+                load_net(self, model_file);
             end
             self.mode = caffe('get_mode');
             self.phase = caffe('get_phase');
@@ -137,13 +136,22 @@ classdef CaffeNet < handle
             assert(strcmp(self.phase,'TRAIN'),'Network should be in TRAIN phase');
             res = caffe('backward_prefilled');
         end
-        function res = init_net(self, model_def_file)
-            self.init_key = caffe('init_net',model_def_file);
+        function res = init(self, model_def_file, model_file)
+            self.init_key = caffe('init',model_def_file, model_file);
             self.model_def_file = model_def_file;
+            self.model_file = model_file;
             self.layers_info = caffe('get_layers_info');
             self.blobs_info = caffe('get_blobs_info');
             self.weights_changed = true;
+            res = self.init_key;
+        end
+        function res = init_net(self, model_def_file)
+            self.init_key = caffe('init_net',model_def_file);
+            self.model_def_file = model_def_file;
             self.model_file = [];
+            self.layers_info = caffe('get_layers_info');
+            self.blobs_info = caffe('get_blobs_info');
+            self.weights_changed = true;
             res = self.init_key;
         end
         function res = load_net(self, model_file)
@@ -211,6 +219,10 @@ classdef CaffeNet < handle
         function reset(self)
             caffe('reset');
             self.init_key = caffe('get_init_key');
+        end
+        function delete(self)
+            reset(self);
+            clear caffe;
         end
     end
 end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -254,10 +254,10 @@ classdef CaffeNet < handle
         end
         function reset(self)
             caffe('reset');
-            self.init_key = caffe('get_init_key');
+            self = [];
         end
         function delete(self)
-            reset(self);
+            caffe('reset');
             clear caffe;
         end
     end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -257,8 +257,10 @@ classdef CaffeNet < handle
             self.init_key = caffe('get_init_key');
             self.layers_info = [];
             self.blobs_info = [];
+            self.weights_store = [];
         end
         function delete(self)
+            self.weights_store = [];
             caffe('reset');
             clear caffe;
         end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -4,7 +4,7 @@ classdef CaffeNet < handle
         model_file = '../../examples/imagenet/caffe_reference_imagenet_model';
         mode
         phase
-        devide_id
+        device_id
         weights
         layers_info
         blobs_info
@@ -94,7 +94,7 @@ classdef CaffeNet < handle
                     error('Phase unknown');
             end
         end
-        function set.device(self, device_id)
+        function set.device_id(self, device_id)
             caffe('set_device', device_id);
             self.device_id = device_id;
         end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -124,7 +124,7 @@ classdef CaffeNet < handle
         end
     end
     methods
-        function res = forward(~,input)
+        function res = forward(self,input)
             if (is_initialized(self))
                 if nargin < 2
                     res = caffe('forward');
@@ -143,7 +143,7 @@ classdef CaffeNet < handle
                 end
             end
         end
-        function res = forward_prefilled(~)
+        function res = forward_prefilled(self)
             if (is_initialized(self))
                 res = caffe('forward_prefilled');
             end
@@ -180,7 +180,7 @@ classdef CaffeNet < handle
                 res = self.init_key;
             end
         end
-        function res = save_net(~, model_file)
+        function res = save_net(self, model_file)
             if (is_initialized(self))
                 res = caffe('save_net', model_file);
             end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -1,13 +1,17 @@
 classdef CaffeNet < handle
-    properties
+    properties (SetAccess = private)
         model_def_file = '../../examples/imagenet/imagenet_deploy.prototxt';
         model_file = '../../examples/imagenet/caffe_reference_imagenet_model';
+        layers_info
+        blobs_info
+    end
+    properties (AbortSet = true)
+        weights
         mode
         phase
         device_id
-        weights
-        layers_info
-        blobs_info
+        input_blobs
+        output_blobs
     end
     properties (Hidden)
         init_key
@@ -100,6 +104,14 @@ classdef CaffeNet < handle
         function set.device_id(self, device_id)
             caffe('set_device', device_id);
             self.device_id = device_id;
+        end
+        function set.input_blobs(self, input_blobs)
+            caffe('set_input_blobs', input_blobs);
+            self.input_blobs = input_blobs;
+        end
+        function set.output_blobs(self, output_blobs)
+            caffe('set_output_blobs', output_blobs);
+            self.output_blobs = output_blobs;
         end
     end
     methods

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -1,0 +1,147 @@
+classdef CaffeNet
+  properties
+    model_def_file
+    model_file
+    init_key        
+  end
+  properties (Hidden)
+    cutoff % Defines a cuttoff point
+  end
+  methods (Access=private)
+    function self = CaffeNet(model_def_file, model_file)
+      if nargin > 0
+        self.model_def_file = model_def_file;
+        self.init_key = caffe('init_net', model_def_file);
+      end
+      if nargin > 1
+        self.model_file = model_file;
+        self.init_key = caffe('init', model_def_file, model_file);
+      end
+    end
+  end    
+  methods (Static)
+    function obj = instance(model_def_file, model_file)
+      persistent self
+      if isempty(self)
+        switch nargin
+          case 1
+            self = CaffeNet(model_def_file);
+          case 2
+            self = CaffeNet(model_def_file, model_file);
+          otherwise
+            error('Need to be initialized with at least model_def_file')
+        end
+      end
+      obj = self;
+    end
+  
+  methods
+    function res = forward(self,input)
+      if nargin < 2
+        res = caffe('forward');
+      else
+        res = caffe('forward',input);
+      end
+    end
+    function res = backward(self,input)
+      if nargin < 2
+        res = caffe('backward');
+      else
+        res = caffe('backward',input);
+      end
+    end
+    function res = forward_prefilled(self)
+      res = caffe('forward_prefilled');
+    end
+    function res = backward_prefilled(self)
+      res = caffe('backward_prefilled');
+    end
+    function res = init_net(self, model_def_file)
+      self.init_key = caffe('init_net',model_def_file);
+      res = self.init_key;
+    end
+    function res = load_net(self, model_file)
+      self.init_key = caffe('load_net',model_file);
+      res = self.init_key;
+    end
+    function res = save_net(self, model_file)
+      res = caffe('save_net', model_file);
+    end
+    function res = is_initialized(self)
+      res = caffe('is_initialized');
+    end
+    function res = set_mode_cpu(self)
+      res = caffe('set_mode_cpu');
+    end
+    function res = set_mode_gpu(self)
+      res = caffe('set_mode_gpu');
+    end
+    function res = set_mode(self,mode)
+      % mode = {'cpu' 'gpu'}
+      switch mode
+        case {'cpu','CPU'}
+          res = caffe('set_mode_cpu');
+        case {'gpu','GPU'}
+          res = caffe('set_mode_gpu');
+        otherwise
+          error('Mode unknown');
+      end
+    end
+    function res = set_phase_train(self)
+      res = caffe('set_phase_train');
+    end
+    function res = set_phase_test(self)
+      res = caffe('set_phase_test');
+    end
+    function res = set_phase(self, phase)
+      % phase = {'train' 'test'}
+      switch phase
+        case {'train','TRAIN'}
+          res = caffe('set_phase_train');
+        case {'test','TEST'}
+          res = caffe('set_phase_test');
+        otherwise
+          error('Phase unknown');
+      end
+    end
+    function res = set_device(self, device_id)
+      res = caffe('set_device', device_id);
+    end
+    function res = get_weights(self)
+      res = caffe('get_weights');
+    end
+    function res = set_weights(self, weights)
+      res = caffe('set_weights', weights);
+    end
+    function res = get_layer_weights(self, layer_name)
+      res = caffe('get_layer_weights', layer_name);
+    end
+    function res = set_layer_weights(self, layer_name, weights)
+      res = caffe('set_layer_weights', layer_name, weights);
+    end
+    function res = get_layers_info(self)
+      res = caffe('get_layers_info');
+    end
+    function res = get_blobs_info(self)
+      res = caffe('get_blobs_info');
+    end
+    function res = get_blob_data(self, blob_name)
+      res = caffe('get_blob_data', blob_name);
+    end
+    function res = get_blob_diff(self, blob_name)
+      res = caffe('get_blob_diff', blob_name);
+    end
+    function res = get_all_data(self)
+      res = caffe('get_all_data');
+    end
+    function res = get_all_diff(self)
+      res = caffe('get_all_diff');
+    end
+    function res = get_init_key(self)
+      res = caffe('get_init_key');
+    end
+    function res = reset(self)
+      res = caffe('reset');
+    end
+  end
+end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -31,6 +31,7 @@ classdef CaffeNet < handle
             if nargin > 1
                 load_net(self, model_file);
             end
+            assert(is_initialized())
             self.mode = caffe('get_mode');
             self.phase = caffe('get_phase');
             self.device_id = caffe('get_device');
@@ -61,22 +62,18 @@ classdef CaffeNet < handle
     end
     methods
         function weights = get.weights(self)
-            if (is_initialized(self))
-                if (self.weights_changed)
-                    self.weights_store = caffe('get_weights');
-                    self.weights_changed = false;
-                end
-                weights = self.weights_store;
-            else
-                weights = [];
-            end
-        end
-        function set.weights(self,weights)
-            if (is_initialized(self))
-                caffe('set_weights', weights);
-                self.weights_store = weights;
+            assert(is_initialized(self))
+            if (self.weights_changed)
+                self.weights_store = caffe('get_weights');
                 self.weights_changed = false;
             end
+            weights = self.weights_store;
+        end
+        function set.weights(self,weights)
+            assert(is_initialized(self))
+            caffe('set_weights', weights);
+            self.weights_store = weights;
+            self.weights_changed = false;
         end
         function set.mode(self,mode)
             % mode = {'CPU' 'GPU'}
@@ -111,49 +108,44 @@ classdef CaffeNet < handle
             self.device_id = device_id;
         end
         function set.input_blobs(self, input_blobs)
-            if (is_initialized(self))
-                caffe('set_input_blobs', input_blobs);
-                self.input_blobs = input_blobs;
-            end
+            assert(is_initialized(self))
+            caffe('set_input_blobs', input_blobs);
+            self.input_blobs = input_blobs;
         end
         function set.output_blobs(self, output_blobs)
-            if (is_initialized(self))
-                caffe('set_output_blobs', output_blobs);
-                self.output_blobs = output_blobs;
-            end
+            assert(is_initialized(self))
+            caffe('set_output_blobs', output_blobs);
+            self.output_blobs = output_blobs;
         end
     end
     methods
         function res = forward(self,input)
-            if (is_initialized(self))
-                if nargin < 2
-                    res = caffe('forward');
-                else
-                    res = caffe('forward',input);
-                end
+            assert(is_initialized(self))
+            if nargin < 2
+                res = caffe('forward');
+            else
+                res = caffe('forward',input);
             end
         end
         function res = backward(self,diff)
-            if (is_initialized(self))
-                if nargin < 2
-                    res = caffe('backward');
-                else
-                    res = caffe('backward',diff);
-                end
+            assert(is_initialized(self))
+            if nargin < 2
+                res = caffe('backward');
+            else
+                res = caffe('backward',diff);
             end
         end
         function res = forward_prefilled(self)
-            if (is_initialized(self))
-                res = caffe('forward_prefilled');
-            end
+            assert(is_initialized(self))
+            res = caffe('forward_prefilled');
         end
         function res = backward_prefilled(self)
-            if (is_initialized(self))
-                res = caffe('backward_prefilled');
-            end
+            assert(is_initialized(self))
+            res = caffe('backward_prefilled');
         end
         function res = init(self, model_def_file, model_file)
             self.init_key = caffe('init',model_def_file, model_file);
+            assert(is_initialized(self))
             self.model_def_file = model_def_file;
             self.model_file = model_file;
             self.layers_info = caffe('get_layers_info');
@@ -163,6 +155,7 @@ classdef CaffeNet < handle
         end
         function res = init_net(self, model_def_file)
             self.init_key = caffe('init_net',model_def_file);
+            assert(is_initialized(self))
             self.model_def_file = model_def_file;
             self.model_file = [];
             self.layers_info = caffe('get_layers_info');
@@ -171,17 +164,15 @@ classdef CaffeNet < handle
             res = self.init_key;
         end
         function res = load_net(self, model_file)
-            if (is_initialized(self))
-                self.init_key = caffe('load_net',model_file);
-                self.model_file = model_file;
-                self.weights_changed = true;
-                res = self.init_key;
-            end
+            assert(is_initialized(self))
+            self.init_key = caffe('load_net',model_file);
+            self.model_file = model_file;
+            self.weights_changed = true;
+            res = self.init_key;
         end
         function res = save_net(self, model_file)
-            if (is_initialized(self))
-                res = caffe('save_net', model_file);
-            end
+            assert(is_initialized(self))
+            res = caffe('save_net', model_file);
         end
         function res = is_initialized(~)
             res = caffe('is_initialized');
@@ -202,53 +193,48 @@ classdef CaffeNet < handle
             self.device_id = device_id;
         end
         function res = get_weights(self)
-            if (is_initialized(self))
-                res = self.weights;
-            end
+            assert(is_initialized(self))
+            res = self.weights;
         end
         function set_weights(self, weights)
             self.weights = weights;
         end
         function res = get_layer_weights(self, layer_name)
-            if (is_initialized(self))
-                res = caffe('get_layer_weights', layer_name);
-            end
+            assert(is_initialized(self))
+            res = caffe('get_layer_weights', layer_name);
         end
         function res = set_layer_weights(self, layer_name, weights)
-            if (is_initialized(self))
-                res = caffe('set_layer_weights', layer_name, weights);
-                self.weights = caffe('get_weights');
-            end
+            assert(is_initialized(self))
+            res = caffe('set_layer_weights', layer_name, weights);
+            self.weights = caffe('get_weights');
         end
         function res = get_layers_info(self)
+            assert(is_initialized(self))
             res = self.layers_info;
         end
         function res = get_blobs_info(self)
+            assert(is_initialized(self))
             res = self.blobs_info;
         end
         function res = get_blob_data(self, blob_name)
-            if (is_initialized(self))
-                res = caffe('get_blob_data', blob_name);
-            end
+            assert(is_initialized(self))
+            res = caffe('get_blob_data', blob_name);
         end
         function res = get_blob_diff(self, blob_name)
-            if (is_initialized(self))
-                res = caffe('get_blob_diff', blob_name);
-            end
+            assert(is_initialized(self))
+            res = caffe('get_blob_diff', blob_name);
         end
         function res = get_all_data(self)
-            if (is_initialized(self))
-                res = caffe('get_all_data');
-            end
+            assert(is_initialized(self))
+            res = caffe('get_all_data');
         end
         function res = get_all_diff(self)
-            if (is_initialized(self))
-                res = caffe('get_all_diff');
-            end
+            assert(is_initialized(self))
+            res = caffe('get_all_diff');
         end
         function res = get_init_key(self)
-            res = caffe('get_init_key');
-            assert(res==self.init_key);
+            self.init_key = caffe('get_init_key');
+            res = self.init_key;
         end
         function reset(self)
             caffe('reset');

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -22,6 +22,9 @@ classdef CaffeNet < handle
     end
     methods (Access=private)
         function self = CaffeNet(model_def_file, model_file)
+            if nargin == 0
+                init_net(self,self.model_def_file);
+                load_net(self,self.model_file);
             if nargin > 0
                 init_net(self,model_def_file);
             end
@@ -37,20 +40,21 @@ classdef CaffeNet < handle
         function obj = instance(model_def_file, model_file)
             persistent self
             if isempty(self)
-            if nargin == 2
-                self = CaffeNet(model_def_file, model_file);
-                % By default use imagenet_deploy
-                model_def_file = '../../examples/imagenet/imagenet_deploy.prototxt';
-            end
-            if isempty(model_file)
-                % By default use caffe reference model
-                model_file = '../../examples/imagenet/caffe_reference_imagenet_model';
-            end
-            if isempty(self)
-                self = CaffeNet(model_def_file, model_file);
+                switch nargin
+                    case 2
+                        self = CaffeNet(model_def_file, model_file);
+                    case 1
+                        self = CaffeNet(model_def_file);
+                    case 0
+                        self = CaffeNet();
+                end
             else
-                self.init_net(model_def_file);
-                self.load_net(mod
+                if nargin > 0 & ~isempty(model_def_file)
+                    init_net(self,model_def_file);
+                end
+                if nargin > 1 & ~isempty(model_file)
+                    load_net(self,model_file);
+                end
             end
             obj = self;
         end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -5,8 +5,8 @@ classdef CaffeNet < handle
         layers_info
         blobs_info
     end
-    properties (AbortSet = true)
-        weights
+    properties
+        weights = [];
         mode
         phase
         device_id
@@ -15,7 +15,7 @@ classdef CaffeNet < handle
     end
     properties (Hidden)
         init_key
-        weights_changed = true;
+        weights_changed = false;
         getting_weights = false;
     end
     methods (Access=private)
@@ -25,11 +25,15 @@ classdef CaffeNet < handle
                 self.init_key = caffe('init_net', model_def_file);
                 self.layers_info = caffe('get_layers_info');
                 self.blobs_info = caffe('get_blobs_info');
+                self.weights_changed  = true;
             end
             if nargin > 1
                 self.model_file = model_file;
                 self.init_key = caffe('init', model_def_file, model_file);
-                self.weights_changed  = true;
+                self.getting_weights = true;
+                self.weights = caffe('get_weights');
+                self.getting_weights = false;
+                self.weights_changed  = false;
             end
             self.mode = caffe('get_mode');
             self.phase = caffe('get_phase');

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -31,10 +31,10 @@ classdef CaffeNet < handle
             if nargin > 1
                 load_net(self, model_file);
             end
-            assert(is_initialized())
-            self.mode = caffe('get_mode');
-            self.phase = caffe('get_phase');
-            self.device_id = caffe('get_device');
+            assert(is_initialized(self))
+            self.mode = caffe_safe('get_mode');
+            self.phase = caffe_safe('get_phase');
+            self.device_id = caffe_safe('get_device');
         end
     end
     methods (Static)
@@ -64,14 +64,14 @@ classdef CaffeNet < handle
         function weights = get.weights(self)
             assert(is_initialized(self))
             if (self.weights_changed)
-                self.weights_store = caffe('get_weights');
+                self.weights_store = caffe_safe('get_weights');
                 self.weights_changed = false;
             end
             weights = self.weights_store;
         end
         function set.weights(self,weights)
             assert(is_initialized(self))
-            caffe('set_weights', weights);
+            caffe_safe('set_weights', weights);
             self.weights_store = weights;
             self.weights_changed = false;
         end
@@ -79,10 +79,10 @@ classdef CaffeNet < handle
             % mode = {'CPU' 'GPU'}
             switch mode
                 case 'CPU'
-                    caffe('set_mode_cpu');
+                    caffe_safe('set_mode_cpu');
                     self.mode = mode;
                 case 'GPU'
-                    caffe('set_mode_gpu');
+                    caffe_safe('set_mode_gpu');
                     self.mode = mode;
                 otherwise
                     fprintf('Mode unknown choose between CPU and GPU\n');
@@ -93,10 +93,10 @@ classdef CaffeNet < handle
             % phase = {'TRAIN' 'TEST'}
             switch phase
                 case 'TRAIN'
-                    caffe('set_phase_train');
+                    caffe_safe('set_phase_train');
                     self.phase = phase;
                 case {'test','TEST'}
-                    caffe('set_phase_test');
+                    caffe_safe('set_phase_test');
                     self.phase = phase;
                 otherwise
                     fprintf('Phase unknown choose between TRAIN and TEST')
@@ -104,17 +104,17 @@ classdef CaffeNet < handle
             end
         end
         function set.device_id(self, device_id)
-            caffe('set_device', device_id);
+            caffe_safe('set_device', device_id);
             self.device_id = device_id;
         end
         function set.input_blobs(self, input_blobs)
             assert(is_initialized(self))
-            caffe('set_input_blobs', input_blobs);
+            caffe_safe('set_input_blobs', input_blobs);
             self.input_blobs = input_blobs;
         end
         function set.output_blobs(self, output_blobs)
             assert(is_initialized(self))
-            caffe('set_output_blobs', output_blobs);
+            caffe_safe('set_output_blobs', output_blobs);
             self.output_blobs = output_blobs;
         end
     end
@@ -122,60 +122,60 @@ classdef CaffeNet < handle
         function res = forward(self,input)
             assert(is_initialized(self))
             if nargin < 2
-                res = caffe('forward');
+                res = caffe_safe('forward');
             else
-                res = caffe('forward',input);
+                res = caffe_safe('forward',input);
             end
         end
         function res = backward(self,diff)
             assert(is_initialized(self))
             if nargin < 2
-                res = caffe('backward');
+                res = caffe_safe('backward');
             else
-                res = caffe('backward',diff);
+                res = caffe_safe('backward',diff);
             end
         end
         function res = forward_prefilled(self)
             assert(is_initialized(self))
-            res = caffe('forward_prefilled');
+            res = caffe_safe('forward_prefilled');
         end
         function res = backward_prefilled(self)
             assert(is_initialized(self))
-            res = caffe('backward_prefilled');
+            res = caffe_safe('backward_prefilled');
         end
         function res = init(self, model_def_file, model_file)
-            self.init_key = caffe('init',model_def_file, model_file);
+            self.init_key = caffe_safe('init',model_def_file, model_file);
             assert(is_initialized(self))
             self.model_def_file = model_def_file;
             self.model_file = model_file;
-            self.layers_info = caffe('get_layers_info');
-            self.blobs_info = caffe('get_blobs_info');
+            self.layers_info = caffe_safe('get_layers_info');
+            self.blobs_info = caffe_safe('get_blobs_info');
             self.weights_changed = true;
             res = self.init_key;
         end
         function res = init_net(self, model_def_file)
-            self.init_key = caffe('init_net',model_def_file);
+            self.init_key = caffe_safe('init_net',model_def_file);
             assert(is_initialized(self))
             self.model_def_file = model_def_file;
             self.model_file = [];
-            self.layers_info = caffe('get_layers_info');
-            self.blobs_info = caffe('get_blobs_info');
+            self.layers_info = caffe_safe('get_layers_info');
+            self.blobs_info = caffe_safe('get_blobs_info');
             self.weights_changed = true;
             res = self.init_key;
         end
         function res = load_net(self, model_file)
             assert(is_initialized(self))
-            self.init_key = caffe('load_net',model_file);
+            self.init_key = caffe_safe('load_net',model_file);
             self.model_file = model_file;
             self.weights_changed = true;
             res = self.init_key;
         end
         function res = save_net(self, model_file)
             assert(is_initialized(self))
-            res = caffe('save_net', model_file);
+            res = caffe_safe('save_net', model_file);
         end
         function res = is_initialized(~)
-            res = caffe('is_initialized');
+            res = caffe_safe('is_initialized')>0;
         end
         function set_mode_cpu(self)
             self.mode = 'CPU';
@@ -201,12 +201,12 @@ classdef CaffeNet < handle
         end
         function res = get_layer_weights(self, layer_name)
             assert(is_initialized(self))
-            res = caffe('get_layer_weights', layer_name);
+            res = caffe_safe('get_layer_weights', layer_name);
         end
         function res = set_layer_weights(self, layer_name, weights)
             assert(is_initialized(self))
-            res = caffe('set_layer_weights', layer_name, weights);
-            self.weights = caffe('get_weights');
+            res = caffe_safe('set_layer_weights', layer_name, weights);
+            self.weights = caffe_safe('get_weights');
         end
         function res = get_layers_info(self)
             assert(is_initialized(self))
@@ -218,34 +218,34 @@ classdef CaffeNet < handle
         end
         function res = get_blob_data(self, blob_name)
             assert(is_initialized(self))
-            res = caffe('get_blob_data', blob_name);
+            res = caffe_safe('get_blob_data', blob_name);
         end
         function res = get_blob_diff(self, blob_name)
             assert(is_initialized(self))
-            res = caffe('get_blob_diff', blob_name);
+            res = caffe_safe('get_blob_diff', blob_name);
         end
         function res = get_all_data(self)
             assert(is_initialized(self))
-            res = caffe('get_all_data');
+            res = caffe_safe('get_all_data');
         end
         function res = get_all_diff(self)
             assert(is_initialized(self))
-            res = caffe('get_all_diff');
+            res = caffe_safe('get_all_diff');
         end
         function res = get_init_key(self)
-            self.init_key = caffe('get_init_key');
+            self.init_key = caffe_safe('get_init_key');
             res = self.init_key;
         end
         function reset(self)
-            caffe('reset');
-            self.init_key = caffe('get_init_key');
+            caffe_safe('reset');
+            self.init_key = caffe_safe('get_init_key');
             self.layers_info = [];
             self.blobs_info = [];
             self.weights_store = [];
         end
         function delete(self)
             self.weights_store = [];
-            caffe('reset');
+            caffe_safe('reset');
             clear caffe;
         end
     end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -1,147 +1,173 @@
-classdef CaffeNet
-  properties
-    model_def_file
-    model_file
-    init_key        
-  end
-  properties (Hidden)
-    cutoff % Defines a cuttoff point
-  end
-  methods (Access=private)
-    function self = CaffeNet(model_def_file, model_file)
-      if nargin > 0
-        self.model_def_file = model_def_file;
-        self.init_key = caffe('init_net', model_def_file);
-      end
-      if nargin > 1
-        self.model_file = model_file;
-        self.init_key = caffe('init', model_def_file, model_file);
-      end
+classdef CaffeNet < handle
+    properties
+        model_def_file
+        model_file
+        mode
+        phase
+        devide_id
+        weights
+        layers_info
+        blobs_info
     end
-  end    
-  methods (Static)
-    function obj = instance(model_def_file, model_file)
-      persistent self
-      if isempty(self)
-        switch nargin
-          case 1
-            self = CaffeNet(model_def_file);
-          case 2
-            self = CaffeNet(model_def_file, model_file);
-          otherwise
-            error('Need to be initialized with at least model_def_file')
+    properties (Hidden)
+        init_key
+    end
+    methods (Access=private)
+        function self = CaffeNet(model_def_file, model_file)
+            if nargin > 0
+                self.model_def_file = model_def_file;
+                self.init_key = caffe('init_net', model_def_file);
+                self.layers_info = caffe('get_layers_info');
+                self.blobs_info = caffe('get_blobs_info');
+            end
+            if nargin > 1
+                self.model_file = model_file;
+                self.init_key = caffe('init', model_def_file, model_file);
+                self.weights = caffe('get_weights');
+            end
         end
-      end
-      obj = self;
     end
-  
-  methods
-    function res = forward(self,input)
-      if nargin < 2
-        res = caffe('forward');
-      else
-        res = caffe('forward',input);
-      end
+    methods (Static)
+        function obj = instance(model_def_file, model_file)
+            if nargin < 1 || isempty(model_def_file)
+                % By default use imagenet_deploy
+                model_def_file = '../../examples/imagenet/imagenet_deploy.prototxt';
+            end
+            if nargin < 2 || isempty(model_file)
+                % By default use caffe reference model
+                model_file = '../../examples/imagenet/caffe_reference_imagenet_model';
+            end
+            persistent self
+            if isempty(self)
+                self = CaffeNet(model_def_file, model_file);
+            end
+            obj = self;
+        end
     end
-    function res = backward(self,input)
-      if nargin < 2
-        res = caffe('backward');
-      else
-        res = caffe('backward',input);
-      end
+    methods
+        function res = forward(~,input)
+            if nargin < 2
+                res = caffe('forward');
+            else
+                res = caffe('forward',input);
+            end
+        end
+        function res = backward(~,diff)
+            if nargin < 2
+                res = caffe('backward');
+            else
+                res = caffe('backward',diff);
+            end
+        end
+        function res = forward_prefilled(~)
+            res = caffe('forward_prefilled');
+        end
+        function res = backward_prefilled(~)
+            res = caffe('backward_prefilled');
+        end
+        function res = init_net(self, model_def_file)
+            self.init_key = caffe('init_net',model_def_file);
+            self.layers_info = caffe('get_layers_info');
+            self.blobs_info = caffe('get_blobs_info');
+            res = self.init_key;
+        end
+        function res = load_net(self, model_file)
+            self.init_key = caffe('load_net',model_file);
+            self.weights = caffe('get_weights');
+            res = self.init_key;
+        end
+        function res = save_net(~, model_file)
+            res = caffe('save_net', model_file);
+        end
+        function res = is_initialized(~)
+            res = caffe('is_initialized');
+        end
+        function set_mode_cpu(self)
+            caffe('set_mode_cpu');
+            self.mode = 'cpu';
+        end
+        function set_mode_gpu(self)
+            caffe('set_mode_gpu');
+            self.mode = 'gpu';
+        end
+        function set_mode(self,mode)
+            % mode = {'cpu' 'gpu'}
+            switch mode
+                case {'cpu','CPU'}
+                    caffe('set_mode_cpu');
+                    self.mode = mode;
+                case {'gpu','GPU'}
+                    caffe('set_mode_gpu');
+                    self.mode = mode;
+                otherwise
+                    error('Mode unknown');
+            end
+        end
+        function set_phase_train(self)
+            caffe('set_phase_train');
+            self.phase = 'train';
+        end
+        function set_phase_test(self)
+            caffe('set_phase_test');
+            self.phase = 'test';
+        end
+        function set_phase(self, phase)
+            % phase = {'train' 'test'}
+            switch phase
+                case {'train','TRAIN'}
+                    caffe('set_phase_train');
+                    self.phase = phase;
+                case {'test','TEST'}
+                    caffe('set_phase_test');
+                    self.phase = phase;
+                otherwise
+                    error('Phase unknown');
+            end
+        end
+        function set_device(self, device_id)
+            caffe('set_device', device_id);
+            self.device_id = device_id;
+        end
+        function res = get_weights(self)
+            self.weights = caffe('get_weights');
+            res = self.weights;
+        end
+        function res = set_weights(self, weights)
+            res = caffe('set_weights', weights);
+            self.weights = caffe('get_weights');
+        end
+        function res = get_layer_weights(~, layer_name)
+            res = caffe('get_layer_weights', layer_name);
+        end
+        function res = set_layer_weights(self, layer_name, weights)
+            res = caffe('set_layer_weights', layer_name, weights);
+            self.weights = caffe('get_weights');
+        end
+        function res = get_layers_info(self)
+            res = self.layers_info;
+        end
+        function res = get_blobs_info(self)
+            res = self.blobs_info;
+        end
+        function res = get_blob_data(~, blob_name)
+            res = caffe('get_blob_data', blob_name);
+        end
+        function res = get_blob_diff(~, blob_name)
+            res = caffe('get_blob_diff', blob_name);
+        end
+        function res = get_all_data(~)
+            res = caffe('get_all_data');
+        end
+        function res = get_all_diff(~)
+            res = caffe('get_all_diff');
+        end
+        function res = get_init_key(self)
+            res = caffe('get_init_key');
+            assert(res==self.init_key);
+        end
+        function res = reset(self)
+            res = caffe('reset');
+            self.init_key
+        end
     end
-    function res = forward_prefilled(self)
-      res = caffe('forward_prefilled');
-    end
-    function res = backward_prefilled(self)
-      res = caffe('backward_prefilled');
-    end
-    function res = init_net(self, model_def_file)
-      self.init_key = caffe('init_net',model_def_file);
-      res = self.init_key;
-    end
-    function res = load_net(self, model_file)
-      self.init_key = caffe('load_net',model_file);
-      res = self.init_key;
-    end
-    function res = save_net(self, model_file)
-      res = caffe('save_net', model_file);
-    end
-    function res = is_initialized(self)
-      res = caffe('is_initialized');
-    end
-    function res = set_mode_cpu(self)
-      res = caffe('set_mode_cpu');
-    end
-    function res = set_mode_gpu(self)
-      res = caffe('set_mode_gpu');
-    end
-    function res = set_mode(self,mode)
-      % mode = {'cpu' 'gpu'}
-      switch mode
-        case {'cpu','CPU'}
-          res = caffe('set_mode_cpu');
-        case {'gpu','GPU'}
-          res = caffe('set_mode_gpu');
-        otherwise
-          error('Mode unknown');
-      end
-    end
-    function res = set_phase_train(self)
-      res = caffe('set_phase_train');
-    end
-    function res = set_phase_test(self)
-      res = caffe('set_phase_test');
-    end
-    function res = set_phase(self, phase)
-      % phase = {'train' 'test'}
-      switch phase
-        case {'train','TRAIN'}
-          res = caffe('set_phase_train');
-        case {'test','TEST'}
-          res = caffe('set_phase_test');
-        otherwise
-          error('Phase unknown');
-      end
-    end
-    function res = set_device(self, device_id)
-      res = caffe('set_device', device_id);
-    end
-    function res = get_weights(self)
-      res = caffe('get_weights');
-    end
-    function res = set_weights(self, weights)
-      res = caffe('set_weights', weights);
-    end
-    function res = get_layer_weights(self, layer_name)
-      res = caffe('get_layer_weights', layer_name);
-    end
-    function res = set_layer_weights(self, layer_name, weights)
-      res = caffe('set_layer_weights', layer_name, weights);
-    end
-    function res = get_layers_info(self)
-      res = caffe('get_layers_info');
-    end
-    function res = get_blobs_info(self)
-      res = caffe('get_blobs_info');
-    end
-    function res = get_blob_data(self, blob_name)
-      res = caffe('get_blob_data', blob_name);
-    end
-    function res = get_blob_diff(self, blob_name)
-      res = caffe('get_blob_diff', blob_name);
-    end
-    function res = get_all_data(self)
-      res = caffe('get_all_data');
-    end
-    function res = get_all_diff(self)
-      res = caffe('get_all_diff');
-    end
-    function res = get_init_key(self)
-      res = caffe('get_init_key');
-    end
-    function res = reset(self)
-      res = caffe('reset');
-    end
-  end
 end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -135,7 +135,6 @@ classdef CaffeNet < handle
         end
         function res = backward(self,diff)
             if (is_initialized(self))
-                assert(strcmp(self.phase,'TRAIN'),'Network should be in TRAIN phase');
                 if nargin < 2
                     res = caffe('backward');
                 else
@@ -150,7 +149,6 @@ classdef CaffeNet < handle
         end
         function res = backward_prefilled(self)
             if (is_initialized(self))
-                assert(strcmp(self.phase,'TRAIN'),'Network should be in TRAIN phase');
                 res = caffe('backward_prefilled');
             end
         end

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -254,7 +254,9 @@ classdef CaffeNet < handle
         end
         function reset(self)
             caffe('reset');
-            self = [];
+            self.init_key = caffe('get_init_key');
+            self.layers_info = [];
+            self.blobs_info = [];
         end
         function delete(self)
             caffe('reset');

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -29,7 +29,7 @@ classdef CaffeNet < handle
             end
             if nargin > 1
                 self.model_file = model_file;
-                self.init_key = caffe('init', model_def_file, model_file);
+                self.init_key = caffe('load_net', model_file);
                 self.getting_weights = true;
                 self.weights = caffe('get_weights');
                 self.getting_weights = false;

--- a/matlab/caffe/CaffeNet.m
+++ b/matlab/caffe/CaffeNet.m
@@ -30,10 +30,10 @@ classdef CaffeNet < handle
             if nargin > 1
                 self.model_file = model_file;
                 self.init_key = caffe('load_net', model_file);
-                self.getting_weights = true;
-                self.weights = caffe('get_weights');
-                self.getting_weights = false;
-                self.weights_changed  = false;
+                % self.getting_weights = true;
+                % self.weights = caffe('get_weights');
+                % self.getting_weights = false;
+                % self.weights_changed  = false;
             end
             self.mode = caffe('get_mode');
             self.phase = caffe('get_phase');

--- a/matlab/caffe/caffe_safe.m
+++ b/matlab/caffe/caffe_safe.m
@@ -1,0 +1,7 @@
+function vargout = caffe_safe(vargin)
+  try
+  	vargout = caffe(vargin);
+  catch
+  	error('Exception in caffe');
+  end
+ end

--- a/matlab/caffe/caffe_safe.m
+++ b/matlab/caffe/caffe_safe.m
@@ -1,7 +1,15 @@
-function vargout = caffe_safe(vargin)
+function varargout = caffe_safe(varargin)
   try
-  	vargout = caffe(vargin);
-  catch
-  	error('Exception in caffe');
+     switch nargout
+	case 0
+	 caffe(varargin{:});
+	 varargout={};
+	case 1
+	 varargout{1} = caffe(varargin{:});
+	case 2
+	 [varargout{1} varargout{2}] = caffe(varargin{:});
   end
- end
+  catch
+    error('Exception in caffe');
+  end
+end

--- a/matlab/caffe/displayData.m
+++ b/matlab/caffe/displayData.m
@@ -1,0 +1,61 @@
+function [h, display_array] = displayData(X, example_width, display_cols)
+%DISPLAYDATA Display 2D data in a nice grid
+%   [h, display_array] = DISPLAYDATA(X, example_width) displays 2D data
+%   stored in X in a nice grid. It returns the figure handle h and the 
+%   displayed array if requested.
+
+% Set example_width automatically if not passed in
+if ~exist('example_width', 'var') || isempty(example_width) 
+	example_width = round(sqrt(size(X, 2)));
+end
+
+% Gray Image
+colormap(gray);
+
+% Compute rows, cols
+[m n] = size(X);
+example_height = (n / example_width);
+
+% Compute number of items to display
+if ~exist('display_cols', 'var')
+    display_cols = floor(sqrt(m));
+end
+display_rows = ceil(m / display_cols);
+
+% Between images padding
+pad = 1;
+
+% Setup blank display
+display_array = - ones(pad + display_rows * (example_height + pad), ...
+                       pad + display_cols * (example_width + pad));
+
+% Copy each example into a patch on the display array
+curr_ex = 1;
+for j = 1:display_rows
+	for i = 1:display_cols
+		if curr_ex > m, 
+			break; 
+		end
+		% Copy the patch
+		
+		% Get the max value of the patch
+		max_val = max(abs(X(curr_ex, :)));
+		display_array(pad + (j - 1) * (example_height + pad) + (1:example_height), ...
+		              pad + (i - 1) * (example_width + pad) + (1:example_width)) = ...
+						reshape(X(curr_ex, :), example_height, example_width) / max_val;
+		curr_ex = curr_ex + 1;
+	end
+	if curr_ex > m, 
+		break; 
+	end
+end
+
+% Display Image
+h = imagesc(display_array, [-1 1]);
+
+% Do not show axis
+axis image off
+
+drawnow;
+
+end

--- a/matlab/caffe/displayFilters.m
+++ b/matlab/caffe/displayFilters.m
@@ -1,0 +1,31 @@
+function displayFilters(X, display_cols)
+%displayFilters Display [height * width * num_channels * num_filters] filters 
+%  in a nice grid using display_cols, at most it displays 32 filters
+%   [h, display_array] = displayFilters(X, display_cols)
+
+% Gray Image
+colormap(gray);
+
+% Compute rows, cols
+[example_height example_width num_channels num_filters] = size(X);
+
+
+% Compute number of items to display
+if ~exist('display_cols', 'var')
+    display_cols = floor(sqrt(num_filters));
+end
+display_rows = ceil(num_filters / display_cols);
+colimage = [];
+for n = 1:min(32,num_filters)
+    if mod(n,8)== 1
+        figure(ceil(n/8))
+        colimage = [];
+    end
+    filter = reshape(X(:,:,:,n),[],num_channels)';
+    [~,dsp] = displayData(filter,example_width,num_channels/4);
+    colimage = cat(1,colimage,dsp,ones(1,size(dsp,2)));
+    if mod(n,8)== 0
+        imagesc(colimage, [-1 1]), axis off; drawnow;
+    end
+end
+

--- a/matlab/caffe/displayRGBFilters.m
+++ b/matlab/caffe/displayRGBFilters.m
@@ -1,0 +1,65 @@
+function [h, display_array] = displayRGBFilters(X, display_cols, contrast)
+%displayRGBFilters Display 2D RGB data in a nice grid
+%   [h, display_array] = displayRGBFilters(X, filter_width, display_cols,contrast)
+%   displays RGB 2D data
+%   stored in X in a nice grid. It returns the figure handle h and the 
+%   displayed array if requested.
+
+[filter_height filter_width num_channels num_filters] = size(X);
+
+assert(num_channels==3);
+
+% Compute number of items to display
+if ~exist('display_cols', 'var')
+    display_cols = floor(sqrt(num_filters));
+end
+display_rows = ceil(num_filters / display_cols);
+
+if ~exist('contrast', 'var')
+    contrast = 'local';
+end
+    
+% Between images padding
+pad = 1;
+
+% Setup blank display
+display_array = ones(pad + display_rows * (filter_height + pad), ...
+                       pad + display_cols * (filter_width + pad),3);
+
+% Copy each example into a patch on the display array
+curr_ex = 1;
+if strcmp(contrast,'global')
+    max_val = max(X(:));
+    min_val = min(X(:));
+end
+for j = 1:display_rows
+	for i = 1:display_cols
+		if curr_ex > num_filters, 
+			break; 
+		end
+		% Copy the patch
+		
+        % Get the max value of the patch
+        if strcmp(contrast,'local')
+            max_val = max(X(:,:,:,curr_ex)(:));
+            min_val = min(X(:,:,:,curr_ex)(:));
+        end
+		display_array(pad + (j - 1) * (filter_height + pad) + (1:filter_height), ...
+		              pad + (i - 1) * (filter_width + pad) + (1:filter_width),:) = ...
+						(X(:,:,:,curr_ex) - min_val) / (max_val-min_val);
+		curr_ex = curr_ex + 1;
+	end
+	if curr_ex > num_filters, 
+		break; 
+	end
+end
+
+% Display Image
+h = imagesc(display_array, [-1 1]);
+
+% Do not show axis
+axis image off
+
+drawnow;
+
+end

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -15,6 +15,39 @@
 
 #define MEX_ARGS int nlhs, mxArray **plhs, int nrhs, const mxArray **prhs
 
+// The interim macro that simply strips the excess and ends up with the required macro
+#define CHECK_EQ_X(A,B,C,FUNC, ...) FUNC
+
+// The macro that the programmer uses
+#define CHECK_EQ(...)  CHECK_EQ_X(__VA_ARGS__,  \
+                       CHECK_EQ_3(__VA_ARGS__),    \
+                       CHECK_EQ_2(__VA_ARGS__))
+
+#define CHECK_EQ_2(a, b)  do {                                  \
+  if ( (a) != (b) ) {                                           \
+    fprintf(stderr, "%s:%d: Check failed because %s != %s\n",   \
+            __FILE__, __LINE__, #a, #b);                        \
+    mexErrMsgTxt("Error in CHECK_EQ");                          \
+  }                                                             \
+} while (0);
+
+#define CHECK_EQ_3(a, b, m)  do {                               \
+  if ( (a) != (b) ) {                                           \
+    fprintf(stderr, "%s:%d: Check failed because %s != %s\n",   \
+            __FILE__, __LINE__, #a, #b);                        \
+    fprintf(stderr, "%s:%d: %s\n",                              \
+            __FILE__, __LINE__, #m);                            \
+    mexErrMsgTxt(#m);                                           \
+  }                                                             \
+} while (0);
+
+#define CUDA_CHECK(condition) \
+  /* Code block avoids redefinition of cudaError_t error */ \
+  do { \
+    cudaError_t error = condition; \
+    CHECK_EQ(error, cudaSuccess, "CUDA_CHECK")  \
+  } while (0)
+
 using namespace caffe;  // NOLINT(build/namespaces)
 
 
@@ -205,8 +238,8 @@ static void do_set_output_blobs(const mxArray* const top_diff) {
   // Copy top_diff to the output diff
   for (unsigned int i = 0; i < output_blobs.size(); ++i) {
     const mxArray* const elem = mxGetCell(top_diff, i);
-    CHECK_EQ(output_blobs[i]->count(),mxGetNumberOfElements(elem)) <<
-      "output_blobs[i]->count() don't match with numel(top_diff{i})";
+    CHECK_EQ(output_blobs[i]->count(),mxGetNumberOfElements(elem),
+      "output_blobs[i]->count() don't match with numel(top_diff{i})");
     const float* const data_ptr =
         reinterpret_cast<const float* const>(mxGetPr(elem));
     switch (Caffe::mode()) {
@@ -450,7 +483,7 @@ static void do_set_layer_weights(const mxArray* const layer_name,
       }
       DLOG(INFO) << "Found layer " << layer_names[i];
       CHECK_EQ(static_cast<unsigned int>(mxGetDimensions(mx_layer_weights)[0]),
-        layer_blobs.size()) << "Num of cells don't match layer_blobs.size";
+        layer_blobs.size(), "Num of cells don't match layer_blobs.size");
       DLOG(INFO) << "layer_blobs.size() = " << layer_blobs.size();
       for (unsigned int j = 0; j < layer_blobs.size(); ++j) {
         // internally data is stored as (width, height, channels, num)
@@ -459,8 +492,8 @@ static void do_set_layer_weights(const mxArray* const layer_name,
         mwSize dims[4] = {layer_blobs[j]->width(), layer_blobs[j]->height(),
             layer_blobs[j]->channels(), layer_blobs[j]->num()};
         DLOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
-        CHECK_EQ(layer_blobs[j]->count(), mxGetNumberOfElements(elem)) <<
-          "Numel of weights don't match count of layer_blob";
+        CHECK_EQ(layer_blobs[j]->count(), mxGetNumberOfElements(elem),
+          "Numel of weights don't match count of layer_blob");
         const mwSize* dims_elem = mxGetDimensions(elem);
         DLOG(INFO) << dims_elem[0] << " " << dims_elem[1];
         const float* const data_ptr =
@@ -740,7 +773,9 @@ static void set_weights(MEX_ARGS) {
     mexErrMsgTxt("Wrong number of arguments");
   }
   const mxArray* const mx_weights = prhs[0];
-  CHECK(mxIsStruct(mx_weights)) << "Input needs to be struct";
+  if (!mxIsStruct(mx_weights)) {
+    mexErrMsgTxt("Input needs to be struct");
+  }
   int num_layers = mxGetNumberOfElements(mx_weights);
   for (int i = 0; i < num_layers; ++i) {
     const mxArray* layer_name= mxGetField(mx_weights,i,"layer_name");
@@ -1091,16 +1126,10 @@ static handler_registry handlers[] = {
 };
 
 
-void FailureFunction() {
-     // Reports something...
-     mexErrMsgTxt("exception");
-}
-
 /** -----------------------------------------------------------------
  ** matlab entry point: caffe(api_command, arg1, arg2, ...)
  **/
 void mexFunction(MEX_ARGS) {
-  google::InstallFailureFunction(&FailureFunction);
   if (nrhs == 0) {
     LOG(ERROR) << "No API command given";
     mexErrMsgTxt("An API command is requires");

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -188,7 +188,7 @@ static mxArray* do_get_weights() {
   mxArray* mx_layers;
   {
     const mwSize dims[2] = {num_layers, 1};
-    const char* fnames[2] = {"weights", "layer_names"};
+    const char* fnames[2] = {"weights", "layer_name"};
     mx_layers = mxCreateStructArray(2, dims, 2, fnames);
   }
 
@@ -208,7 +208,7 @@ static mxArray* do_get_weights() {
         const mwSize dims[2] = {static_cast<mwSize>(layer_blobs.size()), 1};
         mx_layer_cells = mxCreateCellArray(2, dims);
         mxSetField(mx_layers, mx_layer_index, "weights", mx_layer_cells);
-        mxSetField(mx_layers, mx_layer_index, "layer_names",
+        mxSetField(mx_layers, mx_layer_index, "layer_name",
             mxCreateString(layer_names[i].c_str()));
         mx_layer_index++;
       }
@@ -434,6 +434,21 @@ static void get_layer_weights(MEX_ARGS) {
   plhs[0] = do_get_layer_weights(prhs[0]);
 }
 
+static void set_weights(MEX_ARGS) {
+  if (nrhs != 1) {
+    LOG(ERROR) << "Given " << nrhs << " arguments expecting 1";
+    mexErrMsgTxt("Wrong number of arguments");
+  }
+  const mxArray* const mx_weights = prhs[0];
+  CHECK(mxIsStruct(mx_weights)) << "Input needs to be struct";
+  int num_layers = mxGetNumberOfElements(mx_weights);
+  for (int i = 0; i < num_layers; ++i) {
+    const mxArray* layer_name= mxGetField(mx_weights,i,"layer_name");
+    const mxArray* weights= mxGetField(mx_weights,i,"weights");
+    do_set_layer_weights(layer_name,weights);
+  }
+}
+
 static void set_layer_weights(MEX_ARGS) {
   if (nrhs != 2) {
     LOG(ERROR) << "Only given " << nrhs << " arguments";
@@ -655,6 +670,7 @@ static handler_registry handlers[] = {
   { "set_phase_test",     set_phase_test  },
   { "set_device",         set_device      },
   { "get_weights",        get_weights     },
+  { "set_weights",        set_weights     },
   { "get_layer_weights",  get_layer_weights},
   { "set_layer_weights",  set_layer_weights},
   { "get_layers_info",    get_layers_info },

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -824,16 +824,20 @@ static void init_net(MEX_ARGS) {
 
 static void load_net(MEX_ARGS) {
   if (nrhs != 1) {
-    LOG(ERROR) << "Only given " << nrhs << " arguments";
+    LOG(ERROR) << "Given " << nrhs << " arguments";
     mexErrMsgTxt("Wrong number of arguments");
   }
   if (net_) {
-  char* model_file = mxArrayToString(prhs[0]);
+    char* model_file = mxArrayToString(prhs[0]);
 
-  CheckFile(string(model_file));
-  net_->CopyTrainedLayersFrom(string(model_file));
+    CheckFile(string(model_file));
+    net_->CopyTrainedLayersFrom(string(model_file));
 
-  mxFree(model_file);
+    mxFree(model_file);
+    init_key = random();  // NOLINT(caffe/random_fn)
+    if (nlhs == 1) {
+      plhs[0] = mxCreateDoubleScalar(init_key);
+    }
   } else {
     mexErrMsgTxt("Need to initialize the network first with init_net");
   }

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -305,17 +305,17 @@ static mxArray* do_get_blobs_info() {
 
   // Step 2: copy info into output
   {
-    for (unsigned int i = 0; i < num_blobs; ++i) {
+    for (unsigned int i = 0; i < blobs.size(); ++i) {
       mxSetField(mx_blobs, i, "name",
         mxCreateString(blob_names[i].c_str()));
       mxSetField(mx_blobs, i, "num",
-        mxCreateDoubleScalar(layer_blobs[i]->num()));
+        mxCreateDoubleScalar(blobs[i]->num()));
       mxSetField(mx_blobs, i, "channels",
-        mxCreateDoubleScalar(layer_blobs[i]->channels()));
+        mxCreateDoubleScalar(blobs[i]->channels()));
       mxSetField(mx_blobs, i, "height",
-        mxCreateDoubleScalar(layer_blobs[i]->height()));
+        mxCreateDoubleScalar(blobs[i]->height()));
       mxSetField(mx_blobs, i, "width",
-        mxCreateDoubleScalar(layer_blobs[i]->width()));
+        mxCreateDoubleScalar(blobs[i]->width()));
     }
   }
 

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -251,14 +251,14 @@ static mxArray* do_get_layers_info() {
   // Step 1: prepare output array of structures
   mxArray* mx_layers;
   {
-    const char* fnames[3] = {"name", "type", "blobs"};
+    const char* fnames[3] = {"name", "type", "weights"};
     mx_layers = mxCreateStructArray(2, num_layers, 3, fnames);
   }
 
   // Step 2: copy info into output
   {
     mxArray* mx_blob;
-    const char* blobfnames[4] = {"num", "channels", "height", "width"};
+    const char* blobfnames[5] = {"num", "channels", "height", "width", "count"};
     for (unsigned int i = 0; i < layers.size(); ++i) {
       mxSetField(mx_layers, i, "name",
         mxCreateString(layer_names[i].c_str()));
@@ -270,8 +270,8 @@ static mxArray* do_get_layers_info() {
         continue;
       }
 
-      const int num_blobs[2] = {layer_blobs.size(), 1};
-      mx_blob = mxCreateStructArray(1, num_blobs, 4, blobfnames);
+      const int num_blobs[1] = {layer_blobs.size()};
+      mx_blob = mxCreateStructArray(1, num_blobs, 5, blobfnames);
 
       for (unsigned int j = 0; j < layer_blobs.size(); ++j) {
         mxSetField(mx_blob, j, "num",
@@ -282,6 +282,8 @@ static mxArray* do_get_layers_info() {
           mxCreateDoubleScalar(layer_blobs[j]->height()));
         mxSetField(mx_blob, j, "width",
           mxCreateDoubleScalar(layer_blobs[j]->width()));
+        mxSetField(mx_blob, j, "count",
+          mxCreateDoubleScalar(layer_blobs[j]->count()));
       }
       mxSetField(mx_layers, i, "blobs", mx_blob);
     }
@@ -294,13 +296,12 @@ static mxArray* do_get_blobs_info() {
   const vector<shared_ptr<Blob<float> > >& blobs = net_->blobs();
   const vector<string>& blob_names = net_->blob_names();
 
-  const int num_blobs[2] = {blobs.size(), 1};
-
   // Step 1: prepare output array of structures
   mxArray* mx_blobs;
   {
-    const char* fnames[5] = {"name", "num", "channels", "height", "width"};
-    mx_blobs = mxCreateStructArray(2, num_blobs, 5, fnames);
+    const int num_blobs[1] = {blobs.size()};
+    const char* fnames[6] = {"name", "num", "channels", "height", "width", "count"};
+    mx_blobs = mxCreateStructArray(1, num_blobs, 6, fnames);
   }
 
   // Step 2: copy info into output
@@ -316,6 +317,8 @@ static mxArray* do_get_blobs_info() {
         mxCreateDoubleScalar(blobs[i]->height()));
       mxSetField(mx_blobs, i, "width",
         mxCreateDoubleScalar(blobs[i]->width()));
+      mxSetField(mx_blobs, i, "count",
+        mxCreateDoubleScalar(blobs[i]->count()));
     }
   }
 

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -882,7 +882,7 @@ static void forward(MEX_ARGS) {
 static void forward_prefilled(MEX_ARGS) {
   if (nrhs != 0) {
     LOG(ERROR) << "Given " << nrhs << " arguments";
-    mexErrMsgTxt("Wrong number of arguments");
+    mexErrMsgTxt("It takes no arguments");
   }
 
   plhs[1] = mxCreateNumericMatrix(1, 1, mxSINGLE_CLASS, mxREAL);  
@@ -891,9 +891,9 @@ static void forward_prefilled(MEX_ARGS) {
 }
 
 static void backward(MEX_ARGS) {
-  if (nrhs != 1) {
-    LOG(ERROR) << "Only given " << nrhs << " arguments";
-    mexErrMsgTxt("Wrong number of arguments");
+  if (nrhs > 1) {
+    LOG(ERROR) << "Given " << nrhs << " arguments";
+    mexErrMsgTxt("Too many input arguments");
   }
   if (nrhs == 0) {
     //Backward without arguments behaves as backward_prefilled
@@ -904,9 +904,9 @@ static void backward(MEX_ARGS) {
 }
 
 static void backward_prefilled(MEX_ARGS) {
-  if (nrhs != 1) {
-    LOG(ERROR) << "Only given " << nrhs << " arguments";
-    mexErrMsgTxt("Wrong number of arguments");
+  if (nrhs != 0) {
+    LOG(ERROR) << "Given " << nrhs << " arguments";
+    mexErrMsgTxt("It takes no arguments");
   }
 
   plhs[0] = do_backward_prefilled();

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -758,7 +758,7 @@ static void set_mode_gpu(MEX_ARGS) {
 }
 
 static void get_mode(MEX_ARGS) {
-  int mode = Caffe::get_mode();
+  int mode = Caffe::mode();
   if (mode == Caffe::CPU){
     // CPU mode
     plhs[0] = mxCreateString("CPU");
@@ -778,7 +778,7 @@ static void set_phase_test(MEX_ARGS) {
 }
 
 static void get_phase(MEX_ARGS) {
-  int phase = Caffe::get_phase();
+  int phase = Caffe::phase();
   if (phase == Caffe::TRAIN){
     // Train phase
     plhs[0] = mxCreateString("TRAIN");
@@ -800,7 +800,7 @@ static void set_device(MEX_ARGS) {
 }
 
 static void get_device(MEX_ARGS) {
-  int device_id =Caffe::GetDevice();
+  int device_id = Caffe::GetDevice();
   plhs[0] = mxCreateDoubleScalar(device_id);
 }
 

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -247,22 +247,25 @@ static mxArray* do_get_layer_weights(const mxArray* const layer_name) {
   const vector<shared_ptr<Layer<float> > >& layers = net_->layers();
   const vector<string>& layer_names = net_->layer_names();
   char* c_layer_name = mxArrayToString(layer_name);
+  LOG(INFO) << c_layer_name;
   mxArray* mx_layer_weights = NULL;
 
   for (unsigned int i = 0; i < layers.size(); ++i) {
-    if (strcmp(layer_names[i].c_str(),c_layer_name)) {
+    LOG(INFO) << layer_names[i];
+    if (strcmp(layer_names[i].c_str(),c_layer_name) == 0) {
       vector<shared_ptr<Blob<float> > >& layer_blobs = layers[i]->blobs();
       if (layer_blobs.size() == 0) {
         continue;
       }
       const mwSize dims[2] = {layer_blobs.size(), 1};
       mx_layer_weights = mxCreateCellArray(2, dims);
+      LOG(INFO) << "layer_blobs.size()" << layer_blobs.size();
       for (unsigned int j = 0; j < layer_blobs.size(); ++j) {
         // internally data is stored as (width, height, channels, num)
         // where width is the fastest dimension
         mwSize dims[4] = {layer_blobs[j]->width(), layer_blobs[j]->height(),
             layer_blobs[j]->channels(), layer_blobs[j]->num()};
-
+        LOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
         mxArray* mx_weights =
           mxCreateNumericArray(4, dims, mxSINGLE_CLASS, mxREAL);
         mxSetCell(mx_layer_weights, j, mx_weights);
@@ -576,6 +579,7 @@ static handler_registry handlers[] = {
   { "set_phase_test",     set_phase_test  },
   { "set_device",         set_device      },
   { "get_weights",        get_weights     },
+  { "get_layer_weights",  get_layer_weights},
   { "get_layers_info",    get_layers_info },
   { "get_blobs_info",     get_blobs_info  },
   { "get_init_key",       get_init_key    },

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -285,7 +285,7 @@ static mxArray* do_get_layers_info() {
         mxSetField(mx_blob, j, "count",
           mxCreateDoubleScalar(layer_blobs[j]->count()));
       }
-      mxSetField(mx_layers, i, "blobs", mx_blob);
+      mxSetField(mx_layers, i, "weights", mx_blob);
     }
   }
 

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -87,10 +87,9 @@ static mxArray* do_forward(const mxArray* const bottom, mxArray* mx_loss) {
     }  // switch (Caffe::mode())
   }
 
-  mx_loss = mxCreateNumericMatrix(1, 1, mxSINGLE_CLASS, mxREAL);
   float* loss_ptr = reinterpret_cast<float*>(mxGetPr(mx_loss));
   const vector<Blob<float>*>& output_blobs = net_->ForwardPrefilled(loss_ptr);
-  LOG(INFO) << "loss: " << mxGetScalar(mx_loss);
+  DLOG(INFO) << "loss: " << mxGetScalar(mx_loss);
   mxArray* mx_out = mxCreateCellMatrix(output_blobs.size(), 1);
   for (unsigned int i = 0; i < output_blobs.size(); ++i) {
     // internally data is stored as (width, height, channels, num)
@@ -778,9 +777,10 @@ static void forward(MEX_ARGS) {
     LOG(ERROR) << "Only given " << nrhs << " arguments";
     mexErrMsgTxt("Wrong number of arguments");
   }
-  mxArray* mx_loss;
-  plhs[0] = do_forward(prhs[0],mx_loss);
-  plhs[1] = mx_loss;
+
+  plhs[1] = mxCreateNumericMatrix(1, 1, mxSINGLE_CLASS, mxREAL);  
+  plhs[0] = do_forward(prhs[0],plhs[1]);
+
 }
 
 static void backward(MEX_ARGS) {

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -90,6 +90,106 @@ static int init_key = -2;
 //
 // The actual forward function. It takes in a cell array of 4-D arrays as
 // input and outputs a cell array.
+// 
+// 
+// Functions to copy data from mxarray to blobs and viceversa
+// 
+
+static mxArray* blob_data_to_mxarray(const Blob<float>* blob) {
+  mwSize dims[4] = {blob->width(), blob->height(),
+                    blob->channels(), blob->num()};
+  DLOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
+  mxArray* mx_blob_data = mxCreateNumericArray(4, dims, mxSINGLE_CLASS, mxREAL);
+  float* blob_data_ptr = reinterpret_cast<float*>(mxGetPr(mx_blob_data));
+  switch (Caffe::mode()) {
+  case Caffe::CPU:
+    caffe_copy(blob->count(), blob->cpu_data(), blob_data_ptr);
+    break;
+  case Caffe::GPU:
+    caffe_copy(blob->count(), blob->gpu_data(), blob_data_ptr);
+    break;
+  default:
+    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
+  }
+  return mx_blob_data;
+}
+
+static void mxarray_to_blob_data(const mxArray* data, Blob<float>* blob) {
+  mwSize dims[4] = {blob->width(), blob->height(),
+                    blob->channels(), blob->num()};
+  DLOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
+  CHECK_EQ_MEX(blob->count(),mxGetNumberOfElements(data),
+    "blob->count() don't match with numel(data)");
+  const float* const data_ptr =
+      reinterpret_cast<const float* const>(mxGetPr(data));
+  switch (Caffe::mode()) {
+  case Caffe::CPU:
+    caffe_copy(blob->count(), data_ptr, blob->mutable_cpu_data());
+    break;
+  case Caffe::GPU:
+    caffe_copy(blob->count(), data_ptr, blob->mutable_gpu_data());
+    break;
+  default:
+    LOG(FATAL) << "Unknown Caffe mode.";
+  }  // switch (Caffe::mode())
+}
+
+static mxArray* blob_diff_to_mxarray(const Blob<float>* blob) {
+  mwSize dims[4] = {blob->width(), blob->height(),
+                    blob->channels(), blob->num()};
+  DLOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
+  mxArray* mx_blob_data = mxCreateNumericArray(4, dims, mxSINGLE_CLASS, mxREAL);
+  float* blob_data_ptr = reinterpret_cast<float*>(mxGetPr(mx_blob_data));
+  switch (Caffe::mode()) {
+  case Caffe::CPU:
+    caffe_copy(blob->count(), blob->cpu_diff(), blob_data_ptr);
+    break;
+  case Caffe::GPU:
+    caffe_copy(blob->count(), blob->gpu_diff(), blob_data_ptr);
+    break;
+  default:
+    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
+  }
+  return mx_blob_data;
+}
+
+static void mxarray_to_blob_diff(const mxArray* data, Blob<float>* blob) {
+  mwSize dims[4] = {blob->width(), blob->height(),
+                    blob->channels(), blob->num()};
+  DLOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
+  CHECK_EQ_MEX(blob->count(),mxGetNumberOfElements(data),
+    "blob->count() don't match with numel(data)");
+  const float* const data_ptr =
+      reinterpret_cast<const float* const>(mxGetPr(data));
+  switch (Caffe::mode()) {
+  case Caffe::CPU:
+    caffe_copy(blob->count(), data_ptr, blob->mutable_cpu_diff());
+    break;
+  case Caffe::GPU:
+    caffe_copy(blob->count(), data_ptr, blob->mutable_gpu_diff());
+    break;
+  default:
+    LOG(FATAL) << "Unknown Caffe mode.";
+  }  // switch (Caffe::mode())
+}
+
+static mxArray* blobs_data_to_cell(const vector<Blob<float>* >& blobs) {
+  mxArray* mx_out = mxCreateCellMatrix(blobs.size(), 1);
+  for (unsigned int i = 0; i < blobs.size(); ++i) {
+    mxArray* mx_blob =  blob_data_to_mxarray(blobs[i]);
+    mxSetCell(mx_out, i, mx_blob);
+  }
+  return mx_out;
+}
+
+static mxArray* blobs_diff_to_cell(const vector<Blob<float>* >& blobs) {
+  mxArray* mx_out = mxCreateCellMatrix(blobs.size(), 1);
+  for (unsigned int i = 0; i < blobs.size(); ++i) {
+    mxArray* mx_blob =  blob_diff_to_mxarray(blobs[i]);
+    mxSetCell(mx_out, i, mx_blob);
+  }
+  return mx_out;
+}
 
 static mxArray* do_forward_prefilled(mxArray* mx_loss) {
   float* loss_ptr = reinterpret_cast<float*>(mxGetPr(mx_loss));
@@ -202,7 +302,7 @@ static mxArray* do_get_weights() {
         //   mxSetCell(mx_layer_cells, j, mx_weights);
         // }
         // Create Struct
-        mxSetField(mx_layers, mx_layer_index, "weights", mx_layer_cells);
+        mxSetField(mx_layers, mx_layer_index, "weights", mx_layer_weights);
         mxSetField(mx_layers, mx_layer_index, "layer_name",
             mxCreateString(layer_names[i].c_str()));
         mx_layer_index++;        
@@ -236,7 +336,7 @@ static mxArray* do_get_layer_weights(const mxArray* const layer_name) {
       //   // where width is the fastest dimension
       //   mxArray* mx_weights = blob_data_to_mxarray(layer_blobs[j]);
       //   mxSetCell(mx_layer_weights, j, mx_weights);
-      }
+      // }
     }
   }
   return mx_layer_weights;
@@ -354,101 +454,7 @@ static mxArray* do_get_blobs_info() {
   return mx_blobs;
 }
 
-static MxArray* blob_data_to_mxarray(const Blob<float>* blob) {
-  mwSize dims[4] = {blob->width(), blob->height(),
-                    blob->channels(), blob->num()};
-  DLOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
-  mx_blob_data = mxCreateNumericArray(4, dims, mxSINGLE_CLASS, mxREAL);
-  float* blob_data_ptr = reinterpret_cast<float*>(mxGetPr(mx_blob_data));
-  switch (Caffe::mode()) {
-  case Caffe::CPU:
-    caffe_copy(blob->count(), blob->cpu_data(), blob_data_ptr);
-    break;
-  case Caffe::GPU:
-    caffe_copy(blob->count(), blob->gpu_data(), blob_data_ptr);
-    break;
-  default:
-    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
-  }
-  return mx_blob_data;
-}
 
-static void mxarray_to_blob_data(const MxArray* data, Blob<float>& blob) {
-  mwSize dims[4] = {blob->width(), blob->height(),
-                    blob->channels(), blob->num()};
-  DLOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
-  CHECK_EQ_MEX(blob->count(),mxGetNumberOfElements(data),
-    "blob->count() don't match with numel(data)");
-  const float* const data_ptr =
-      reinterpret_cast<const float* const>(mxGetPr(data));
-  switch (Caffe::mode()) {
-  case Caffe::CPU:
-    caffe_copy(blob->count(), data_ptr, blob->mutable_cpu_data());
-    break;
-  case Caffe::GPU:
-    caffe_copy(blob->count(), data_ptr, blob->mutable_gpu_data());
-    break;
-  default:
-    LOG(FATAL) << "Unknown Caffe mode.";
-  }  // switch (Caffe::mode())
-}
-
-static MxArray* blob_diff_to_mxarray(const Blob<float>* blob) {
-  mwSize dims[4] = {blob->width(), blob->height(),
-                    blob->channels(), blob->num()};
-  DLOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
-  mx_blob_data = mxCreateNumericArray(4, dims, mxSINGLE_CLASS, mxREAL);
-  float* blob_data_ptr = reinterpret_cast<float*>(mxGetPr(mx_blob_data));
-  switch (Caffe::mode()) {
-  case Caffe::CPU:
-    caffe_copy(blob->count(), blob->cpu_diff(), blob_data_ptr);
-    break;
-  case Caffe::GPU:
-    caffe_copy(blob->count(), blob->gpu_diff(), blob_data_ptr);
-    break;
-  default:
-    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
-  }
-  return mx_blob_data;
-}
-
-static void mxarray_to_blob_diff(const MxArray* data, Blob<float>& blob) {
-  mwSize dims[4] = {blob->width(), blob->height(),
-                    blob->channels(), blob->num()};
-  DLOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
-  CHECK_EQ_MEX(blob->count(),mxGetNumberOfElements(data),
-    "blob->count() don't match with numel(data)");
-  const float* const data_ptr =
-      reinterpret_cast<const float* const>(mxGetPr(data));
-  switch (Caffe::mode()) {
-  case Caffe::CPU:
-    caffe_copy(blob->count(), data_ptr, blob->mutable_cpu_diff());
-    break;
-  case Caffe::GPU:
-    caffe_copy(blob->count(), data_ptr, blob->mutable_gpu_diff());
-    break;
-  default:
-    LOG(FATAL) << "Unknown Caffe mode.";
-  }  // switch (Caffe::mode())
-}
-
-static mxArray* blobs_data_to_cell(const vector<Blob<float>* >* blobs) {
-  mxArray* mx_out = mxCreateCellMatrix(blobs.size(), 1);
-  for (unsigned int i = 0; i < output_blobs.size(); ++i) {
-    mxArray* mx_blob =  blob_data_to_mxarray(blobs[i]);
-    mxSetCell(mx_out, i, mx_blob);
-  }
-  return mx_out;
-}
-
-static mxArray* blobs_diff_to_cell(const vector<Blob<float>* >* blobs) {
-  mxArray* mx_out = mxCreateCellMatrix(blobs.size(), 1);
-  for (unsigned int i = 0; i < output_blobs.size(); ++i) {
-    mxArray* mx_blob =  blob_diff_to_mxarray(blobs[i]);
-    mxSetCell(mx_out, i, mx_blob);
-  }
-  return mx_out;
-}
 
 static mxArray* do_get_blob_data(const mxArray* const blob_name) {
   // const vector<shared_ptr<Blob<float> > >& blobs = net_->blobs();

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -3,7 +3,6 @@
 // caffe::Caffe functions so that one could easily call it from matlab.
 // Note that for matlab, we will simply use float as the data type.
 
-#include <boost/shared_ptr.hpp>
 // these need to be included after boost on OS X
 #include <string>  // NOLINT(build/include_order)
 #include <vector>  // NOLINT(build/include_order)

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -757,12 +757,36 @@ static void set_mode_gpu(MEX_ARGS) {
   Caffe::set_mode(Caffe::GPU);
 }
 
+static void get_mode(MEX_ARGS) {
+  int mode = Caffe::get_mode();
+  if (mode == Caffe::CPU){
+    // CPU mode
+    plhs[0] = mxCreateString("CPU");
+  }
+  if (mode == Caffe::GPU){
+    // GPU mode
+    plhs[0] = mxCreateString("GPU");
+  }
+}
+
 static void set_phase_train(MEX_ARGS) {
   Caffe::set_phase(Caffe::TRAIN);
 }
 
 static void set_phase_test(MEX_ARGS) {
   Caffe::set_phase(Caffe::TEST);
+}
+
+static void get_phase(MEX_ARGS) {
+  int phase = Caffe::get_phase();
+  if (phase == Caffe::TRAIN){
+    // Train phase
+    plhs[0] = mxCreateString("TRAIN");
+  }
+  if (phase == Caffe::TEST){
+    // Test phase
+    plhs[0] = mxCreateString("TEST");
+  }
 }
 
 static void set_device(MEX_ARGS) {
@@ -773,6 +797,11 @@ static void set_device(MEX_ARGS) {
 
   int device_id = static_cast<int>(mxGetScalar(prhs[0]));
   Caffe::SetDevice(device_id);
+}
+
+static void get_device(MEX_ARGS) {
+  int device_id =Caffe::GetDevice();
+  plhs[0] = mxCreateDoubleScalar(device_id);
 }
 
 static void get_init_key(MEX_ARGS) {
@@ -970,9 +999,12 @@ static handler_registry handlers[] = {
   { "is_initialized",     is_initialized    },
   { "set_mode_cpu",       set_mode_cpu      },
   { "set_mode_gpu",       set_mode_gpu      },
+  { "get_mode",           get_mode          },
   { "set_phase_train",    set_phase_train   },
   { "set_phase_test",     set_phase_test    },
+  { "get_phase",          get_phase         },
   { "set_device",         set_device        },
+  { "get_device",         get_device        },
   { "get_weights",        get_weights       },
   { "set_weights",        set_weights       },
   { "get_layer_weights",  get_layer_weights },

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -61,7 +61,7 @@ static int init_key = -2;
 // The actual forward function. It takes in a cell array of 4-D arrays as
 // input and outputs a cell array.
 
-static mxArray* do_forward(const mxArray* const bottom) {
+static mxArray* do_forward(const mxArray* const bottom, mxArray* mx_loss) {
   vector<Blob<float>*>& input_blobs = net_->input_blobs();
   CHECK_EQ(static_cast<unsigned int>(mxGetDimensions(bottom)[0]),
       input_blobs.size());
@@ -86,7 +86,11 @@ static mxArray* do_forward(const mxArray* const bottom) {
       LOG(FATAL) << "Unknown Caffe mode.";
     }  // switch (Caffe::mode())
   }
-  const vector<Blob<float>*>& output_blobs = net_->ForwardPrefilled();
+
+  mx_loss = mxCreateNumericMatrix(1, 1, mxSINGLE_CLASS, mxREAL);
+  float* loss_ptr = reinterpret_cast<float*>(mxGetPr(mx_loss));
+  const vector<Blob<float>*>& output_blobs = net_->ForwardPrefilled(loss_ptr);
+  LOG(INFO) << "loss: " << mxGetScalar(mx_loss);
   mxArray* mx_out = mxCreateCellMatrix(output_blobs.size(), 1);
   for (unsigned int i = 0; i < output_blobs.size(); ++i) {
     // internally data is stored as (width, height, channels, num)
@@ -121,6 +125,7 @@ static mxArray* do_backward(const mxArray* const top_diff) {
   // First, copy the output diff
   for (unsigned int i = 0; i < output_blobs.size(); ++i) {
     const mxArray* const elem = mxGetCell(top_diff, i);
+    CHECK_EQ(output_blobs[i]->count(),mxGetNumberOfElements(elem));
     const float* const data_ptr =
         reinterpret_cast<const float* const>(mxGetPr(elem));
     switch (Caffe::mode()) {
@@ -773,8 +778,9 @@ static void forward(MEX_ARGS) {
     LOG(ERROR) << "Only given " << nrhs << " arguments";
     mexErrMsgTxt("Wrong number of arguments");
   }
-
-  plhs[0] = do_forward(prhs[0]);
+  mxArray* mx_loss;
+  plhs[0] = do_forward(prhs[0],mx_loss);
+  plhs[1] = mx_loss;
 }
 
 static void backward(MEX_ARGS) {

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -295,7 +295,7 @@ static void do_set_layer_weights(const mxArray* const layer_name,
   const vector<string>& layer_names = net_->layer_names();
 
   char* c_layer_name = mxArrayToString(layer_name);
-  LOG(INFO) << c_layer_name;
+  LOG(INFO) << "Looking for: " << c_layer_name;
 
   for (unsigned int i = 0; i < layers.size(); ++i) {
     LOG(INFO) << layer_names[i];
@@ -304,24 +304,28 @@ static void do_set_layer_weights(const mxArray* const layer_name,
       if (layer_blobs.size() == 0) {
         continue;
       }
+      LOG(INFO) << "Found layer " << layer_names[i];
       CHECK_EQ(static_cast<unsigned int>(mxGetDimensions(mx_layer_weights)[0]),
         layer_blobs.size());
-      LOG(INFO) << "layer_blobs.size()" << layer_blobs.size();
+      LOG(INFO) << "layer_blobs.size() = " << layer_blobs.size();
       for (unsigned int j = 0; j < layer_blobs.size(); ++j) {
         // internally data is stored as (width, height, channels, num)
         // where width is the fastest dimension
-        // 
-        const mxArray* const elem = mxGetCell(mx_layer_weights, i);
+        const mxArray* const elem = mxGetCell(mx_layer_weights, j);
+        const mwSize* dims = mxGetDimensions(elem);
+        LOG(INFO) << dims[0] << " " << dims[1] << " " << dims[2] << " " << dims[3];
         const float* const data_ptr =
             reinterpret_cast<const float* const>(mxGetPr(elem));
+        LOG(INFO) << "elem: " << data_ptr[0] << " " << data_ptr[1];
+        LOG(INFO) << "count: " << layer_blobs[j]->count();
         switch (Caffe::mode()) {
         case Caffe::CPU:
-          memcpy(layer_blobs[i]->mutable_cpu_data(), data_ptr,
-              sizeof(float) * layer_blobs[i]->count());
+          memcpy(layer_blobs[j]->mutable_cpu_data(), data_ptr,
+              sizeof(float) * layer_blobs[j]->count());
           break;
         case Caffe::GPU:
-          cudaMemcpy(layer_blobs[i]->mutable_gpu_data(), data_ptr,
-              sizeof(float) * layer_blobs[i]->count(), cudaMemcpyHostToDevice);
+          cudaMemcpy(layer_blobs[j]->mutable_gpu_data(), data_ptr,
+              sizeof(float) * layer_blobs[j]->count(), cudaMemcpyHostToDevice);
           break;
         default:
           LOG(FATAL) << "Unknown Caffe mode.";

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -1091,10 +1091,16 @@ static handler_registry handlers[] = {
 };
 
 
+void FailureFunction() {
+     // Reports something...
+     mexErrMsgTxt("exception");
+}
+
 /** -----------------------------------------------------------------
  ** matlab entry point: caffe(api_command, arg1, arg2, ...)
  **/
 void mexFunction(MEX_ARGS) {
+  google::InstallFailureFunction(&FailureFunction);
   if (nrhs == 0) {
     LOG(ERROR) << "No API command given";
     mexErrMsgTxt("An API command is requires");

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -7,6 +7,7 @@
 #include <string>  // NOLINT(build/include_order)
 #include <vector>  // NOLINT(build/include_order)
 #include <fstream>  // NOLINT
+#include <stdexcept>
 
 #include "mex.h"
 
@@ -245,38 +246,42 @@ static mxArray* do_get_layers_info() {
   const vector<shared_ptr<Layer<float> > >& layers = net_->layers();
   const vector<string>& layer_names = net_->layer_names();
 
-  int num_layers = layers.size();
+  const int num_layers[2] = {layers.size(), 1};
 
   // Step 1: prepare output array of structures
   mxArray* mx_layers;
   {
     const char* fnames[3] = {"name", "type", "blobs"};
-    mx_layers = mxCreateStructArray(1, num_layers, 3, fnames);
+    mx_layers = mxCreateStructArray(2, num_layers, 3, fnames);
   }
 
   // Step 2: copy info into output
   {
     mxArray* mx_blob;
     const char* blobfnames[4] = {"num", "channels", "height", "width"};
-    string prev_layer_name = "";
-    int mx_layer_index = 0;
     for (unsigned int i = 0; i < layers.size(); ++i) {
-      mxSetField(mx_layers, i, "name", mxCreateString(layer_names[i].c_str()));
-      mxSetField(mx_layers, i, "type", mxCreateString(layers[i]->type_name()));
+      mxSetField(mx_layers, i, "name",
+        mxCreateString(layer_names[i].c_str()));
+      mxSetField(mx_layers, i, "type",
+        mxCreateString(layers[i]->type_name().c_str()));
 
       vector<shared_ptr<Blob<float> > >& layer_blobs = layers[i]->blobs();
-      int num_blobs = layer_blobs.size();
-      if (num_blobs == 0) {
+      if (layer_blobs.size() == 0) {
         continue;
       }
 
+      const int num_blobs[2] = {layer_blobs.size(), 1};
       mx_blob = mxCreateStructArray(1, num_blobs, 4, blobfnames);
 
-      for (unsigned int j = 0; j < num_blobs; ++j) {
-        mxSetField(mx_blob, j, "num", layer_blobs[j]->num());
-        mxSetField(mx_blob, j, "channels", layer_blobs[j]->channels());
-        mxSetField(mx_blob, j, "height", layer_blobs[j]->height());
-        mxSetField(mx_blob, j, "width", layer_blobs[j]->width());
+      for (unsigned int j = 0; j < layer_blobs.size(); ++j) {
+        mxSetField(mx_blob, j, "num",
+          mxCreateDoubleScalar(layer_blobs[j]->num()));
+        mxSetField(mx_blob, j, "channels",
+          mxCreateDoubleScalar(layer_blobs[j]->channels()));
+        mxSetField(mx_blob, j, "height",
+          mxCreateDoubleScalar(layer_blobs[j]->height()));
+        mxSetField(mx_blob, j, "width",
+          mxCreateDoubleScalar(layer_blobs[j]->width()));
       }
       mxSetField(mx_layers, i, "blobs", mx_blob);
     }
@@ -289,23 +294,28 @@ static mxArray* do_get_blobs_info() {
   const vector<shared_ptr<Blob<float> > >& blobs = net_->blobs();
   const vector<string>& blob_names = net_->blob_names();
 
-  int num_blobs = blobs.size();
+  const int num_blobs[2] = {blobs.size(), 1};
 
   // Step 1: prepare output array of structures
   mxArray* mx_blobs;
   {
     const char* fnames[5] = {"name", "num", "channels", "height", "width"};
-    mx_blobs = mxCreateStructArray(1, num_blobs, 5, fnames);
+    mx_blobs = mxCreateStructArray(2, num_blobs, 5, fnames);
   }
 
   // Step 2: copy info into output
   {
     for (unsigned int i = 0; i < num_blobs; ++i) {
-      mxSetField(mx_blobs, i, "name", mxCreateString(blob_names[i].c_str()));
-      mxSetField(mx_blobs, j, "num", layer_blobs[j]->num());
-      mxSetField(mx_blobs, j, "channels", layer_blobs[j]->channels());
-      mxSetField(mx_blobs, j, "height", layer_blobs[j]->height());
-      mxSetField(mx_blobs, j, "width", layer_blobs[j]->width());
+      mxSetField(mx_blobs, i, "name",
+        mxCreateString(blob_names[i].c_str()));
+      mxSetField(mx_blobs, i, "num",
+        mxCreateDoubleScalar(layer_blobs[i]->num()));
+      mxSetField(mx_blobs, i, "channels",
+        mxCreateDoubleScalar(layer_blobs[i]->channels()));
+      mxSetField(mx_blobs, i, "height",
+        mxCreateDoubleScalar(layer_blobs[i]->height()));
+      mxSetField(mx_blobs, i, "width",
+        mxCreateDoubleScalar(layer_blobs[i]->width()));
     }
   }
 

--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -407,19 +407,21 @@ static void init_net(MEX_ARGS) {
   }
 }
 
-static void load_model(MEX_ARGS) {
+static void load_net(MEX_ARGS) {
   if (nrhs != 1) {
     LOG(ERROR) << "Only given " << nrhs << " arguments";
     mexErrMsgTxt("Wrong number of arguments");
   }
-
+  if (net_) {
   char* model_file = mxArrayToString(prhs[0]);
 
   CheckFile(string(model_file));
   net_->CopyTrainedLayersFrom(string(model_file));
 
   mxFree(model_file);
-
+  } else {
+    mexErrMsgTxt("Need to initialize the network first with init_net");
+  }
 }
 
 static void reset(MEX_ARGS) {
@@ -495,7 +497,7 @@ static handler_registry handlers[] = {
   { "backward",           backward        },
   { "init",               init            },
   { "init_net",           init_net        },
-  { "load_model",         load_model      },
+  { "load_net",           load_net        },
   { "is_initialized",     is_initialized  },
   { "set_mode_cpu",       set_mode_cpu    },
   { "set_mode_gpu",       set_mode_gpu    },

--- a/matlab/caffe/matcaffe_demo.m
+++ b/matlab/caffe/matcaffe_demo.m
@@ -67,11 +67,13 @@ toc;
 % do forward pass to get scores
 % scores are now Width x Height x Channels x Num
 tic;
-scores = caffe('forward', input_data);
+[scores,loss] = caffe('forward', input_data);
 toc;
 
 scores = scores{1};
 size(scores)
+size(loss)
+loss
 scores = squeeze(scores);
 scores = mean(scores,2);
 

--- a/matlab/caffe/matcaffe_demo.m
+++ b/matlab/caffe/matcaffe_demo.m
@@ -67,13 +67,11 @@ toc;
 % do forward pass to get scores
 % scores are now Width x Height x Channels x Num
 tic;
-[scores,loss] = caffe('forward', input_data);
+scores = caffe('forward', input_data);
 toc;
 
 scores = scores{1};
 size(scores)
-size(loss)
-loss
 scores = squeeze(scores);
 scores = mean(scores,2);
 

--- a/matlab/caffe/matcaffe_demo.m
+++ b/matlab/caffe/matcaffe_demo.m
@@ -1,5 +1,6 @@
 function [scores, maxlabel] = matcaffe_demo(im, use_gpu)
 % scores = matcaffe_demo(im, use_gpu)
+% By default uses cpu
 %
 % Demo of the matlab wrapper using the ILSVRC network.
 %
@@ -51,17 +52,18 @@ net = CaffeNet.instance;
 if exist('use_gpu', 'var')
   if use_gpu
     net.set_mode_gpu;
+    fprintf('Done with set_mode_gpu\n');
   else
     net.set_mode_cpu;
+    fprintf('Done with set_mode_cpu\n');
   end
-  fprintf('Done with set_mode\n');
 end
 
 % put into test mode
 net.set_phase_test;
 fprintf('Done with set_phase_test\n');
 
-if nargin < 1
+if nargin < 1 || isempty(im)
   % For demo purposes we will use the peppers image
   im = imread('peppers.png');
 end

--- a/matlab/caffe/matcaffe_demo.m
+++ b/matlab/caffe/matcaffe_demo.m
@@ -47,14 +47,18 @@ function [scores, maxlabel] = matcaffe_demo(im, use_gpu)
 
 
 % init caffe network (spews logging info)
+net = CaffeNet.instance;
 if exist('use_gpu', 'var')
-  matcaffe_init(use_gpu);
-else
-  matcaffe_init();
+  if use_gpu
+    net.set_mode_gpu;
+  else
+    net.set_mode_cpu;
+  end
+  fprintf('Done with set_mode\n');
 end
 
 % put into test mode
-caffe('set_phase_test');
+net.set_phase_test;
 fprintf('Done with set_phase_test\n');
 
 if nargin < 1
@@ -71,7 +75,7 @@ toc;
 % do forward pass to get scores
 % scores are now Width x Height x Channels x Num
 tic;
-scores = caffe('forward', input_data);
+scores = net.forward(input_data);
 toc;
 
 scores = scores{1};

--- a/matlab/caffe/matcaffe_demo.m
+++ b/matlab/caffe/matcaffe_demo.m
@@ -53,6 +53,10 @@ else
   matcaffe_init();
 end
 
+% put into test mode
+caffe('set_phase_test');
+fprintf('Done with set_phase_test\n');
+
 if nargin < 1
   % For demo purposes we will use the peppers image
   im = imread('peppers.png');

--- a/matlab/caffe/matcaffe_demo_backward.m
+++ b/matlab/caffe/matcaffe_demo_backward.m
@@ -68,26 +68,29 @@ end
 net.set_phase_test;
 fprintf('Done with set_phase_test\n');
 
-% prepare oversampled input
+% prepare oversampled input (4 corners + center)x flipped
 % input_data is Height x Width x Channel x Num
 tic;
 input_data = prepare_image(im);
 toc;
 
-% do forward pass to get scores
+% Do forward pass to get scores
 % scores are now Width x Height x Channels x Num
 tic;
 scores = net.forward({input_data});
 toc;
 
-% One can permute back Width and Height.
+% Get scores of each class
 scores = scores{1};
 size(scores)
 scores = squeeze(scores);
+% Find the maximum score and its label
 [~,maxlabels] = max(scores);
 
+% Assign the scores to the output_diff to be able to backpropagate it
 output_diff(1,1,:,:) = scores;
 
+% Compute gradients based on the scores
 tic;
 gradients = net.backward({output_diff});
 toc;

--- a/matlab/caffe/matcaffe_demo_backward.m
+++ b/matlab/caffe/matcaffe_demo_backward.m
@@ -1,0 +1,137 @@
+function [scores, gradients] = matcaffe_demo_backward(im, use_gpu)
+% scores = matcaffe_demo(im, use_gpu)
+% By default uses cpu, recomeded gpu
+
+% Demo of the matlab wrapper using the ILSVRC network.
+%
+% input
+%   im       color image as uint8 HxWx3
+%   use_gpu  1 to use the GPU, 0 to use the CPU
+%
+% output
+%   scores   1000-dimensional ILSVRC score vector
+%
+% You may need to do the following before you start matlab:
+%  $ export LD_LIBRARY_PATH=/opt/intel/mkl/lib/intel64:/usr/local/cuda-5.5/lib64
+% Or the equivalent based on where things are installed on your system
+%
+% Usage:
+%  im = imread('../../examples/cat.jpg');
+%  scores = matcaffe_demo(im, 1);
+%  [score, class] = max(scores);
+
+% Five things to be aware of:
+%   caffe uses row-major order
+%   matlab uses column-major order
+%   caffe uses BGR color channel order
+%   matlab uses RGB color channel order
+%   images need to have the data mean subtracted
+
+% Data coming in from matlab needs to be in the order 
+%   [width, height, channels, images]
+% where width is the fastest dimension.
+% Here is the rough matlab for putting image data into the correct
+% format:
+%   % convert from uint8 to single
+%   im = single(im);
+%   % reshape to a fixed size (e.g., 227x227)
+%   im = imresize(im, [IMAGE_DIM IMAGE_DIM], 'bilinear');
+%   % permute from RGB to BGR and subtract the data mean (already in BGR)
+%   im = im(:,:,[3 2 1]) - data_mean;
+%   % flip width and height to make width the fastest dimension
+%   im = permute(im, [2 1 3]);
+
+% If you have multiple images, cat them with cat(4, ...)
+
+% The actual forward function. It takes in a cell array of 4-D arrays as
+% input and outputs a cell array. 
+
+% init caffe network (spews logging info)
+if nargin < 1 || isempty(im)
+  % For demo purposes we will use the peppers image
+  im = imread('peppers.png');
+end
+
+% init caffe network (spews logging info)
+net = CaffeNet.instance;
+if exist('use_gpu', 'var')
+  if use_gpu
+    net.set_mode_gpu;
+    fprintf('Done with set_mode_gpu\n');
+  else
+    net.set_mode_cpu;
+    fprintf('Done with set_mode_cpu\n');
+  end
+end
+
+% put into test mode
+net.set_phase_train;
+fprintf('Done with set_phase_train\n');
+
+% prepare oversampled input
+% input_data is Height x Width x Channel x Num
+tic;
+input_data = prepare_image(im);
+toc;
+
+% do forward pass to get scores
+% scores are now Width x Height x Channels x Num
+tic;
+scores = net.forward({input_data});
+toc;
+
+% One can permute back Width and Height.
+scores = scores{1};
+size(scores)
+scores = squeeze(scores);
+[~,maxlabels] = max(scores);
+
+output_diff(1,1,:,:) = scores;
+
+tic;
+gradients = net.backward({output_diff});
+toc;
+gradients = gradients{1};
+% Get center image and permute BGR to RGB
+img_gradients = gradients(:,:,[3 2 1],5);
+% Permute width and height back
+img_gradients = permute(img_gradients,[2 1 3]);
+% Scale gradients for easy visualization
+max_g = max(img_gradients(:));
+min_g = min(img_gradients(:));
+% Visualize the gradient of one image
+imtool(permute(input_data(:,:,[3 2 1],5),[2 1 3]));
+imtool((img_gradients)/(max_g-min_g)*2);
+
+
+% ------------------------------------------------------------------------
+function images = prepare_image(im)
+% ------------------------------------------------------------------------
+d = load('ilsvrc_2012_mean');
+IMAGE_MEAN = d.image_mean;
+IMAGE_DIM = 256;
+CROPPED_DIM = 227;
+
+% resize to fixed input size
+im = single(im);
+im = imresize(im, [IMAGE_DIM IMAGE_DIM], 'bilinear');
+% permute from RGB to BGR (IMAGE_MEAN is already BGR)
+im = im(:,:,[3 2 1]) - IMAGE_MEAN;
+
+% oversample (4 corners, center, and their x-axis flips)
+images = zeros(CROPPED_DIM, CROPPED_DIM, 3, 10, 'single');
+indices = [0 IMAGE_DIM-CROPPED_DIM] + 1;
+curr = 1;
+for i = indices
+  for j = indices
+    images(:, :, :, curr) = ...
+        permute(im(i:i+CROPPED_DIM-1, j:j+CROPPED_DIM-1, :), [2 1 3]);
+    images(:, :, :, curr+5) = images(end:-1:1, :, :, curr);
+    curr = curr + 1;
+  end
+end
+center = floor(indices(2) / 2)+1;
+images(:,:,:,5) = ...
+    permute(im(center:center+CROPPED_DIM-1,center:center+CROPPED_DIM-1,:), ...
+        [2 1 3]);
+images(:,:,:,10) = images(end:-1:1, :, :, curr);

--- a/matlab/caffe/matcaffe_demo_backward.m
+++ b/matlab/caffe/matcaffe_demo_backward.m
@@ -65,8 +65,8 @@ if exist('use_gpu', 'var')
 end
 
 % put into test mode
-net.set_phase_train;
-fprintf('Done with set_phase_train\n');
+net.set_phase_test;
+fprintf('Done with set_phase_test\n');
 
 % prepare oversampled input
 % input_data is Height x Width x Channel x Num

--- a/matlab/caffe/matcaffe_extract_weights.m
+++ b/matlab/caffe/matcaffe_extract_weights.m
@@ -1,0 +1,19 @@
+function layers = matcaffe_extract_weights()
+% layers = matcaffe_extract_weights()
+% 
+% Demo of how to extract network parameters ("weights") using the matlab
+% wrapper.
+%
+%
+% output
+%   layers   struct array of layers and their weights
+%
+% You may need to do the following before you start matlab:
+%  $ export LD_LIBRARY_PATH=/opt/intel/mkl/lib/intel64:/usr/local/cuda/lib64
+%  $ export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
+% Or the equivalent based on where things are installed on your system
+
+% init caffe network (spews logging info)
+net = CaffeNet.instance;
+
+layers = net.weights;

--- a/matlab/caffe/matcaffe_init.m
+++ b/matlab/caffe/matcaffe_init.m
@@ -39,6 +39,3 @@ else
 end
 fprintf('Done with set_mode\n');
 
-% put into test mode
-caffe('set_phase_test');
-fprintf('Done with set_phase_test\n');

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -124,6 +124,12 @@ void Caffe::set_random_seed(const unsigned int seed) {
   Get().random_generator_.reset(new RNG(seed));
 }
 
+int Caffe::GetDevice() {
+  int current_device;
+  CUDA_CHECK(cudaGetDevice(&current_device));
+  return current_device;
+}
+
 void Caffe::SetDevice(const int device_id) {
   int current_device;
   CUDA_CHECK(cudaGetDevice(&current_device));

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -529,6 +529,7 @@ const vector<Blob<Dtype>*>& Net<Dtype>::ForwardPrefilled(Dtype* loss) {
   } else {
     ForwardFromTo(0, layers_.size() - 1);
   }
+  DLOG(INFO) << "loss: " << *loss;
   return net_output_blobs_;
 }
 

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -529,7 +529,6 @@ const vector<Blob<Dtype>*>& Net<Dtype>::ForwardPrefilled(Dtype* loss) {
   } else {
     ForwardFromTo(0, layers_.size() - 1);
   }
-  LOG(INFO) << "loss in caffe: " << *loss;
   return net_output_blobs_;
 }
 

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -529,6 +529,7 @@ const vector<Blob<Dtype>*>& Net<Dtype>::ForwardPrefilled(Dtype* loss) {
   } else {
     ForwardFromTo(0, layers_.size() - 1);
   }
+  LOG(INFO) << "loss in caffe: " << *loss;
   return net_output_blobs_;
 }
 


### PR DESCRIPTION
Inspired by PyCaffe, a new and completely renovated MatCaffe interface (although backward compatible).

Now there is class CaffeNet that handle all the interactions with caffe. 

New Features:
- `net = CaffeNet.instance` gets a instance of caffe network using default imagenet_deploy and caffe_reference_model
- `net = CaffeNet.instance(model_def_file, model_file)` gets an instance of caffe network using the parameters specified.
```
net = 
  CaffeNet with properties:

    model_def_file: '../../examples/imagenet/imagenet_deploy.prototxt'
        model_file: '../../examples/imagenet/caffe_reference_imagenet_model'
       layers_info: [23x1 struct]
        blobs_info: [15x1 struct]
              mode: 'CPU'
             phase: 'TRAIN'
         device_id: 0
       input_blobs: []
      output_blobs: []
           weights: [8x1 struct]
```
- Now one can set mode, phase or device_id, just by assigning the properties or using the corresponding methods.
``` net.phase = 'TEST'; net.set_phase_test; net.set_phase('TEST');```
```net.mode = 'GPU'; net.set_mode_gpu; net_set_mode('GPU');```
```net.device_id = 1;net.set_device(1); ```

- One can access the weights of the network just by 
```
net.weights   
8x1 struct array with fields:

    layer_name
    weights
```
-  More amazingly can change the weights of the network by just assigning a new set of weights, for example changing the bias of the first layer `conv1`.
```
new_weights = net.weights;
new_weights(1)                    
    layer_name: 'conv1'
       weights: {2x1 cell}
new_weights(1).weights{2}(:) = 0; 
net.weights = new_weights;
```
- Then one can save the new network in a different model_file
```
net.save_net('path_to/new_model')
```

- And load it later
```
net.load_net('path_to/new_model')
```

More examples about new features to follow.