### PR TITLE
Add comment for how to set the CUDA path when cuda tools are installed b...

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -3,6 +3,9 @@
 
 # CUDA directory contains bin/ and lib/ directories that we need.
 CUDA_DIR := /usr/local/cuda
+# On Ubuntu 14.04, if cuda tools are installed via
+# "sudo apt-get install nvidia-cuda-toolkit" then use this instead:
+# CUDA_DIR := /usr
 
 # CUDA architecture setting: going with all of them.
 CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \


### PR DESCRIPTION
...y package manager.

This is a trivial modification to the Makefile.config.example file for installing on Ubuntu 14.04. 

Mainly I'm trying to see if I can figure out how github, git and "pull requests" work. This seemed like an innocuous change to submit. I expect you'll let me know if I'm doing something wrong.

BTW, to get it building on Ubuntu 14.04, I also had to modify the Makefile to specify g++-4.6 compiler instead of g++. But since I don't expect we want to hard-wire a particular compiler version in the Makefile, I left that change out.
