### PR TITLE
Fixed the bug with random offset selection

### DIFF
--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -39,7 +39,15 @@ class DataTransformer {
                  const Dtype* mean, Dtype* transformed_data);
 
  protected:
-  virtual unsigned int Rand();
+   /**
+   * @brief Generates a random integer from Uniform({0, 1, ..., n-1}).
+   * 
+   * @param n
+   *    The upperbound (exclusive) value of the random number.
+   * @return 
+   *    A uniformly random integer value from ({0, 1, ..., n-1}).
+   */
+  virtual int Rand(int n);
 
   // Tranformation parameters
   TransformationParameter param_;

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -31,13 +31,13 @@ void DataTransformer<Dtype>::Transform(const int batch_item_id,
     int h_off, w_off;
     // We only do random crop when we do training.
     if (phase_ == Caffe::TRAIN) {
-      h_off = Rand() % (height - crop_size);
-      w_off = Rand() % (width - crop_size);
+      h_off = Rand(height - crop_size + 1);
+      w_off = Rand(width - crop_size + 1);
     } else {
       h_off = (height - crop_size) / 2;
       w_off = (width - crop_size) / 2;
     }
-    if (mirror && Rand() % 2) {
+    if (mirror && (Rand(2) == 1)) {
       // Copy mirrored version
       for (int c = 0; c < channels; ++c) {
         for (int h = 0; h < crop_size; ++h) {
@@ -99,11 +99,12 @@ void DataTransformer<Dtype>::InitRand() {
 }
 
 template <typename Dtype>
-unsigned int DataTransformer<Dtype>::Rand() {
+int DataTransformer<Dtype>::Rand(int n) {
   CHECK(rng_);
+  CHECK_GT(n, 0);
   caffe::rng_t* rng =
       static_cast<caffe::rng_t*>(rng_->generator());
-  return (*rng)();
+  return ((*rng)() % n);
 }
 
 INSTANTIATE_CLASS(DataTransformer);


### PR DESCRIPTION
When you wish to mirror the image you are also forced to set the crop_size param, which is fine. But if you set the crop_size to be equal to the width (or height) to cancel its behaviour, the program will terminate without any explanations.

The problem is here

``` c++
h_off = Rand() % (height - crop_size);
w_off = Rand() % (width - crop_size);
```

This bugfix sets the h_off or w_off to be zero where appropriate.
