### PR TITLE
make figure show on the screen after plt.imshow() or plt.plot()

### DIFF
--- a/examples/imagenet_classification.ipynb
+++ b/examples/imagenet_classification.ipynb
@@ -98,7 +98,8 @@
      "collapsed": false,
      "input": [
       "input_image = caffe.io.load_image(IMAGE_FILE)\n",
-      "plt.imshow(input_image)"
+      "plt.imshow(input_image)",
+      "plt.show()"
      ],
      "language": "python",
      "metadata": {},
@@ -135,7 +136,8 @@
      "input": [
       "prediction = net.predict([input_image])  # predict takes any number of images, and formats them for the Caffe net automatically\n",
       "print 'prediction shape:', prediction[0].shape\n",
-      "plt.plot(prediction[0])"
+      "plt.plot(prediction[0])",
+      "plt.show()"
      ],
      "language": "python",
      "metadata": {},
@@ -179,7 +181,8 @@
      "input": [
       "prediction = net.predict([input_image], oversample=False)\n",
       "print 'prediction shape:', prediction[0].shape\n",
-      "plt.plot(prediction[0])"
+      "plt.plot(prediction[0])",
+      "plt.show()"
      ],
      "language": "python",
      "metadata": {},
@@ -304,7 +307,8 @@
      "input": [
       "prediction = net.predict([input_image])\n",
       "print 'prediction shape:', prediction[0].shape\n",
-      "plt.plot(prediction[0])"
+      "plt.plot(prediction[0])",
+      "plt.show()"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
after plt.imshow() or plt.plot(), the figure won't show on the screen until you call plt.show() function,
I add plt.show() after each plt.imshow() or plt.plot(), make the doc code more clearly
