### PR TITLE
Modified mvn_layer.cpp

### DIFF
--- a/src/caffe/layers/mvn_layer.cpp
+++ b/src/caffe/layers/mvn_layer.cpp
@@ -18,8 +18,12 @@ void MVNLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       1, 1);
   temp_.Reshape(bottom[0]->num(), bottom[0]->channels(),
       bottom[0]->height(), bottom[0]->width());
-  sum_multiplier_.Reshape(1, 1,
-      bottom[0]->height(), bottom[0]->width());
+  if (this->layer_param_.mvn_param().across_channels())
+      sum_multiplier_.Reshape(1, bottom[0]->channels(),
+            bottom[0]->height(), bottom[0]->width());
+  else
+      sum_multiplier_.Reshape(1, 1,
+            bottom[0]->height(), bottom[0]->width());
   Dtype* multiplier_data = sum_multiplier_.mutable_cpu_data();
   caffe_set(sum_multiplier_.count(), Dtype(1), multiplier_data);
 }


### PR DESCRIPTION
I have tested the mean-variance normalization in https://github.com/zszhong/caffe/tree/test/test/test_mvn. But it seems to have different results from that outputed by `https://github.com/zszhong/caffe/tree/test/test/test_mvn.m` with the same input data.

The four types of normalization have been tested:
        1. mean normalization per channel
        2. mean normalization across channels
        3. mean-variance normalization per channel
        4. mean-variance normalization across channels

The `type 1` and `type 3` have no problem with the original code. But the result of `type 2` and `type 4` seems to be different from that in `MATLAB`. The fixed code has provide the same results as in `MATLB`.
