### PR TITLE
using ::gflags seems incompatible with homebrew's gflags 2.0

### DIFF
--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -25,7 +25,7 @@ int64_t cluster_seedgen(void) {
 
 void GlobalInit(int* pargc, char*** pargv) {
   // Google flags.
-  ::gflags::ParseCommandLineFlags(pargc, pargv, true);
+  ::google::ParseCommandLineFlags(pargc, pargv, true);
   // Google logging.
   ::google::InitGoogleLogging(*(pargv)[0]);
 }


### PR DESCRIPTION
Changing the namespace to `::google` fixed the issue for me.

Also the header file being used (`gflags/gflags.h`) seems a bit outdated as well, since by default homebrew puts `gflags.h` under `google/gflags.h` (this seems to confirm that namespace `::gflags` has been merged into `::google`).
