### PR TITLE
Small improvements to pycaffe

### DIFF
--- a/python/caffe/pycaffe.py
+++ b/python/caffe/pycaffe.py
@@ -262,9 +262,9 @@ def _Net_preprocess(self, input_name, input_):
     in_size = self.blobs[input_name].data.shape[2:]
     if caffe_in.shape[:2] != in_size:
         caffe_in = caffe.io.resize_image(caffe_in, in_size)
-    if input_scale:
+    if input_scale is not None:
         caffe_in *= input_scale
-    if channel_order:
+    if channel_order is not None:
         caffe_in = caffe_in[:, :, channel_order]
     caffe_in = caffe_in.transpose((2, 0, 1))
     if hasattr(self, 'mean'):
@@ -282,11 +282,11 @@ def _Net_deprocess(self, input_name, input_):
     if hasattr(self, 'mean'):
         decaf_in += self.mean.get(input_name, 0)
     decaf_in = decaf_in.transpose((1,2,0))
-    if channel_order:
+    if channel_order is not None:
         channel_order_inverse = [channel_order.index(i)
                                  for i in range(decaf_in.shape[2])]
         decaf_in = decaf_in[:, :, channel_order_inverse]
-    if input_scale:
+    if input_scale is not None:
         decaf_in /= input_scale
     return decaf_in
 


### PR DESCRIPTION
I haven't tested these exact commits yet, although I've made the same changes elsewhere in the past.

These three commits:
- fix issue #671, by correctly defaulting mean to zero even if `set_mean` is never called,
- reorder exceptions to provide a more helpful message for non-4d blob input, and
- change checks on `channel_order` and `input_scale` so that pathological input behaves closer to expectation.

Expanding on the last point in particular:
- Right now setting `input_scale` to zero is the same as setting `input_scale` to one, due to the check `if input_scale`. Allowing the multiplication/division by zero properly breaks things or produces warnings.
- Right now setting `channel_order` to `()` or `0` is the same as setting it to the identity, due to the check `if channel_order`. Note that both of these are valid indices in numpy, although actually using them in this context is probably a mistake. Allowing the indexing will make such usages crash in most cases, instead of continuing as if the input were valid.
