### PR TITLE
speed up Travis build by installing only the CUDA subpackages necessary for building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,14 @@ install:
   - cd /tmp/glog-0.3.3 && ./configure && make && sudo make install && cd -
   - wget https://github.com/schuhschuh/gflags/archive/master.zip -O /tmp/gflags-master.zip && pushd /tmp/ && unzip gflags-master.zip && cd gflags-master && mkdir build && cd build && export CXXFLAGS="-fPIC" && cmake .. && make VERBOSE=1 && sudo make install && popd
   - curl http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_6.0-37_amd64.deb -o /tmp/cuda_install.deb && sudo dpkg -i /tmp/cuda_install.deb && rm /tmp/cuda_install.deb
-  - sudo apt-get -y update && sudo apt-get -y install cuda
+  - sudo apt-get -y update
+  # Install the minimal CUDA subpackages required to test Caffe build.
+  # For a full CUDA installation, add 'cuda' to the list of packages.
+  - sudo apt-get -y install cuda-core-6-0 cuda-extra-libs-6-0
+  # Create CUDA symlink at /usr/local/cuda
+  # (This would normally be created by the CUDA installer, but we create it
+  # manually since we did a partial installation.)
+  - sudo ln -s /usr/local/cuda-6.0 /usr/local/cuda
   - curl https://gitorious.org/mdb/mdb/archive/7f038d0f15bec57b4c07aa3f31cd5564c88a1897.tar.gz -o /tmp/mdb.tar.gz && tar -C /tmp -xzvf /tmp/mdb.tar.gz && rm /tmp/mdb.tar.gz
   - cd /tmp/mdb-mdb/libraries/liblmdb/ && make && sudo make install && cd -
 


### PR DESCRIPTION
Instead of installing the entire "cuda" package, install only a couple subpackages (which the cuda package installs, along with many other large packages).  Some of the packages are unnecessary since they're related to documentation, examples, UI, etc.; others are (probably?) only unnecessary because we're not actually running the GPU tests (since Travis doesn't have GPUs).

This cuts down the download size from 833 MB (https://travis-ci.org/BVLC/caffe/builds/30988484) to 271 MB (https://travis-ci.org/jeffdonahue/caffe/builds/31008638).  It's hard to say exactly how much of an improvement this is because there seems to be a lot of variance in the CUDA download speed, but I think the download was a significant bottleneck, and 833 MB -> 271 MB is an improvement regardless of how fast the download is.
