### PR TITLE
Fixed CMake building test objects multiple times

### DIFF
--- a/src/caffe/test/CMakeLists.txt
+++ b/src/caffe/test/CMakeLists.txt
@@ -19,6 +19,14 @@ set(GEN_EXT .gen.cmake)    # generated output file extension
 set(TEST_DEFINES_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cmake_test_defines.hpp)
 set(TEST_DATA_FILE ${CMAKE_CURRENT_SOURCE_DIR}/test_data/sample_data_list.txt)
 
+# Function prepares name of a test executable
+#    @output_name -  output variable's name
+#    @filename    -  test_*.cpp file path
+function(test_name output_name filename)
+    get_filename_component(name ${filename} NAME_WE)
+    set(${output_name} ${name}${TEST_EXT} PARENT_SCOPE)
+endfunction()
+
 set(IN_FILES             # generator input files
     ${TEST_DEFINES_FILE}
     ${TEST_DATA_FILE}
@@ -39,20 +47,14 @@ include_directories(
 # Remove main from test sources and prepare an Object lib with main
 file(GLOB TEST_MAIN ${TEST_MAIN}) 
 list(REMOVE_ITEM TEST_CPP_SOURCES ${TEST_MAIN})
-add_library(main_obj EXCLUDE_FROM_ALL OBJECT ${TEST_MAIN})
-
-#if(NOT CPU_ONLY)
-#    set(TEST_CPP_SOURCES ${TEST_CPP_SOURCES} ${TEST_CU_SOURCES})
-#endif()
+add_library(main_obj EXCLUDE_FROM_ALL OBJECT ${TEST_MAIN} ../common.cpp)
 
 #    Build each test separately from *.cpp files
 foreach(source ${TEST_CPP_SOURCES})
-    #
-    get_filename_component(name ${source} NAME_WE)
-    set(TEST_NAME ${name}${TEST_EXT})
+    test_name(TEST_NAME ${source})
     
     #
-    add_library(${TEST_NAME}.obj OBJECT ${source})
+    add_library(${TEST_NAME}.obj EXCLUDE_FROM_ALL OBJECT ${source})
     set(TEST_OBJ_LIB $<TARGET_OBJECTS:${TEST_NAME}.obj>)
     
     add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${TEST_OBJ_LIB} $<TARGET_OBJECTS:main_obj>)     
@@ -67,26 +69,21 @@ foreach(source ${TEST_CPP_SOURCES})
 endforeach()
 
 #    Build each test separately from *.cu files
-if(NOT CPU_ONLY)
-    foreach(source ${TEST_CU_SOURCES})
-        #
-        get_filename_component(name ${source} NAME_WE)
-        set(TEST_NAME ${name}${TEST_EXT})
-        
-        #
-        add_library(${TEST_NAME}.lib ${source})
-        
-        add_executable(${TEST_NAME} EXCLUDE_FROM_ALL $<TARGET_OBJECTS:main_obj>)     
-        target_link_libraries(${TEST_NAME} ${TEST_NAME}.lib gtest caffe)
-        
-        #    output dir
-        set_target_properties(${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test)
-        
-        # Targets and object libs
-        set(TEST_TARGETS ${TEST_TARGETS} ${TEST_NAME})
-        set(TEST_CU_LIBS ${TEST_CU_LIBS} ${TEST_NAME}.lib)
-    endforeach()
-endif()
+foreach(source ${TEST_CU_SOURCES})
+    test_name(TEST_NAME ${source})
+    
+    cuda_add_library(${TEST_NAME}.lib EXCLUDE_FROM_ALL ${source})
+    
+    add_executable(${TEST_NAME} EXCLUDE_FROM_ALL $<TARGET_OBJECTS:main_obj>)     
+    target_link_libraries(${TEST_NAME} ${TEST_NAME}.lib gtest caffe)
+    
+    #    output dir
+    set_target_properties(${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test)
+    
+    # Targets and object libs
+    set(TEST_TARGETS ${TEST_TARGETS} ${TEST_NAME})
+    set(TEST_CU_LIBS ${TEST_CU_LIBS} ${TEST_NAME}.lib)
+endforeach()
 
 #    Build a compound test excluded from the ALL target
 add_executable(${ALL_TEST} EXCLUDE_FROM_ALL ${TEST_OBJ_LIBS} $<TARGET_OBJECTS:main_obj>)
@@ -96,8 +93,9 @@ endif()
 target_link_libraries(${ALL_TEST} gtest caffe)
 add_dependencies(${ALL_TEST} ${TEST_TARGETS})
 
-#    output dir
+#    Output directory
 set_target_properties(${ALL_TEST} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TEST_OUTPUT_DIRECTORY})
+
 #    Test command
 set(TEST_ARGS --gtest_shuffle)
 if(CPU_ONLY)


### PR DESCRIPTION
@jeffdonahue noticed in #943 that some test objects were built multiple times. E.g. `test_caffe_main.cpp` was built separately for each test executable. I fixed it by employing CMake's Object Library (available since CMake 2.8.8). It is not available for CUDA, however, and in this case I'm creating a separate library for every `test_*.cu`.

Surprisingly, CMake builds are now faster than Make's.
