### PR TITLE
[bug fix] Fix pthread linking order for gflags for CMake

### DIFF
--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -111,13 +111,13 @@ endif()
 target_link_libraries(caffe proto
         ${BLAS_LIBRARIES}
         ${Boost_LIBRARIES}
-        ${CMAKE_THREAD_LIBS_INIT}
         ${GFLAGS_LIBRARIES}
         ${GLOG_LIBRARIES}
         ${HDF5_LIBRARIES}
         ${LEVELDB_LIBS}
         ${LMDB_LIBRARIES}
         ${OpenCV_LIBS}
+        ${CMAKE_THREAD_LIBS_INIT}
 )
 
 #set output directory


### PR DESCRIPTION
This patch is the equivalent to #1179 for CMake.

This patch resolves an error with linking to the static gflags library under Ubuntu 14.04.
The linking otherwise fails with an undefined reference to symbol 'pthread_rwlock_wrlock@@GLIBC_2.2.5'
error.
