### PR TITLE
Fix Caffe::SetDevice to avoid initializing on default device

### DIFF
--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -69,11 +69,13 @@ void Caffe::SetDevice(const int device_id) {
   if (current_device == device_id) {
     return;
   }
+  // The call to cudaSetDevice must come before any calls to Get, which
+  // may perform initialization using the GPU.
+  CUDA_CHECK(cudaSetDevice(device_id));
   if (Get().cublas_handle_) CUBLAS_CHECK(cublasDestroy(Get().cublas_handle_));
   if (Get().curand_generator_) {
     CURAND_CHECK(curandDestroyGenerator(Get().curand_generator_));
   }
-  CUDA_CHECK(cudaSetDevice(device_id));
   CUBLAS_CHECK(cublasCreate(&Get().cublas_handle_));
   CURAND_CHECK(curandCreateGenerator(&Get().curand_generator_,
       CURAND_RNG_PSEUDO_DEFAULT));


### PR DESCRIPTION
This PR addresses #440 by moving the call to `cudaSetDevice` before any calls to `Get`, which may perform GPU memory allocation.

Despite what is written in #440, this _can_ be used in Python without any further changes, provided (somewhat counterintuitively) one calls `Net.set_device` before `Net.set_mode_gpu`.

AFAICT there is no need for the `cu*Destroy` cleanup to come before `cudaSetDevice`; let me know if you think otherwise.
