### PR TITLE
[docs] Fix lenet.prototxt path in MNIST tutorial

### DIFF
--- a/examples/mnist/readme.md
+++ b/examples/mnist/readme.md
@@ -32,7 +32,7 @@ The design of LeNet contains the essence of CNNs that are still used in larger m
 
 This section explains the prototxt file `lenet_train.prototxt` used in the MNIST demo. We assume that you are familiar with [Google Protobuf](https://developers.google.com/protocol-buffers/docs/overview), and assume that you have read the protobuf definitions used by Caffe, which can be found at [src/caffe/proto/caffe.proto](https://github.com/Yangqing/caffe/blob/master/src/caffe/proto/caffe.proto).
 
-Specifically, we will write a `caffe::NetParameter` (or in python, `caffe.proto.caffe_pb2.NetParameter`) protubuf. We will start by giving the network a name:
+Specifically, we will write a `caffe::NetParameter` (or in python, `caffe.proto.caffe_pb2.NetParameter`) protobuf. We will start by giving the network a name:
 
     name: "LeNet"
 


### PR DESCRIPTION
The file resides under CAFFE_ROOT/examples/ not CAFFE_ROOT/data.
