### PR TITLE
Skip col_buffer allocation when not needed

### DIFF
--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -97,7 +97,7 @@ class ConvolutionLayer : public Layer<Dtype> {
   int num_output_;
   int height_out_, width_out_;
   bool bias_term_;
-  bool is_1x1_;
+  bool skip_col_buff_;
 
   /// M_ is the channel dimension of the output for a single group, which is the
   /// leading dimension of the filter matrix.

--- a/src/caffe/layers/conv_layer.cpp
+++ b/src/caffe/layers/conv_layer.cpp
@@ -131,20 +131,17 @@ void ConvolutionLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
     caffe_set(N_, Dtype(1), bias_multiplier_.mutable_cpu_data());
   }
   // Special case: im2col is the identity for no padding and one of:
-  // 1x1 convolution with stride 1
-  // bottom height x width == kernel_w x kernel_h
-  // or stride alings with kernel
+  // 1x1: convolution with stride 1
+  // Single: bottom height x width == kernel_w x kernel_h
+  // or cases where stride alings with kernel in memory
   // so flag for skipping the buffer and transformation.
   skip_col_buff_ = (pad_h_ == 0 && pad_w_ == 0) &&
     ((kernel_w_ == 1 && kernel_h_ == 1 && stride_h_ == 1 && stride_w_ == 1) ||
     (width_ == kernel_w_ && height_ == kernel_h_) ||
-    (stride_w_ == kernel_w_ && width_ % kernel_w_ == 0 &&
-      (height_ == kernel_h_ || kernel_h_ == 1)) ||
-    (stride_h_ == kernel_h_ && height_ % kernel_h_ == 0 &&
-      (width_ == kernel_w_ || kernel_w_ == 1)));
-  if (skip_col_buff_) {
-    LOG(INFO) << "Skipping use of col_buff";
-  }
+    (stride_w_ == kernel_w_ && width_ % kernel_w_ == 0
+      && kernel_h_ == 1) ||
+    (stride_h_ == kernel_h_ && height_ % kernel_h_ == 0
+      && kernel_w_ == width_));
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/conv_layer.cpp
+++ b/src/caffe/layers/conv_layer.cpp
@@ -142,7 +142,9 @@ void ConvolutionLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       (height_ == kernel_h_ || kernel_h_ == 1)) ||
     (stride_h_ == kernel_h_ && height_ % kernel_h_ == 0 &&
       (width_ == kernel_w_ || kernel_w_ == 1)));
-  LOG(INFO) << "skip_col_buff: " << skip_col_buff_;
+  if (skip_col_buff_) {
+    LOG(INFO) << "Skipping use of col_buff";
+  }
 }
 
 template <typename Dtype>

--- a/src/caffe/test/test_convolution_layer.cpp
+++ b/src/caffe/test/test_convolution_layer.cpp
@@ -244,6 +244,33 @@ TYPED_TEST(ConvolutionLayerTest, Test1x1Convolution) {
   }
 }
 
+TYPED_TEST(ConvolutionLayerTest, TestSingleConvolution) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  ConvolutionParameter* convolution_param =
+      layer_param.mutable_convolution_param();
+  convolution_param->set_kernel_h(6);
+  convolution_param->set_kernel_w(4);
+  convolution_param->set_num_output(4);
+  convolution_param->mutable_weight_filler()->set_type("gaussian");
+  convolution_param->mutable_bias_filler()->set_type("constant");
+  convolution_param->mutable_bias_filler()->set_value(0.1);
+  shared_ptr<Layer<Dtype> > layer(
+      new ConvolutionLayer<Dtype>(layer_param));
+  layer->SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // Check against reference convolution.
+  const Dtype* top_data;
+  const Dtype* ref_top_data;
+  caffe_conv(this->blob_bottom_, convolution_param, layer->blobs(),
+      this->MakeReferenceTop(this->blob_top_));
+  top_data = this->blob_top_->cpu_data();
+  ref_top_data = this->ref_blob_top_->cpu_data();
+  for (int i = 0; i < this->blob_top_->count(); ++i) {
+    EXPECT_NEAR(top_data[i], ref_top_data[i], 1e-4);
+  }
+}
+
 TYPED_TEST(ConvolutionLayerTest, TestSimpleConvolutionGroup) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
@@ -395,6 +422,24 @@ TYPED_TEST(ConvolutionLayerTest, Test1x1Gradient) {
   this->blob_top_vec_.push_back(this->blob_top_2_);
   convolution_param->set_kernel_size(1);
   convolution_param->set_stride(1);
+  convolution_param->set_num_output(2);
+  convolution_param->mutable_weight_filler()->set_type("gaussian");
+  convolution_param->mutable_bias_filler()->set_type("gaussian");
+  ConvolutionLayer<Dtype> layer(layer_param);
+  GradientChecker<Dtype> checker(1e-2, 1e-3);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_);
+}
+
+TYPED_TEST(ConvolutionLayerTest, TestSingleGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  ConvolutionParameter* convolution_param =
+      layer_param.mutable_convolution_param();
+  this->blob_bottom_vec_.push_back(this->blob_bottom_2_);
+  this->blob_top_vec_.push_back(this->blob_top_2_);
+  convolution_param->set_kernel_h(6);
+  convolution_param->set_kernel_w(4);
   convolution_param->set_num_output(2);
   convolution_param->mutable_weight_filler()->set_type("gaussian");
   convolution_param->mutable_bias_filler()->set_type("gaussian");


### PR DESCRIPTION
In the line of #1118 this PR based on the discussion with @longjon and @shelhamer extends the cases when the col_buffer is not needed and a matrix multiplication is enough to compute the result.