### PR TITLE
fix layer_factory.cpp bug: there should be no ifdefs

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -1,6 +1,3 @@
-#ifndef CAFFE_LAYER_FACTORY_HPP_
-#define CAFFE_LAYER_FACTORY_HPP_
-
 #include <string>
 
 #include "caffe/layer.hpp"
@@ -98,5 +95,3 @@ template Layer<float>* GetLayer(const LayerParameter& param);
 template Layer<double>* GetLayer(const LayerParameter& param);
 
 }  // namespace caffe
-
-#endif  // CAFFE_LAYER_FACTORY_HPP_


### PR DESCRIPTION
This is a simple fix - the ifdefs are there probably because layer_factory used to be a header file.
