### PR TITLE
'caffe test' computes and prints all scores and their names

### DIFF
--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -136,14 +136,47 @@ int test() {
   caffe_net.CopyTrainedLayersFrom(FLAGS_weights);
   LOG(INFO) << "Running for " << FLAGS_iterations << " iterations.";
 
-  double test_score = 0;
+  vector<Blob<float>* > bottom_vec;
+  vector<int> test_score_output_id;
+  vector<float> test_score;
+  float loss = 0;
   for (int i = 0; i < FLAGS_iterations; ++i) {
-    const vector<Blob<float>*>& result = caffe_net.ForwardPrefilled();
-    test_score += result[0]->cpu_data()[0];
-    LOG(INFO) << "Batch " << i << ", score: " << result[0]->cpu_data()[0];
+    float iter_loss;
+    const vector<Blob<float>*>& result =
+        caffe_net.Forward(bottom_vec, &iter_loss);
+    loss += iter_loss;
+    int idx = 0;
+    for (int j = 0; j < result.size(); ++j) {
+      const float* result_vec = result[j]->cpu_data();
+      for (int k = 0; k < result[j]->count(); ++k, ++idx) {
+        const float score = result_vec[k];
+        if (i == 0) {
+          test_score.push_back(score);
+          test_score_output_id.push_back(j);
+        } else {
+          test_score[idx] += score;
+        }
+        const std::string& output_name = caffe_net.blob_names()[
+            caffe_net.output_blob_indices()[j]];
+        LOG(INFO) << "Batch " << i << ", " << output_name << " = " << score;
+      }
+    }
   }
-  test_score /= FLAGS_iterations;
-  LOG(INFO) << "Score: " << test_score;
+  loss /= FLAGS_iterations;
+  LOG(INFO) << "Loss: " << loss;
+  for (int i = 0; i < test_score.size(); ++i) {
+    const std::string& output_name = caffe_net.blob_names()[
+        caffe_net.output_blob_indices()[test_score_output_id[i]]];
+    const float loss_weight =
+        caffe_net.blob_loss_weights()[caffe_net.output_blob_indices()[i]];
+    std::ostringstream loss_msg_stream;
+    const float mean_score = test_score[i] / FLAGS_iterations;
+    if (loss_weight) {
+      loss_msg_stream << " (* " << loss_weight
+                      << " = " << loss_weight * mean_score << " loss)";
+    }
+    LOG(INFO) << output_name << " = " << mean_score << loss_msg_stream.str();
+  }
 
   return 0;
 }


### PR DESCRIPTION
Currently `caffe test` prints just one test output (I think whatever it first pulls out of the `std::set` of net outputs...) -- this changes it to print all the outputs and put the blob names with them, and compute the loss as well (code mostly duplicated from `solver`).  It looks like this:

```
I0825 11:58:44.750967 17817 caffe.cpp:126] Running for 5 iterations.
I0825 11:58:45.537837 17817 caffe.cpp:150] Batch 0, accuracy = 0.112
I0825 11:58:45.537922 17817 caffe.cpp:150] Batch 0, softmax_loss = 4.79346
I0825 11:58:45.537976 17817 caffe.cpp:150] Batch 0, top_10_accuracy = 0.408
I0825 11:58:45.538023 17817 caffe.cpp:150] Batch 0, top_50_accuracy = 0.684
I0825 11:58:45.538036 17817 caffe.cpp:150] Batch 0, top_5_accuracy = 0.296
I0825 11:58:46.206611 17817 caffe.cpp:150] Batch 1, accuracy = 0.14
I0825 11:58:46.206686 17817 caffe.cpp:150] Batch 1, softmax_loss = 4.79524
I0825 11:58:46.206698 17817 caffe.cpp:150] Batch 1, top_10_accuracy = 0.428
I0825 11:58:46.206715 17817 caffe.cpp:150] Batch 1, top_50_accuracy = 0.648
I0825 11:58:46.206727 17817 caffe.cpp:150] Batch 1, top_5_accuracy = 0.344
I0825 11:58:46.875533 17817 caffe.cpp:150] Batch 2, accuracy = 0.116
I0825 11:58:46.875605 17817 caffe.cpp:150] Batch 2, softmax_loss = 5.03115
I0825 11:58:46.875618 17817 caffe.cpp:150] Batch 2, top_10_accuracy = 0.372
I0825 11:58:46.875633 17817 caffe.cpp:150] Batch 2, top_50_accuracy = 0.636
I0825 11:58:46.875643 17817 caffe.cpp:150] Batch 2, top_5_accuracy = 0.312
I0825 11:58:47.544790 17817 caffe.cpp:150] Batch 3, accuracy = 0.096
I0825 11:58:47.544865 17817 caffe.cpp:150] Batch 3, softmax_loss = 4.88417
I0825 11:58:47.544879 17817 caffe.cpp:150] Batch 3, top_10_accuracy = 0.42
I0825 11:58:47.544893 17817 caffe.cpp:150] Batch 3, top_50_accuracy = 0.664
I0825 11:58:47.544905 17817 caffe.cpp:150] Batch 3, top_5_accuracy = 0.316
I0825 11:58:48.214391 17817 caffe.cpp:150] Batch 4, accuracy = 0.112
I0825 11:58:48.214468 17817 caffe.cpp:150] Batch 4, softmax_loss = 4.73312
I0825 11:58:48.214480 17817 caffe.cpp:150] Batch 4, top_10_accuracy = 0.456
I0825 11:58:48.214496 17817 caffe.cpp:150] Batch 4, top_50_accuracy = 0.692
I0825 11:58:48.214509 17817 caffe.cpp:150] Batch 4, top_5_accuracy = 0.328
I0825 11:58:48.214519 17817 caffe.cpp:155] Loss: 4.84743
I0825 11:58:48.214532 17817 caffe.cpp:167] accuracy = 0.1152
I0825 11:58:48.214550 17817 caffe.cpp:167] softmax_loss = 4.84743 (* 1 = 4.84743 loss)
I0825 11:58:48.214563 17817 caffe.cpp:167] top_10_accuracy = 0.4168
I0825 11:58:48.214576 17817 caffe.cpp:167] top_50_accuracy = 0.6648
I0825 11:58:48.214587 17817 caffe.cpp:167] top_5_accuracy = 0.3192
```
