### PR TITLE
Minor doc update: protobuf should be installed with Python support on Mac

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -173,7 +173,8 @@ To edit the formulae in turn, run
 
 After this, run
 
-    for x in snappy leveldb protobuf gflags glog szip lmdb homebrew/science/opencv; do brew uninstall $x; brew install --build-from-source --fresh -vd $x; done
+    for x in snappy leveldb gflags glog szip lmdb homebrew/science/opencv; do brew uninstall $x; brew install --build-from-source --fresh -vd $x; done
+    brew uninstall protobuf; brew install --build-from-source --with-python --fresh -vd protobuf
     brew install --build-from-source --with-python --fresh -vd boost
 
 **Note** that `brew install --build-from-source --fresh -vd boost` is fine if you do not need the Caffe Python wrapper.


### PR DESCRIPTION
On Mac OS X, if one installs protobuf as recommended with

```
brew install protobuf
```

then pycaffe import fails:

```
[~/s/caffe/python] $ python
Python 2.7.8 (default, Jul  2 2014, 10:14:58)
[GCC 4.2.1 Compatible Apple LLVM 5.1 (clang-503.0.40)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys; caffe_root = '../'; sys.path.insert(0, caffe_root + 'python'); import caffe
ImportError                               Traceback (most recent call last)
<ipython-input-3-a65a880449a1> in <module>()
----> 1 import sys; caffe_root = '../'; sys.path.insert(0, caffe_root + 'python'); import caffe

/Users/jason/s/caffe/python/caffe/__init__.py in <module>()
----> 1 from .pycaffe import Net, SGDSolver
      2 from .classifier import Classifier
      3 from .detector import Detector
      4 import io

/Users/jason/s/caffe/python/caffe/pycaffe.py in <module>()
      9
     10 from ._caffe import Net, SGDSolver
---> 11 import caffe.io
     12
     13 # We directly update methods from Net here (rather than using composition or

/Users/jason/s/caffe/python/caffe/io.py in <module>()
      4 from skimage.transform import resize
      5
----> 6 from caffe.proto import caffe_pb2
      7
      8

/Users/jason/s/caffe/python/caffe/proto/caffe_pb2.py in <module>()
      2 # source: caffe/proto/caffe.proto
      3
----> 4 from google.protobuf.internal import enum_type_wrapper
      5 from google.protobuf import descriptor as _descriptor
      6 from google.protobuf import message as _message

ImportError: No module named google.protobuf.internal
```

The solution is just to use the following brew command instead:

```
brew install --with-python protobuf
```
