### PR TITLE
GPU memory debugging option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,7 @@ endif
 ifeq ($(DEBUG), 1)
 	COMMON_FLAGS += -DDEBUG -g -O0
 	NVCCFLAGS += -G
+	LDFLAGS += -rdynamic
 else
 	COMMON_FLAGS += -DNDEBUG -O2
 endif

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -54,8 +54,12 @@ class SyncedMemory {
   enum SyncedHead { UNINITIALIZED, HEAD_AT_CPU, HEAD_AT_GPU, SYNCED };
   SyncedHead head() { return head_; }
   size_t size() { return size_; }
+  static void set_debug_info(const bool debug_info) {
+    debug_info_ = debug_info;
+  }
 
  private:
+  void debug_alloc();
   void to_cpu();
   void to_gpu();
   void* cpu_ptr_;
@@ -63,6 +67,7 @@ class SyncedMemory {
   size_t size_;
   SyncedHead head_;
   bool own_cpu_data_;
+  static bool debug_info_;
 
   DISABLE_COPY_AND_ASSIGN(SyncedMemory);
 };  // class SyncedMemory

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -1,10 +1,59 @@
-#include <cstring>
+#include <cxxabi.h>
+#include <execinfo.h>
+#include <unistd.h>
+
+#include <string>
 
 #include "caffe/common.hpp"
 #include "caffe/syncedmem.hpp"
 #include "caffe/util/math_functions.hpp"
 
 namespace caffe {
+
+bool SyncedMemory::debug_info_ = false;
+
+void SyncedMemory::debug_alloc() {
+  // first just print the size of the allocation
+  std::ostringstream size_str;
+  size_str << size_ << " bytes";
+  if (size_ > (1 << 20)) {
+    size_str << " (" << static_cast<float>(size_) / (1 << 20) << " MB)";
+  }
+  LOG(INFO) << "debug: gpu alloc " << size_str.str();
+
+  // now try to figure out who is responsible
+  // the call stack should always go:
+  // original caller -> Blob::*_gpu_(type) -> SyncedMemory::*_gpu_data ->
+  //  -> SyncedMemory::to_gpu -> this function, so we need index four
+  //  in the stack frame
+  // if this fails, we'll just give up
+  void* bt_buffer[5];
+  int bt_size = backtrace(bt_buffer, sizeof(bt_buffer) / sizeof(void*));
+  char** bt_strings = backtrace_symbols(bt_buffer, bt_size);
+  if (bt_strings == NULL) {
+    // out of memory for the backtrace
+    return;
+  }
+  // parse and demangle the calling function name
+  std::string caller_frame(bt_strings[4]);
+  free(bt_strings);
+  int start = caller_frame.find("(");
+  int end = caller_frame.find("+");
+  if (start == std::string::npos || end == std::string::npos) {
+    return;
+  }
+  std::string caller_name = caller_frame.substr(start + 1, end - start - 1);
+  int status;
+  char* demang = abi::__cxa_demangle(caller_name.c_str(), NULL, NULL, &status);
+  if (status) {
+    return;
+  }
+  std::string demang_str(demang);
+  free(demang);
+  // cut out the argument list, which can be very long and hard to read
+  demang_str = demang_str.substr(0, demang_str.find("("));
+  LOG(INFO) << "debug:  from " <<  demang_str;
+}
 
 SyncedMemory::~SyncedMemory() {
   if (cpu_ptr_ && own_cpu_data_) {
@@ -48,12 +97,18 @@ inline void SyncedMemory::to_gpu() {
 #ifndef CPU_ONLY
   switch (head_) {
   case UNINITIALIZED:
+    if (debug_info_) {
+      debug_alloc();
+    }
     CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
     caffe_gpu_memset(size_, 0, gpu_ptr_);
     head_ = HEAD_AT_GPU;
     break;
   case HEAD_AT_CPU:
     if (gpu_ptr_ == NULL) {
+      if (debug_info_) {
+        debug_alloc();
+      }
       CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
     }
     caffe_gpu_memcpy(size_, cpu_ptr_, gpu_ptr_);

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "caffe/caffe.hpp"
+#include "caffe/syncedmem.hpp"
 
 using caffe::Blob;
 using caffe::Caffe;
@@ -29,6 +30,8 @@ DEFINE_string(weights, "",
     "Cannot be set simultaneously with snapshot.");
 DEFINE_int32(iterations, 50,
     "The number of iterations to run.");
+DEFINE_bool(debug_gpu_alloc, false,
+    "Show debugging information for GPU memory allocations.");
 
 // A simple registry for caffe commands.
 typedef int (*BrewFunction)();
@@ -270,6 +273,10 @@ int main(int argc, char** argv) {
   // Run tool or show usage.
   caffe::GlobalInit(&argc, &argv);
   if (argc == 2) {
+    // Handle tool-independent flags.
+    if (FLAGS_debug_gpu_alloc) {
+      caffe::SyncedMemory::set_debug_info(true);
+    }
     return GetBrewFunction(caffe::string(argv[1]))();
   } else {
     gflags::ShowUsageWithFlagsRestrict(argv[0], "tools/caffe");


### PR DESCRIPTION
Often a net will fail to run due to a CUDA out-of-memory error. In such cases, Caffe currently provides no easy way to see the breakdown of allocated memory, which may include data blobs, gradient blobs, parameter blobs, and buffers.

This PR adds an option to the `caffe` tool, `-debug_gpu_alloc`, which causes allocations of GPU memory from `SyncedMemory` (which is all of them) to print their size and the name of the function which caused the allocation. (It would be nice to have information about exactly what kind of blob is being allocated and what its name is, but such information is not readily available (although it's accessible in theory by finding the calling `Net` in the backtrace). This PR takes a simpler approach which still provides more information than just the size of the allocation.)

The output looks like this:
```
$ caffe train -solver examples/mnist/lenet_solver.prototxt -debug_gpu_alloc
[...]
I0909 20:44:09.574717  4663 syncedmem.cpp:22] debug: gpu alloc 313600 bytes
I0909 20:44:09.575876  4663 syncedmem.cpp:55] debug:  from caffe::BasePrefetchingDataLayer<float>::Forward_gpu
I0909 20:44:09.671166  4663 syncedmem.cpp:22] debug: gpu alloc 400 bytes
I0909 20:44:09.672235  4663 syncedmem.cpp:55] debug:  from caffe::BasePrefetchingDataLayer<float>::Forward_gpu
I0909 20:44:09.672392  4663 syncedmem.cpp:22] debug: gpu alloc 4608000 bytes (4.39453 MB)
I0909 20:44:09.673388  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
I0909 20:44:09.673722  4663 syncedmem.cpp:22] debug: gpu alloc 57600 bytes
I0909 20:44:09.674720  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
I0909 20:44:09.675045  4663 syncedmem.cpp:22] debug: gpu alloc 2000 bytes
I0909 20:44:09.676031  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
I0909 20:44:09.676441  4663 syncedmem.cpp:22] debug: gpu alloc 2304 bytes
I0909 20:44:09.677489  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
I0909 20:44:09.677553  4663 syncedmem.cpp:22] debug: gpu alloc 80 bytes
I0909 20:44:09.678539  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
I0909 20:44:09.680603  4663 syncedmem.cpp:22] debug: gpu alloc 1152000 bytes (1.09863 MB)
I0909 20:44:09.681604  4663 syncedmem.cpp:55] debug:  from caffe::PoolingLayer<float>::Forward_gpu
I0909 20:44:09.681941  4663 syncedmem.cpp:22] debug: gpu alloc 1152000 bytes (1.09863 MB)
I0909 20:44:09.682940  4663 syncedmem.cpp:55] debug:  from caffe::PoolingLayer<float>::Forward_gpu
I0909 20:44:09.683285  4663 syncedmem.cpp:22] debug: gpu alloc 1280000 bytes (1.2207 MB)
I0909 20:44:09.684269  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
I0909 20:44:09.684597  4663 syncedmem.cpp:22] debug: gpu alloc 128000 bytes
I0909 20:44:09.685577  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
I0909 20:44:09.685900  4663 syncedmem.cpp:22] debug: gpu alloc 100000 bytes
I0909 20:44:09.686889  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
I0909 20:44:09.687021  4663 syncedmem.cpp:22] debug: gpu alloc 256 bytes
I0909 20:44:09.687999  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
I0909 20:44:09.688057  4663 syncedmem.cpp:22] debug: gpu alloc 200 bytes
I0909 20:44:09.689028  4663 syncedmem.cpp:55] debug:  from caffe::ConvolutionLayer<float>::Forward_gpu
[...]
```

Consider:
* What do you think the output format and parameter name should be?
* Should the debugging code live in `syncedmem.cpp` or somewhere else?
* According to the Internet, this should work on OS X, but someone should check that.