### PR TITLE
[WIP] [example] training a classifier on hdf5 data

### DIFF
--- a/examples/hdf5_classification.ipynb
+++ b/examples/hdf5_classification.ipynb
@@ -1,0 +1,32 @@
+{
+ "metadata": {
+  "name": "Learning a classifier on HDF5 data",
+  "description": "Use Caffe as a generic SGD optimizer to train a classifier on non-image HDF5 data.",
+  "include_in_docs": true,
+  "signature": "sha256:9ec08127fb61240a29be7b30a2ed833d5cb644d77f6c7d126171b34758d5f434"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "# Caffe as a generic SGD optimizer, running on free-form data in HDF5 format"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
Since there's repeated interest (e.g. #550, #595), there should be an IPython notebook showing how to use Caffe as a generic SGD solver for classification tasks, running on HDF5 data.
