### PR TITLE
Expose Net.copy_trained_layers_from and Net.share_trained_layers_with in pycaffe

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -148,6 +148,7 @@ BOOST_PYTHON_MODULE(_caffe) {
       "Net", bp::init<string, string>())
       .def(bp::init<string>())
       .def("copy_from",             &PyNet::CopyTrainedLayersFrom)
+      .def("share_with",            &PyNet::ShareTrainedLayersWith)
       .def("_forward",              &PyNet::Forward)
       .def("_backward",             &PyNet::Backward)
       .def("reshape",               &PyNet::Reshape)

--- a/python/caffe/_caffe.hpp
+++ b/python/caffe/_caffe.hpp
@@ -99,6 +99,9 @@ class PyNet {
   void CopyTrainedLayersFrom(const string filename) {
     net_->CopyTrainedLayersFrom(filename);
   }
+  void ShareTrainedLayersWith(PyNet* other) {
+    net_->ShareTrainedLayersWith(other->net_.get());
+  }
   void Forward(int start, int end) { net_->ForwardFromTo(start, end); }
   void Backward(int start, int end) { net_->BackwardFromTo(start, end); }
   void Reshape() { net_->Reshape(); }


### PR DESCRIPTION
This allows finetuning from Python, for example.

Misgivings: `copy_trained_layers_from` and `share_trained_layers_with` are very long names, while pycaffe mostly has pretty succinct naming. Also, the layers don't really have to be trained at all, so maybe the simple `copy_from` and `share_with` would be better. But these are the names in the C++ interface.

I don't know what will happen if you `share_trained_layers_with` a net, and then delete that net. But it's the same as what will happen if you do the same in C++; does anyone know how that is handled? For the use case I have in mind (the solver), this issue does not arise, because the solver is holding all the nets.
