### PR TITLE
Don't make clean when running linecount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ SUPERCLEAN_EXTS := .so .a .o .bin .testbin .pb.cc .pb.h _pb2.py .cuo
 
 all: $(NAME) $(STATIC_NAME) tools examples
 
-linecount: clean
+linecount:
 	cloc --read-lang-def=$(PROJECT).cloc src/$(PROJECT)/
 
 lint: $(LINT_REPORT)


### PR DESCRIPTION
All built files are put into `build/`, outside of `src/` where the linecount is run -- so there is no reason to make clean first. (I verified results are the same before and after running `make clean`.)
