### PR TITLE
Cleanup pthread code for data layers

### DIFF
--- a/include/caffe/internal_thread.hpp
+++ b/include/caffe/internal_thread.hpp
@@ -1,0 +1,46 @@
+// Copyright 2014 BVLC and contributors.
+
+#ifndef CAFFE_INTERNAL_THREAD_HPP_
+#define CAFFE_INTERNAL_THREAD_HPP_
+
+#include <pthread.h>
+
+namespace caffe {
+
+/**
+ * Virutal class encapsulate pthread for use in base class
+ * The child class will acquire the ability to run a single pthread,
+ * by reimplementing the virutal function InternalThreadEntry.
+ */
+class InternalThread {
+ public:
+  InternalThread() {}
+  virtual ~InternalThread() {}
+
+  /** Returns true if the thread was successfully started **/
+  bool StartInternalThread() {
+    return pthread_create(&_thread, NULL, InternalThreadEntryFunc, this);
+  }
+
+  /** Will not return until the internal thread has exited. */
+  bool WaitForInternalThreadToExit() {
+    return pthread_join(_thread, NULL);
+  }
+
+ protected:
+  /* Implement this method in your subclass 
+      with the code you want your thread to run. */
+  virtual void InternalThreadEntry() = 0;
+
+ private:
+  static void * InternalThreadEntryFunc(void * This) {
+    reinterpret_cast<InternalThread *>(This)->InternalThreadEntry();
+    return NULL;
+  }
+
+  pthread_t _thread;
+};
+
+}  // namespace caffe
+
+#endif

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -2,7 +2,6 @@
 
 #include <stdint.h>
 #include <leveldb/db.h>
-#include <pthread.h>
 
 #include <string>
 #include <vector>
