### PR TITLE
bugfix for tools/extra/parse_log.sh

### DIFF
--- a/tools/extra/parse_log.sh
+++ b/tools/extra/parse_log.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Usage parse_log.sh caffe.log
-# It creates two files one caffe.log.test that contains the loss and test accuracy of the test and
-# another one caffe.log.loss that contains the loss computed during the training
+# It creates the following two text files, each containing a table:
+#     caffe.log.test (columns: '#Iters Seconds TestAccuracy TestLoss')
+#     caffe.log.train (columns: '#Iters Seconds TrainingLoss LearningRate')
+
 
 # get the dirname of the script
 DIR="$( cd "$(dirname "$0")" ; pwd -P )"
@@ -14,31 +16,31 @@ fi
 LOG=`basename $1`
 grep -B 1 'Test ' $1 > aux.txt
 grep 'Iteration ' aux.txt | sed  's/.*Iteration \([[:digit:]]*\).*/\1/g' > aux0.txt
-grep 'Test score #0' aux.txt | awk '{print $8}' > aux1.txt
-grep 'Test score #1' aux.txt | awk '{print $8}' > aux2.txt
+grep 'Test net output #0' aux.txt | awk '{print $11}' > aux1.txt
+grep 'Test net output #1' aux.txt | awk '{print $11}' > aux2.txt
 
-# Extracting elpased seconds
-# For extraction of time since this line constains the start time
+# Extracting elapsed seconds
+# For extraction of time since this line contains the start time
 grep '] Solving ' $1 > aux3.txt
 grep 'Testing net' $1 >> aux3.txt
 $DIR/extract_seconds.py aux3.txt aux4.txt
 
 # Generating
-echo '# Iters Seconds TestAccuracy TestLoss'> $LOG.test
+echo '#Iters Seconds TestAccuracy TestLoss'> $LOG.test
 paste aux0.txt aux4.txt aux1.txt aux2.txt | column -t >> $LOG.test
 rm aux.txt aux0.txt aux1.txt aux2.txt aux3.txt aux4.txt
 
-# For extraction of time since this line constains the start time
+# For extraction of time since this line contains the start time
 grep '] Solving ' $1 > aux.txt
 grep ', loss = ' $1 >> aux.txt
 grep 'Iteration ' aux.txt | sed  's/.*Iteration \([[:digit:]]*\).*/\1/g' > aux0.txt
 grep ', loss = ' $1 | awk '{print $9}' > aux1.txt
 grep ', lr = ' $1 | awk '{print $9}' > aux2.txt
 
-# Extracting elpased seconds
+# Extracting elapsed seconds
 $DIR/extract_seconds.py aux.txt aux3.txt
 
 # Generating
-echo '# Iters Seconds TrainingLoss LearningRate'> $LOG.train
+echo '#Iters Seconds TrainingLoss LearningRate'> $LOG.train
 paste aux0.txt aux3.txt aux1.txt aux2.txt | column -t >> $LOG.train
 rm aux.txt aux0.txt aux1.txt aux2.txt  aux3.txt


### PR DESCRIPTION
./tools/extra/parse_log.sh was broken by the recent changes to the training output, in particular by the way test accuracy and test loss are now displayed. caffe.log.test had empty columns where accuracy and loss per iteration were supposed to show up.

previously (training output):
I0828 00:56:34.795725 31294 solver.cpp:177] Test score #0: 0.9319
I0828 00:56:34.795765 31294 solver.cpp:177] Test score #1: 0.173513

now (training output): 
I0831 01:21:36.325670  8457 solver.cpp:302]     Test net output #0: accuracy = 0.9426
I0831 01:21:36.325687  8457 solver.cpp:302]     Test net output #1: loss = 0.152957 (\* 1 = 0.152957 loss)

culprit in parse_log.sh:
grep 'Test **score** #0' aux.txt | awk '{print **$8**}' > aux1.txt
grep 'Test **score** #1' aux.txt | awk '{print **$8**}' > aux2.txt

Also, fixed a number of typos and updated the script description.
