### PR TITLE
Python layer for rapidly writing nets in Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ OBJ_BUILD_DIR := $(BUILD_DIR)/src/$(PROJECT)
 LAYER_BUILD_DIR := $(OBJ_BUILD_DIR)/layers
 UTIL_BUILD_DIR := $(OBJ_BUILD_DIR)/util
 OBJS := $(PROTO_OBJS) $(CXX_OBJS) $(CU_OBJS)
+ifeq ($(USE_PYTHON_LAYER), 1)
+	OBJS += python/$(PROJECT)/_$(PROJECT).o
+endif
 # tool, example, and test objects
 TOOL_OBJS := $(addprefix $(BUILD_DIR)/, ${TOOL_SRCS:.cpp=.o})
 TOOL_BUILD_DIR := $(BUILD_DIR)/tools
@@ -172,6 +175,9 @@ LIBRARIES += pthread \
 	hdf5_hl hdf5 \
 	opencv_core opencv_highgui opencv_imgproc
 PYTHON_LIBRARIES := boost_python python2.7
+ifeq ($(USE_PYTHON_LAYER), 1)
+	LIBRARIES += $(PYTHON_LIBRARIES)
+endif
 WARNINGS := -Wall -Wno-sign-compare
 
 ##############################
@@ -308,6 +314,10 @@ else
 endif
 INCLUDE_DIRS += $(BLAS_INCLUDE)
 LIBRARY_DIRS += $(BLAS_LIB)
+
+ifeq ($(USE_PYTHON_LAYER), 1)
+	COMMON_FLAGS += -DUSE_PYTHON_LAYER
+endif
 
 # Complete build flags.
 COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -7,6 +7,9 @@
 # CPU-only switch (uncomment to build without GPU support).
 # CPU_ONLY := 1
 
+# Uncomment to include the Python layer (will link caffe against Python libs).
+# USE_PYTHON_LAYER := 1
+
 # To customize your choice of compiler, uncomment and set the following.
 # N.B. the default for Linux is g++ and the default for OSX is clang++
 # CUSTOM_CXX := g++

