### PR TITLE
Fix choice of MKL directory from Makefile.config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ ifeq ($(BLAS), mkl)
 	# MKL
 	LIBRARIES += mkl_rt
 	COMMON_FLAGS += -DUSE_MKL
-	MKL_DIR = /opt/intel/mkl
+	MKL_DIR ?= /opt/intel/mkl
 	BLAS_INCLUDE ?= $(MKL_DIR)/include
 	BLAS_LIB ?= $(MKL_DIR)/lib $(MKL_DIR)/lib/intel64
 else ifeq ($(BLAS), open)


### PR DESCRIPTION
MKL directory could not be set from the Makefile.config file, because it was overriden in the Makefile.
This fixes it.
