### PR TITLE
[Bugfix] Move file reading error checking closer to actual file read command

### DIFF
--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -71,16 +71,18 @@ bool ReadImageToDatum(const string& filename, const int label,
   cv::Mat cv_img;
   int cv_read_flag = (is_color ? CV_LOAD_IMAGE_COLOR :
     CV_LOAD_IMAGE_GRAYSCALE);
-  if (height > 0 && width > 0) {
-    cv::Mat cv_img_origin = cv::imread(filename, cv_read_flag);
-    cv::resize(cv_img_origin, cv_img, cv::Size(width, height));
-  } else {
-    cv_img = cv::imread(filename, cv_read_flag);
-  }
-  if (!cv_img.data) {
+
+  cv::Mat cv_img_origin = cv::imread(filename, cv_read_flag);
+  if (!cv_img_origin.data) {
     LOG(ERROR) << "Could not open or find file " << filename;
     return false;
   }
+  if (height > 0 && width > 0) {
+    cv::resize(cv_img_origin, cv_img, cv::Size(height, width));
+  } else {
+    cv_img = cv_img_origin;
+  }
+
   int num_channels = (is_color ? 3 : 1);
   datum->set_channels(num_channels);
   datum->set_height(cv_img.rows);


### PR DESCRIPTION
Previously, if (height > 0 && width > 0) was true, the
cv::resize() function would be called before cv_img_origin was
confirmed valid; if the image file/filename was not valid, this
caused an opencv assert error like this:

terminate called after throwing an instance of 'cv::Exception'
  what():  /tmp/A3p0_4200_32550/batserve/A3p0/glnxa64/OpenCV/modules/imgproc/src/imgwarp.cpp:1725: error: (-215)
  ssize.area() > 0 in function resize
