### PR TITLE
PyramidLevelLayer for spatial pyramid pooling [under development, don't merge]

### DIFF
--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -276,6 +276,45 @@ class PoolingLayer : public Layer<Dtype> {
   shared_ptr<Blob<int> > max_idx_;
 };
 
+/* PyramidLevelLayer
+*/
+template <typename Dtype>
+class PyramidLevelLayer : public Layer<Dtype> {
+ public:
+  explicit PyramidLevelLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void SetUp(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+
+  virtual inline LayerParameter_LayerType type() const {
+    return LayerParameter_LayerType_POOLING;
+  }
+  virtual inline int ExactNumBottomBlobs() const { return 1; }
+  virtual inline int MinTopBlobs() const { return 1; }
+  virtual inline int MaxTopBlobs() const { return max_top_blobs_; }
+
+ protected:
+  virtual Dtype Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual Dtype Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom);
+
+  int max_top_blobs_;
+  int bin_num_h_;
+  int bin_num_w_;
+  float bin_size_h_;
+  float bin_size_w_;
+  int channels_;
+  int height_;
+  int width_;
+  Blob<Dtype> rand_idx_;
+  shared_ptr<Blob<int> > max_idx_;
+};
+
 }  // namespace caffe
 
 #endif  // CAFFE_VISION_LAYERS_HPP_

