### PR TITLE
Fix bug introduced by warning logs (errors didn't print)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,13 +384,15 @@ $(STATIC_NAME): $(PROTO_OBJS) $(OBJS) | $(LIB_BUILD_DIR)
 
 $(TEST_BUILD_DIR)/%.o: src/$(PROJECT)/test/%.cpp $(HXX_SRCS) $(TEST_HDRS) \
 		| $(TEST_BUILD_DIR)
-	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT)
+	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
 $(TEST_BUILD_DIR)/%.cuo: src/$(PROJECT)/test/%.cu $(HXX_SRCS) $(TEST_HDRS) \
 		| $(TEST_BUILD_DIR)
-	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@ 2> $@.$(WARNS_EXT)
+	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
@@ -422,50 +424,59 @@ $(EXAMPLE_BINS): %.bin : %.o $(STATIC_NAME)
 
 $(LAYER_BUILD_DIR)/%.o: src/$(PROJECT)/layers/%.cpp $(HXX_SRCS) \
 		| $(LAYER_BUILD_DIR)
-	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT)
+	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
 $(PROTO_BUILD_DIR)/%.pb.o: $(PROTO_BUILD_DIR)/%.pb.cc $(PROTO_GEN_HEADER) \
 		| $(PROTO_BUILD_DIR)
-	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT)
+	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
 $(UTIL_BUILD_DIR)/%.o: src/$(PROJECT)/util/%.cpp $(HXX_SRCS) | $(UTIL_BUILD_DIR)
-	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT)
+	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
 $(GTEST_OBJ): $(GTEST_SRC) | $(GTEST_BUILD_DIR)
-	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT)
+	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
 $(LAYER_BUILD_DIR)/%.cuo: src/$(PROJECT)/layers/%.cu $(HXX_SRCS) \
 		| $(LAYER_BUILD_DIR)
-	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@ 2> $@.$(WARNS_EXT)
+	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
 $(UTIL_BUILD_DIR)/%.cuo: src/$(PROJECT)/util/%.cu | $(UTIL_BUILD_DIR)
-	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@ 2> $@.$(WARNS_EXT)
+	$(CUDA_DIR)/bin/nvcc $(NVCCFLAGS) $(CUDA_ARCH) -c $< -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
 $(TOOL_BUILD_DIR)/%.o: tools/%.cpp $(PROTO_GEN_HEADER) | $(TOOL_BUILD_DIR)
-	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT)
+	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
 $(EXAMPLE_BUILD_DIR)/%.o: examples/%.cpp $(PROTO_GEN_HEADER) \
 		| $(EXAMPLE_BUILD_DIRS)
-	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT)
+	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 
 $(BUILD_DIR)/src/$(PROJECT)/%.o: src/$(PROJECT)/%.cpp $(HXX_SRCS)
-	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT)
+	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+		|| cat $@.$(WARNS_EXT); exit 1
 	@ cat $@.$(WARNS_EXT)
 	@ echo
 


### PR DESCRIPTION
Not sure how I missed that this would be an issue but after my warning logging by redirecting the compiler's stderr output to a file, errors no longer printed as they were just getting sent to that file (of course) and then make will immediately stop when any command returns a non-zero exit code so the `cat <warning file>` command wasn't being reached.  I don't know of a way to avoid the errors going to the warning logs (seems ok to me), so now if compilation fails I print that warning log file and exit with a non-zero code.
