### PR TITLE
Snapshot naming issue in mnist_autoencoder_solver_adagrad.prototxt

### DIFF
--- a/examples/mnist/mnist_autoencoder_solver_adagrad.prototxt
+++ b/examples/mnist/mnist_autoencoder_solver_adagrad.prototxt
@@ -11,7 +11,7 @@ display: 100
 max_iter: 65000
 weight_decay: 0.0005
 snapshot: 10000
-snapshot_prefix: "mnist_autoencoder_train"
+snapshot_prefix: "examples/mnist/mnist_autoencoder_adagrad_train"
 # solver mode: CPU or GPU
 solver_mode: GPU
 solver_type: ADAGRAD


### PR DESCRIPTION
The relative path and prefix for the network snapshots was slightly off for the mnist_adagrad_autoencoder demo. The snapshots were being stored in the caffe root folder.
