### PR TITLE
Fix build issue with pycaffe

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -2,6 +2,7 @@
 // caffe::Caffe functions so that one could easily call it from Python.
 // Note that for Python, we will simply use float as the data type.
 
+#include <Python.h>
 #include <boost/make_shared.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 

--- a/python/caffe/_caffe.hpp
+++ b/python/caffe/_caffe.hpp
@@ -3,6 +3,7 @@
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
+#include <Python.h>
 #include <boost/python.hpp>
 #include <boost/shared_ptr.hpp>
 #include <numpy/arrayobject.h>


### PR DESCRIPTION
- Add Python.h to prevent macro name colliding with function name

Signed-off-by: Vimal Thilak vimalthilak@gmail.com
