### PR TITLE
Fix comments in internal_thread.hpp

### DIFF
--- a/include/caffe/internal_thread.hpp
+++ b/include/caffe/internal_thread.hpp
@@ -15,7 +15,7 @@ class InternalThread {
   InternalThread() {}
   virtual ~InternalThread() {}
 
-  /** Returns true if the thread was successfully started **/
+  /** Returns 0 if the thread was successfully started **/
   bool StartInternalThread() {
     return pthread_create(&_thread, NULL, InternalThreadEntryFunc, this);
   }


### PR DESCRIPTION
Fix comments in internal_thread.hpp. If successful, the pthread_create() function returns zero. Otherwise, an error number is returned to indicate the error. Details http://pubs.opengroup.org/onlinepubs/7908799/xsh/pthread_create.html
