### PR TITLE
Implement the triplet ranking hinge loss layer

### DIFF
--- a/include/caffe/loss_layers.hpp
+++ b/include/caffe/loss_layers.hpp
@@ -204,6 +204,29 @@ class HingeLossLayer : public LossLayer<Dtype> {
       const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom);
 };
 
+/* TripletRankingHingeLossLayer
+*/
+template <typename Dtype>
+class TripletRankingHingeLossLayer : public LossLayer<Dtype> {
+ public:
+  explicit TripletRankingHingeLossLayer(const LayerParameter& param)
+      : LossLayer<Dtype>(param) {}
+
+  virtual inline LayerParameter_LayerType type() const {
+    return LayerParameter_LayerType_TRIPLET_RANKING_HINGE_LOSS;
+  }
+  // 0: Query feature
+  // 1: Similar sample feature
+  // 2: Dissimilar sample feature
+  virtual inline int ExactNumBottomBlobs() const { return 3; }
+
+ protected:
+  virtual Dtype Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom);
+};
+
 /* MultinomialLogisticLossLayer
 */
 template <typename Dtype>

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -82,6 +82,8 @@ Layer<Dtype>* GetLayer(const LayerParameter& param) {
     return new SplitLayer<Dtype>(param);
   case LayerParameter_LayerType_TANH:
     return new TanHLayer<Dtype>(param);
+  case LayerParameter_LayerType_TRIPLET_RANKING_HINGE_LOSS:
+    return new TripletRankingHingeLossLayer<Dtype>(param);
   case LayerParameter_LayerType_WINDOW_DATA:
     return new WindowDataLayer<Dtype>(param);
   case LayerParameter_LayerType_NONE:

--- a/src/caffe/layers/triplet_ranking_hinge_loss_layer.cpp
+++ b/src/caffe/layers/triplet_ranking_hinge_loss_layer.cpp
@@ -1,0 +1,104 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <algorithm>
+#include <cmath>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/util/io.hpp"
+
+namespace caffe {
+
+using std::max;
+
+template <typename Dtype>
+Dtype TripletRankingHingeLossLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom, vector<Blob<Dtype>*>* top) {
+  const Dtype* query_data = bottom[0]->cpu_data();
+  const Dtype* similar_sample_data = bottom[1]->cpu_data();
+  const Dtype* dissimilar_sample_data = bottom[2]->cpu_data();
+  Dtype* similar_sample_diff = bottom[1]->mutable_cpu_diff();
+  Dtype* dissimilar_sample_diff = bottom[2]->mutable_cpu_diff();
+  int num = bottom[0]->num();
+  int count = bottom[0]->count();
+  int dim = count / num;
+  caffe_sub(count, query_data, similar_sample_data,
+            similar_sample_diff);
+  caffe_sub(count, query_data, dissimilar_sample_data,
+            dissimilar_sample_diff);
+
+  Dtype loss = 0;
+  Dtype query_similar_distance_norm;
+  Dtype query_dissimilar_distance_norm;
+  switch (this->layer_param_.triplet_ranking_hinge_loss_param().norm()) {
+  case TripletRankingHingeLossParameter_Norm_L1: {
+    for (int i = 0; i < num; ++i) {
+      query_similar_distance_norm = caffe_cpu_asum(
+          dim, similar_sample_diff + bottom[1]->offset(i));
+      query_dissimilar_distance_norm = caffe_cpu_asum(
+          dim, dissimilar_sample_diff + bottom[2]->offset(i));
+      loss += max(Dtype(0), query_similar_distance_norm -
+                  query_dissimilar_distance_norm + 1);
+    }
+    break;
+  }
+  case TripletRankingHingeLossParameter_Norm_L2: {
+    for (int i = 0; i < num; ++i) {
+      query_similar_distance_norm = caffe_cpu_dot(
+          dim, similar_sample_diff + bottom[1]->offset(i),
+          similar_sample_diff + bottom[1]->offset(i));
+      query_dissimilar_distance_norm = caffe_cpu_dot(
+          dim, dissimilar_sample_diff + bottom[2]->offset(i),
+          dissimilar_sample_diff + bottom[2]->offset(i));
+      loss += max(Dtype(0), query_similar_distance_norm -
+                  query_dissimilar_distance_norm + 1);
+    }
+    break;
+  }
+  default: {
+    LOG(FATAL) << "Unknown TripletRankingHingeLoss norm " <<
+        this->layer_param_.triplet_ranking_hinge_loss_param().norm();
+  }
+  }
+  return loss / num;
+}
+
+template <typename Dtype>
+void TripletRankingHingeLossLayer<Dtype>::Backward_cpu(
+    const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+    vector<Blob<Dtype>*>* bottom) {
+  if (propagate_down[0]) {
+//    const Dtype* top_diff = top[0]->cpu_diff();
+    Dtype* similar_sample_diff = (*bottom)[1]->mutable_cpu_diff();
+    Dtype* dissimilar_sample_diff = (*bottom)[2]->mutable_cpu_diff();
+
+    int num = (*bottom)[0]->num();
+    int count = (*bottom)[0]->count();
+
+    switch (this->layer_param_.triplet_ranking_hinge_loss_param().norm()) {
+    case TripletRankingHingeLossParameter_Norm_L1: {
+      caffe_cpu_sign(count, similar_sample_diff, similar_sample_diff);
+      caffe_scal(count, Dtype(-1. / num), similar_sample_diff);
+      caffe_cpu_sign(count, dissimilar_sample_diff, dissimilar_sample_diff);
+      caffe_scal(count, Dtype(1. / num), similar_sample_diff);
+      break;
+    }
+    case TripletRankingHingeLossParameter_Norm_L2: {
+      caffe_scal(count, Dtype(-2. / num), similar_sample_diff);
+      caffe_scal(count, Dtype(2. / num), dissimilar_sample_diff);
+      break;
+    }
+    default: {
+      LOG(FATAL) << "Unknown TripletRankingHingeLoss norm " <<
+          this->layer_param_.triplet_ranking_hinge_loss_param().norm();
+    }
+    }
+  }
+}
+
+INSTANTIATE_CLASS(TripletRankingHingeLossLayer);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -115,7 +115,7 @@ message SolverState {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available ID: 28 (last added: accuracy_param)
+// LayerParameter next available ID: 31 (last added: triplet_ranking_hinge_loss_param)
 message LayerParameter {
   repeated string bottom = 2; // the name of the bottom blobs
   repeated string top = 3; // the name of the top blobs
@@ -127,7 +127,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 33 (last added: DUMMY_DATA)
+  // LayerType next available ID: 34 (last added: TRIPLET_RANKING_HINGE_LOSS)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if
@@ -163,6 +163,7 @@ message LayerParameter {
     SOFTMAX_LOSS = 21;
     SPLIT = 22;
     TANH = 23;
+    TRIPLET_RANKING_HINGE_LOSS = 33;
     WINDOW_DATA = 24;
     THRESHOLD = 31;
   }
@@ -198,6 +199,7 @@ message LayerParameter {
   optional EltwiseParameter eltwise_param = 24;
   optional HDF5DataParameter hdf5_data_param = 13;
   optional HDF5OutputParameter hdf5_output_param = 14;
+  optional HingeLossParameter hinge_loss_param = 29;
   optional ImageDataParameter image_data_param = 15;
   optional InfogainLossParameter infogain_loss_param = 16;
   optional InnerProductParameter inner_product_param = 17;
@@ -205,9 +207,9 @@ message LayerParameter {
   optional MemoryDataParameter memory_data_param = 22;
   optional PoolingParameter pooling_param = 19;
   optional PowerParameter power_param = 21;
-  optional WindowDataParameter window_data_param = 20;
   optional ThresholdParameter threshold_param = 25;
-  optional HingeLossParameter hinge_loss_param = 29;
+  optional TripletRankingHingeLossParameter triplet_ranking_hinge_loss_param = 30;
+  optional WindowDataParameter window_data_param = 20;
 
   // DEPRECATED: The layer parameters specified as a V0LayerParameter.
   // This should never be used by any code except to upgrade to the new
@@ -307,11 +309,6 @@ message EltwiseParameter {
   }
   optional EltwiseOp operation = 1 [default = SUM]; // element-wise operation
   repeated float coeff = 2; // blob-wise coefficient for SUM operation
-}
-
-// Message that stores parameters used by ThresholdLayer
-message ThresholdParameter {
-  optional float threshold = 1 [default = 0]; // Strictly Positive values
 }
 
 // Message that stores parameters used by HDF5DataLayer
@@ -418,6 +415,20 @@ message PowerParameter {
   optional float power = 1 [default = 1.0];
   optional float scale = 2 [default = 1.0];
   optional float shift = 3 [default = 0.0];
+}
+
+// Message that stores parameters used by ThresholdLayer
+message ThresholdParameter {
+  optional float threshold = 1 [default = 0]; // Strictly Positive values
+}
+
+message TripletRankingHingeLossParameter {
+  enum Norm {
+    L1 = 1;
+    L2 = 2;
+  }
+  // Specify the Norm to use L1 or L2
+  optional Norm norm = 1 [default = L2];
 }
 
 // Message that stores parameters used by WindowDataLayer

--- a/src/caffe/test/test_triplet_ranking_hinge_loss_layer.cpp
+++ b/src/caffe/test/test_triplet_ranking_hinge_loss_layer.cpp
@@ -1,0 +1,111 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "cuda_runtime.h"
+#include "gtest/gtest.h"
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/vision_layers.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+extern cudaDeviceProp CAFFE_TEST_CUDA_PROP;
+
+template <typename Dtype>
+class TripletRankingHingeLossLayerTest : public ::testing::Test {
+ protected:
+  TripletRankingHingeLossLayerTest()
+      : blob_bottom_query_(new Blob<Dtype>(10, 11, 1, 1)),
+        blob_bottom_similar_sample_(new Blob<Dtype>(10, 11, 1, 1)),
+        blob_bottom_dissimilar_sample_(new Blob<Dtype>(10, 11, 1, 1)) {
+    // fill the values
+    FillerParameter filler_param;
+    filler_param.set_std(10);
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_query_);
+    filler.Fill(this->blob_bottom_similar_sample_);
+    filler.Fill(this->blob_bottom_dissimilar_sample_);
+    blob_bottom_vec_.push_back(blob_bottom_query_);
+    blob_bottom_vec_.push_back(blob_bottom_similar_sample_);
+    blob_bottom_vec_.push_back(blob_bottom_dissimilar_sample_);
+  }
+  virtual ~TripletRankingHingeLossLayerTest() {
+    delete blob_bottom_query_;
+    delete blob_bottom_similar_sample_;
+    delete blob_bottom_dissimilar_sample_;
+  }
+  Blob<Dtype>* const blob_bottom_query_;
+  Blob<Dtype>* const blob_bottom_similar_sample_;
+  Blob<Dtype>* const blob_bottom_dissimilar_sample_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+typedef ::testing::Types<float, double> Dtypes;
+TYPED_TEST_CASE(TripletRankingHingeLossLayerTest, Dtypes);
+
+TYPED_TEST(TripletRankingHingeLossLayerTest, TestGradientL1CPU) {
+  Caffe::set_mode(Caffe::CPU);
+  LayerParameter layer_param;
+  TripletRankingHingeLossParameter* triplet_ranking_hinge_loss_param =
+      layer_param.mutable_triplet_ranking_hinge_loss_param();
+  triplet_ranking_hinge_loss_param->set_norm(
+      TripletRankingHingeLossParameter_Norm_L1);
+  TripletRankingHingeLossLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, &this->blob_top_vec_);
+  GradientChecker<TypeParam> checker(1e-2, 1e-3, 1701, 1, 0.01);
+  checker.CheckGradientSingle(&layer, &(this->blob_bottom_vec_),
+      &(this->blob_top_vec_), 0, -1, -1);
+}
+
+TYPED_TEST(TripletRankingHingeLossLayerTest, TestGradientL1GPU) {
+  Caffe::set_mode(Caffe::GPU);
+  LayerParameter layer_param;
+  TripletRankingHingeLossParameter* triplet_ranking_hinge_loss_param =
+      layer_param.mutable_triplet_ranking_hinge_loss_param();
+  triplet_ranking_hinge_loss_param->set_norm(
+      TripletRankingHingeLossParameter_Norm_L1);
+  TripletRankingHingeLossLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, &this->blob_top_vec_);
+  GradientChecker<TypeParam> checker(1e-2, 1e-3, 1701, 1, 0.01);
+  checker.CheckGradientSingle(&layer, &(this->blob_bottom_vec_),
+      &(this->blob_top_vec_), 0, -1, -1);
+}
+
+TYPED_TEST(TripletRankingHingeLossLayerTest, TestGradientL2CPU) {
+  Caffe::set_mode(Caffe::CPU);
+  LayerParameter layer_param;
+  TripletRankingHingeLossParameter* triplet_ranking_hinge_loss_param =
+      layer_param.mutable_triplet_ranking_hinge_loss_param();
+  triplet_ranking_hinge_loss_param->set_norm(
+      TripletRankingHingeLossParameter_Norm_L2);
+  TripletRankingHingeLossLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, &this->blob_top_vec_);
+  GradientChecker<TypeParam> checker(1e-2, 1e-3, 1701, 1, 0.01);
+  checker.CheckGradientSingle(&layer, &(this->blob_bottom_vec_),
+      &(this->blob_top_vec_), 0, -1, -1);
+}
+
+TYPED_TEST(TripletRankingHingeLossLayerTest, TestGradientL2GPU) {
+  Caffe::set_mode(Caffe::GPU);
+  LayerParameter layer_param;
+  TripletRankingHingeLossParameter* triplet_ranking_hinge_loss_param =
+      layer_param.mutable_triplet_ranking_hinge_loss_param();
+  triplet_ranking_hinge_loss_param->set_norm(
+      TripletRankingHingeLossParameter_Norm_L2);
+  TripletRankingHingeLossLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, &this->blob_top_vec_);
+  GradientChecker<TypeParam> checker(1e-2, 1e-3, 1701, 1, 0.01);
+  checker.CheckGradientSingle(&layer, &(this->blob_bottom_vec_),
+      &(this->blob_top_vec_), 0, -1, -1);
+}
+
+}  // namespace caffe


### PR DESCRIPTION
The triplet ranking hinge loss plays an important role in the deep ranking network of Google (#578). The major reference for the loss function is [1].

Compared with the Weighted Approximate Rank Pairwise (WARP) loss layer (#257, #126, #88), this loss is much simpler.

[1] Mohammad Norouzi, David Fleet, and Ruslan Salakhutdinov. Hamming Distance Metric Learning. NIPS 2013.
 