### PR TITLE
Shuffle hdf5 input data

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -189,7 +189,9 @@ class HDF5DataLayer : public Layer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {}
   virtual void LoadHDF5FileData(const char* filename);
+  void ShuffleData(const hsize_t max_val);
 
+  std::vector<int> permutation_;
   std::vector<std::string> hdf_filenames_;
   unsigned int num_files_;
   unsigned int current_file_;

--- a/src/caffe/layers/hdf5_data_layer.cu
+++ b/src/caffe/layers/hdf5_data_layer.cu
@@ -17,6 +17,13 @@ TODO:
 namespace caffe {
 
 template <typename Dtype>
+void HDF5DataLayer<Dtype>::PermutateData(const hsize_t max_val){
+  LOG(INFO) << "shuffle data";
+  std::random_shuffle(permutation_.begin(), permutation_.end());
+}
+
+
+template <typename Dtype>
 void HDF5DataLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   const int batch_size = this->layer_param_.hdf5_data_param().batch_size();
@@ -29,13 +36,17 @@ void HDF5DataLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
           DLOG(INFO) << "Looping around to first file.";
         }
         LoadHDF5FileData(hdf_filenames_[current_file_].c_str());
+        if(this->layer_param_.hdf5_data_param().shuffle())
+          ShuffleData(hdf_blobs_[0]->num());
       }
       current_row_ = 0;
+      if(this->layer_param_.hdf5_data_param().shuffle())
+        ShuffleData(hdf_blobs_[0]->num());
     }
     for (int j = 0; j < this->layer_param_.top_size(); ++j) {
       int data_dim = top[j]->count() / top[j]->num();
       caffe_copy(data_dim,
-          &hdf_blobs_[j]->cpu_data()[current_row_ * data_dim],
+          &hdf_blobs_[j]->cpu_data()[permutation_[current_row_] * data_dim],
           &top[j]->mutable_gpu_data()[i * data_dim]);
     }
   }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -476,6 +476,8 @@ message HDF5DataParameter {
   optional string source = 1;
   // Specify the batch size.
   optional uint32 batch_size = 2;
+  // specify shuffle
+  optional bool shuffle = 3 [default = false];
 }
 
 // Message that stores parameters used by HDF5OutputLayer


### PR DESCRIPTION
After loading a hdf5data file the order of the data can be changed
by setting "shuffle:true" in prototxt for the specific layer. Per-
mutation is done after switching to a new hdf5 file or after each
of the data in the hdf5 file was presented to the neural network.

(compilation was tested)
