### PR TITLE
Use glog to provide a backtrace on crash

### DIFF
--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -35,6 +35,8 @@ void GlobalInit(int* pargc, char*** pargv) {
   ::gflags::ParseCommandLineFlags(pargc, pargv, true);
   // Google logging.
   ::google::InitGoogleLogging(*(pargv)[0]);
+  // Provide a backtrace on segfault.
+  ::google::InstallFailureSignalHandler();
 }
 
 #ifdef CPU_ONLY  // CPU-only Caffe.


### PR DESCRIPTION
The google logging library has the ability to install a signal handler that dumps a backtrace on certain signals, such as `SIGSEGV`. This seems like a zero-cost way to make debugging slightly easier.