@@ -18,17 +17,14 @@
 
 namespace caffe {
 
+// This function is used to create a pthread that prefetches the data.
 template <typename Dtype>
-void* ImageDataLayerPrefetch(void* layer_pointer) {
-  CHECK(layer_pointer);
-  ImageDataLayer<Dtype>* layer =
-      reinterpret_cast<ImageDataLayer<Dtype>*>(layer_pointer);
-  CHECK(layer);
+void ImageDataLayer<Dtype>::InternalThreadEntry() {
   Datum datum;
-  CHECK(layer->prefetch_data_.count());
-  Dtype* top_data = layer->prefetch_data_.mutable_cpu_data();
-  Dtype* top_label = layer->prefetch_label_.mutable_cpu_data();
-  ImageDataParameter image_data_param = layer->layer_param_.image_data_param();
+  CHECK(prefetch_data_.count());
+  Dtype* top_data = prefetch_data_.mutable_cpu_data();
+  Dtype* top_label = prefetch_label_.mutable_cpu_data();
+  ImageDataParameter image_data_param = this->layer_param_.image_data_param();
   const Dtype scale = image_data_param.scale();
   const int batch_size = image_data_param.batch_size();
   const int crop_size = image_data_param.crop_size();
@@ -41,17 +37,17 @@ void* ImageDataLayerPrefetch(void* layer_pointer) {
         << "set at the same time.";
   }
   // datum scales
-  const int channels = layer->datum_channels_;
-  const int height = layer->datum_height_;
-  const int width = layer->datum_width_;
-  const int size = layer->datum_size_;
-  const int lines_size = layer->lines_.size();
-  const Dtype* mean = layer->data_mean_.cpu_data();
+  const int channels = datum_channels_;
+  const int height = datum_height_;
+  const int width = datum_width_;
+  const int size = datum_size_;
+  const int lines_size = lines_.size();
+  const Dtype* mean = data_mean_.cpu_data();
   for (int item_id = 0; item_id < batch_size; ++item_id) {
     // get a blob
-    CHECK_GT(lines_size, layer->lines_id_);
-    if (!ReadImageToDatum(layer->lines_[layer->lines_id_].first,
-          layer->lines_[layer->lines_id_].second,
+    CHECK_GT(lines_size, lines_id_);
+    if (!ReadImageToDatum(lines_[lines_id_].first,
+          lines_[lines_id_].second,
           new_height, new_width, &datum)) {
       continue;
     }
@@ -60,14 +56,14 @@ void* ImageDataLayerPrefetch(void* layer_pointer) {
       CHECK(data.size()) << "Image cropping only support uint8 data";
       int h_off, w_off;
       // We only do random crop when we do training.
-      if (layer->phase_ == Caffe::TRAIN) {
-        h_off = layer->PrefetchRand() % (height - crop_size);
-        w_off = layer->PrefetchRand() % (width - crop_size);
+      if (phase_ == Caffe::TRAIN) {
+        h_off = PrefetchRand() % (height - crop_size);
+        w_off = PrefetchRand() % (width - crop_size);
       } else {
         h_off = (height - crop_size) / 2;
         w_off = (width - crop_size) / 2;
       }
-      if (mirror && layer->PrefetchRand() % 2) {
+      if (mirror && PrefetchRand() % 2) {
         // Copy mirrored version
         for (int c = 0; c < channels; ++c) {
           for (int h = 0; h < crop_size; ++h) {
@@ -114,18 +110,16 @@ void* ImageDataLayerPrefetch(void* layer_pointer) {
 
     top_label[item_id] = datum.label();
     // go to the next iter
-    layer->lines_id_++;
-    if (layer->lines_id_ >= lines_size) {
+    lines_id_++;
+    if (lines_id_ >= lines_size) {
       // We have reached the end. Restart from the first.
       DLOG(INFO) << "Restarting data prefetching from start.";
-      layer->lines_id_ = 0;
-      if (layer->layer_param_.image_data_param().shuffle()) {
-        layer->ShuffleImages();
+      lines_id_ = 0;
+      if (this->layer_param_.image_data_param().shuffle()) {
+        ShuffleImages();
       }
     }
   }
-
-  return reinterpret_cast<void*>(NULL);
 }
 
 template <typename Dtype>
@@ -239,8 +233,7 @@ void ImageDataLayer<Dtype>::CreatePrefetchThread() {
     prefetch_rng_.reset();
   }
   // Create the thread.
-  CHECK(!pthread_create(&thread_, NULL, ImageDataLayerPrefetch<Dtype>,
-        static_cast<void*>(this))) << "Pthread execution failed.";
+  CHECK(!StartInternalThread()) << "Pthread execution failed";
 }
 
 template <typename Dtype>
@@ -255,9 +248,10 @@ void ImageDataLayer<Dtype>::ShuffleImages() {
   }
 }
 
+
 template <typename Dtype>
 void ImageDataLayer<Dtype>::JoinPrefetchThread() {
-  CHECK(!pthread_join(thread_, NULL)) << "Pthread joining failed.";
+  CHECK(!WaitForInternalThreadToExit()) << "Pthread joining failed";
 }
 
 template <typename Dtype>

--- a/src/caffe/test/test_power_layer.cpp
+++ b/src/caffe/test/test_power_layer.cpp
@@ -13,8 +13,6 @@
 
 #include "caffe/test/test_caffe_main.hpp"
 
-using std::isnan;
-
 namespace caffe {
 
 template <typename TypeParam>


### PR DESCRIPTION
While creating a new data layer class needed for my Siamese network, I noticed that the
pthread code wasn't particularely clean.

Thus I
- Got rid of the needless friend functions. Previously the threads were defined as a friend function.
  This forced to pass a pointer to the current layer, and do needless casts and pointer checks.
- Created an InternalThread class that makes it easy to create a class requiring a single thread (such as DataLayer, ImageDataLayer...).
  It is done by inheriting the InternalThread class, and overriding the InternalThreadEntry virtual function to
  define the thread's code. It has the necessary mechanism to start and wait for a thread.

This is my first contribution to Caffe, I hope I followed all the guidelines properly ;)

Cheers,
Arnaud
