### PR TITLE
Missing param.pad condition for CUDNN pooling

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -47,7 +47,8 @@ Layer<Dtype>* GetPoolingLayer(const LayerParameter& param) {
 #ifdef USE_CUDNN
   } else if (engine == PoolingParameter_Engine_CUDNN) {
     PoolingParameter p_param = param.pooling_param();
-    if (p_param.pad_h() || p_param.pad_w() || param.top_size() > 1) {
+    if (p_param.pad() || p_param.pad_h() || p_param.pad_w() ||
+        param.top_size() > 1) {
       LOG(INFO) << "CUDNN does not support padding or multiple tops. "
                 << "Using Caffe's own pooling layer.";
       return new PoolingLayer<Dtype>(param);


### PR DESCRIPTION
Added check for pad >= 1
