### PR TITLE
No backward in the feature extraction network

### DIFF
--- a/examples/feature_extraction/imagenet_val.prototxt
+++ b/examples/feature_extraction/imagenet_val.prototxt
@@ -19,6 +19,8 @@ layers {
   type: CONVOLUTION
   bottom: "data"
   top: "conv1"
+  blobs_lr: 0
+  blobs_lr: 0
   convolution_param {
     num_output: 96
     kernel_size: 11
@@ -58,6 +60,8 @@ layers {
   type: CONVOLUTION
   bottom: "norm1"
   top: "conv2"
+  blobs_lr: 0
+  blobs_lr: 0
   convolution_param {
     num_output: 256
     pad: 2
@@ -98,6 +102,8 @@ layers {
   type: CONVOLUTION
   bottom: "norm2"
   top: "conv3"
+  blobs_lr: 0
+  blobs_lr: 0
   convolution_param {
     num_output: 384
     pad: 1
@@ -115,6 +121,8 @@ layers {
   type: CONVOLUTION
   bottom: "conv3"
   top: "conv4"
+  blobs_lr: 0
+  blobs_lr: 0
   convolution_param {
     num_output: 384
     pad: 1
@@ -133,6 +141,8 @@ layers {
   type: CONVOLUTION
   bottom: "conv4"
   top: "conv5"
+  blobs_lr: 0
+  blobs_lr: 0
   convolution_param {
     num_output: 256
     pad: 1
@@ -162,6 +172,8 @@ layers {
   type: INNER_PRODUCT
   bottom: "pool5"
   top: "fc6"
+  blobs_lr: 0
+  blobs_lr: 0
   inner_product_param {
     num_output: 4096
   }
@@ -186,6 +198,8 @@ layers {
   type: INNER_PRODUCT
   bottom: "fc6"
   top: "fc7"
+  blobs_lr: 0
+  blobs_lr: 0
   inner_product_param {
     num_output: 4096
   }
@@ -210,6 +224,8 @@ layers {
   type: INNER_PRODUCT
   bottom: "fc7"
   top: "fc8"
+  blobs_lr: 0
+  blobs_lr: 0
   inner_product_param {
     num_output: 1000
   }


### PR DESCRIPTION
Because the learning rate is default to be 1 and backward is default to be true (#389), even though the phase is set to `Caffe::TEST`, the feature extraction network still performs backward propagation unnecessarily.
