### PR TITLE
Always create CAFFE:RNG for prefetch thread to simplify logic

### DIFF
--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -317,16 +317,9 @@ void DataLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
 
 template <typename Dtype>
 void DataLayer<Dtype>::CreatePrefetchThread() {
-  phase_ = Caffe::phase();
-  const bool prefetch_needs_rand = (phase_ == Caffe::TRAIN) &&
-      (this->layer_param_.data_param().mirror() ||
-       this->layer_param_.data_param().crop_size());
-  if (prefetch_needs_rand) {
-    const unsigned int prefetch_rng_seed = caffe_rng_rand();
-    prefetch_rng_.reset(new Caffe::RNG(prefetch_rng_seed));
-  } else {
-    prefetch_rng_.reset();
-  }
+  // Create Caffe::RNG for the thread
+  const unsigned int prefetch_rng_seed = caffe_rng_rand();
+  prefetch_rng_.reset(new Caffe::RNG(prefetch_rng_seed));
   // Create the thread.
   CHECK(!pthread_create(&thread_, NULL, DataLayerPrefetch<Dtype>,
         static_cast<void*>(this))) << "Pthread execution failed.";

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -233,16 +233,9 @@ void ImageDataLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
 
 template <typename Dtype>
 void ImageDataLayer<Dtype>::CreatePrefetchThread() {
-  phase_ = Caffe::phase();
-  const bool prefetch_needs_rand =
-      this->layer_param_.image_data_param().shuffle() ||
-      this->layer_param_.image_data_param().crop_size();
-  if (prefetch_needs_rand) {
-    const unsigned int prefetch_rng_seed = caffe_rng_rand();
-    prefetch_rng_.reset(new Caffe::RNG(prefetch_rng_seed));
-  } else {
-    prefetch_rng_.reset();
-  }
+  // Create Caffe::RNG for the thread
+  const unsigned int prefetch_rng_seed = caffe_rng_rand();
+  prefetch_rng_.reset(new Caffe::RNG(prefetch_rng_seed));
   // Create the thread.
   CHECK(!pthread_create(&thread_, NULL, ImageDataLayerPrefetch<Dtype>,
         static_cast<void*>(this))) << "Pthread execution failed.";

--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -411,15 +411,9 @@ void WindowDataLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
 
 template <typename Dtype>
 void WindowDataLayer<Dtype>::CreatePrefetchThread() {
-  const bool prefetch_needs_rand =
-      this->layer_param_.window_data_param().mirror() ||
-      this->layer_param_.window_data_param().crop_size();
-  if (prefetch_needs_rand) {
-    const unsigned int prefetch_rng_seed = caffe_rng_rand();
-    prefetch_rng_.reset(new Caffe::RNG(prefetch_rng_seed));
-  } else {
-    prefetch_rng_.reset();
-  }
+  // Create Caffe::RNG for the thread
+  const unsigned int prefetch_rng_seed = caffe_rng_rand();
+  prefetch_rng_.reset(new Caffe::RNG(prefetch_rng_seed));
   // Create the thread.
   CHECK(!pthread_create(&thread_, NULL, WindowDataLayerPrefetch<Dtype>,
         static_cast<void*>(this))) << "Pthread execution failed.";


### PR DESCRIPTION
To avoid untested cases in the `Data_layer`, `Image_Data_Layer` and `Window_Data_Layer` always create the random number generator.
This should fix #553 #508 and should help in the Data source redesign @Yangqing 
