### PR TITLE
linecount counts more dirs than just src/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,9 @@ all: $(NAME) $(STATIC_NAME) tools examples
 everything: all py$(PROJECT) mat$(PROJECT) test warn lint runtest
 
 linecount:
-	cloc --read-lang-def=$(PROJECT).cloc src/$(PROJECT)/
+	cloc --read-lang-def=$(PROJECT).cloc \
+		src/$(PROJECT) include/$(PROJECT) tools examples \
+		python matlab
 
 lint: $(EMPTY_LINT_REPORT)
 


### PR DESCRIPTION
we were selling ourselves short with `make linecount` as it only counted the `src/` directory.

Before:

```
$ make linecount
cloc --read-lang-def=caffe.cloc src/caffe/
     140 text files.
     140 unique files.
       5 files ignored.

http://cloc.sourceforge.net v 1.62  T=0.38 s (353.3 files/s, 62414.0 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
C++                            101           1664            832          18259
CUDA                            30            338            178           2300
CMake                            3             47             39            152
Python                           1              7              5             30
-------------------------------------------------------------------------------
SUM:                           135           2056           1054          20741
-------------------------------------------------------------------------------
```

After:

```
$ make linecount
cloc --read-lang-def=caffe.cloc \
                src/caffe include/caffe tools examples \
                python matlab
     267 text files.
     265 unique files.
      51 files ignored.

http://cloc.sourceforge.net v 1.62  T=0.71 s (308.1 files/s, 51849.3 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
C++                            117           1876           1036          19800
Python                          17            443            442           4451
C/C++ Header                    28            636           1577           2800
CUDA                            30            338            178           2300
MATLAB                           6             32             95            206
CMake                            7             64             47            183
Bourne Shell                    13             48             42            128
HTML                             1             13              4            121
-------------------------------------------------------------------------------
SUM:                           219           3450           3421          29989
-------------------------------------------------------------------------------
```
