### PR TITLE
CMake was not building Python wrapper

### DIFF
--- a/CMakeScripts/ProtobufPython.cmake
+++ b/CMakeScripts/ProtobufPython.cmake
@@ -1,0 +1,32 @@
+
+function(PROTOBUF_GENERATE_PYTHON OUTPUT)
+  if(NOT ARGN)
+    message(SEND_ERROR "Error: PROTOBUF_GENERATE_PYTHON() called without any proto files")
+    return()
+  endif(NOT ARGN)
+
+  set(${OUTPUT})
+  foreach(FIL ${ARGN})
+    get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
+    get_filename_component(FIL_WE ${FIL} NAME_WE)
+    get_filename_component(PATH ${FIL} PATH)
+
+    list(APPEND ${OUTPUT} "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}_pb2.py")
+
+    add_custom_command(
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}_pb2.py"
+      COMMAND  ${PROTOBUF_PROTOC_EXECUTABLE}
+      ARGS --python_out=${CMAKE_CURRENT_BINARY_DIR}
+           --proto_path=${PATH}
+           ${ABS_FIL}
+      DEPENDS ${ABS_FIL}
+      COMMENT "Running Python protocol buffer compiler on ${FIL}"
+      VERBATIM )
+  endforeach()
+
+  add_custom_target(protopython ALL
+    DEPENDS ${${OUTPUT}})
+
+  set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
+  set(${OUTPUT} ${${OUTPUT}} PARENT_SCOPE)
+endfunction()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -3,14 +3,18 @@ project( Python )
 #    Python
 find_package(PythonLibs REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
+# TODO: Numpy should be found with a find_package command
+include_directories(/usr/local/anaconda/lib/python2.7/site-packages/numpy/core/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/caffe)
 
 #    Boost.Python
 find_package(Boost 1.46 COMPONENTS python REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
-file(GLOB_RECURSE Python_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+file(GLOB_RECURSE Python_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/caffe/*.cpp)
 
 add_library(pycaffe SHARED ${Python_SOURCES})
+set_target_properties(pycaffe PROPERTIES OUTPUT_NAME _caffe PREFIX "")
 target_link_libraries(pycaffe caffe ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
 
 ###    Install    #################################################################################

--- a/src/caffe/proto/CMakeLists.txt
+++ b/src/caffe/proto/CMakeLists.txt
@@ -15,6 +15,25 @@ include_directories(${PROTOBUF_INCLUDE_DIR})
 file(GLOB ProtoFiles "${CMAKE_CURRENT_SOURCE_DIR}/*.proto")
 PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${ProtoFiles})
 
+if(BUILD_PYTHON)
+	include(${CMAKE_MODULE_PATH}/ProtobufPython.cmake)
+    PROTOBUF_GENERATE_PYTHON(ProtoPython ${ProtoFiles})
+
+    file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/python/caffe/proto)
+
+    foreach(header ${ProtoPython})
+
+        ADD_CUSTOM_COMMAND(TARGET protopython
+            COMMAND cmake -E copy ${header}
+            ${CMAKE_SOURCE_DIR}/python/caffe/proto/
+            DEPENDS ${header}
+        )
+
+    endforeach(header)
+
+    install(FILES ${ProtoPython} DESTINATION python/caffe/proto/)
+endif()
+
 add_library(proto
         ${ProtoSources}
         ${ProtoHeaders}


### PR DESCRIPTION
CMake system was not correctly building the python wrapper.
Paths of _caffe.so library were incorrect and protobuf was not being build at all.

Numpy include path is not being automatically detected. It should be modified to be.
