### PR TITLE
Fixed the GPU implementation of EuclideanLoss!

### DIFF
--- a/src/caffe/layers/euclidean_loss_layer.cu
+++ b/src/caffe/layers/euclidean_loss_layer.cu
@@ -19,6 +19,9 @@ Dtype EuclideanLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   Dtype dot;
   caffe_gpu_dot(count, diff_.gpu_data(), diff_.gpu_data(), &dot);
   Dtype loss = dot / bottom[0]->num() / Dtype(2);
+  if (top->size() == 1) {
+    (*top)[0]->mutable_cpu_data()[0] = loss;
+  }
   return loss;
 }
 


### PR DESCRIPTION
Whoever added the EuclideanLoss top output, forgot to update the Cuda version.
When you're testing the network with a EuclideanLoss this seems to be the only way to see the result.
