### PR TITLE
use plt namespace for imshow in filter_visualization.ipynb

### DIFF
--- a/examples/filter_visualization.ipynb
+++ b/examples/filter_visualization.ipynb
@@ -193,7 +193,7 @@
       "    data = data.reshape((n, n) + data.shape[1:]).transpose((0, 2, 1, 3) + tuple(range(4, data.ndim + 1)))\n",
       "    data = data.reshape((n * data.shape[1], n * data.shape[3]) + data.shape[4:])\n",
       "    \n",
-      "    imshow(data)"
+      "    plt.imshow(data)"
      ],
      "language": "python",
      "metadata": {},
@@ -212,7 +212,7 @@
      "collapsed": false,
      "input": [
       "# index four is the center crop\n",
-      "imshow(net.deprocess('data', net.blobs['data'].data[4]))"
+      "plt.imshow(net.deprocess('data', net.blobs['data'].data[4]))"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
I've got errors in the filter_visualization.ipynb notebook because of

**In [6]**

``` python
    # ...
    imshow(data)
```

and
**In [7]**

``` python
# index four is the center crop
imshow(net.deprocess('data', net.blobs['data'].data[4]))
```

With `plt.imshow(...)` the bug is fixed
