### PR TITLE
Fixed some errors in layer_factory and cudnn_pooling

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -55,7 +55,7 @@ PoolingLayer<Dtype>* GetPoolingLayer(const string& name,
     if (p_param.pad_h() || p_param.pad_w() || param.top_size() > 1) {
       LOG(INFO) << "CUDNN does not support padding or multiple tops. "
                 << "Using Caffe's own pooling layer.";
-      return new PoolingLayer<DType>(param);
+      return new PoolingLayer<Dtype>(param);
     }
     return new CuDNNPoolingLayer<Dtype>(param);
 #endif

--- a/src/caffe/layers/cudnn_pooling_layer.cpp
+++ b/src/caffe/layers/cudnn_pooling_layer.cpp
@@ -14,8 +14,8 @@ void CuDNNPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   PoolingLayer<Dtype>::LayerSetUp(bottom, top);
   // Sanity check: CUDNN currently only supports pad=0 and top.size()=1 cases.
-  CHECK_EQ(pad_h_, 0);
-  CHECK_EQ(pad_w_, 0);
+  CHECK_EQ(this->pad_h_, 0);
+  CHECK_EQ(this->pad_w_, 0);
   CHECK_EQ(top.size(), 1);
   CUDNN_CHECK(cudnnCreate(&handle_));
   cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);


### PR DESCRIPTION
I guess Travis doesn't check builds with CUDNN active. You shouldn't be able to build the current dev if you have CUDNN active, and this patch fixes the errors.
