### PR TITLE
Painless binary mean conversion to matlab matrices.

### DIFF
--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -312,26 +312,28 @@ static void is_initialized(MEX_ARGS) {
   }
 }
 
-static void read_mean(MEX_ARGS){
-    if (nrhs != 1){
+static void read_mean(MEX_ARGS) {
+    if (nrhs != 1) {
         mexErrMsgTxt("Usage: caffe('read_mean', 'path_to_binary_mean_file'");
-        return ;
+        return;
     }
     const string& mean_file = mxArrayToString(prhs[0]);
     Blob<float> data_mean;
-    
     LOG(INFO) << "Loading mean file from" << mean_file;
     BlobProto blob_proto;
-    ReadProtoFromBinaryFileOrDie(mean_file.c_str(), &blob_proto);
+    bool result = ReadProtoFromBinaryFile(mean_file.c_str(), &blob_proto);
+    if (!result) {
+        mexErrMsgTxt("Couldn't read the file");
+        return;
+    }
     data_mean.FromProto(blob_proto);
-
-    mwSize dims[4] = {data_mean.width(), data_mean.height(), data_mean.channels(), data_mean.num()};
+    mwSize dims[4] = {data_mean.width(), data_mean.height(),
+                      data_mean.channels(), data_mean.num() };
     mxArray* mx_blob =  mxCreateNumericArray(4, dims, mxSINGLE_CLASS, mxREAL);
-
     float* data_ptr = reinterpret_cast<float*>(mxGetPr(mx_blob));
     caffe_copy(data_mean.count(), data_mean.cpu_data(), data_ptr);
-    
-    mexWarnMsgTxt("Remember that Caffe saves in [width, height, channels] format and channels are also BGR!");
+    mexWarnMsgTxt("Remember that Caffe saves in [width, height, channels]"
+                  " format and channels are also BGR!");
     plhs[0] = mx_blob;
 }
 


### PR DESCRIPTION
I've seen many people confused and wondering if there's a straightforward way to convert these binary mean files to a Matlab matrix. So I simply added a new function to the Caffe Matlab wrapper that does exactly that.

It's fairly simple to use:

``` matlab
caffe('read_mean', 'path to the mean file');
```

The output is a matrix.

```
>> mean_mat = caffe('read_mean', 'caffe/examples/cifar10/mean.binaryproto');
Warning: Remember that Caffe saves in [width, height, channels] format and channels are also
BGR! 
>> whos mean_mat
  Name           Size              Bytes  Class     Attributes

  mean_mat      32x32x3            12288  single              

```