--- a/include/caffe/python_layer.hpp
+++ b/include/caffe/python_layer.hpp
@@ -1,0 +1,51 @@
+#ifndef CAFFE_PYTHON_LAYER_HPP_
+#define CAFFE_PYTHON_LAYER_HPP_
+
+#include <boost/python.hpp>
+#include <vector>
+
+#include "../python/caffe/_caffe.hpp"
+#include "caffe/layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Wrap a layer implemented in Python.
+ */
+template <typename Dtype>
+class PythonLayer : public Layer<Dtype> {
+ public:
+  /**
+   * @param param provides python_param, with required parameters:
+   * - module. The module to import with the layer implementation. Note that
+   *   the current directory is not in the module search path by default.
+   * - layer. The name of the layer class, which must implement setup
+   *   (for LayerSetUp), reshape (for Reshape), forward (for Forward_cpu), and
+   *   backward (for Backward_cpu).
+   */
+  explicit PythonLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline LayerParameter_LayerType type() const {
+    return LayerParameter_LayerType_PYTHON;
+  }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  boost::python::object layer_;
+
+ private:
+  vector<PyBlob<Dtype> > PythonBlobVector(const vector<Blob<Dtype>*>& vec);
+};
+
+}  // namespace caffe
+
+#endif

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -198,6 +198,9 @@ BOOST_PYTHON_MODULE(_caffe) {
   bp::class_<vector<string> >("StringVec")
       .def(bp::vector_indexing_suite<vector<string> >());
 
+  bp::class_<vector<bool> >("BoolVec")
+      .def(bp::vector_indexing_suite<vector<bool> >());
+
   import_array();
 }
 

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -37,7 +37,7 @@ static void CheckFile(const string& filename) {
 bp::object PyBlobWrap::get_data() {
   npy_intp dims[] = {num(), channels(), height(), width()};
 
-  PyObject *obj = PyArray_SimpleNewFromData(4, dims, NPY_FLOAT32,
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, NPY_FLOAT32,
                                             blob_->mutable_cpu_data());
   PyArray_SetBaseObject(reinterpret_cast<PyArrayObject *>(obj), self_);
   Py_INCREF(self_);
@@ -49,9 +49,9 @@ bp::object PyBlobWrap::get_data() {
 bp::object PyBlobWrap::get_diff() {
   npy_intp dims[] = {num(), channels(), height(), width()};
 
-  PyObject *obj = PyArray_SimpleNewFromData(4, dims, NPY_FLOAT32,
+  PyObject* obj = PyArray_SimpleNewFromData(4, dims, NPY_FLOAT32,
                                             blob_->mutable_cpu_diff());
-  PyArray_SetBaseObject(reinterpret_cast<PyArrayObject *>(obj), self_);
+  PyArray_SetBaseObject(reinterpret_cast<PyArrayObject*>(obj), self_);
   Py_INCREF(self_);
   bp::handle<> h(obj);
 

--- a/python/caffe/_caffe.hpp
+++ b/python/caffe/_caffe.hpp
@@ -18,6 +18,7 @@ using boost::shared_ptr;
 
 namespace caffe {
 
+
 // wrap shared_ptr<Blob> in a class that we construct in C++ and pass
 // to Python
 template <typename Dtype>
@@ -25,13 +26,13 @@ class PyBlob {
  public:
   // Construct from shared_ptr: memory will be correctly managed,
   // even if Python holds onto a Blob beyond the life of its Net.
-  explicit PyBlob(const shared_ptr<Blob<Dtype> > &blob)
-      : blob_(blob) {}
+  explicit PyBlob(const shared_ptr<Blob<Dtype> >& blob)
+      : blob_(blob) { }
   // Construct from raw pointer: memory will become invalid once the
   // owning Net is deleted. This exists only so that the raw Blob*s
   // used in the layer interface can be passed to embedded Python.
   explicit PyBlob(Blob<Dtype>* blob)
-      : blob_(blob, null_deleter()) {}
+      : blob_(blob, null_deleter()) { }
 
   int num() const { return blob_->num(); }
   int channels() const { return blob_->channels(); }
@@ -104,7 +105,6 @@ class PyNet {
   virtual ~PyNet() {}
 
   void Init(string param_file);
-
 
   // Generate Python exceptions for badly shaped or discontiguous arrays.
   inline void check_contiguous_array(PyArrayObject* arr, string name,

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -3,6 +3,9 @@
 #include "caffe/layer.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/vision_layers.hpp"
+#ifdef USE_PYTHON_LAYER
+#include "caffe/python_layer.hpp"
+#endif
 
 namespace caffe {
 
@@ -231,6 +234,13 @@ Layer<Dtype>* GetLayer(const LayerParameter& param) {
     return GetPoolingLayer<Dtype>(name, param);
   case LayerParameter_LayerType_POWER:
     return new PowerLayer<Dtype>(param);
+  case LayerParameter_LayerType_PYTHON:
+#ifdef USE_PYTHON_LAYER
+    return new PythonLayer<Dtype>(param);
+#else
+    LOG(FATAL) << "Attempt to use PythonLayer, but built without "
+                  "USE_PYTHON_LAYER option.";
+#endif
   case LayerParameter_LayerType_RELU:
     return GetReLULayer<Dtype>(name, param);
   case LayerParameter_LayerType_SILENCE:

--- a/src/caffe/layers/python_layer.cpp
+++ b/src/caffe/layers/python_layer.cpp
@@ -1,0 +1,74 @@
+#ifdef USE_PYTHON_LAYER
+#include <boost/python.hpp>
+#include <Python.h>
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/python_layer.hpp"
+
+namespace bp = boost::python;
+
+namespace caffe {
+
+template <typename Dtype>
+vector<PyBlob<Dtype> > PythonLayer<Dtype>::PythonBlobVector(
+    const vector<Blob<Dtype>*>& vec) {
+  return vector<PyBlob<Dtype> >(vec.begin(), vec.end());
+}
+
+template <typename Dtype>
+void PythonLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+     const vector<Blob<Dtype>*>& top) {
+  Py_Initialize();
+  init_caffe();
+
+  try {
+    bp::object module_ = bp::import(
+        this->layer_param_.python_param().module().c_str());
+    layer_ = module_.attr(this->layer_param_.python_param().layer().c_str())();
+
+    layer_.attr("setup")(PythonBlobVector(bottom), PythonBlobVector(top));
+  } catch (bp::error_already_set) {
+    PyErr_Print();
+    throw;
+  }
+}
+
+template <typename Dtype>
+void PythonLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  try {
+    layer_.attr("reshape")(PythonBlobVector(bottom), PythonBlobVector(top));
+  } catch (bp::error_already_set) {
+    PyErr_Print();
+    throw;
+  }
+}
+
+template <typename Dtype>
+void PythonLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  try {
+    layer_.attr("forward")(PythonBlobVector(bottom), PythonBlobVector(top));
+  } catch (bp::error_already_set) {
+    PyErr_Print();
+    throw;
+  }
+}
+
+template <typename Dtype>
+void PythonLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  try {
+    layer_.attr("backward")(PythonBlobVector(top), propagate_down,
+        PythonBlobVector(bottom));
+  } catch (bp::error_already_set) {
+    PyErr_Print();
+    throw;
+  }
+}
+
+INSTANTIATE_CLASS(PythonLayer);
+
+}  // namespace caffe
+#endif

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -198,7 +198,7 @@ message NetStateRule {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available ID: 41 (last added: contrastive_loss_param)
+// LayerParameter next available ID: 42 (last added: python_param)
 message LayerParameter {
   repeated string bottom = 2; // the name of the bottom blobs
   repeated string top = 3; // the name of the top blobs
@@ -219,7 +219,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 38 (last added: CONTRASTIVE_LOSS)
+  // LayerType next available ID: 39 (last added: PYTHON)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if
@@ -251,6 +251,7 @@ message LayerParameter {
     MVN = 34;
     POOLING = 17;
     POWER = 26;
+    PYTHON = 38;
     RELU = 18;
     SIGMOID = 19;
     SIGMOID_CROSS_ENTROPY_LOSS = 27;
@@ -310,6 +311,7 @@ message LayerParameter {
   optional MVNParameter mvn_param = 34;
   optional PoolingParameter pooling_param = 19;
   optional PowerParameter power_param = 21;
+  optional PythonParameter python_param = 41;
   optional ReLUParameter relu_param = 30;
   optional SigmoidParameter sigmoid_param = 38;
   optional SoftmaxParameter softmax_param = 39;
@@ -601,6 +603,12 @@ message PowerParameter {
   optional float power = 1 [default = 1.0];
   optional float scale = 2 [default = 1.0];
   optional float shift = 3 [default = 0.0];
+}
+
+// Message that stores parameters used by PythonLayer
+message PythonParameter {
+  optional string module = 1;
+  optional string layer = 2;
 }
 
 // Message that stores parameters used by ReLULayer


### PR DESCRIPTION
~~This PR depends on #1014, and shouldn't be merged before that one.~~

Caffe is fast, but adding new layers is a multistep process (see #684), and is subject to all of the pitfalls of development in a low-level, compiled language. For quickly trying new ideas, speed of development may be more important than runtime speed.

This PR addresses this gap by allowing layers to be written in Python. One adds layers to the net prototxt that look like the following:
```
layers {
  name: "python"
  type: PYTHON
  bottom: "data"
  top: "output"
  python_param {
    module: "my_module"
    layer: "MyLayer"
  }
}
```

Then, one implements layers in Python with more or less the same interface as in C++, as below.
```python
class MyLayer(object):
    """Simple layer that multiplies input by ten."""

    def setup(self, bottom, top):
        pass

    def reshape(self, bottom, top):
        top[0].reshape(bottom[0].num, bottom[0].channels,
                bottom[0].height, bottom[0].width)

    def forward(self, bottom, top):
        top[0].data[...] = 10 * bottom[0].data

    def backward(self, top, propagate_down, bottom):
        if propagate_down[0]:
            bottom[0].diff[...] = 10 * top[0].diff
```

In order to make this work, the main caffe binaries need to be linked against the Python libraries. This is solved by adding a build option, `WITH_PYTHON_LAYER`, as well as a couple `ifdef`s. These changes are probably not quite ready for merge; in particular, this should break the cmake build system, and the build option is not being tested in Travis yet. (@akosiorek or others, if you're eager to make this work with cmake, PRs against this branch are welcome.)

Layers with learnable parameters are not supported yet.

In theory, this means you ought to be able to write layers in Theano (making use of Theano's symbolic differentiation), embed them in caffe nets, and solve using caffe. I haven't tried that yet, but it might be worth adding some Python-level helper code for that later on.

This hasn't really been tested at all (but does build and run).
