### PR TITLE
[fix] check solver prototxt parsing

### DIFF
--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -23,7 +23,7 @@ template <typename Dtype>
 Solver<Dtype>::Solver(const string& param_file)
     : net_() {
   SolverParameter param;
-  ReadProtoFromTextFile(param_file, &param);
+  ReadProtoFromTextFileOrDie(param_file, &param);
   Init(param);
 }
 


### PR DESCRIPTION
Commit be8d83603c559cb46170442c3c0cbd663492db05 changed the behavior of `ReadProtoFromTextFile` to return an error code, and added `ReadProtoFromTextFileOrDie` for the old behavior of failing on error. (This was useful for upgrading V0 net files.)

Unfortunately, the solver code still uses `ReadProtoFromTextFile`, which has an unchecked error return. You've probably never noticed this, because the solver is normally invoked from the `caffe` tool, which itself calls `ReadProtoFromTextFileOrDie`; however, the solver can be invoked in other ways.

This patch switches to the `OrDie` variant to properly fail on error. Even though this issue occurs uncommonly, I'm sending this to master as it can cause very unexpected behavior.

(Also, given that `ReadProtoFromTextFileOrDie` is called everywhere except in the upgrade tool, perhaps the naming should be changed to reflect the fact that the "plain version" is actually the special case...)
