### PR TITLE
There are 256 filters in conv2.

### DIFF
--- a/examples/filter_visualization.ipynb
+++ b/examples/filter_visualization.ipynb
@@ -298,7 +298,7 @@
      "source": [
       "The second layer filters, `conv2`\n",
       "\n",
-      "There are 128 filters, each of which has dimension 5 x 5 x 48. We show only the first 48 filters, with each channel shown separately, so that each filter is a row."
+      "There are 256 filters, each of which has dimension 5 x 5 x 48. We show only the first 48 filters, with each channel shown separately, so that each filter is a row."
      ]
     },
     {


### PR DESCRIPTION
AlexNet paper splits conv2 into two GPU's, each with 128 filters. Reference paper: http://www.cs.toronto.edu/~fritz/absps/imagenet.pdf Applying #528 to dev instead of master per @Yangqing.
