### PR TITLE
Fix norm_region param in cifar10 deployment net

### DIFF
--- a/examples/cifar10/cifar10_full.prototxt
+++ b/examples/cifar10/cifar10_full.prototxt
@@ -75,7 +75,6 @@ layers {
   bottom: "conv2"
   top: "pool2"
   pooling_param {
-    norm_region: WITHIN_CHANNEL
     pool: AVE
     kernel_size: 3
     stride: 2
@@ -87,6 +86,7 @@ layers {
   bottom: "pool2"
   top: "norm2"
   lrn_param {
+    norm_region: WITHIN_CHANNEL
     local_size: 3
     alpha: 5e-05
     beta: 0.75


### PR DESCRIPTION
The `norm_region` parameter was meant for layer norm2's LRNParameter instead of layer pool2's PoolingParameter. This causes the latter to complain since the parameter is not valid.
