### PR TITLE
Use the same CXX for matcaffe as for the rest of the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,7 @@ $(MAT$(PROJECT)_SO): $(MAT$(PROJECT)_SRC) $(STATIC_NAME)
 		exit 1; \
 	fi
 	$(MATLAB_DIR)/bin/mex $(MAT$(PROJECT)_SRC) \
+			CXX="$(CXX)" \
 			CXXFLAGS="\$$CXXFLAGS $(MATLAB_CXXFLAGS)" \
 			CXXLIBS="\$$CXXLIBS $(STATIC_NAME) $(LDFLAGS)" -output $@
 	@ echo


### PR DESCRIPTION
A very small change that tells MATLAB's mex to use the same C++ compiler that is used for the rest of the Caffe build.
