### PR TITLE
Fix solver GPU initialization order (e.g., training with cuDNN on non-default device)

### DIFF
--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -32,11 +32,6 @@ void Solver<Dtype>::Init(const SolverParameter& param) {
   LOG(INFO) << "Initializing solver from parameters: " << std::endl
             << param.DebugString();
   param_ = param;
-  if (param_.solver_mode() == SolverParameter_SolverMode_GPU &&
-      param_.has_device_id()) {
-    Caffe::SetDevice(param_.device_id());
-  }
-  Caffe::set_mode(Caffe::Brew(param_.solver_mode()));
   if (param_.random_seed() >= 0) {
     Caffe::set_random_seed(param_.random_seed());
   }


### PR DESCRIPTION
To address #925, allowing the --gpu flag to override the `device_id` setting in the solver prototxt, patch #961 reads the --gpu flag _after_ constructing the solver.

Unfortunately, this means that nets used by the solver are constructed using the default GPU, which is unexpected and breaks cuDNN, which constructs handles in `LayerSetUp` calls. To fix this, we take care of setting mode and device (with --gpu flag overriding `device_id` param) before the solver is constructed.

In accordance with the feeling at #925, setting mode and device is completely removed from the solver code. N.B., this does change the behavior when invoking the solver _without_ using `caffe train`. But I don't really expect this to affect anybody.
