### PR TITLE
cmake compile under Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE}) # set release flags
 
 #    Link Flags
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")  # clang++
-  set(CAFFE_STATIC_LINK -Wl,-force_load $(STATIC_NAME))
+  set(CAFFE_STATIC_LINK -Wl,-force_load caffe)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")  # g++
   set(CAFFE_STATIC_LINK -Wl,--whole-archive caffe -Wl,--no-whole-archive)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,11 +121,21 @@ elseif(BLAS STREQUAL "mkl")
     include_directories(${MKL_INCLUDE_DIR})
     set(BLAS_LIBRARIES ${MKL_LIBRARIES})
 
+elseif(BLAS STREQUAL "veclib")
+
+    find_package(vecLib REQUIRED)
+    include_directories(${vecLib_INCLUDE_DIR})
+    set(BLAS_LIBRARIES ${vecLib_LIBRARY})
+
 endif()
 
 #    HDF5
 find_package(HDF5 COMPONENTS HL REQUIRED)
 include_directories(${HDF5_INCLUDE_DIRS})
+
+#    OpenCV
+find_package(OpenCV REQUIRED core highgui imgproc)
+include_directories(${OpenCV_INCLUDE_DIRS})
 
 #    LevelDB
 find_package(LevelDB REQUIRED)
@@ -143,9 +153,6 @@ endif()
 find_package(LMDB REQUIRED)
 include_directories(${LMDB_INCLUDE_DIR})
 
-#    OpenCV
-find_package(OpenCV REQUIRED core highgui imgproc)
-include_directories(${OpenCV_INCLUDE_DIRS})
 
 ###    Subdirectories    ##########################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ if(NOT CUDA_TEST_DEVICE)
     set(CUDA_TEST_DEVICE -1)
 endif()
 
+if(APPLE)
+    # ask gtest to use internal tuple to avoid conflicting with clang compiler
+    add_definitions(-DGTEST_USE_OWN_TR1_TUPLE=1)
+endif()
+
 #    Install Prefix
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Default install path" FORCE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,11 @@ option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_SHARED_LIBS "Build SHARED libs if ON and STATIC otherwise" OFF)
 
 if(NOT BLAS)
-    set(BLAS atlas)
+    if(APPLE)
+        set(BLAS veclib) # Accelerate / vecLib Framework from OS X
+    else()
+        set(BLAS atlas)
+    endif()
 endif()
 
 if(NOT CUDA_TEST_DEVICE)

--- a/CMakeScripts/FindVecLib.cmake
+++ b/CMakeScripts/FindVecLib.cmake
@@ -1,0 +1,15 @@
+SET(vecLib_INCLUDE_SEARCH_PATHS
+  /System/Library/Frameworks/vecLib.framework/Versions/Current/Headers/
+  /System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Versions/Current/Headers/
+)
+
+FIND_PATH(vecLib_INCLUDE_DIR NAMES cblas.h PATHS ${vecLib_INCLUDE_SEARCH_PATHS})
+FIND_LIBRARY(vecLib_LIBRARY Accelerate)
+
+SET(vecLib_FOUND ON)
+
+MARK_AS_ADVANCED(
+    vecLib_INCLUDE_DIR
+    vecLib_LIBRARY
+    vecLib
+)

--- a/CMakeScripts/FindVecLib.cmake
+++ b/CMakeScripts/FindVecLib.cmake
@@ -13,3 +13,4 @@ MARK_AS_ADVANCED(
     vecLib_LIBRARY
     vecLib
 )
+


### PR DESCRIPTION
1. Use `Accelerate / vecLib` as atlas by default if under OS X. Also the path for framework header files seem to changed a bit in OS X 10.10.
2. I moved the the library finding code from the `src/caffe` directory to top-level cmake script, too. Because I have problems finding header files when compiling for the `tools` directory.
3. A small fix to `gtest` is included by adding `-DGTEST_USE_OWN_TR1_TUPLE=1` to avoid compiling conflict (`fatal error: 'tr1/tuple' file not found`) with clang.