### PR TITLE
Solver callback

### DIFF
--- a/include/caffe/default_solver_actions.hpp
+++ b/include/caffe/default_solver_actions.hpp
@@ -1,0 +1,116 @@
+// Copyright 2014 BVLC and contributors.
+#pragma once
+
+#include <string>
+#include "caffe/iter_callback.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+template< typename Dtype >
+struct DefaultSolverActions {
+  DefaultSolverActions() {
+  }
+
+  explicit DefaultSolverActions(const SolverParameter& solver_param):
+      param_(solver_param) {
+  }
+
+  void SetResumeFile(const std::string& resume_file) {
+      resume_file_ = resume_file;
+  }
+
+  // Function operator overload implements the functor needed by
+  // solver to handle training iteration notifications and provide
+  // indications as to what to do.
+  IterActions<Dtype> operator()(const TrainingStats<Dtype>& stats) {
+    IterActions<Dtype> actions;
+
+    if (stats.GetIter() < param_.max_iter()) {
+      actions.SetShouldContinue();
+    } else {
+      actions.SetShouldStop();
+    }
+
+    if (this->param_.display() &&
+         (stats.GetIter() % this->param_.display() == 0)) {
+      actions.SetShouldDisplay();
+    }
+
+    actions.SetLearnRate(this->GetLearningRate(stats));
+    actions.SetMomentum(this->param_.momentum());
+    actions.SetWeightDecay(this->param_.weight_decay());
+
+    // We haven't started training yet when GetIter() == 0.
+    if (stats.GetIter() == 0) {
+      // Resume before starting if a resume file was specified.
+      if ( !resume_file_.empty() ) {
+        actions.SetResumeFile(resume_file_);
+      }
+
+      // Run a test pass before doing any training to avoid waiting a
+      // potentially very long time (param_.test_interval() training iterations)
+      // to report that there's not enough memory to run the test net and crash,
+      // etc.; and to gauge the effect of the first training iterations.
+      if (param_.test_interval()) {
+        actions.SetShouldTest();
+      }
+    } else {
+      // We have begun training.
+      if (this->param_.display() && (stats.GetIter() %
+                                       param_.display() == 0) ) {
+         actions.SetShouldDisplay();
+      }
+
+      if (param_.test_interval() && ( stats.GetIter() %
+                                       param_.test_interval() == 0)) {
+        actions.SetShouldTest();
+      }
+
+      if (param_.snapshot() &&
+         (stats.GetIter() % param_.snapshot() == 0) &&
+         (stats.GetIter() > stats.GetStartIter())) {
+        actions.SetShouldSnapshot();
+      }
+    }
+    return actions;
+  }
+
+  // Return the current learning rate. The currently implemented learning rate
+  // policies are as follows:
+  //    - fixed: always return base_lr.
+  //    - step: return base_lr * gamma ^ (floor(iter / step))
+  //    - exp: return base_lr * gamma ^ iter
+  //    - inv: return base_lr * (1 + gamma * iter) ^ (- power)
+  // where base_lr, gamma, step and power are defined in the solver parameter
+  // protocol buffer, and iter is the current iteration.
+  Dtype GetLearningRate(const TrainingStats<Dtype>& stats) {
+    Dtype rate;
+    const string& lr_policy = this->param_.lr_policy();
+    if (lr_policy == "fixed") {
+      rate = this->param_.base_lr();
+    } else if (lr_policy == "step") {
+      int current_step = stats.GetIter() / this->param_.stepsize();
+      rate = this->param_.base_lr() *
+          pow(this->param_.gamma(), current_step);
+    } else if (lr_policy == "exp") {
+      rate = this->param_.base_lr() *
+          pow(this->param_.gamma(), stats.GetIter());
+    } else if (lr_policy == "inv") {
+      rate = this->param_.base_lr() *
+          pow(Dtype(1) + this->param_.gamma() * stats.GetIter(),
+              - this->param_.power());
+    } else {
+      LOG(FATAL) << "Unknown learning rate policy: " << lr_policy;
+    }
+    return rate;
+  }
+
+ private:
+  // The solver parameter object specificed in proto file.
+  SolverParameter param_;
+  // File to resume from, if any.
+  std::string resume_file_;
+};
+
+}  // namespace caffe

