### PR TITLE
Distribute the generated proto header files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -558,6 +558,8 @@ $(DIST_ALIASES): $(DISTRIBUTE_DIR)
 $(DISTRIBUTE_DIR): all py $(HXX_SRCS) | $(DISTRIBUTE_SUBDIRS)
 	# add include
 	cp -r include $(DISTRIBUTE_DIR)/
+	mkdir -p $(DISTRIBUTE_DIR)/include/caffe/proto
+	cp $(PROTO_GEN_HEADER_SRCS) $(DISTRIBUTE_DIR)/include/caffe/proto
 	# add tool and example binaries
 	cp $(TOOL_BINS) $(DISTRIBUTE_DIR)/bin
 	cp $(EXAMPLE_BINS) $(DISTRIBUTE_DIR)/bin


### PR DESCRIPTION
The two generated headers are depended on by the blob.hpp etc.
