### PR TITLE
set up datum size for WindowDataLayer

### DIFF
--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -158,6 +158,12 @@ void WindowDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   LOG(INFO) << "output data size: " << (*top)[0]->num() << ","
       << (*top)[0]->channels() << "," << (*top)[0]->height() << ","
       << (*top)[0]->width();
+  // datum size
+  this->datum_channels_ = (*top)[0]->channels();
+  this->datum_height_ = (*top)[0]->height();
+  this->datum_width_ = (*top)[0]->width();
+  this->datum_size_ =
+      (*top)[0]->channels() * (*top)[0]->height() * (*top)[0]->width();
   // label
   (*top)[1]->Reshape(batch_size, 1, 1, 1);
   this->prefetch_label_.Reshape(batch_size, 1, 1, 1);


### PR DESCRIPTION
set up datum size for WindowDataLayer to adapt for the new BaseDataLayer inferface.

otherwise, WindowDataLayer fails due to #1089 
