### PR TITLE
Fix bug that breaks MATLAB 2014a compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,9 +336,9 @@ $(MAT$(PROJECT)_SO): $(MAT$(PROJECT)_SRC) $(STATIC_NAME)
 			"to build mat$(PROJECT)."; \
 		exit 1; \
 	fi
-	$(MATLAB_DIR)/bin/mex $(MAT$(PROJECT)_SRC) $(STATIC_NAME) \
+	$(MATLAB_DIR)/bin/mex $(MAT$(PROJECT)_SRC) \
 			CXXFLAGS="\$$CXXFLAGS $(MATLAB_CXXFLAGS)" \
-			CXXLIBS="\$$CXXLIBS $(LDFLAGS)" -o $@
+			CXXLIBS="\$$CXXLIBS $(STATIC_NAME) $(LDFLAGS)" -output $@
 	@ echo
 
 runtest: $(TEST_ALL_BIN)


### PR DESCRIPTION
Change how mex is called to fix broken compilation with MATLAB 2014a. I've tested this with 2014a and 2012b (2012b was working previous to this change and continues to work with this fix). This PR may address issues that people have been reporting (e.g., #605, #677).
