### PR TITLE
gflags 2.1 bugfix (or rather a hack).

### DIFF
--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -15,7 +15,7 @@
 // remove the following hack.
 #ifdef GFLAGS_GFLAGS_H_
 namespace google {
-using namespace gflags; 
+using ::gflags::ParseCommandLineFlags;
 }  // namespace google
 #endif  // GFLAGS_GFLAGS_H_
 


### PR DESCRIPTION
This is a temporary fix. A more complete workaround is going to be placed in gflags 2.1.1 by @schuhschuh. After that, we should remove this hack.
