### PR TITLE
Add a leveldb option function in io.hpp/cpp

### DIFF
--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -12,6 +12,11 @@
 
 #define HDF5_NUM_DIMS 4
 
+namespace leveldb {
+// Forward declaration for leveldb::Options to be used in GetlevelDBOptions().
+class Options;
+}
+
 namespace caffe {
 
 using ::google::protobuf::Message;
@@ -70,6 +75,7 @@ inline bool ReadImageToDatum(const string& filename, const int label,
   return ReadImageToDatum(filename, label, 0, 0, datum);
 }
 
+leveldb::Options GetLevelDBOptions();
 
 template <typename Dtype>
 void hdf5_load_nd_dataset_helper(

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -173,9 +173,8 @@ void DataLayer<Dtype>::SetUp(const vector<Blob<Dtype>*>& bottom,
   case DataParameter_DB_LEVELDB:
     {
     leveldb::DB* db_temp;
-    leveldb::Options options;
+    leveldb::Options options = GetLevelDBOptions();
     options.create_if_missing = false;
-    options.max_open_files = 100;
     LOG(INFO) << "Opening leveldb " << this->layer_param_.data_param().source();
     leveldb::Status status = leveldb::DB::Open(
         options, this->layer_param_.data_param().source(), &db_temp);

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -2,6 +2,7 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/text_format.h>
+#include <leveldb/db.h>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/highgui/highgui_c.h>
@@ -106,6 +107,14 @@ bool ReadImageToDatum(const string& filename, const int label,
       }
   }
   return true;
+}
+
+leveldb::Options GetLevelDBOptions() {
+  // In default, we will return the leveldb option and set the max open files
+  // in order to avoid using up the operating system's limit.
+  leveldb::Options options;
+  options.max_open_files = 100;
+  return options;
 }
 
 // Verifies format of data stored in HDF5 file and reshapes blob accordingly.


### PR DESCRIPTION
Isolating the leveldb option to an io utility function. For some environments that do not use the default file IO, this may be helpful (see https://code.google.com/p/leveldb/source/browse/include/leveldb/env.h?r=213a68eb68ece93a8915ef18a8eba920d5a924a4#5).
