### PR TITLE
Fix conflict on setting of LRN layers between train/test net and deploy net

### DIFF
--- a/examples/cifar10/cifar10_full.prototxt
+++ b/examples/cifar10/cifar10_full.prototxt
@@ -43,6 +43,7 @@ layers {
   bottom: "pool1"
   top: "norm1"
   lrn_param {
+    norm_region: WITHIN_CHANNEL
     local_size: 3
     alpha: 5e-05
     beta: 0.75
@@ -74,6 +75,7 @@ layers {
   bottom: "conv2"
   top: "pool2"
   pooling_param {
+    norm_region: WITHIN_CHANNEL
     pool: AVE
     kernel_size: 3
     stride: 2


### PR DESCRIPTION
I found small differences between cifar10_full.prototxt and cifar10_full_train_test.prototxt, which introduce worse performance using the former one with parameters learned by the latter one.
