### PR TITLE
Clean up CPU signbit definition

### DIFF
--- a/include/caffe/util/math_functions.hpp
+++ b/include/caffe/util/math_functions.hpp
@@ -137,11 +137,10 @@ inline char caffe_sign(Dtype val) {
 DEFINE_CAFFE_CPU_UNARY_FUNC(sign, y[i] = caffe_sign<Dtype>(x[i]));
 
 // This returns a nonzero value if the input has its sign bit set.
-// The name sngbit is meant to avoid conflicts with std::signbit in the macro
-bool caffe_signbit(float arg);
-bool caffe_signbit(double arg);
-bool caffe_signbit(long double arg);
-DEFINE_CAFFE_CPU_UNARY_FUNC(sgnbit, y[i] = caffe_signbit(x[i]));
+// The name sngbit is meant to avoid conflicts with std::signbit in the macro.
+// The extra parens are needed because CUDA < 6.5 defines signbit as a macro,
+// and we don't want that to expand here when CUDA headers are also included.
+DEFINE_CAFFE_CPU_UNARY_FUNC(sgnbit, y[i] = (std::signbit)(x[i]));
 
 DEFINE_CAFFE_CPU_UNARY_FUNC(fabs, y[i] = std::fabs(x[i]));
 

--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -387,16 +387,4 @@ void caffe_cpu_scale<double>(const int n, const double alpha, const double *x,
   cblas_dscal(n, alpha, y, 1);
 }
 
-
-using std::signbit;
-bool caffe_signbit(float arg) {
-    return signbit(arg);
-}
-bool caffe_signbit(double arg) {
-    return signbit(arg);
-}
-bool caffe_signbit(long double arg) {
-    return signbit(arg);
-}
-
 }  // namespace caffe


### PR DESCRIPTION
#788 / 41a56376816b8c59c4777c1ab2d3230f8a785241 presents a puzzle. Why introduce a function (okay, three functions) that just call `std::signbit`, instead of calling it directly? After all, in the next line, we just call `std::fabs`, and everything works fine.

It turns out that CUDA (before 6.5RC) defines `signbit` as a macro, which was expanding inside `std::signbit` whenever CUDA's `math_functions.h` was included before `caffe/util/math_functions.hpp`. The fix works around this by only saying `signbit` in a file that doesn't include CUDA's `math_functions.h`.

That's not necessary; we can use parens to prevent the macro expansion, dispense with the redundant functions, and not worry about where CUDA headers might be included.
