### PR TITLE
Fix plotting and metadata in notebook examples

### DIFF
--- a/examples/classification.ipynb
+++ b/examples/classification.ipynb
@@ -1,8 +1,9 @@
 {
  "metadata": {
-  "name": "ImageNet classification",
   "description": "Use the pre-trained ImageNet model to classify images with the Python interface.",
-  "include_in_docs": true
+  "example_name": "ImageNet classification",
+  "include_in_docs": true,
+  "signature": "sha256:4f8d4c079c30d20ef4b6818e9672b1741fd1377354e5b83e291710736cecd24f"
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/detection.ipynb
+++ b/examples/detection.ipynb
@@ -1,8 +1,9 @@
 {
  "metadata": {
-  "name": "ImageNet detection",
   "description": "Run a pretrained model as a detector in Python.",
-  "include_in_docs": true
+  "example_name": "R-CNN detection",
+  "include_in_docs": true,
+  "signature": "sha256:8a744fbbb9ed80acab471247eaf50c27dcbd652105404df9feca599939f0c0ee"
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/filter_visualization.ipynb
+++ b/examples/filter_visualization.ipynb
@@ -1,8 +1,9 @@
 {
  "metadata": {
-  "name": "Filter visualization",
   "description": "Extracting features and visualizing trained filters with an example image, viewed layer-by-layer.",
-  "include_in_docs": true
+  "example_name": "Filter visualization",
+  "include_in_docs": true,
+  "signature": "sha256:b1b0457e2b10110aca847a718a3fe631ebcfce63a61cbc33653244f52b1ff4af"
  },
  "nbformat": 3,
  "nbformat_minor": 0,

--- a/examples/net_surgery.ipynb
+++ b/examples/net_surgery.ipynb
@@ -1,8 +1,9 @@
 {
  "metadata": {
-  "name": "Editing model parameters",
   "description": "How to do net surgery and manually change model parameters, making a fully-convolutional classifier for dense feature extraction.",
-  "include_in_docs": true
+  "example_name": "Editing model parameters",
+  "include_in_docs": true,
+  "signature": "sha256:0b2ad61622122fa34a40c250be2c0799a85fb65c149b802ce844c46eceba066e"
  },
  "nbformat": 3,
  "nbformat_minor": 0,


### PR DESCRIPTION
This brings us up to date with modern IPython:
- use `%matplotlib inline` magic everywhere instead of command line arg
- include `plt` namespace for plotting functions
- switch metadata key to `example_name` to avoid conflict with deprecated `name`
- include metadata signature saved by IPython

...plus rename the detection example to reflect it is the all-Caffe example of R-CNN.
