### PR TITLE
Lock the mex file to avoid Matlab crashes.

### DIFF
--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -372,6 +372,7 @@ static handler_registry handlers[] = {
  ** matlab entry point: caffe(api_command, arg1, arg2, ...)
  **/
 void mexFunction(MEX_ARGS) {
+  mexLock(); // Avoid clearing the mex file.
   if (nrhs == 0) {
     LOG(ERROR) << "No API command given";
     mexErrMsgTxt("An API command is requires");


### PR DESCRIPTION
Commands like "clear all" and "clear function" causes segmentation faults or errors like these (especially after an 'init'):
 libprotobuf ERROR google/protobuf/descriptor_database.cc:57] File already exists in database: caffe/proto/caffe.proto
 libprotobuf FATAL google/protobuf/descriptor.cc:862] CHECK failed: generated_database_->Add(encoded_file_descriptor, size):
 [libprotobuf ERROR google/protobuf/message.cc:333] Type appears to be in generated pool but wasn't registered: caffe.LayerParameter
 Attempt to restart MATLAB?
To avoid these, lock the the mex file.
