### PR TITLE
Add an "everything" target to make for comprehensive build testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,9 @@ SUPERCLEAN_EXTS := .so .a .o .bin .testbin .pb.cc .pb.h _pb2.py .cuo
 ##############################
 .PHONY: all test clean linecount lint tools examples $(DIST_ALIASES) \
 	py mat py$(PROJECT) mat$(PROJECT) proto runtest \
-	superclean supercleanlist supercleanfiles warn
+	superclean supercleanlist supercleanfiles warn everything
+
+everything: all py$(PROJECT) mat$(PROJECT) test warn lint runtest
 
 all: $(NAME) $(STATIC_NAME) tools examples
 


### PR DESCRIPTION
The everything target builds all components, checks warnings, runs lint, and runs tests.

This makes it easy to check that nothing is wrong with a build, just `make -jn everything`. This goes beyond Travis by including matcaffe and GPU tests.

If you think this is useful, merge. If you think this should be done another way, tell me what you prefer.
