### PR TITLE
Update hdf5_data_layer.cpp

### DIFF
--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -75,9 +75,9 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   // Reshape blobs.
   const int batch_size = this->layer_param_.hdf5_data_param().batch_size();
   (*top)[0]->Reshape(batch_size, data_blob_.channels(),
-                     data_blob_.width(), data_blob_.height());
+                     data_blob_.height(), data_blob_.width());
   (*top)[1]->Reshape(batch_size, label_blob_.channels(),
-                     label_blob_.width(), label_blob_.height());
+                     label_blob_.height(), label_blob_.width());
   LOG(INFO) << "output data size: " << (*top)[0]->num() << ","
       << (*top)[0]->channels() << "," << (*top)[0]->height() << ","
       << (*top)[0]->width();


### PR DESCRIPTION
Fixing a bug.

The bug is in the following lines:

top[0]->Reshape(batch_size, data_blob_.channels(),
data_blob_.width(), data_blob_.height());
top[1]->Reshape(batch_size, label_blob_.channels(),
label_blob_.width(), label_blob_.height());

It should be:

top[0]->Reshape(batch_size, data_blob_.channels(),
data_blob_.height(), data_blob_.width());
top[1]->Reshape(batch_size, label_blob_.channels(),
label_blob_.height(), label_blob_.width());

The implication of the bug, is that when images that are loaded by the hdf5_data_layer with height != width, the original images will get scrambled.
