### PR TITLE
Add invert_channels option to TransformData

### DIFF
--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -21,6 +21,8 @@ void DataTransformer<Dtype>::Transform(const int batch_item_id,
   const bool mirror = param_.mirror();
   const Dtype scale = param_.scale();
 
+  const bool invert_channels = param_.invert_channels();
+
   if (mirror && crop_size == 0) {
     LOG(FATAL) << "Current implementation requires mirror and crop_size to be "
                << "set at the same time.";
@@ -45,6 +47,10 @@ void DataTransformer<Dtype>::Transform(const int batch_item_id,
             int data_index = (c * height + h + h_off) * width + w + w_off;
             int top_index = ((batch_item_id * channels + c) * crop_size + h)
                 * crop_size + (crop_size - 1 - w);
+            if (invert_channels) {
+              data_index = ((channels - 1 - c) * height + h + h_off)
+                * width + w + w_off;
+            }
             Dtype datum_element =
                 static_cast<Dtype>(static_cast<uint8_t>(data[data_index]));
             transformed_data[top_index] =
@@ -60,6 +66,10 @@ void DataTransformer<Dtype>::Transform(const int batch_item_id,
             int top_index = ((batch_item_id * channels + c) * crop_size + h)
                 * crop_size + w;
             int data_index = (c * height + h + h_off) * width + w + w_off;
+            if (invert_channels) {
+              data_index = ((channels - 1 - c) * height + h + h_off)
+                * width + w + w_off;
+            }
             Dtype datum_element =
                 static_cast<Dtype>(static_cast<uint8_t>(data[data_index]));
             transformed_data[top_index] =

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -344,6 +344,7 @@ message TransformationParameter {
   // Specify if we would like to randomly crop an image.
   optional uint32 crop_size = 3 [default = 0];
   optional string mean_file = 4;
+  optional bool invert_channels = 5 [default = false];
 }
 
 // Message that stores parameters used by AccuracyLayer


### PR DESCRIPTION
Added invert_channels option to TransformData. That would invert the order of the channels in datum and mean to be able to use the models released in #1138 with current level_db/lmdb and image_mean stored in BGR format.
This is a simple fix, what do you think @ksimonyan @shelhamer?

Ex.

```
name: "VGG_CNN_F"
layers {
  name: "data"
  type: DATA
  top: "data"
  top: "label"
  data_param {
    source: "examples/imagenet/ilsvrc12_val_leveldb"
    batch_size: 50
  }
  transform_param {
    crop_size: 224
    mean_file: "data/ilsvrc12/imagenet_mean.binaryproto"
    mirror: false
    invert_channels: true
  }
  include: { phase: TEST }
}
```
