### PR TITLE
Bug in param order of cv::Size in cv::resize

### DIFF
--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -78,7 +78,7 @@ bool ReadImageToDatum(const string& filename, const int label,
     return false;
   }
   if (height > 0 && width > 0) {
-    cv::resize(cv_img_origin, cv_img, cv::Size(height, width));
+    cv::resize(cv_img_origin, cv_img, cv::Size(width, height));
   } else {
     cv_img = cv_img_origin;
   }


### PR DESCRIPTION
According to http://docs.opencv.org/java/org/opencv/core/Size.html#constructor_summary
the correct order of parameters are cv::Size(double width, double height) 

It didn't affect any resize that used the same height and width, but was a bug