--- a/src/caffe/layers/pyramid_level_layer.cpp
+++ b/src/caffe/layers/pyramid_level_layer.cpp
@@ -1,0 +1,254 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+#include "caffe/syncedmem.hpp"
+#include "caffe/util/math_functions.hpp"
+
+using std::max;
+using std::min;
+
+namespace caffe {
+
+template <typename Dtype>
+void PyramidLevelLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top) {
+  // Set the max number of top blobs before calling base Layer::SetUp.
+  // If doing MAX PyramidLevel, we can optionally output an extra top Blob
+  // for the mask.  Otherwise, we only have one top Blob.
+  if (this->layer_param_.PyramidLevel_param().pool() ==
+      PyramidLevelParameter_PoolMethod_MAX) {
+    max_top_blobs_ = 2;
+  } else {
+    max_top_blobs_ = 1;
+  }
+  Layer<Dtype>::SetUp(bottom, top);
+  PyramidLevelParameter pyramid_level_param = this->layer_param_.pyramid_level_param();
+  // Set the max number of top blobs before calling base Layer::SetUp.
+  // If doing MAX pooling, we can optionally output an extra top Blob
+  // for the mask.  Otherwise, we only have one top Blob.
+  if (this->layer_param_.pooling_param().pool() ==
+      PoolingParameter_PoolMethod_MAX) {
+    max_top_blobs_ = 2;
+  } else {
+    max_top_blobs_ = 1;
+  }
+  CHECK(pyramid_level_param.has_bin_num_h() && pyramid_level_param.has_bin_num_w)
+      << "Both bin_num_h and bin_num_w are required";
+  bin_num_h_ = pyramid_level_param.bin_num_h();
+  bin_num_w_ = pyramid_level_param.bin_num_w();
+  CHECK_GT(bin_num_h_, 0) << "Bin number cannot be zero";
+  CHECK_GT(bin_num_w_, 0) << "Bin number cannot be zero";
+  channels_ = bottom[0]->channels();
+  height_ = bottom[0]->height();
+  width_ = bottom[0]->width();
+  bin_size_h_ = float(height) / bin_num_h_;
+  bin_size_w_ = float(width) / bin_num_w_;
+  (*top)[0]->Reshape(bottom[0]->num(), channels_, bin_num_h_,
+      bin_num_w_);
+  if (top->size() > 1) {
+    (*top)[1]->ReshapeLike(*(*top)[0]);
+  }
+  // If max PyramidLevel, we will initialize the vector index part.
+  if (this->layer_param_.PyramidLevel_param().pool() ==
+      PyramidLevelParameter_PoolMethod_MAX && top->size() == 1) {
+    max_idx_.reset(new Blob<int>(bottom[0]->num(), channels_,
+                                 bin_num_h_, bin_num_w_));
+  }
+  // If stochastic PyramidLevel, we will initialize the random index part.
+  if (this->layer_param_.PyramidLevel_param().pool() ==
+      PyramidLevelParameter_PoolMethod_STOCHASTIC) {
+    rand_idx_.Reshape(bottom[0]->num(), channels_, bin_num_h_,
+      bin_num_w_);
+  }
+}
+
+// TODO(Yangqing): Is there a faster way to do PyramidLevel in the channel-first
+// case?
+template <typename Dtype>
+Dtype PyramidLevelLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  Dtype* top_data = (*top)[0]->mutable_cpu_data();
+  const int top_count = (*top)[0]->count();
+  // We'll output the mask to top[1] if it's of size >1.
+  const bool use_top_mask = top->size() > 1;
+  int* mask = NULL;  // suppress warnings about uninitalized variables
+  Dtype* top_mask = NULL;
+  // Different PyramidLevel methods. We explicitly do the switch outside the for
+  // loop to save time, although this results in more code.
+  switch (this->layer_param_.PyramidLevel_param().pool()) {
+  case PyramidLevelParameter_PoolMethod_MAX:
+    // Initialize
+    if (use_top_mask) {
+      top_mask = (*top)[1]->mutable_cpu_data();
+      caffe_set(top_count, Dtype(-1), top_mask);
+    } else {
+      mask = max_idx_->mutable_cpu_data();
+      caffe_set(top_count, -1, mask);
+    }
+    caffe_set(top_count, Dtype(-FLT_MAX), top_data);
+    // The main loop
+    for (int n = 0; n < bottom[0]->num(); ++n) {
+      for (int c = 0; c < channels_; ++c) {
+        for (int ph = 0; ph < bin_num_h_; ++ph) {
+          for (int pw = 0; pw < bin_num_w_; ++pw) {
+            int hstart = max(floor(ph * bin_size_h_), 0);
+            int wstart = max(floor(pw * bin_size_w_), 0);
+            int hend = min(ceil((ph + 1) * bin_size_h_), height_);
+            int wend = min(ceil((pw + 1) * bin_size_w_), width_);
+            const int pool_index = ph * bin_num_w_ + pw;
+            for (int h = hstart; h < hend; ++h) {
+              for (int w = wstart; w < wend; ++w) {
+                const int index = h * width_ + w;
+                if (bottom_data[index] > top_data[pool_index]) {
+                  top_data[pool_index] = bottom_data[index];
+                  if (use_top_mask) {
+                    top_mask[pool_index] = static_cast<Dtype>(index);
+                  } else {
+                    mask[pool_index] = index;
+                  }
+                }
+              }
+            }
+          }
+        }
+        // compute offset
+        bottom_data += bottom[0]->offset(0, 1);
+        top_data += (*top)[0]->offset(0, 1);
+        if (use_top_mask) {
+          top_mask += (*top)[0]->offset(0, 1);
+        } else {
+          mask += (*top)[0]->offset(0, 1);
+        }
+      }
+    }
+    break;
+  case PyramidLevelParameter_PoolMethod_AVE:
+    for (int i = 0; i < top_count; ++i) {
+      top_data[i] = 0;
+    }
+    // The main loop
+    for (int n = 0; n < bottom[0]->num(); ++n) {
+      for (int c = 0; c < channels_; ++c) {
+        for (int ph = 0; ph < bin_num_h_; ++ph) {
+          for (int pw = 0; pw < bin_num_w_; ++pw) {
+            int hstart = max(floor(ph * bin_size_h_), 0);
+            int wstart = max(floor(pw * bin_size_w_), 0);
+            int hend = min(ceil((ph + 1) * bin_size_h_), height_);
+            int wend = min(ceil((pw + 1) * bin_size_w_), width_);
+            int pool_size = (hend - hstart) * (wend - wstart);
+            for (int h = hstart; h < hend; ++h) {
+              for (int w = wstart; w < wend; ++w) {
+                top_data[ph * bin_num_w_ + pw] +=
+                    bottom_data[h * width_ + w];
+              }
+            }
+            top_data[ph * bin_num_w_ + pw] /= pool_size;
+          }
+        }
+        // compute offset
+        bottom_data += bottom[0]->offset(0, 1);
+        top_data += (*top)[0]->offset(0, 1);
+      }
+    }
+    break;
+  case PyramidLevelParameter_PoolMethod_STOCHASTIC:
+    NOT_IMPLEMENTED;
+    break;
+  default:
+    LOG(FATAL) << "Unknown PyramidLevel method.";
+  }
+  return Dtype(0.);
+}
+
+template <typename Dtype>
+void PyramidLevelLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom) {
+  if (!propagate_down[0]) {
+    return;
+  }
+  const Dtype* top_diff = top[0]->cpu_diff();
+  Dtype* bottom_diff = (*bottom)[0]->mutable_cpu_diff();
+  // Different PyramidLevel methods. We explicitly do the switch outside the for
+  // loop to save time, although this results in more codes.
+  caffe_set((*bottom)[0]->count(), Dtype(0), bottom_diff);
+  // We'll output the mask to top[1] if it's of size >1.
+  const bool use_top_mask = top.size() > 1;
+  const int* mask = NULL;  // suppress warnings about uninitialized variables
+  const Dtype* top_mask = NULL;
+  switch (this->layer_param_.PyramidLevel_param().pool()) {
+  case PyramidLevelParameter_PoolMethod_MAX:
+    // The main loop
+    if (use_top_mask) {
+      top_mask = top[1]->cpu_data();
+    } else {
+      mask = max_idx_->cpu_data();
+    }
+    for (int n = 0; n < top[0]->num(); ++n) {
+      for (int c = 0; c < channels_; ++c) {
+        for (int ph = 0; ph < bin_num_h_; ++ph) {
+          for (int pw = 0; pw < bin_num_w_; ++pw) {
+            const int index = ph * bin_num_w_ + pw;
+            const int bottom_index =
+                use_top_mask ? top_mask[index] : mask[index];
+            bottom_diff[bottom_index] += top_diff[index];
+          }
+        }
+        bottom_diff += (*bottom)[0]->offset(0, 1);
+        top_diff += top[0]->offset(0, 1);
+        if (use_top_mask) {
+          top_mask += top[0]->offset(0, 1);
+        } else {
+          mask += top[0]->offset(0, 1);
+        }
+      }
+    }
+    break;
+  case PyramidLevelParameter_PoolMethod_AVE:
+    // The main loop
+    for (int n = 0; n < top[0]->num(); ++n) {
+      for (int c = 0; c < channels_; ++c) {
+        for (int ph = 0; ph < bin_num_h_; ++ph) {
+          for (int pw = 0; pw < bin_num_w_; ++pw) {
+            int hstart = max(floor(ph * bin_size_h_), 0);
+            int wstart = max(floor(pw * bin_size_w_), 0);
+            int hend = min(ceil((ph + 1) * bin_size_h_), height_);
+            int wend = min(ceil((pw + 1) * bin_size_w_), width_);
+            int pool_size = (hend - hstart) * (wend - wstart);
+            hstart = max(hstart, 0);
+            wstart = max(wstart, 0);
+            hend = min(hend, height_);
+            wend = min(wend, width_);
+            for (int h = hstart; h < hend; ++h) {
+              for (int w = wstart; w < wend; ++w) {
+                bottom_diff[h * width_ + w] +=
+                  top_diff[ph * bin_num_w_ + pw] / pool_size;
+              }
+            }
+          }
+        }
+        // offset
+        bottom_diff += (*bottom)[0]->offset(0, 1);
+        top_diff += top[0]->offset(0, 1);
+      }
+    }
+    break;
+  case PyramidLevelParameter_PoolMethod_STOCHASTIC:
+    NOT_IMPLEMENTED;
+    break;
+  default:
+    LOG(FATAL) << "Unknown PyramidLevel method.";
+  }
+}
+
+
+INSTANTIATE_CLASS(PyramidLevelLayer);
+
+
+}  // namespace caffe

