### PR TITLE
(WIP) Overlap the CUDA data transfers with computations with cudaMemcpyAsync

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -148,6 +148,11 @@ class Caffe {
   static void SetDevice(const int device_id);
   // Prints the current GPU status.
   static void DeviceQuery();
+#ifndef CPU_ONLY
+  inline static cudaStream_t cuda_memcpy_async_stream() {
+    return Get().cuda_memcpy_async_stream_;
+  }
+#endif
 
  protected:
 #ifndef CPU_ONLY
@@ -159,6 +164,9 @@ class Caffe {
   Brew mode_;
   Phase phase_;
   static shared_ptr<Caffe> singleton_;
+#ifndef CPU_ONLY
+  cudaStream_t cuda_memcpy_async_stream_;
+#endif
 
  private:
   // The private constructor to avoid duplicate instantiation.

--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -89,7 +89,8 @@ void caffe_copy(const int N, const Dtype* X, Dtype* Y) {
   if (X != Y) {
     if (Caffe::mode() == Caffe::GPU) {
 #ifndef CPU_ONLY
-      CUDA_CHECK(cudaMemcpy(Y, X, sizeof(Dtype) * N, cudaMemcpyDefault));
+      CUDA_CHECK(cudaMemcpyAsync(Y, X, sizeof(Dtype) * N, cudaMemcpyDefault,
+                                 Caffe::cuda_memcpy_async_stream()));
 #else
       NO_GPU;
 #endif

--- a/src/caffe/util/math_functions.cu
+++ b/src/caffe/util/math_functions.cu
@@ -80,7 +80,8 @@ void caffe_gpu_axpy<double>(const int N, const double alpha, const double* X,
 
 void caffe_gpu_memcpy(const size_t N, const void* X, void* Y) {
   if (X != Y) {
-    CUDA_CHECK(cudaMemcpy(Y, X, N, cudaMemcpyDefault));
+    CUDA_CHECK(cudaMemcpyAsync(Y, X, N, cudaMemcpyDefault,
+                               Caffe::cuda_memcpy_async_stream()));
   }
 }
 


### PR DESCRIPTION
This is the first step tried to enable copying data among CPU and multiple GPUs which is required by #876. Of course, even there is only a single GPU, the non-blocking memory copying can still accelerate the speed.

The detailed theories under the hood are explained in "[How to Overlap Data Transfers in CUDA C/C++](http://devblogs.nvidia.com/parallelforall/how-overlap-data-transfers-cuda-cc/)".

Not tested on GPU yet.