### PR TITLE
Legacy nvcc support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,6 @@ ifeq ($(OSX), 1)
 	endif
 	# boost::thread is called boost_thread-mt to mark multithreading on OS X
 	LIBRARIES += boost_thread-mt
-        NVCCFLAGS += -DOSX
 endif
 
 # Custom compiler

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -64,6 +64,9 @@ private:\
 // is executed we will see a fatal log.
 #define NOT_IMPLEMENTED LOG(FATAL) << "Not Implemented Yet"
 
+// See PR #1236
+namespace cv {class Mat;}
+
 namespace caffe {
 
 // We will use the boost shared_ptr instead of the new C++11 one mainly

--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -1,10 +1,6 @@
 #ifndef CAFFE_DATA_TRANSFORMER_HPP
 #define CAFFE_DATA_TRANSFORMER_HPP
 
-#ifndef OSX
-#include <opencv2/core/core.hpp>
-#endif
-
 #include <vector>
 
 #include "caffe/blob.hpp"
@@ -64,9 +60,7 @@ class DataTransformer {
    *    This is destination blob. It can be part of top blob's data if
    *    set_cpu_data() is used See image_data_layer.cpp for an example.
    */
-#ifndef OSX
   void Transform(const cv::Mat& cv_img, Blob<Dtype>* transformed_blob);
-#endif
 
   /**
    * @brief Applies the same transformation defined in the data layer's

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -1,10 +1,6 @@
 #ifndef CAFFE_UTIL_IO_H_
 #define CAFFE_UTIL_IO_H_
 
-#ifndef OSX
-#include <opencv2/core/core.hpp>
-#endif
-
 #include <unistd.h>
 #include <string>
 
@@ -13,6 +9,7 @@
 #include "hdf5_hl.h"
 
 #include "caffe/blob.hpp"
+#include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"
 
 #define HDF5_NUM_DIMS 4
@@ -127,43 +124,29 @@ inline bool DecodeDatum(Datum* datum) {
   return DecodeDatum(0, 0, true, datum);
 }
 
-#ifndef OSX
 cv::Mat ReadImageToCVMat(const string& filename,
     const int height, const int width, const bool is_color);
 
-inline cv::Mat ReadImageToCVMat(const string& filename,
-    const int height, const int width) {
-  return ReadImageToCVMat(filename, height, width, true);
-}
+cv::Mat ReadImageToCVMat(const string& filename,
+    const int height, const int width);
 
-inline cv::Mat ReadImageToCVMat(const string& filename,
-    const bool is_color) {
-  return ReadImageToCVMat(filename, 0, 0, is_color);
-}
+cv::Mat ReadImageToCVMat(const string& filename,
+    const bool is_color);
 
-inline cv::Mat ReadImageToCVMat(const string& filename) {
-  return ReadImageToCVMat(filename, 0, 0, true);
-}
+cv::Mat ReadImageToCVMat(const string& filename);
 
 cv::Mat DecodeDatumToCVMat(const Datum& datum,
     const int height, const int width, const bool is_color);
 
-inline cv::Mat DecodeDatumToCVMat(const Datum& datum,
-    const int height, const int width) {
-  return DecodeDatumToCVMat(datum, height, width, true);
-}
+cv::Mat DecodeDatumToCVMat(const Datum& datum,
+    const int height, const int width);
 
-inline cv::Mat DecodeDatumToCVMat(const Datum& datum,
-    const bool is_color) {
-  return DecodeDatumToCVMat(datum, 0, 0, is_color);
-}
+cv::Mat DecodeDatumToCVMat(const Datum& datum,
+    const bool is_color);
 
-inline cv::Mat DecodeDatumToCVMat(const Datum& datum) {
-  return DecodeDatumToCVMat(datum, 0, 0, true);
-}
+cv::Mat DecodeDatumToCVMat(const Datum& datum);
 
 void CVMatToDatum(const cv::Mat& cv_img, Datum* datum);
-#endif
 
 template <typename Dtype>
 void hdf5_load_nd_dataset_helper(

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -1,6 +1,4 @@
-#ifndef OSX
 #include <opencv2/core/core.hpp>
-#endif
 
 #include <string>
 #include <vector>
@@ -175,7 +173,6 @@ void DataTransformer<Dtype>::Transform(const vector<Datum> & datum_vector,
   }
 }
 
-#ifndef OSX
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
                                        Blob<Dtype>* transformed_blob) {
@@ -276,7 +273,6 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
     }
   }
 }
-#endif
 
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -1,3 +1,5 @@
+#include <opencv2/core/core.hpp>
+
 #include <stdint.h>
 
 #include <string>

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -1,3 +1,5 @@
+#include <opencv2/core/core.hpp>
+
 #include <fstream>  // NOLINT(readability/streams)
 #include <iostream>  // NOLINT(readability/streams)
 #include <string>

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -83,6 +83,20 @@ cv::Mat ReadImageToCVMat(const string& filename,
   return cv_img;
 }
 
+cv::Mat ReadImageToCVMat(const string& filename,
+    const int height, const int width) {
+  return ReadImageToCVMat(filename, height, width, true);
+}
+
+cv::Mat ReadImageToCVMat(const string& filename,
+    const bool is_color) {
+  return ReadImageToCVMat(filename, 0, 0, is_color);
+}
+
+cv::Mat ReadImageToCVMat(const string& filename) {
+  return ReadImageToCVMat(filename, 0, 0, true);
+}
+
 bool ReadImageToDatum(const string& filename, const int label,
     const int height, const int width, const bool is_color, Datum* datum) {
   cv::Mat cv_img = ReadImageToCVMat(filename, height, width, is_color);
@@ -133,6 +147,20 @@ cv::Mat DecodeDatumToCVMat(const Datum& datum,
     LOG(ERROR) << "Could not decode datum ";
   }
   return cv_img;
+}
+
+cv::Mat DecodeDatumToCVMat(const Datum& datum,
+    const int height, const int width) {
+  return DecodeDatumToCVMat(datum, height, width, true);
+}
+
+cv::Mat DecodeDatumToCVMat(const Datum& datum,
+    const bool is_color) {
+  return DecodeDatumToCVMat(datum, 0, 0, is_color);
+}
+
+cv::Mat DecodeDatumToCVMat(const Datum& datum) {
+  return DecodeDatumToCVMat(datum, 0, 0, true);
 }
 
 // If Datum is encoded will decoded using DecodeDatumToCVMat and CVMatToDatum


### PR DESCRIPTION
Hey,

unfortunately, commit 0ba046bc3ec7362b49d239d9d0947c2598a75ef0 (merge PR #1070) breaks compilation in our legacy environment (we currently use cuda toolkit 5.0 and nvcc with gcc 4.4). The compilation errors we get are of the following type:
```
emmintrin.h(1312): error: identifier "__builtin_ia32_vec_ext_v8hi" is undefined
```
This could be related to a similar issue with intrinsics when compiling under OSX (mentioned in #1070).

The proposed fix is to avoid inclusion of the opencv header when compiling with nvcc and the host gcc is < 4.7.

I kept the original workaround with the OSX flag for now, but my guess is the whole check could be simplified as:
```
#if __NVCC__
namespace cv {class Mat;}
#else
#include <opencv2/core/core.hpp>
#endif
```
that is, the cuda code does not actually require opencv, except for the class declaration `cv::Mat`.

The downside of this approach is that `ReadImageToCVMat` is not inlined.