--- a/include/caffe/iter_callback.hpp
+++ b/include/caffe/iter_callback.hpp
@@ -1,0 +1,111 @@
+// Copyright 2014 BVLC and contributors.
+#pragma once
+
+#include <boost/function.hpp>
+#include <boost/optional.hpp>
+#include <string>
+#include <vector>
+
+namespace caffe {
+
+// Provides indication to the solver after each iteration  if it should save
+// a snapshot, continue or stop, what the learning rate should be and cetera.
+template< typename Dtype>
+struct IterActions {
+    // Constructor.
+    IterActions();
+    void SetResumeFile(const std::string& resume_file);
+    void SetShouldSnapshot();
+    void SetShouldTest();
+    void SetLearnRate(Dtype learn_rate);
+    void SetMomentum(Dtype momentum);
+    void SetWeightDecay(double weight_decay);
+    void SetShouldContinue();
+    void SetShouldStop();
+    void SetShouldDisplay();
+    // True if the solver should create a snapshot.
+    bool ShouldSnapshot() const;
+    // True if solver should write to the log.
+    bool ShouldDisplay() const;
+    // True if the solver should test.
+    bool ShouldTest() const;
+    // True if the solver should continue running.
+    bool ShouldContinue() const;
+    // True if the solver should resume from the resume file.
+    bool ShouldResume() const;
+    // Path to the file to load when resuming.
+    std::string GetResumeFile() const;
+    Dtype GetLearningRate() const;
+    Dtype GetMomentum() const;
+    Dtype GetWeightDecay() const;
+
+ private:
+    // True iff the solver should save a snapshot.
+    bool create_snapshot_;
+    // True iff the solver should continue training.
+    bool continue_;
+    bool test_;
+    bool display_;
+    Dtype learn_rate_;
+    Dtype momentum_;
+    bool resume_;
+    std::string resume_file_;
+    Dtype weight_decay_;
+};
+
+template<typename Dtype>
+struct TestResult{
+    void SetLoss(Dtype loss);
+    // One score for each test iteration.
+    void SetScores(const std::vector<Dtype>& scores);
+    boost::optional<Dtype> GetLoss() const;
+    std::vector<Dtype> GetScores() const;
+
+ private:
+    // Loss on the test net, if param_.test_compute_loss_ was true.
+    // Otherwise the loss is not present.
+    boost::optional<Dtype> loss_;
+    // Scores of the test net on each "test iteration". So size is equal
+    // to param_.test_iter(test_net_id).
+    std::vector<Dtype> scores_;
+};
+
+// Current training statistics.
+template<typename Dtype>
+struct TrainingStats {
+    void SetStartIter(int start_iter);
+    void SetIter(int iter);
+    void SetLoss(Dtype loss);
+    void AddTestNetResult(const TestResult<Dtype>& result);
+    int GetIter() const;
+    int GetStartIter() const;
+    Dtype GetLoss() const;
+    // One TestResult instance for each test net.
+    std::vector< TestResult<Dtype> > GetTestNetResults() const;
+
+ private:
+    // Number of iterations when training started. Greater than zero
+    // if we started by resuming from a previously-saved state.
+    int start_iter_;
+    // Number of iterations completed.
+    int iter_;
+    // Loss on the net being trained.
+    Dtype loss_;
+    // Results of the test net testing.
+    std::vector< TestResult<Dtype> > testnet_results_;
+};
+
+// Type of the training iteration callback functor that is provided to the
+// solver. The function is called by the solver to deliver
+// statistics to the solver's client, and the client returns IterActions
+// indicating whether training continue, if a snapshot should be saved, learning
+// rate and cetera.
+template <typename Dtype>
+struct IterCallback {
+  // Type for a function that takes a TrainingStats object, and returns
+  // an IterActions object.
+  typedef boost::function< IterActions<Dtype>(
+                              const TrainingStats<Dtype>&)> Type;
+};
+
+}  // namespace caffe

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -5,6 +5,8 @@
 
 #include <string>
 #include <vector>
