### PR TITLE
switch data layer default source to lmdb from leveldb

### DIFF
--- a/examples/cifar10/cifar10_full_train_test.prototxt
+++ b/examples/cifar10/cifar10_full_train_test.prototxt
@@ -6,6 +6,7 @@ layers {
   top: "label"
   data_param {
     source: "examples/cifar10/cifar10_train_leveldb"
+    backend: LEVELDB
     batch_size: 100
   }
   transform_param {
@@ -20,6 +21,7 @@ layers {
   top: "label"
   data_param {
     source: "examples/cifar10/cifar10_test_leveldb"
+    backend: LEVELDB
     batch_size: 100
   }
   transform_param {

--- a/examples/cifar10/cifar10_quick_train_test.prototxt
+++ b/examples/cifar10/cifar10_quick_train_test.prototxt
@@ -6,6 +6,7 @@ layers {
   top: "label"
   data_param {
     source: "examples/cifar10/cifar10_train_leveldb"
+    backend: LEVELDB
     batch_size: 100
   }
   transform_param {
@@ -20,6 +21,7 @@ layers {
   top: "label"
   data_param {
     source: "examples/cifar10/cifar10_test_leveldb"
+    backend: LEVELDB
     batch_size: 100
   }
   transform_param {

--- a/examples/cifar10/create_cifar10.sh
+++ b/examples/cifar10/create_cifar10.sh
@@ -13,6 +13,6 @@ rm -rf $EXAMPLE/cifar10_train_leveldb $EXAMPLE/cifar10_test_leveldb
 echo "Computing image mean..."
 
 ./build/tools/compute_image_mean $EXAMPLE/cifar10_train_leveldb \
-  $EXAMPLE/mean.binaryproto
+  $EXAMPLE/mean.binaryproto leveldb
 
 echo "Done."

--- a/examples/siamese/mnist_siamese_train_test.prototxt
+++ b/examples/siamese/mnist_siamese_train_test.prototxt
@@ -6,6 +6,7 @@ layers {
   top: "sim"
   data_param {
     source: "examples/siamese/mnist_siamese_train_leveldb"
+    backend: LEVELDB
     scale: 0.00390625
     batch_size: 64
   }
@@ -18,6 +19,7 @@ layers {
   top: "sim"
   data_param {
     source: "examples/siamese/mnist_siamese_test_leveldb"
+    backend: LEVELDB
     scale: 0.00390625
     batch_size: 100
   }

--- a/examples/siamese/readme.md
+++ b/examples/siamese/readme.md
@@ -71,6 +71,7 @@ or different classes (`sim`).
       top: "sim"
       data_param {
         source: "examples/siamese/mnist-siamese-train-leveldb"
+        backend: LEVELDB
         scale: 0.00390625
         batch_size: 64
       }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -414,9 +414,9 @@ message DataParameter {
   // The rand_skip variable is for the data layer to skip a few data points
   // to avoid all asynchronous sgd clients to start at the same point. The skip
   // point would be set as rand_skip * rand(0,1). Note that rand_skip should not
-  // be larger than the number of keys in the leveldb.
+  // be larger than the number of keys in the db.
   optional uint32 rand_skip = 7 [default = 0];
-  optional DB backend = 8 [default = LEVELDB];
+  optional DB backend = 8 [default = LMDB];
   // DEPRECATED. See TransformationParameter. For data pre-processing, we can do
   // simple scaling and subtracting the data mean, if provided. Note that the
   // mean subtraction is always carried out before scaling.
@@ -504,7 +504,7 @@ message ImageDataParameter {
   // The rand_skip variable is for the data layer to skip a few data points
   // to avoid all asynchronous sgd clients to start at the same point. The skip
   // point would be set as rand_skip * rand(0,1). Note that rand_skip should not
-  // be larger than the number of keys in the leveldb.
+  // be larger than the number of keys in the db.
   optional uint32 rand_skip = 7 [default = 0];
   // Whether or not ImageLayer should shuffle the list of files at every epoch.
   optional bool shuffle = 8 [default = false];
@@ -741,7 +741,7 @@ message V0LayerParameter {
   // The rand_skip variable is for the data layer to skip a few data points
   // to avoid all asynchronous sgd clients to start at the same point. The skip
   // point would be set as rand_skip * rand(0,1). Note that rand_skip should not
-  // be larger than the number of keys in the leveldb.
+  // be larger than the number of keys in the db.
   optional uint32 rand_skip = 53 [default = 0];
 
   // Fields related to detection (det_*)


### PR DESCRIPTION
`DATA` layers now default to lmdb storage instead of leveldb.  See #1128 for reasoning.

**Update your model definitions if the models rely on the leveldb default for loading your input data by setting `backend: LEVELDB` in `data_layer_param`.

- [ ] try both formats
- [ ] warn if mismatched