### PR TITLE
Reduce extract_features memory footprint, and fix bug for > 1 exported features.

### DIFF
--- a/tools/extract_features.cpp
+++ b/tools/extract_features.cpp
@@ -35,7 +35,7 @@ int feature_extraction_pipeline(int argc, char** argv) {
     "Usage: extract_features  pretrained_net_param"
     "  feature_extraction_proto_file  extract_feature_blob_name1[,name2,...]"
     "  save_feature_leveldb_name1[,name2,...]  num_mini_batches  [CPU/GPU]"
-    "  [DEVICE_ID=0] [DatabaseBatchSize=100]\n"
+    "  [DEVICE_ID=0] [database_batch_size=100]\n"
     "Note: you can extract multiple features in one pass by specifying"
     " multiple feature blob names and leveldb names seperated by ','."
     " The names cannot contain white space characters and the number of blobs"
@@ -50,12 +50,7 @@ int feature_extraction_pipeline(int argc, char** argv) {
   while (arg_pos < argc) {
     if ( arg_pos == num_required_args ) {
       if (strcmp(argv[arg_pos], "GPU") == 0) {
-        LOG(ERROR)<< "Using GPU";
-        Caffe::set_mode(Caffe::GPU);
         using_gpu = true;
-      } else {
-        LOG(ERROR) << "Using CPU";
-        Caffe::set_mode(Caffe::CPU);
       }
     } else if (arg_pos == num_required_args+1) {
       device_id = atoi(argv[arg_pos]);
@@ -68,8 +63,13 @@ int feature_extraction_pipeline(int argc, char** argv) {
   }
 
   if (using_gpu) {
+    LOG(ERROR)<< "Using GPU";
     LOG(ERROR) << "Using Device_id=" << device_id;
     Caffe::SetDevice(device_id);
+    Caffe::set_mode(Caffe::GPU);
+  } else {
+    LOG(ERROR) << "Using CPU";
+    Caffe::set_mode(Caffe::CPU);
   }
 
   LOG(ERROR) << "Using DB batch size=" << db_batch_size;


### PR DESCRIPTION
I found for what seems like a "normal" scenario, extract_feature was being killed by the kernel presumably due to out-of-memory, after a while of the machine becoming very slow with lots of VM swapping going on. The leveldb::WriteBatch instance is storing up 1000 images' worth of features in memory before committing to the file system (prior to this PR). Which can be a lot of memory. Changing the DB-write-batch-size to 100 allowed extract_feature to complete without any errors, with top showing extract_feature topping out at about 45% memory. This PR changes the DB write batch size to 100.

A bit of arithmetic on the scenario I had:
A machine with 8 GB of RAM (admittedly light). I was writing 4 feature blobs each roughly the same size. One of them was 1024 channels x 12 height x 12 width x 4 bytes/float = 655032 feature bytes per image. With the batch size at 1000, it stores up 1000 of those in the leveldb::WriteBatch, so about 0.65 GB. There were 4 feature blobs (num_features) being exported. And I think leveldb may double buffer what you store, and in any case with other memory being consumed it was over the limit. 

Admittedly this isn't a very thorough solution to the problem. I'm merely pushing the tripwire a ways (10x) further out. I don't see any downside to making the change other than since we have more disk operations maybe slightly less efficient. But that doesn't seem significant compared to crashing.