+#include "caffe/iter_callback.hpp"
+#include "caffe/default_solver_actions.hpp"
 
 #include "caffe/net.hpp"
 
@@ -20,8 +22,7 @@ class Solver {
   void InitTestNets();
   // The main entry of the solver function. In default, iter will be zero. Pass
   // in a non-zero iter number to resume training for a pre-trained net.
-  virtual void Solve(const char* resume_file = NULL);
-  inline void Solve(const string resume_file) { Solve(resume_file.c_str()); }
+  virtual void Solve(typename IterCallback<Dtype>::Type iter_callback);
   virtual ~Solver() {}
   inline shared_ptr<Net<Dtype> > net() { return net_; }
   inline const vector<shared_ptr<Net<Dtype> > >& test_nets() {
@@ -33,15 +34,15 @@ class Solver {
   // put up some scaffold.
   virtual void PreSolve() {}
   // Get the update value for the current iteration.
-  virtual void ComputeUpdateValue() = 0;
+  virtual void ComputeUpdateValue(const IterActions<Dtype>& actions) = 0;
   // The Solver::Snapshot function implements the basic snapshotting utility
   // that stores the learned net. You should implement the SnapshotSolverState()
   // function that produces a SolverState protocol buffer that needs to be
   // written to disk together with the learned net.
   void Snapshot();
   // The test routine
-  void TestAll();
-  void Test(const int test_net_id = 0);
+  TrainingStats<Dtype> TestAll();
+  TestResult<Dtype> Test(const int test_net_id = 0);
   virtual void SnapshotSolverState(SolverState* state) = 0;
   // The Restore function implements how one should restore the solver to a
   // previously snapshotted state. You should implement the RestoreSolverState()
@@ -53,31 +54,57 @@ class Solver {
   int iter_;
   shared_ptr<Net<Dtype> > net_;
   vector<shared_ptr<Net<Dtype> > > test_nets_;
+  typename IterCallback<Dtype>::Type callback_;
 
   DISABLE_COPY_AND_ASSIGN(Solver);
 };
 
-
 template <typename Dtype>
-class SGDSolver : public Solver<Dtype> {
+class SGDSolverEx : public Solver<Dtype> {
  public:
-  explicit SGDSolver(const SolverParameter& param)
+  explicit SGDSolverEx(const SolverParameter& param )
       : Solver<Dtype>(param) {}
-  explicit SGDSolver(const string& param_file)
+  explicit SGDSolverEx(const string& param_file )
       : Solver<Dtype>(param_file) {}
 
  protected:
   virtual void PreSolve();
   Dtype GetLearningRate();
-  virtual void ComputeUpdateValue();
+  virtual void ComputeUpdateValue(const IterActions<Dtype>& actions);
   virtual void SnapshotSolverState(SolverState * state);
   virtual void RestoreSolverState(const SolverState& state);
   // history maintains the historical momentum data.
   vector<shared_ptr<Blob<Dtype> > > history_;
 
-  DISABLE_COPY_AND_ASSIGN(SGDSolver);
+  DISABLE_COPY_AND_ASSIGN(SGDSolverEx);
 };
 
+template <typename Dtype>
+class SGDSolver : public SGDSolverEx<Dtype> {
+ public:
+    explicit SGDSolver(const SolverParameter& param)
+      : SGDSolverEx<Dtype>(param),
+        handler_(param) {}
+    explicit SGDSolver(const string& param_file)
+      : SGDSolverEx<Dtype>(param_file),
+        handler_() {
+        handler_ = DefaultSolverActions<Dtype>(
+                    this->param_);
+    }
+    void Solve(const char* resume_file = 0) {
+        bool is_null = (resume_file == 0);
+        std::string file_string;
+        if (!is_null) {
+            file_string = std::string(resume_file);
+        }
+        handler_.SetResumeFile(file_string);
+        Solver<Dtype>::Solve(handler_);
+    }
+    inline void Solve(const string resume_file) { Solve(resume_file.c_str()); }
+ protected:
+    DefaultSolverActions<Dtype> handler_;
+    DISABLE_COPY_AND_ASSIGN(SGDSolver);
+};
 
 }  // namespace caffe
 

--- a/src/caffe/iter_callback.cpp
+++ b/src/caffe/iter_callback.cpp
@@ -1,0 +1,187 @@
+// Copyright 2014 BVLC and contributors.
+
+#include <string>
+#include <vector>
+#include "caffe/common.hpp"
+#include "caffe/iter_callback.hpp"
+
+// Provides indication to the solver after each iteration  if it should save
+// a snapshot, continue or stop, what the learning rate should be and cetera.
+
+namespace caffe {
+
+// Constructor.
+template<typename Dtype>
+IterActions<Dtype>::IterActions():
+        create_snapshot_(false),
+        continue_(false),
+        test_(false),
+        display_(false),
+        learn_rate_(0.0),
+        momentum_(0.0),
+        resume_(false),
+        resume_file_(),
+        weight_decay_(0.0) {}
+
+template<typename Dtype>
+void IterActions<Dtype>::SetResumeFile(
+    const std::string& resume_file ) {
+  resume_file_ = resume_file;
+  resume_ = true;
+}
+
+template<typename Dtype>
+void IterActions<Dtype>::SetShouldSnapshot() {
+  create_snapshot_ = true;
+}
+
+template<typename Dtype>
+void IterActions<Dtype>::SetShouldTest() {
+  test_ = true;
+}
+
+template<typename Dtype>
+void IterActions<Dtype>::SetLearnRate(Dtype learn_rate) {
+  learn_rate_ = learn_rate;
+}
+
+template<typename Dtype>
+void IterActions<Dtype>::SetMomentum(Dtype momentum) {
+  momentum_ = momentum;
+}
+
+template<typename Dtype>
+void IterActions<Dtype>::SetWeightDecay(double weight_decay) {
+  weight_decay_ = weight_decay;
+}
+
+template<typename Dtype>
+void IterActions<Dtype>::SetShouldContinue() {
+  continue_ = true;
+}
+
+template<typename Dtype>
+void IterActions<Dtype>::SetShouldStop() {
+  continue_ = false;
+}
+
+template<typename Dtype>
+void IterActions<Dtype>::SetShouldDisplay() {
+  display_ = true;
+}
+
+template<typename Dtype>
+bool IterActions<Dtype>::ShouldSnapshot() const {
+  return create_snapshot_;
+}
+
+template<typename Dtype>
+bool IterActions<Dtype>::ShouldDisplay() const {
+  return display_;
+}
+
+template<typename Dtype>
+bool IterActions<Dtype>::ShouldTest() const {
+  return test_;
+}
+
+template<typename Dtype>
+bool IterActions<Dtype>::ShouldContinue() const {
+  return continue_;
+}
+
+template<typename Dtype>
+bool IterActions<Dtype>::ShouldResume() const {
+  return resume_;
+}
+
+template<typename Dtype>
+std::string IterActions<Dtype>::GetResumeFile() const {
+  return resume_file_;
+}
+
+template<typename Dtype>
+Dtype IterActions<Dtype>::GetLearningRate() const {
+  return learn_rate_;
+}
+
+template<typename Dtype>
+Dtype IterActions<Dtype>::GetMomentum() const {
+  return momentum_;
+}
+
+template<typename Dtype>
+Dtype IterActions<Dtype>::GetWeightDecay() const {
+  return weight_decay_;
+}
+
+//==============================================================================
+// TestResult class
+//==============================================================================
+template<typename Dtype>
+void TestResult<Dtype>::SetLoss(Dtype loss) {
+  loss_ = loss;
+}
+
+template<typename Dtype>
+void TestResult<Dtype>::SetScores(const std::vector<Dtype>& scores) {
+  scores_ = scores;
+}
+
+template<typename Dtype>
+boost::optional<Dtype> TestResult<Dtype>::GetLoss() const {
+  return loss_;
+}
+
+template<typename Dtype>
+std::vector<Dtype> TestResult<Dtype>::GetScores() const {
+  return scores_;
+}
+
+template<typename Dtype>
+void TrainingStats<Dtype>::SetStartIter(int start_iter) {
+  start_iter_ = start_iter;
+}
+
+template<typename Dtype>
+void TrainingStats<Dtype>::SetIter(int iter) {
+  iter_ = iter;
+}
+
+template<typename Dtype>
+void TrainingStats<Dtype>::SetLoss(Dtype loss) {
+  loss_ = loss;
+}
+
+template<typename Dtype>
+void TrainingStats<Dtype>::AddTestNetResult(
+                                    const TestResult<Dtype>& result) {
+  testnet_results_.push_back(result);
+}
+
+template<typename Dtype>
+int TrainingStats<Dtype>::GetIter() const {
+  return iter_;
+}
+
+template<typename Dtype>
+int TrainingStats<Dtype>::GetStartIter() const {
+  return start_iter_;
+}
+
+template<typename Dtype>
+Dtype TrainingStats<Dtype>::GetLoss() const {
+  return loss_;
+}
+
+template<typename Dtype>
+std::vector< TestResult<Dtype> >
+TrainingStats<Dtype>::GetTestNetResults() const {
+  return testnet_results_;
+}
+
+INSTANTIATE_CLASS(IterActions);
+INSTANTIATE_CLASS(TestResult);
+INSTANTIATE_CLASS(TrainingStats);
+
+}  // namespace caffe

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -1,8 +1,7 @@
 // Copyright 2014 BVLC and contributors.
 
-#include <cstdio>
-
 #include <algorithm>
+#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -12,6 +11,10 @@
 #include "caffe/util/io.hpp"
 #include "caffe/util/math_functions.hpp"
 #include "caffe/util/upgrade_proto.hpp"
+#include "caffe/iter_callback.hpp"
+
+using std::max;
+using std::min;
 
 namespace caffe {
 
@@ -162,15 +165,23 @@ void Solver<Dtype>::InitTestNets() {
 }
 
 template <typename Dtype>
-void Solver<Dtype>::Solve(const char* resume_file) {
+void Solver<Dtype>::Solve(typename IterCallback<Dtype>::Type callback) {
+  if (callback.empty()) {
+      LOG(FATAL) << "Solver iter callback is not set.";
+  }
+
   Caffe::set_phase(Caffe::TRAIN);
   LOG(INFO) << "Solving " << net_->name();
   PreSolve();
 
   iter_ = 0;
-  if (resume_file) {
+  TrainingStats<Dtype> stats;
+  stats.SetIter(iter_);
+  IterActions<Dtype> actions = callback(stats);
+  if (actions.ShouldResume()) {
+    std::string resume_file = actions.GetResumeFile();
     LOG(INFO) << "Restoring previous solver status from " << resume_file;
-    Restore(resume_file);
+    Restore(resume_file.c_str());
   }
   // Remember the initial iter_ value; will be non-zero if we loaded from a
   // resume_file above.
@@ -179,27 +190,34 @@ void Solver<Dtype>::Solve(const char* resume_file) {
   // For a network that is trained by the solver, no bottom or top vecs
   // should be given, and we will just provide dummy vecs.
   vector<Blob<Dtype>*> bottom_vec;
-  for (; iter_ < param_.max_iter(); ++iter_) {
+  while (actions.ShouldContinue()) {
     // Save a snapshot if needed.
-    if (param_.snapshot() && iter_ > start_iter &&
-        iter_ % param_.snapshot() == 0) {
-      Snapshot();
+    if (actions.ShouldSnapshot()) {
+        Snapshot();
     }
 
-    if (param_.test_interval() && iter_ % param_.test_interval() == 0) {
-      TestAll();
+    if (actions.ShouldTest()) {
+        stats = TestAll();
     }
 
-    const bool display = param_.display() && iter_ % param_.display() == 0;
-    net_->set_debug_info(display && param_.debug_info());
+    net_->set_debug_info(actions.ShouldDisplay() && param_.debug_info());
     Dtype loss = net_->ForwardBackward(bottom_vec);
-    if (display) {
-      LOG(INFO) << "Iteration " << iter_ << ", loss = " << loss;
+    if (actions.ShouldDisplay()) {
+        LOG(INFO) << "Iteration " << iter_ << ", loss = " << loss;
     }
 
-    ComputeUpdateValue();
+    ComputeUpdateValue(actions);
     net_->Update();
+
+    ++iter_;
+    stats.SetStartIter(start_iter);
+    stats.SetIter(iter_);
+    stats.SetLoss(loss);
+    // Call the client, delivering the statistics and getting his
+    // instructions for the next iteration.
+    actions = callback(stats);
   }
+
   // Always save a snapshot after optimization.
   Snapshot();
   // After the optimization is done, run an additional train and test pass to
@@ -219,17 +237,18 @@ void Solver<Dtype>::Solve(const char* resume_file) {
   LOG(INFO) << "Optimization Done.";
 }
 
-
 template <typename Dtype>
-void Solver<Dtype>::TestAll() {
+TrainingStats<Dtype> Solver<Dtype>::TestAll() {
+  TrainingStats<Dtype> stats;
   for (int test_net_id = 0; test_net_id < test_nets_.size(); ++test_net_id) {
-    Test(test_net_id);
+     TestResult<Dtype> result = Test(test_net_id);
+     stats.AddTestNetResult(result);
   }
+  return stats;
 }
 
-
 template <typename Dtype>
-void Solver<Dtype>::Test(const int test_net_id) {
+TestResult<Dtype> Solver<Dtype>::Test(const int test_net_id) {
   LOG(INFO) << "Iteration " << iter_
             << ", Testing net (#" << test_net_id << ")";
   // We need to set phase to test before running.
@@ -238,7 +257,7 @@ void Solver<Dtype>::Test(const int test_net_id) {
       ShareTrainedLayersWith(net_.get());
   vector<Dtype> test_score;
   vector<Blob<Dtype>*> bottom_vec;
-  Dtype loss = 0;
+  Dtype loss = 0.0;
   for (int i = 0; i < param_.test_iter(test_net_id); ++i) {
     Dtype iter_loss;
     const vector<Blob<Dtype>*>& result =
@@ -263,17 +282,24 @@ void Solver<Dtype>::Test(const int test_net_id) {
       }
     }
   }
+
+  TestResult<Dtype> result;
   if (param_.test_compute_loss()) {
     loss /= param_.test_iter(test_net_id);
     LOG(INFO) << "Test loss: " << loss;
+    result.SetLoss(loss);
   }
+  std::vector<Dtype> reported_scores;
   for (int i = 0; i < test_score.size(); ++i) {
+    Dtype reported_score = test_score[i] / param_.test_iter(test_net_id);
     LOG(INFO) << "Test score #" << i << ": "
-        << test_score[i] / param_.test_iter(test_net_id);
+        << reported_score;
+    reported_scores.push_back(reported_score);
   }
+  result.SetScores(reported_scores);
   Caffe::set_phase(Caffe::TRAIN);
+  return result;
 }
-
 
 template <typename Dtype>
 void Solver<Dtype>::Snapshot() {
@@ -309,40 +335,8 @@ void Solver<Dtype>::Restore(const char* state_file) {
   RestoreSolverState(state);
 }
 
-
-// Return the current learning rate. The currently implemented learning rate
-// policies are as follows:
-//    - fixed: always return base_lr.
-//    - step: return base_lr * gamma ^ (floor(iter / step))
-//    - exp: return base_lr * gamma ^ iter
-//    - inv: return base_lr * (1 + gamma * iter) ^ (- power)
-// where base_lr, gamma, step and power are defined in the solver parameter
-// protocol buffer, and iter is the current iteration.
 template <typename Dtype>
-Dtype SGDSolver<Dtype>::GetLearningRate() {
-  Dtype rate;
-  const string& lr_policy = this->param_.lr_policy();
-  if (lr_policy == "fixed") {
-    rate = this->param_.base_lr();
-  } else if (lr_policy == "step") {
-    int current_step = this->iter_ / this->param_.stepsize();
-    rate = this->param_.base_lr() *
-        pow(this->param_.gamma(), current_step);
-  } else if (lr_policy == "exp") {
-    rate = this->param_.base_lr() * pow(this->param_.gamma(), this->iter_);
-  } else if (lr_policy == "inv") {
-    rate = this->param_.base_lr() *
-        pow(Dtype(1) + this->param_.gamma() * this->iter_,
-            - this->param_.power());
-  } else {
-    LOG(FATAL) << "Unknown learning rate policy: " << lr_policy;
-  }
-  return rate;
-}
-
-
-template <typename Dtype>
-void SGDSolver<Dtype>::PreSolve() {
+void SGDSolverEx<Dtype>::PreSolve() {
   // Initialize the history
   vector<shared_ptr<Blob<Dtype> > >& net_params = this->net_->params();
   history_.clear();
@@ -354,19 +348,18 @@ void SGDSolver<Dtype>::PreSolve() {
   }
 }
 
-
 template <typename Dtype>
-void SGDSolver<Dtype>::ComputeUpdateValue() {
+void SGDSolverEx<Dtype>::ComputeUpdateValue(const IterActions<Dtype>& actions) {
   vector<shared_ptr<Blob<Dtype> > >& net_params = this->net_->params();
   vector<float>& net_params_lr = this->net_->params_lr();
   vector<float>& net_params_weight_decay = this->net_->params_weight_decay();
   // get the learning rate
-  Dtype rate = GetLearningRate();
-  if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
+  Dtype rate = actions.GetLearningRate();
+  if ( actions.ShouldDisplay() ) {
     LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate;
   }
-  Dtype momentum = this->param_.momentum();
-  Dtype weight_decay = this->param_.weight_decay();
+  Dtype momentum = actions.GetMomentum();
+  Dtype weight_decay = actions.GetWeightDecay();
   switch (Caffe::mode()) {
   case Caffe::CPU:
     for (int param_id = 0; param_id < net_params.size(); ++param_id) {
@@ -420,7 +413,7 @@ void SGDSolver<Dtype>::ComputeUpdateValue() {
 }
 
 template <typename Dtype>
-void SGDSolver<Dtype>::SnapshotSolverState(SolverState* state) {
+void SGDSolverEx<Dtype>::SnapshotSolverState(SolverState* state) {
   state->clear_history();
   for (int i = 0; i < history_.size(); ++i) {
     // Add history
@@ -430,7 +423,7 @@ void SGDSolver<Dtype>::SnapshotSolverState(SolverState* state) {
 }
 
 template <typename Dtype>
-void SGDSolver<Dtype>::RestoreSolverState(const SolverState& state) {
+void SGDSolverEx<Dtype>::RestoreSolverState(const SolverState& state) {
   CHECK_EQ(state.history_size(), history_.size())
       << "Incorrect length of history blobs.";
   LOG(INFO) << "SGDSolver: restoring history";
@@ -440,6 +433,7 @@ void SGDSolver<Dtype>::RestoreSolverState(const SolverState& state) {
 }
 
 INSTANTIATE_CLASS(Solver);
+INSTANTIATE_CLASS(SGDSolverEx);
 INSTANTIATE_CLASS(SGDSolver);
 
 }  // namespace caffe


### PR DESCRIPTION
The goal of this PR is provide a mechanism for a client of the library (such as a GUI) to take control of the training process to decide when to start and stop training, resume, and to be notified of training stats.

A callback function is passed to the Solve method. Solver calls the callback function on each training iteration. It passes the current training statistics to the callback. The callback returns an object that tells the solver what actions it should take (make a snapshot, resume, continue training or stop and cetera) as well as learning rate and weight decay.

A default implementation of the callback is provided (DefaultSolverActions) that preserves the existing behavior of the solver. 

I think this improves a [separation-of-concerns](http://en.wikipedia.org/wiki/Separation_of_concerns) with Solver. It seems to monolithic, trying to do too much. This change factors the logic for the decisions related to stopping, learning rate, weight decay, snapshots and resuming into a dependency on the callback and moves the current logic for doing these things into DefaultSolverActions.
