### PR TITLE
Changed "blas" to "openblas"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ ifeq ($(BLAS), mkl)
 	BLAS_LIB ?= $(MKL_DIR)/lib $(MKL_DIR)/lib/intel64
 else ifeq ($(BLAS), open)
 	# OpenBLAS
-	LIBRARIES += blas
+	LIBRARIES += openblas
 else
 	# ATLAS
 	ifeq ($(LINUX), 1)


### PR DESCRIPTION
The change was made because openblas has to be linked as "-lopenblas" and not "-lblas". This was causing an error when compiling.