--- a/src/caffe/layers/pyramid_level_layer.cu
+++ b/src/caffe/layers/pyramid_level_layer.cu
@@ -1,0 +1,366 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+
+using std::max;
+using std::min;
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void MaxPoolForward(const int nthreads, const Dtype* bottom_data,
+    const int num, const int channels, const int height,
+    const int width, const int bin_num_h, const int bin_num_w,
+    const float bin_size_h, const float bin_size_w, Dtype* top_data,
+    int* mask, Dtype* top_mask) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    int pw = index % bin_num_w;
+    int ph = (index / bin_num_w) % bin_num_h;
+    int c = (index / bin_num_w / bin_num_h) % channels;
+    int n = index / bin_num_w / bin_num_h / channels;
+    int hstart = max(floor(ph * bin_size_h), 0);
+    int wstart = max(floor(pw * bin_size_w), 0);
+    int hend = min(ceil((ph + 1) * bin_size_h), height);
+    int wend = min(ceil((pw + 1) * bin_size_w), width);
+    Dtype maxval = -FLT_MAX;
+    int maxidx = -1;
+    bottom_data += (n * channels + c) * height * width;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        if (bottom_data[h * width + w] > maxval) {
+          maxidx = h * width + w;
+          maxval = bottom_data[maxidx];
+        }
+      }
+    }
+    top_data[index] = maxval;
+    if (mask) {
+      mask[index] = maxidx;
+    } else {
+      top_mask[index] = maxidx;
+    }
+  }
+}
+
+template <typename Dtype>
+__global__ void AvePoolForward(const int nthreads, const Dtype* bottom_data,
+    const int num, const int channels, const int height,
+    const int width, const int bin_num_h, const int bin_num_w,
+    const float bin_size_h, const float bin_size_w, Dtype* top_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    int pw = index % bin_num_w;
+    int ph = (index / bin_num_w) % bin_num_h;
+    int c = (index / bin_num_w / bin_num_h) % channels;
+    int n = index / bin_num_w / bin_num_h / channels;
+    int hstart = max(floor(ph * bin_size_h), 0);
+    int wstart = max(floor(pw * bin_size_w), 0);
+    int hend = min(ceil((ph + 1) * bin_size_h), height);
+    int wend = min(ceil((pw + 1) * bin_size_w), width);
+    int pool_size = (hend - hstart) * (wend - wstart);
+    Dtype aveval = 0;
+    bottom_data += (n * channels + c) * height * width;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        aveval += bottom_data[h * width + w];
+      }
+    }
+    top_data[index] = aveval / pool_size;
+  }
+}
+
+template <typename Dtype>
+__global__ void StoPoolForwardTrain(const int nthreads,
+    const Dtype* bottom_data,
+    const int num, const int channels, const int height,
+    const int width, const int bin_num_h, const int bin_num_w,a
+    const float bin_size_h, const float bin_size_w,
+    Dtype* rand_idx, Dtype* top_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    int pw = index % bin_num_w;
+    int ph = (index / bin_num_w) % bin_num_h;
+    int c = (index / bin_num_w / bin_num_h) % channels;
+    int n = index / bin_num_w / bin_num_h / channels;
+    int hstart = max(floor(ph * bin_size_h), 0);
+    int wstart = max(floor(pw * bin_size_w), 0);
+    int hend = min(ceil((ph + 1) * bin_size_h), height);
+    int wend = min(ceil((pw + 1) * bin_size_w), width);
+    Dtype cumsum = 0.;
+    bottom_data += (n * channels + c) * height * width;
+    // First pass: get sum
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        cumsum += bottom_data[h * width + w];
+      }
+    }
+    float thres = rand_idx[index] * cumsum;
+    // Second pass: get value, and set index.
+    cumsum = 0;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        cumsum += bottom_data[h * width + w];
+        if (cumsum >= thres) {
+          rand_idx[index] = ((n * channels + c) * height + h) * width + w;
+          top_data[index] = bottom_data[h * width + w];
+          return;
+        }
+      }
+    }
+  }
+}
+
+
+template <typename Dtype>
+__global__ void StoPoolForwardTest(const int nthreads,
+    const Dtype* bottom_data,
+    const int num, const int channels, const int height,
+    const int width, const int bin_num_h, const int bin_num_w,
+    const float bin_size_h, const float bin_size_w, Dtype* top_data) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    int pw = index % bin_num_w;
+    int ph = (index / bin_num_w) % bin_num_h;
+    int c = (index / bin_num_w / bin_num_h) % channels;
+    int n = index / bin_num_w / bin_num_h / channels;
+    int hstart = max(floor(ph * bin_size_h), 0);
+    int wstart = max(floor(pw * bin_size_w), 0);
+    int hend = min(ceil((ph + 1) * bin_size_h), height);
+    int wend = min(ceil((pw + 1) * bin_size_w), width);
+    // We set cumsum to be 0 to avoid divide-by-zero problems
+    Dtype cumsum = FLT_MIN;
+    Dtype cumvalues = 0.;
+    bottom_data += (n * channels + c) * height * width;
+    // First pass: get sum
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        cumsum += bottom_data[h * width + w];
+        cumvalues += bottom_data[h * width + w] * bottom_data[h * width + w];
+      }
+    }
+    top_data[index] = cumvalues / cumsum;
+  }
+}
+
+
+template <typename Dtype>
+Dtype PoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      vector<Blob<Dtype>*>* top) {
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  Dtype* top_data = (*top)[0]->mutable_gpu_data();
+  int count = (*top)[0]->count();
+  // We'll output the mask to top[1] if it's of size >1.
+  const bool use_top_mask = top->size() > 1;
+  int* mask = NULL;
+  Dtype* top_mask = NULL;
+  switch (this->layer_param_.pooling_param().pool()) {
+  case PoolingParameter_PoolMethod_MAX:
+    if (use_top_mask) {
+      top_mask = (*top)[1]->mutable_gpu_data();
+    } else {
+      mask = max_idx_->mutable_gpu_data();
+    }
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    MaxPoolForward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, bottom_data, bottom[0]->num(), channels_,
+        height_, width_, bin_num_h_, bin_num_w_, bin_size_h_, bin_size_w_,
+        top_data, mask, top_mask);
+    break;
+  case PoolingParameter_PoolMethod_AVE:
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    AvePoolForward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, bottom_data, bottom[0]->num(), channels_,
+        height_, width_, bin_num_h_, bin_num_w_, bin_size_h_, bin_size_w_,
+        top_data);
+    break;
+  case PoolingParameter_PoolMethod_STOCHASTIC:
+    if (Caffe::phase() == Caffe::TRAIN) {
+      // We need to create the random index as well.
+      caffe_gpu_rng_uniform(count, Dtype(0), Dtype(1),
+                            rand_idx_.mutable_gpu_data());
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      StoPoolForwardTrain<Dtype><<<CAFFE_GET_BLOCKS(count),
+                                   CAFFE_CUDA_NUM_THREADS>>>(
+          count, bottom_data, bottom[0]->num(), channels_,
+          height_, width_, bin_num_h_, bin_num_w_, bin_size_h_, bin_size_w_,
+          rand_idx_.mutable_gpu_data(), top_data);
+    } else {
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      StoPoolForwardTest<Dtype><<<CAFFE_GET_BLOCKS(count),
+                                  CAFFE_CUDA_NUM_THREADS>>>(
+          count, bottom_data, bottom[0]->num(), channels_,
+          height_, width_, bin_num_h_, bin_num_w_, bin_size_h_, bin_size_w_,
+          top_data);
+    }
+    break;
+  default:
+    LOG(FATAL) << "Unknown pooling method.";
+  }
+  CUDA_POST_KERNEL_CHECK;
+  return Dtype(0.);
+}
+
+
+template <typename Dtype>
+__global__ void MaxPoolBackward(const int nthreads, const Dtype* top_diff,
+    const int* mask, const Dtype* top_mask, const int num, const int channels,
+    const int height, const int width, const int bin_num_h,
+    const int bin_num_w, const float bin_size_h, const float bin_size_w,
+    Dtype* bottom_diff) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    // find out the local index
+    // find out the local offset
+    int w = index % width;
+    int h = (index / width) % height;
+    int c = (index / width / height) % channels;
+    int n = index / width / height / channels;
+    int phstart = max(floor(h / bin_size_h - 1), 0);
+    int phend = min(ceil((h + 1) / bin_size_h), bin_num_h);
+    int pwstart = max(floor(w / bin_size_w - 1), 0);
+    int pwend = min(ceil((w + 1) / bin_size_w), bin_num_w);
+    Dtype gradient = 0;
+    int offset = (n * channels + c) * bin_num_h * bin_num_w;
+    top_diff += offset;
+    if (mask) {
+      mask += offset;
+      for (int ph = phstart; ph < phend; ++ph) {
+        for (int pw = pwstart; pw < pwend; ++pw) {
+          if (mask[ph * bin_num_w + pw] == h * width + w) {
+            gradient += top_diff[ph * bin_num_w + pw];
+          }
+        }
+      }
+    } else {
+      top_mask += offset;
+      for (int ph = phstart; ph < phend; ++ph) {
+        for (int pw = pwstart; pw < pwend; ++pw) {
+          if (top_mask[ph * bin_num_w + pw] == h * width + w) {
+            gradient += top_diff[ph * bin_num_w + pw];
+          }
+        }
+      }
+    }
+    bottom_diff[index] = gradient;
+  }
+}
+
+template <typename Dtype>
+__global__ void AvePoolBackward(const int nthreads, const Dtype* top_diff,
+    const int num, const int channels, const int height,
+    const int width, const int bin_num_h, const int bin_num_w,
+    const float bin_size_h, const float bin_size_w, Dtype* bottom_diff) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    // find out the local index
+    // find out the local offset
+    int w = index % width;
+    int h = (index / width) % height;
+    int c = (index / width / height) % channels;
+    int n = index / width / height / channels;
+    int phstart = max(floor(h / bin_size_h - 1), 0);
+    int phend = min(ceil((h + 1) / bin_size_h), bin_num_h);
+    int pwstart = max(floor(w / bin_size_w - 1), 0);
+    int pwend = min(ceil((w + 1) / bin_size_w), bin_num_w);
+    Dtype gradient = 0;
+    top_diff += (n * channels + c) * bin_num_h * bin_num_w;
+    for (int ph = phstart; ph < phend; ++ph) {
+      for (int pw = pwstart; pw < pwend; ++pw) {
+        // figure out the pooling size
+        int hstart = max(floor(ph * bin_size_h), 0);
+        int wstart = max(floor(pw * bin_size_w), 0);
+        int hend = min(ceil((ph + 1) * bin_size_h), height);
+        int wend = min(ceil((pw + 1) * bin_size_w), width);
+        int pool_size = (hend - hstart) * (wend - wstart);
+        gradient += top_diff[ph * bin_num_w + pw] / pool_size;
+      }
+    }
+    bottom_diff[index] = gradient;
+  }
+}
+
+
+template <typename Dtype>
+__global__ void StoPoolBackward(const int nthreads,
+    const Dtype* rand_idx, const Dtype* top_diff,
+    const int num, const int channels, const int height,
+    const int width, const int bin_num_h, const int bin_num_w,
+    const float bin_size_h, const float bin_size_w, Dtype* bottom_diff) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    // find out the local index
+    // find out the local offset
+    int w = index % width;
+    int h = (index / width) % height;
+    int c = (index / width / height) % channels;
+    int n = index / width / height / channels;
+    int phstart = max(floor(h / bin_size_h - 1), 0);
+    int phend = min(ceil((h + 1) / bin_size_h), bin_num_h);
+    int pwstart = max(floor(w / bin_size_w - 1), 0);
+    int pwend = min(ceil((w + 1) / bin_size_w), bin_num_w);
+    Dtype gradient = 0;
+    rand_idx += (n * channels + c) * bin_num_h * bin_num_w;
+    top_diff += (n * channels + c) * bin_num_h * bin_num_w;
+    for (int ph = phstart; ph < phend; ++ph) {
+      for (int pw = pwstart; pw < pwend; ++pw) {
+        gradient += top_diff[ph * bin_num_w + pw] *
+            (index == static_cast<int>(rand_idx[ph * bin_num_w + pw]));
+      }
+    }
+    bottom_diff[index] = gradient;
+  }
+}
+
+
+template <typename Dtype>
+void PoolingLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, vector<Blob<Dtype>*>* bottom) {
+  if (!propagate_down[0]) {
+    return;
+  }
+  const Dtype* top_diff = top[0]->gpu_diff();
+  Dtype* bottom_diff = (*bottom)[0]->mutable_gpu_diff();
+  const int count = (*bottom)[0]->count();
+  caffe_gpu_set(count, Dtype(0.), bottom_diff);
+  // We'll output the mask to top[1] if it's of size >1.
+  const bool use_top_mask = top.size() > 1;
+  const int* mask = NULL;
+  const Dtype* top_mask = NULL;
+  switch (this->layer_param_.pooling_param().pool()) {
+  case PoolingParameter_PoolMethod_MAX:
+    if (use_top_mask) {
+      top_mask = top[1]->gpu_data();
+    } else {
+      mask = max_idx_->gpu_data();
+    }
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    MaxPoolBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, top_diff, mask, top_mask, top[0]->num(), channels_,
+        height_, width_, bin_num_h_, bin_num_w_,
+        bin_size_h_, bin_size_w_, bottom_diff);
+    break;
+  case PoolingParameter_PoolMethod_AVE:
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    AvePoolBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, top_diff, top[0]->num(), channels_,
+        height_, width_, bin_num_h_, bin_num_w_,
+        bin_size_h_, bin_size_w_, bottom_diff);
+    break;
+  case PoolingParameter_PoolMethod_STOCHASTIC:
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    StoPoolBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, rand_idx_.gpu_data(), top_diff,
+        top[0]->num(), channels_, height_, width_, bin_num_h_,
+        bin_num_w_, bin_size_h_, bin_size_w_, bottom_diff);
+    break;
+  default:
+    LOG(FATAL) << "Unknown pooling method.";
+  }
+  CUDA_POST_KERNEL_CHECK;
+}
+
+
+INSTANTIATE_CLASS(PoolingLayer);
+
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -115,7 +115,7 @@ message SolverState {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available ID: 28 (last added: accuracy_param)
+// LayerParameter next available ID: 31 (last added: accuracy_param)
 message LayerParameter {
   repeated string bottom = 2; // the name of the bottom blobs
   repeated string top = 3; // the name of the top blobs
@@ -127,7 +127,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 33 (last added: DUMMY_DATA)
+  // LayerType next available ID: 34 (last added: PYRAMID_LEVEL)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if
@@ -156,6 +156,7 @@ message LayerParameter {
     MULTINOMIAL_LOGISTIC_LOSS = 16;
     POOLING = 17;
     POWER = 26;
+    PYRAMID_LEVEL = 33;
     RELU = 18;
     SIGMOID = 19;
     SIGMOID_CROSS_ENTROPY_LOSS = 27;
@@ -208,6 +209,7 @@ message LayerParameter {
   optional WindowDataParameter window_data_param = 20;
   optional ThresholdParameter threshold_param = 25;
   optional HingeLossParameter hinge_loss_param = 29;
+  optional PyramidLevelParameter pyramid_level_param = 31;
 
   // DEPRECATED: The layer parameters specified as a V0LayerParameter.
   // This should never be used by any code except to upgrade to the new
@@ -416,6 +418,18 @@ message PoolingParameter {
   optional uint32 stride = 3 [default = 1]; // The stride (equal in Y, X)
   optional uint32 stride_h = 7; // The stride height
   optional uint32 stride_w = 8; // The stride width
+}
+
+// Message that stores parameters used by PyramidLevelParameter
+message PyramidLevelParameter {
+  enum PoolMethod {
+    MAX = 0;
+    AVE = 1;
+    STOCHASTIC = 2;
+  }
+  optional PoolMethod pool = 1 [default = MAX]; // The pooling method
+  optional uint32 bin_num_h = 2; // number of spatial bins along height axis
+  optional uint32 bin_num_w = 3; // number of spatial bins along width axis
 }
 
 // Message that stores parameters used by PowerLayer


### PR DESCRIPTION
Note: DO NOT use the code now, for it is incomplete and under development.

This is a PyramidLevelLayer implementation, which can be used to build spatial pyramids, especially designed for #560 (Spatial Pyramid Pooling).

The pooling region is calculated in the following way:

A pooling region starts with `hstart` (include) and ends with `hend` (exclude):
`hstart = floor(ph * bin_size_h_)`
`hend = ceil((ph + 1) * bin_size_h_)`
where `bin_size_h_ = float(bottom[0]->height()) / bin_num_h_` is float-point bin length
and similar for `wstart` and `wend`

I will add tests and update.
