### PR TITLE
learn a distance function suitable for use with hinge loss in siamese network

### DIFF
--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -130,6 +130,39 @@ class ConvolutionLayer : public Layer<Dtype> {
   int N_;
 };
 
+/* DistanceLayer
+
+  y = b + \sum_i w_i f( x0_i - x1_i )
+
+  where f(x) = |x| or f(x) = x^2
+*/
+template <typename Dtype>
+class DistanceLayer : public Layer<Dtype> {
+ public:
+  explicit DistanceLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void SetUp(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+
+ protected:   
+  virtual Dtype Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual Dtype Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom);
+
+  int M_;
+  int K_;
+  int N_;
+  bool bias_term_;
+  shared_ptr<SyncedMemory> bias_multiplier_;
+  Blob<Dtype> difference_;
+  Blob<Dtype> difference_squared_;
+};
+
 /* EltwiseLayer
   Compute elementwise operations like product or sum.
 */

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -84,6 +84,8 @@ Layer<Dtype>* GetLayer(const LayerParameter& param) {
     return new TanHLayer<Dtype>(param);
   case LayerParameter_LayerType_WINDOW_DATA:
     return new WindowDataLayer<Dtype>(param);
+  case LayerParameter_LayerType_DISTANCE:
+    return new DistanceLayer<Dtype>(param);
   case LayerParameter_LayerType_NONE:
     LOG(FATAL) << "Layer " << name << " has unspecified type.";
   default:

--- a/src/caffe/layers/distance_layer.cpp
+++ b/src/caffe/layers/distance_layer.cpp
@@ -1,0 +1,172 @@
+#include <vector>
+#include <stdio.h>
+#include <cfloat>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void DistanceLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top) {
+  CHECK_EQ(bottom.size(), 2) << "EM Layer takes two blobs as input.";
+
+  CHECK_EQ(bottom[0]->num(), bottom[1]->num())
+      << "The data and label should have the same number.";
+  CHECK_EQ(bottom[0]->channels(), bottom[1]->channels());
+  CHECK_EQ(bottom[0]->height(), bottom[1]->height());
+  CHECK_EQ(bottom[0]->width(), bottom[1]->width());
+
+  // Figure out the dimensions for the difference
+  difference_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+  difference_squared_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+
+  CHECK_EQ(top->size(), 1) << "EM Layer takes a single blob as output.";
+  const int num_output = this->layer_param_.distance_param().num_output();
+  bias_term_ = this->layer_param_.distance_param().bias_term();
+  // Figure out the dimensions
+  M_ = bottom[0]->num();
+  K_ = bottom[0]->count() / bottom[0]->num();
+  N_ = num_output;
+  (*top)[0]->Reshape(bottom[0]->num(), num_output, 1, 1);
+
+  // Check if we need to set up the weights
+  if (this->blobs_.size() > 0) {
+    LOG(INFO) << "Skipping parameter initialization";
+  } else {
+    if (bias_term_) {
+      this->blobs_.resize(2);
+    } else {
+      this->blobs_.resize(1);
+    }
+    // Intialize the weight
+    this->blobs_[0].reset(new Blob<Dtype>(1, 1, N_, K_));
+    // fill the weights
+    shared_ptr<Filler<Dtype> > weight_filler(GetFiller<Dtype>(
+        this->layer_param_.distance_param().weight_filler()));
+    weight_filler->Fill(this->blobs_[0].get());
+    // If necessary, intiialize and fill the bias term
+    if (bias_term_) {
+      this->blobs_[1].reset(new Blob<Dtype>(1, 1, 1, N_));
+      shared_ptr<Filler<Dtype> > bias_filler(GetFiller<Dtype>(
+          this->layer_param_.distance_param().bias_filler()));
+      bias_filler->Fill(this->blobs_[1].get());
+    }
+  }  // parameter initialization
+  // Setting up the bias multiplier
+  if (bias_term_) {
+    bias_multiplier_.reset(new SyncedMemory(M_ * sizeof(Dtype)));
+    Dtype* bias_multiplier_data =
+        reinterpret_cast<Dtype*>(bias_multiplier_->mutable_cpu_data());
+    for (int i = 0; i < M_; ++i) {
+        bias_multiplier_data[i] = 1.;
+    }
+  }
+}
+
+template <typename Dtype>
+Dtype DistanceLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    vector<Blob<Dtype>*>* top) {
+  const Dtype* bottom_data_0 = bottom[0]->cpu_data();
+  const Dtype* bottom_data_1 = bottom[1]->cpu_data();
+  Dtype* top_data = (*top)[0]->mutable_cpu_data();
+  const Dtype* weight = this->blobs_[0]->cpu_data();
+
+  int count = bottom[0]->count();
+
+  caffe_sub(count, bottom_data_0, bottom_data_1,
+      difference_.mutable_cpu_data());
+
+  const Dtype* diff_data = difference_.cpu_data();
+  const Dtype* diff_sq_data = difference_squared_.cpu_data();
+
+  switch (this->layer_param_.distance_param().distance()) {
+  case DistanceParameter_Distance_Squared:
+    caffe_mul(count, diff_data, diff_data,
+        difference_squared_.mutable_cpu_data());
+
+    // project diff squared on w
+    caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasTrans, M_, N_, K_, (Dtype)1.,
+        diff_sq_data, weight, (Dtype)0., top_data);
+
+    break;
+  case DistanceParameter_Distance_Abs:
+  default:
+    LOG(FATAL) << "Unknown Distance";
+  }
+
+  if (bias_term_) {
+    caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, M_, N_, 1, (Dtype)1.,
+        reinterpret_cast<const Dtype*>(bias_multiplier_->cpu_data()),
+        this->blobs_[1]->cpu_data(), (Dtype)1., top_data);
+
+    //LOG(ERROR) << "b: " << this->blobs_[1]->cpu_data()[0];
+  }
+
+  return Dtype(0);
+}
+
+template <typename Dtype>
+void DistanceLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down,
+    vector<Blob<Dtype>*>* bottom) {
+  const Dtype* top_diff = top[0]->cpu_diff();
+  const Dtype* diff_sq_data = difference_squared_.cpu_data();
+  const Dtype* diff_data = difference_.cpu_data();
+
+  int count = (*bottom)[0]->count();
+
+  switch (this->layer_param_.distance_param().distance()) {
+  case DistanceParameter_Distance_Squared:
+    // Gradient with respect to weight, squared diff
+    caffe_cpu_gemm<Dtype>(CblasTrans, CblasNoTrans, N_, K_, M_, (Dtype)1.,
+        top_diff, diff_sq_data, (Dtype)0., this->blobs_[0]->mutable_cpu_diff());
+    break;
+  case DistanceParameter_Distance_Abs:
+  default:
+    LOG(FATAL) << "Unknown Distance";
+  }
+
+  if (bias_term_) {
+    // Gradient with respect to bias
+    caffe_cpu_gemv<Dtype>(CblasTrans, M_, N_, (Dtype)1., top_diff,
+        reinterpret_cast<const Dtype*>(bias_multiplier_->cpu_data()), (Dtype)0.,
+        this->blobs_[1]->mutable_cpu_diff());
+  }
+
+  if (propagate_down[0]) {
+    switch (this->layer_param_.distance_param().distance()) {
+    case DistanceParameter_Distance_Squared:
+
+      // Gradient with respect to bottom data, squared diff
+      caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, M_, K_, N_, (Dtype)2.,
+          top_diff, this->blobs_[0]->cpu_data(), (Dtype)0.,
+          (*bottom)[0]->mutable_cpu_diff());
+      caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, M_, K_, N_, (Dtype)-2.,
+          top_diff, this->blobs_[0]->cpu_data(), (Dtype)0.,
+          (*bottom)[1]->mutable_cpu_diff());
+
+   
+      caffe_mul(count, diff_data, (*bottom)[0]->cpu_diff(),
+        (*bottom)[0]->mutable_cpu_diff());
+      caffe_mul(count, diff_data, (*bottom)[1]->cpu_diff(),
+        (*bottom)[1]->mutable_cpu_diff());
+
+      break;
+    case DistanceParameter_Distance_Abs:
+    default:
+      LOG(FATAL) << "Unknown Distance";
+    }
+  }
+}
+
+INSTANTIATE_CLASS(DistanceLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/distance_layer.cu
+++ b/src/caffe/layers/distance_layer.cu
@@ -1,0 +1,113 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <cublas_v2.h>
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+Dtype DistanceLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    vector<Blob<Dtype>*>* top) {
+  const Dtype* bottom_data_0 = bottom[0]->gpu_data();
+  const Dtype* bottom_data_1 = bottom[1]->gpu_data();
+  Dtype* top_data = (*top)[0]->mutable_gpu_data();
+  const Dtype* weight = this->blobs_[0]->gpu_data();
+  const Dtype* diff_data = difference_.gpu_data();
+  const Dtype* diff_sq_data = difference_squared_.gpu_data();
+
+  int count = bottom[0]->count();
+
+  switch (this->layer_param_.distance_param().distance()) {
+  case DistanceParameter_Distance_Squared:
+    caffe_gpu_copy(count, bottom_data_0, difference_.mutable_gpu_data());
+    caffe_gpu_axpy(count, Dtype(-1), bottom_data_1,
+        difference_.mutable_gpu_data());
+
+    caffe_gpu_mul(count, diff_data, diff_data,
+        difference_squared_.mutable_gpu_data());
+
+    // project diff squared on w
+    caffe_gpu_gemm<Dtype>(CblasNoTrans, CblasTrans, M_, N_, K_, (Dtype)1.,
+        diff_sq_data, weight, (Dtype)0., top_data);
+    break;
+  case DistanceParameter_Distance_Abs:
+  default:
+    LOG(FATAL) << "Unknown Distance";
+  }
+
+  if (bias_term_) {
+    caffe_gpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, M_, N_, 1, (Dtype)1.,
+        reinterpret_cast<const Dtype*>(bias_multiplier_->gpu_data()),
+        this->blobs_[1]->gpu_data(), (Dtype)1., top_data);
+
+    //LOG(ERROR) << "b: " << this->blobs_[1]->gpu_data()[0];
+  }
+  return Dtype(0);
+}
+
+template <typename Dtype>
+void DistanceLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down,
+    vector<Blob<Dtype>*>* bottom) {
+  const Dtype* top_diff = top[0]->gpu_diff();
+  const Dtype* diff_sq_data = difference_squared_.gpu_data();
+  const Dtype* diff_data = difference_.gpu_data();
+
+  int count = (*bottom)[0]->count();
+  int num = (*bottom)[0]->num();
+ 
+  switch (this->layer_param_.distance_param().distance()) {
+  case DistanceParameter_Distance_Squared:
+    // Gradient with respect to weight, squared diff
+    caffe_gpu_gemm<Dtype>(CblasTrans, CblasNoTrans, N_, K_, M_, (Dtype)1.,
+        top_diff, diff_sq_data, (Dtype)0., this->blobs_[0]->mutable_gpu_diff());
+    break;
+  case DistanceParameter_Distance_Abs:
+  default:
+    LOG(FATAL) << "Unknown Distance";
+  }
+ 
+  if (bias_term_) {
+    // Gradient with respect to bias
+    caffe_gpu_gemv<Dtype>(CblasTrans, M_, N_, (Dtype)1., top_diff,
+        reinterpret_cast<const Dtype*>(bias_multiplier_->gpu_data()), (Dtype)0.,
+        this->blobs_[1]->mutable_gpu_diff());
+  }
+  if (propagate_down[0]) {
+    switch (this->layer_param_.distance_param().distance()) {
+    case DistanceParameter_Distance_Squared:
+
+      // Gradient with respect to bottom data, squared diff
+      caffe_gpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, M_, K_, N_, (Dtype)2.,
+          top_diff, this->blobs_[0]->gpu_data(), (Dtype)0.,
+          (*bottom)[0]->mutable_gpu_diff());
+      caffe_gpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, M_, K_, N_, (Dtype)-2.,
+          top_diff, this->blobs_[0]->gpu_data(), (Dtype)0.,
+          (*bottom)[1]->mutable_gpu_diff());
+
+
+      caffe_gpu_mul(count, diff_data, (*bottom)[0]->gpu_diff(),
+          (*bottom)[0]->mutable_gpu_diff());
+      caffe_gpu_mul(count, diff_data, (*bottom)[1]->gpu_diff(),
+          (*bottom)[1]->mutable_gpu_diff());
+      break;
+
+    case DistanceParameter_Distance_Abs:
+    default:
+      LOG(FATAL) << "Unknown Distance";
+    }
+
+  }
+}
+
+INSTANTIATE_CLASS(DistanceLayer);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -127,7 +127,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 33 (last added: DUMMY_DATA)
+  // LayerType next available ID: 34 (last added: DISTANCE)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if
@@ -139,6 +139,7 @@ message LayerParameter {
     CONCAT = 3;
     CONVOLUTION = 4;
     DATA = 5;
+    DISTANCE = 33;
     DROPOUT = 6;
     DUMMY_DATA = 32;
     EUCLIDEAN_LOSS = 7;
@@ -193,6 +194,7 @@ message LayerParameter {
   optional ConcatParameter concat_param = 9;
   optional ConvolutionParameter convolution_param = 10;
   optional DataParameter data_param = 11;
+  optional DistanceParameter distance_param = 30;
   optional DropoutParameter dropout_param = 12;
   optional DummyDataParameter dummy_data_param = 26;
   optional EltwiseParameter eltwise_param = 24;
@@ -377,6 +379,21 @@ message InnerProductParameter {
   optional FillerParameter bias_filler = 4; // The filler for the bias
 }
 
+// Message that stores parameters used by DistanceLayer
+message DistanceParameter {
+  enum Distance {
+    Squared = 1;
+    Abs = 2;
+  }
+  // Specify the type of distance
+  optional Distance distance = 1 [default = Squared];
+
+  optional uint32 num_output = 2; // The number of outputs for the layer  
+  optional bool bias_term = 3 [default = true]; // whether to have bias terms
+  optional FillerParameter weight_filler = 4; // The filler for the weight
+  optional FillerParameter bias_filler = 5; // The filler for the bias
+}
+  
 // Message that stores parameters used by LRNLayer
 message LRNParameter {
   optional uint32 local_size = 1 [default = 5];

--- a/src/caffe/test/test_distance_layer.cpp
+++ b/src/caffe/test/test_distance_layer.cpp
@@ -1,0 +1,146 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <cstring>
+#include <vector>
+
+#include "cuda_runtime.h"
+#include "gtest/gtest.h"
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/vision_layers.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+extern cudaDeviceProp CAFFE_TEST_CUDA_PROP;
+
+template <typename Dtype>
+class DistanceLayerTest : public ::testing::Test {
+ protected:
+	DistanceLayerTest()
+      : blob_bottom_0_(new Blob<Dtype>(2, 1, 1, 3)),
+        blob_bottom_1_(new Blob<Dtype>(2, 1, 1, 3)),
+        blob_top_(new Blob<Dtype>()) {
+    // fill the values
+    FillerParameter filler_param;
+    UniformFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_0_);
+    filler.Fill(this->blob_bottom_1_);
+    blob_bottom_vec_.push_back(blob_bottom_0_);
+    blob_bottom_vec_.push_back(blob_bottom_1_);
+    blob_top_vec_.push_back(blob_top_);
+  }
+  virtual ~DistanceLayerTest() {
+    delete blob_bottom_0_;
+    delete blob_bottom_1_;
+    delete blob_top_;
+  }
+  Blob<Dtype>* const blob_bottom_0_;
+  Blob<Dtype>* const blob_bottom_1_;
+  Blob<Dtype>* const blob_top_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+typedef ::testing::Types<float, double> Dtypes;
+TYPED_TEST_CASE(DistanceLayerTest, Dtypes);
+
+TYPED_TEST(DistanceLayerTest, TestSetUp) {
+  LayerParameter layer_param;
+  DistanceParameter* distance_param =
+      layer_param.mutable_distance_param();
+  distance_param->set_num_output(2);
+  shared_ptr<DistanceLayer<TypeParam> > layer(
+      new DistanceLayer<TypeParam>(layer_param));
+  layer->SetUp(this->blob_bottom_vec_, &(this->blob_top_vec_));
+  EXPECT_EQ(this->blob_top_->num(), 2);
+  EXPECT_EQ(this->blob_top_->height(), 1);
+  EXPECT_EQ(this->blob_top_->width(), 1);
+  EXPECT_EQ(this->blob_top_->channels(), 2);
+}
+
+TYPED_TEST(DistanceLayerTest, TestCPU) {
+  LayerParameter layer_param;
+  DistanceParameter* distance_param =
+      layer_param.mutable_distance_param();
+  Caffe::set_mode(Caffe::CPU);
+  distance_param->set_num_output(2);
+  distance_param->mutable_weight_filler()->set_type("uniform");
+  distance_param->mutable_bias_filler()->set_type("uniform");
+  distance_param->mutable_bias_filler()->set_min(1);
+  distance_param->mutable_bias_filler()->set_max(2);
+  shared_ptr<DistanceLayer<TypeParam> > layer(
+      new DistanceLayer<TypeParam>(layer_param));
+  layer->SetUp(this->blob_bottom_vec_, &(this->blob_top_vec_));
+  layer->Forward(this->blob_bottom_vec_, &(this->blob_top_vec_));
+  const TypeParam* data = this->blob_top_->cpu_data();
+  const int count = this->blob_top_->count();
+  for (int i = 0; i < count; ++i) {
+    EXPECT_GE(data[i], 1.);
+  }
+}
+
+TYPED_TEST(DistanceLayerTest, TestGPU) {
+  if (sizeof(TypeParam) == 4 || CAFFE_TEST_CUDA_PROP.major >= 2) {
+    LayerParameter layer_param;
+    DistanceParameter* distance_param =
+        layer_param.mutable_distance_param();
+    Caffe::set_mode(Caffe::GPU);
+    distance_param->set_num_output(2);
+    distance_param->mutable_weight_filler()->set_type("uniform");
+    distance_param->mutable_bias_filler()->set_type("uniform");
+    distance_param->mutable_bias_filler()->set_min(1);
+    distance_param->mutable_bias_filler()->set_max(2);
+    shared_ptr<DistanceLayer<TypeParam> > layer(
+      new DistanceLayer<TypeParam>(layer_param));
+    layer->SetUp(this->blob_bottom_vec_, &(this->blob_top_vec_));
+    layer->Forward(this->blob_bottom_vec_, &(this->blob_top_vec_));
+    const TypeParam* data = this->blob_top_->cpu_data();
+    const int count = this->blob_top_->count();
+    for (int i = 0; i < count; ++i) {
+      EXPECT_GE(data[i], 1.);
+    }
+  } else {
+    LOG(ERROR) << "Skipping test due to old architecture.";
+  }
+}
+
+TYPED_TEST(DistanceLayerTest, TestCPUGradient) {
+  LayerParameter layer_param;
+  DistanceParameter* distance_param =
+      layer_param.mutable_distance_param();
+  Caffe::set_mode(Caffe::CPU);
+  distance_param->set_num_output(2);
+  distance_param->mutable_weight_filler()->set_type("gaussian");
+  distance_param->mutable_bias_filler()->set_type("gaussian");
+  distance_param->mutable_bias_filler()->set_min(1);
+  distance_param->mutable_bias_filler()->set_max(2);
+  DistanceLayer<TypeParam> layer(layer_param);
+  GradientChecker<TypeParam> checker(1e-2, 1e-3);
+  checker.CheckGradientExhaustive(&layer, &(this->blob_bottom_vec_),
+      &(this->blob_top_vec_));
+}
+
+TYPED_TEST(DistanceLayerTest, TestGPUGradient) {
+  if (sizeof(TypeParam) == 4 || CAFFE_TEST_CUDA_PROP.major >= 2) {
+    LayerParameter layer_param;
+    DistanceParameter* distance_param =
+        layer_param.mutable_distance_param();
+    Caffe::set_mode(Caffe::GPU);
+    distance_param->set_num_output(2);
+    distance_param->mutable_weight_filler()->set_type("gaussian");
+    distance_param->mutable_bias_filler()->set_type("gaussian");
+    DistanceLayer<TypeParam> layer(layer_param);
+
+    GradientChecker<TypeParam> checker(1e-2, 1e-2);
+    checker.CheckGradient(&layer, &(this->blob_bottom_vec_),
+        &(this->blob_top_vec_));
+  } else {
+    LOG(ERROR) << "Skipping test due to old architecture.";
+  }
+}
+
+}  // namespace caffe


### PR DESCRIPTION
This layer takes two inputs (x0 and x1) and learns a weights vector (w) and scalar bias (b).

y = b + \sum_i w_i f( x0_i - x1_i )

where f(x) = x^2 or f(x) = |x|.

This is useful for learning siamese networks, which has been talked about in other issues (https://github.com/BVLC/caffe/issues/316, https://github.com/BVLC/caffe/pull/546).

Weights sharing has already been merged into dev, but a layer of this type is also necessary.
