### PR TITLE
Correctly apply padding to pooling layers when upgrading from V0

### DIFF
--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -82,11 +82,13 @@ void UpgradeV0PaddingLayers(const NetParameter& param,
       LayerParameter source_layer = param.layers(top_idx);
       if (source_layer.layer().type() == "padding") {
         // This layer has a padding layer as input -- check that it is a conv
-        // layer and takes only one input.  Also check that the padding layer
-        // input has only one input and one output.  Other cases have undefined
-        // behavior in Caffe.
-        CHECK_EQ(layer_param.type(), "conv") << "Padding layer input to "
-            "non-convolutional layer type " << layer_param.type();
+        // layer or a pooling layer and takes only one input.  Also check that
+        // the padding layer input has only one input and one output.  Other
+        // cases have undefined behavior in Caffe.
+        CHECK((layer_param.type() == "conv") || (layer_param.type() == "pool"))
+            << "Padding layer input to "
+            "non-convolutional / non-pooling layer type "
+            << layer_param.type();
         CHECK_EQ(layer_connection.bottom_size(), 1)
             << "Conv Layer takes a single blob as input.";
         CHECK_EQ(source_layer.bottom_size(), 1)
@@ -186,6 +188,8 @@ bool UpgradeLayerParameter(const LayerParameter& v0_layer_connection,
     if (v0_layer_param.has_pad()) {
       if (type == "conv") {
         layer_param->mutable_convolution_param()->set_pad(v0_layer_param.pad());
+      } else if (type == "pool") {
+        layer_param->mutable_pooling_param()->set_pad(v0_layer_param.pad());
       } else {
         LOG(ERROR) << "Unknown parameter pad for layer type " << type;
         is_fully_compatible = false;


### PR DESCRIPTION
The pooling layer supports padding for average and max pooling, however the V0 prototext upgrade script doesn't correctly translate pooling layers with padding when upgrading. This fixes that bug. 

Currently there is no check that the pooling layer being upgraded uses average or max pooling. I figure it's best to translate the prototxt as is and let downstream operations catch that error (also, in the future padding may be supported for other pooling operations).
