### PR TITLE
Ignore LevelDB files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,13 @@ data/*
 *leveldb
 *lmdb
 
+# LevelDB files
+*.ldb
+LOCK
+LOG*
+CURRENT
+MANIFEST-*
+
 # Generated documentation
 docs/_site
 docs/gathered


### PR DESCRIPTION
The users don't always name their LevelDB directory as *leveldb.

@shelhamer
