### PR TITLE
Changed path in description to point to parse_log.sh

### DIFF
--- a/tools/extra/plot_log.gnuplot.example
+++ b/tools/extra/plot_log.gnuplot.example
@@ -5,7 +5,7 @@
 # You had better check the data files before designing your own plots.
 
 # Please generate the neccessary data files with 
-# /path/to/caffe/scripts/parse_log.sh before plotting.
+# /path/to/caffe/tools/extra/parse_log.sh before plotting.
 # Example usage: 
 #     ./parse_log.sh mnist.log
 # Now you have mnist.log.train and mnist.log.test.


### PR DESCRIPTION
It seems that parse_log.sh has moved from /path/to/caffe/scripts/ to /path/to/caffe/tools/extra. The edit changes the description to reflect this change. Nothing major really.
