### PR TITLE
Transform layers [DON'T MERGE]

### DIFF
--- a/include/caffe/transform_layers.hpp
+++ b/include/caffe/transform_layers.hpp
@@ -1,0 +1,126 @@
+// Copyright 2014 BVLC and contributors.
+
+#ifndef CAFFE_TRANSFORM_LAYERS_HPP_
+#define CAFFE_TRANSFORM_LAYERS_HPP_
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pthread.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/* TransformationLayer
+
+  An interface for layers that take a vector of blobs as input (x),
+  and produce a vector of transformed blobs as output (y=f(x)).
+  For now meant to be used within the data layer for preprocessing
+  For example Crop_Mirror, Center_Scale, ...
+
+*/
+template <typename Dtype>
+class TransformationLayer : public Layer<Dtype> {
+ public:
+  explicit TransformationLayer(const LayerParameter& param)
+     : Layer<Dtype>(param) {}
+  virtual void SetUp(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+
+  virtual inline LayerParameter_LayerType type() const {
+    return LayerParameter_LayerType_NONE;
+  }
+  virtual inline int MinNumBottomBlobs() const { return 1; }
+  virtual inline int MinNumTopBlobs() const { return 1; }
+};
+
+/* Crop_Mirror
+
+  Allows to crop portions of the blobs and flip horizontally at
+  the same time. 
+
+*/
+template <typename Dtype>
+class CropMirrorLayer : public TransformationLayer<Dtype> {
+ public:
+  explicit CropMirrorLayer(const LayerParameter& param)
+      : TransformationLayer<Dtype>(param) {}
+
+  virtual inline LayerParameter_LayerType type() const {
+    return LayerParameter_LayerType_CROP_MIRROR;
+  }
+
+ protected:
+  virtual Dtype Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom) {
+    NOT_IMPLEMENTED;
+  int crop_size_;
+  bool mirror_;
+};
+
+/* Center_Scale
+
+  Allows to center values by removing a predifined mean value/s or mean_blob.
+  Also allows to scale the values at the same time.
+
+*/
+template <typename Dtype>
+class CenterScaleLayer : public TransformationLayer<Dtype> {
+ public:
+  explicit CenterScaleLayer(const LayerParameter& param)
+      : TransformationLayer<Dtype>(param) {}
+
+  virtual inline LayerParameter_LayerType type() const {
+    return LayerParameter_LayerType_CENTER_SCALE;
+  }
+
+ protected:
+  virtual Dtype Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom) {
+    NOT_IMPLEMENTED;
+
+  Blob<Dtype> data_mean_;
+  bool has_mean_file_;
+  bool has_scale_;
+  Dtype scale_;
+  std::vector<Dtype> mean_values_;
+  std::vector<Dtype> scale_values_;
+
+};
+
+/* Color Jittering 
+
+  Creates random perturbation of the color space
+
+*/
+template <typename Dtype>
+class ColorJitteringLayer : public TransformationLayer<Dtype> {
+ public:
+  explicit ColorJitteringLayer(const LayerParameter& param)
+      : TransformationLayer<Dtype>(param) {}
+
+  virtual inline LayerParameter_LayerType type() const {
+    return LayerParameter_LayerType_COLOR_JITTERING;
+  }
+
+ protected:
+  virtual Dtype Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom) {
+    NOT_IMPLEMENTED;
+
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_TRANSFORM_LAYERS_HPP_

--- a/include/caffe/transform_layers.hpp
+++ b/include/caffe/transform_layers.hpp
@@ -90,8 +90,6 @@ class CenterScaleLayer : public TransformationLayer<Dtype> {
 
   Blob<Dtype> data_mean_;
   bool has_mean_file_;
-  bool has_scale_;
-  Dtype scale_;
   std::vector<Dtype> mean_values_;
   std::vector<Dtype> scale_values_;
 

--- a/src/caffe/layers/center_scale_layer.cpp
+++ b/src/caffe/layers/center_scale_layer.cpp
@@ -1,0 +1,123 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/transfrom_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void CenterScaleLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top) {
+  TransformLayer<Dtype>::SetUp(bottom, top);
+  
+  // Initialize the mean/s
+  
+  has_mean_file_ = this->layer_param_.centerscale_param().has_mean_file();
+  if (has_mean_file_) {
+    const string& mean_file = this->layer_param_.centerscale_param().mean_file();
+    LOG(INFO) << "Loading mean file from" << mean_file;
+    BlobProto blob_proto;
+    ReadProtoFromBinaryFileOrDie(mean_file.c_str(), &blob_proto);
+    data_mean_.FromProto(blob_proto);
+  }
+
+  int size_mean_value_ = this->layer_param_.centerscale_param().size_mean_value();
+  if (size_mean_value_ > 0) {
+    CHECK(!has_mean_file_) <<
+      "Cannot specify mean_file and mean_value at the same time";
+    for (int i = 0; i < size_mean_value_; ++i) {
+      Dtype mean_value_ = this->layer_param_.centerscale_param().mean_value(i);
+      mean_values_.pushback(mean_value_);
+    }
+  }
+
+  // Initialize the scale/s
+  int size_scale_value_ = this->layer_param_.centerscale_param().size_scale_value();
+  if (size_scale_value_ > 0) {
+    for (int i = 0; i < size_scale_value_; ++i) {
+      Dtype scale_value_ = this->layer_param_.centerscale_param().scale_value(i);
+      scale_values_.pushback(scale_value_);
+    } 
+  }
+
+  // Initialize top blobs with the same size as bottom if not in-place
+  for (int i = 1; i < bottom.size(); ++i) {
+    if (bottom[i] != (*top)[i]) {
+      (*top)[i]->ReshapeLike(bottom[i]);  
+    }
+  }
+}
+
+template <typename Dtype>
+Dtype CenterScaleLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top) {
+
+  for (int i = 0; i < bottom.size(); ++i) {
+    int count = (*top)[i]->count();
+    int num = (*top)[i]->num();
+    int channels = (*top)[i]->channels();
+    int dim = count / num;
+    // Copy bottom_blob to top_blob
+    Dtype* top_data = (*top)[i]->mutable_cpu_data();
+    caffe_copy(count, bottom[i]->cpu_data(), top_data);
+    if (has_mean_file_) {
+      // Subtract the data_mean
+      CHECK_EQ(count, data_mean_->count());
+      caffe_apxy(count, Dtype(-1), data_mean_->cpu_data(), top_data);
+    } else {
+      switch (mean_values_->size()) {
+      case 0:
+        // Do nothing
+        break;
+      case 1:
+        // Subtract mean_value
+        Dtype mean_value = mean_values_[0];
+        caffe_add_scalar(count, -mean_value, top_data);
+        break;
+      default:
+        CHECK_EQ(channels, mean_values_->size()) <<
+          "The number of mean_value_ should match the number of channels";
+        // Subtract mean_value per channel
+        for (int c = 0; c < channels; ++c) {
+          Dtype mean_value = mean_values_[c];
+          for (int n = 0; n < num; ++n) {
+            int offset = (*top)[i]->offset(n,c);
+            caffe_add_scalar(dim, -mean_value, top_data + offset);
+          }
+        }
+      }
+    }
+
+    // Scale the values
+    switch (scale_values_->size()) {
+    case 0:
+      // Do nothing
+      break;
+    case 1:
+      Dtype scale_value_ = scale_values_[0];
+      caffe_scal(count, scale_value_, top_data);
+      break;
+    default:
+      CHECK(channels, scale_values_->size()) <<
+        "The number of scale_value should match the number of channels";
+      // Scale every channel independently
+      for (int c = 0; c < channels; ++c) {
+        Dtype scale_value_ = scale_values_[c];
+        for (int n = 0; n < num; ++n) {
+          int offset = (*top)[i]->offset(n,c);
+          caffe_scal(count, scale_value_, top_data + offset);
+        }
+      }
+    }
+  }
+
+  return Dtype(0.);
+}
+
+
+INSTANTIATE_CLASS(CenterScaleLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/crop_mirror_layer.cpp
+++ b/src/caffe/layers/crop_mirror_layer.cpp
@@ -1,0 +1,49 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/transfrom_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void CropMirrorLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top) {
+  TransformLayer<Dtype>::SetUp(bottom, top);
+  
+  crop_size_ = this->layer_param_.cropmirror_param().crop_size();
+  mirror_ = this->layer_param_.cropmirror_param().mirror();
+
+  CHECK_GE(crop_size_, 0) <<
+    "crop_size_ should be >= 0";
+ 
+  // Initialize with the top blobs.
+  for (int i = 1; i < bottom.size(); ++i) {
+    CHECK_GE(bottom[i]->height(), crop_size_);
+    CHECK_GE(bottom[i]->width(), crop_size_);
+    if (crop_size_ > 0) {
+      (*top)[i]->Reshape(bottom[i]->num(), bottom[i]->channels(), crop_size_, crop_size_);
+    } else {
+      (*top)[i]->ReshapeLike(bottom[i]);
+    }
+  }
+}
+
+template <typename Dtype>
+Dtype CropMirrorLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top) {
+
+  for (int i = 0; i < bottom.size(); ++i) {
+    // crop_mirror each blob
+    caffe_crop_mirror(bottom[i], crop_size_, mirror_, (*top)[i]);
+  }
+
+  return Dtype(0.);
+}
+
+
+INSTANTIATE_CLASS(CropMirrorLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/transform_layer.cpp
+++ b/src/caffe/layers/transform_layer.cpp
@@ -1,0 +1,21 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/tranform_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void TransformLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top) {
+  Layer<Dtype>::SetUp(bottom, top);
+  // TransformLayer should maintain the same number of blobs
+  CHECK_EQ(bottom.size(), top->size()) <<
+  	"TransformLayers should have the same number of bottom and top blobs";
+}
+
+INSTANTIATE_CLASS(TransformLayer);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -127,7 +127,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 33 (last added: DUMMY_DATA)
+  // LayerType next available ID: 34 (last added: CENTER_SCALE)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if
@@ -136,6 +136,7 @@ message LayerParameter {
     ACCURACY = 1;
     ARGMAX = 30;
     BNLL = 2;
+    CENTER_SCALE = 34;
     CONCAT = 3;
     CONVOLUTION = 4;
     DATA = 5;
@@ -188,8 +189,10 @@ message LayerParameter {
   // The weight decay that is multiplied on the global weight decay.
   repeated float weight_decay = 8;
 
+  // Layerparm next available ID: 31 (last added: CenterScaleParameter)
   optional AccuracyParameter accuracy_param = 27;
   optional ArgMaxParameter argmax_param = 23;
+  optional CenterScaleParameter center_scale_param = 30;
   optional ConcatParameter concat_param = 9;
   optional ConvolutionParameter convolution_param = 10;
   optional DataParameter data_param = 11;
@@ -227,6 +230,13 @@ message AccuracyParameter {
 message ArgMaxParameter {
   // If true produce pairs (argmax, maxval)
   optional bool out_max_val = 1 [default = false];
+}
+
+// Message that stores parameters used by CenterScaleLayer
+message CenterScaleParameter {
+  optional string mean_file = 1;
+  repeated float mean_value = 2;
+  repeated float scale_value = 3;
 }
 
 // Message that stores parameters used by ConcatLayer


### PR DESCRIPTION
This is a tentative approach to add transformation layers that would allow to crop_mirror, center_scale the blobs.

The first use would be to help Data source and pre-processing separation. The source would produce a vector of blobs, one per image, the transformation layers and finally concat all the blobs into one.

The concept is similar to do `map(transformation, bottom_blobs, top_blobs)` 

@Yangqing What do you think?