### PR TITLE
Proto data layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project( Caffe )
 
 ###    Build Options     ##########################################################################
 
+option(WORKAROUND_PROTOBUF_FIND_EXTENSION "Enable protobuf reflection workaround" OFF)
 option(CPU_ONLY "Build Caffe without GPU support" OFF)
 option(BUILD_PYTHON "Build Python wrapper" OFF)
 option(BUILD_MATLAB "Build Matlab wrapper" OFF)
@@ -39,6 +40,10 @@ endif()
 #    Global Definitions
 if(CPU_ONLY)
     add_definitions(-DCPU_ONLY)
+endif()
+
+if(WORKAROUND_PROTOBUF_FIND_EXTENSION)
+    add_definitions(-DWORKAROUND_PROTOBUF_FIND_EXTENSION)
 endif()
 
 #    Include Directories

--- a/CMakeScripts/Findlibjpeg.cmake
+++ b/CMakeScripts/Findlibjpeg.cmake
@@ -1,0 +1,93 @@
+#  Adapted from cmake-modules Google Code project
+#
+#  Copyright (c) 2006 Andreas Schneider <mail@cynapses.org>
+#
+#  (Changes for libfreenect) Copyright (c) 2011 Yannis Gravezas <wizgrav@infrael.com>
+#
+# Redistribution and use is allowed according to the terms of the New BSD license.
+#
+# CMake-Modules Project New BSD License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the CMake-Modules Project nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+if (LIBJPEG_LIBRARIES AND LIBJPEG_INCLUDE_DIRS)
+  # in cache already
+  set(LIBJPEG_FOUND TRUE)
+else (LIBJPEG_LIBRARIES AND LIBJPEG_INCLUDE_DIRS)
+  find_path(LIBJPEG_INCLUDE_DIR
+    NAMES
+	jpeglib.h
+    PATHS
+	  /opt/libjpeg-turbo/include
+      /usr/include/libjpeg-turbo
+      /usr/include/libjpeg
+      /usr/local/include/libjpeg-turbo
+      /usr/local/include/libjpeg
+    PATH_SUFFIXES
+	  libjpeg-turbo
+	  libjpeg
+  )
+
+  find_library(LIBJPEG_LIBRARY
+    NAMES
+      jpeg
+    PATHS
+	  /opt/libjpeg-turbo/lib
+      /usr/local/lib64
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+  set(LIBJPEG_INCLUDE_DIRS
+    ${LIBJPEG_INCLUDE_DIR}
+  )
+  set(LIBJPEG_LIBRARIES
+    ${LIBJPEG_LIBRARY}
+)
+  if (LIBJPEG_INCLUDE_DIRS AND LIBJPEG_LIBRARIES)
+     set(LIBJPEG_FOUND TRUE)
+  endif (LIBJPEG_INCLUDE_DIRS AND LIBJPEG_LIBRARIES)
+
+  if (LIBJPEG_FOUND)
+    if (NOT libjpeg_FIND_QUIETLY)
+      message(STATUS "Found libjpeg:")
+	  message(STATUS " - Includes: ${LIBJPEG_INCLUDE_DIRS}")
+	  message(STATUS " - Libraries: ${LIBJPEG_LIBRARIES}")
+	  
+    endif (NOT libjpeg_FIND_QUIETLY)
+  else (LIBJPEG_FOUND)
+    if (libjpeg_FIND_REQUIRED)
+      message(FATAL_ERROR "Could not find libjpeg")
+    endif (libjpeg_FIND_REQUIRED)
+  endif (LIBJPEG_FOUND)
+
+  # show the LIBFREENECT_INCLUDE_DIRS and LIBFREENECT_LIBRARIES variables only in the advanced view
+  mark_as_advanced(LIBJPEG_INCLUDE_DIRS LIBJPEG_LIBRARIES)
+
+endif (LIBJPEG_LIBRARIES AND LIBJPEG_INCLUDE_DIRS)

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,8 @@ ifneq ($(CPU_ONLY), 1)
 endif
 LIBRARIES += glog gflags protobuf leveldb snappy \
 	lmdb boost_system hdf5_hl hdf5 m \
-	opencv_core opencv_highgui opencv_imgproc
+	opencv_core opencv_highgui opencv_imgproc \
+	turbojpeg
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare
 
@@ -324,7 +325,8 @@ LIBRARY_DIRS += $(LIB_BUILD_DIR)
 
 # Complete build flags.
 COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
-CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
+CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS) \
+		`pkg-config curlpp --cflags`
 NVCCFLAGS += -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS)
 # mex may invoke an older gcc that is too liberal with -Wuninitalized
 MATLAB_CXXFLAGS := $(CXXFLAGS) -Wno-uninitialized
@@ -337,6 +339,7 @@ else
 	PKG_CONFIG :=
 endif
 LDFLAGS += $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir)) $(PKG_CONFIG) \
+		`pkg-config curlpp --libs` \
 		$(foreach library,$(LIBRARIES),-l$(library))
 PYTHON_LDFLAGS := $(LDFLAGS) $(foreach library,$(PYTHON_LIBRARIES),-l$(library))
 

--- a/include/caffe/util/download_manager.hpp
+++ b/include/caffe/util/download_manager.hpp
@@ -1,0 +1,40 @@
+#ifndef CAFFE_DOWNLOAD_MANAGER_H_
+#define CAFFE_DOWNLOAD_MANAGER_H_
+
+#include <curlpp/cURLpp.hpp>
+#include <curlpp/Multi.hpp>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "caffe/common.hpp"
+
+namespace caffe {
+
+using std::string;
+using std::stringstream;
+
+class DownloadManager {
+ public:
+  virtual ~DownloadManager() { }
+  void AddUrl(const string& url);
+  const vector<shared_ptr<stringstream> >& RetrieveResults() const;
+  void Reset();
+  virtual void Download();
+
+  static DownloadManager* DefaultDownloadManagerFactory() {
+    return new DownloadManager();
+  }
+
+ protected:
+  void Register(const string& url);
+
+  vector<shared_ptr<stringstream> > streams_;
+  vector<string> urls_;
+  curlpp::Multi curl_multi_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_DOWNLOAD_MANAGER_H_

--- a/scripts/travis/travis_build_and_test.sh
+++ b/scripts/travis/travis_build_and_test.sh
@@ -7,7 +7,7 @@ MAKE="make --jobs=$NUM_THREADS --keep-going"
 if $WITH_CMAKE; then
   mkdir build
   cd build
-  cmake -DBUILD_PYTHON=ON -DBUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release -DCPU_ONLY=ON ..
+  cmake -DBUILD_PYTHON=ON -DBUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release -DCPU_ONLY=ON -DLIBJPEG_INCLUDE_DIR=/opt/libjpeg-turbo/include -DLIBJPEG_LIBRARY=/opt/libjpeg-turbo/lib64/libturbojpeg.so -DWORKAROUND_PROTOBUF_FIND_EXTENSION=ON ..
   $MAKE
   if ! $WITH_CUDA; then
     $MAKE runtest

--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -11,14 +11,28 @@ MAKE="make --jobs=$NUM_THREADS"
 add-apt-repository -y ppa:tuleu/precise-backports
 apt-get -y update
 apt-get install \
-    wget git curl \
+    wget git curl nasm libcurl4-openssl-dev \
     python-dev python-numpy \
     libleveldb-dev libsnappy-dev libopencv-dev \
-    libboost-dev libboost-system-dev libboost-python-dev libboost-thread-dev \
-    libprotobuf-dev protobuf-compiler \
+    libboost-all-dev \
     libatlas-dev libatlas-base-dev \
     libhdf5-serial-dev libgflags-dev libgoogle-glog-dev \
     bc
+
+PROTOBUF_URL=https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.gz
+PROTOBUF_FILE=/tmp/protobuf-2.5.0.tar.gz
+PROTOBUF_DIR=protobuf-2.5.0
+curl $PROTOBUF_URL -o $PROTOBUF_FILE
+pushd .
+cd /tmp
+tar xf $PROTOBUF_FILE
+cd $PROTOBUF_DIR
+./configure
+$MAKE
+make install
+echo "/usr/local/lib" >> /etc/ld.so.conf
+ldconfig
+protoc --version
 
 # Add a special apt-repository to install CMake 2.8.9 for CMake Caffe build,
 # if needed.  By default, Aptitude in Ubuntu 12.04 installs CMake 2.8.7, but
@@ -57,3 +71,41 @@ $MAKE
 $MAKE install
 popd
 rm -f $LMDB_FILE
+
+# Install curlpp
+CURLPP_URL=https://curlpp.googlecode.com/files/curlpp-0.7.3.tar.gz
+CURLPP_FILE=/tmp/curlpp.tar.gz
+CURLPP_DIR=curlpp-0.7.3
+curl $CURLPP_URL -o $CURLPP_FILE
+pushd .
+cd /tmp
+tar xf $CURLPP_FILE
+pushd .
+cd $CURLPP_DIR
+./configure
+$MAKE
+make install
+popd
+rm -rf $CURLPP_DIR
+popd
+rm -f $CURLPP_FILE
+
+# Install turbo-jpeg
+TURBO_JPEG_URL=http://downloads.sourceforge.net/project/libjpeg-turbo/1.3.1/libjpeg-turbo-1.3.1.tar.gz
+TURBO_JPEG_FILE=/tmp/libjpeg-turbo.tar.gz
+TURBO_JPEG_DIR=libjpeg-turbo-1.3.1
+curl $TURBO_JPEG_URL -o $TURBO_JPEG_FILE -L
+pushd .
+cd /tmp
+tar xf $TURBO_JPEG_FILE
+pushd .
+cd $TURBO_JPEG_DIR
+./configure
+$MAKE
+make install
+popd
+rm -rf $TURBO_JPEG_DIR
+popd
+rm -f $TURBO_JPEG_FILE
+echo "/opt/libjpeg-turbo/lib64" >> /etc/ld.so.conf
+ldconfig

--- a/scripts/travis/travis_setup_makefile_config.sh
+++ b/scripts/travis/travis_setup_makefile_config.sh
@@ -12,3 +12,9 @@ if $WITH_CUDA; then
   GENCODE="$GENCODE -gencode arch=compute_50,code=compute_50"
   echo "CUDA_ARCH := $GENCODE" >> Makefile.config
 fi
+
+TURBO_JPEG_INCLUDE=/opt/libjpeg-turbo/include
+TURBO_JPEG_LIBRARY=/opt/libjpeg-turbo/lib64
+echo "INCLUDE_DIRS += $TURBO_JPEG_INCLUDE" >> Makefile.config
+echo "LIBRARY_DIRS += $TURBO_JPEG_LIBRARY" >> Makefile.config
+echo "COMMON_FLAGS += -DWORKAROUND_PROTOBUF_FIND_EXTENSION" >> Makefile.config

--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -1,6 +1,15 @@
 project( CaffeSrc )
 
 
+find_package(libjpeg REQUIRED)
+include_directories(${LIBJPEG_INCLUDE_DIRS})
+link_directories(${LIBJPEG_LIBRARY_DIRS})
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(CURLPP REQUIRED curlpp)
+include_directories(${CURLPP_INCLUDE_DIRS})
+link_directories(${CURLPP_LIBRARY_DIRS})
+
 add_subdirectory(proto)
 
 #    Recursively find source files
@@ -40,6 +49,8 @@ target_link_libraries(caffe proto
         ${LMDB_LIBRARIES}
         ${OpenCV_LIBS}
         ${CMAKE_THREAD_LIBS_INIT}
+        ${LIBJPEG_LIBRARIES}
+        ${CURLPP_LIBRARIES}
 )
 
 #set output directory

--- a/src/caffe/layers/protobuf_data_layer.cpp
+++ b/src/caffe/layers/protobuf_data_layer.cpp
@@ -339,7 +339,7 @@ void ProtobufDataLayer<Dtype>::InternalThreadEntry() {
           // copy
           for (int channel = 0; channel < 3; ++channel) {
             pixel_base[channel * crop_height * crop_width] =
-                (pixel[channel] - 128.0f) / 128.0f;
+                (pixel[channel] - 128.0f);
           }
         }
       }

--- a/src/caffe/layers/protobuf_data_layer.cpp
+++ b/src/caffe/layers/protobuf_data_layer.cpp
@@ -1,0 +1,529 @@
+#include <opencv2/opencv.hpp>
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/variate_generator.hpp>
+
+#include <turbojpeg.h>
+
+#include <google/protobuf/descriptor.h>
+
+#include <algorithm>
+#include <fstream>  // NOLINT(readability/streams)
+#include <iostream>  // NOLINT(readability/streams)
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "caffe/data_layers.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/util/download_manager.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/util/rng.hpp"
+
+#if CV_VERSION_MAJOR == 3
+const int CV_LOAD_IMAGE_COLOR = cv::IMREAD_COLOR;
+#endif
+
+namespace caffe {
+using boost::posix_time::ptime;
+using boost::posix_time::microsec_clock;
+
+using std::ofstream;
+
+using google::protobuf::RepeatedPtrField;
+using google::protobuf::Reflection;
+using google::protobuf::FieldDescriptor;
+using google::protobuf::Descriptor;
+using google::protobuf::Message;
+
+template <typename Dtype>
+ProtobufDataLayer<Dtype>::~ProtobufDataLayer<Dtype>() {
+  this->JoinPrefetchThread();
+  tjDestroy(jpeg_decompressor_);
+}
+
+template <typename Dtype>
+void ProtobufDataLayer<Dtype>::LayerSetUp(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  BaseDataLayer<Dtype>::LayerSetUp(bottom, top);
+  // Now, start the prefetch thread. Before calling prefetch, we make two
+  // cpu_data calls so that the prefetch thread does not accidentally make
+  // simultaneous cudaMalloc calls when the main thread is running. In some
+  // GPUs this seems to cause failures if we do not so.
+  this->prefetch_data_.mutable_cpu_data();
+  if (this->output_labels_) {
+    for (int label_index = 0; label_index < num_labels_; ++label_index) {
+      this->prefetch_labels_.at(label_index)->mutable_cpu_data();
+    }
+
+    typedef typename vector<shared_ptr<Blob<Dtype> > >::iterator Iter;
+    for (Iter iter = prefetch_weights_.begin(); iter != prefetch_weights_.end();
+        ++iter) {
+      (*iter)->mutable_cpu_data();
+    }
+  }
+  DLOG(INFO) << "Initializing prefetch";
+  this->CreatePrefetchThread();
+  DLOG(INFO) << "Prefetch initialized.";
+}
+
+// TODO(kmatzen): Remove this NOLINT.  Even after removing LayerSetUp,
+// it still complained.
+template <typename Dtype>
+void ProtobufDataLayer<Dtype>::
+    DataLayerSetUp(  // NOLINT(caffe/data_layer_setup)
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  jpeg_decompressor_ = tjInitDecompress();
+
+  const ProtobufDataParameter& protobuf_data_param =
+      this->layer_param_.protobuf_data_param();
+
+  const int crop_height = protobuf_data_param.crop_height();
+  const int crop_width  = protobuf_data_param.crop_width();
+  CHECK((crop_height == 0 && crop_width == 0) ||
+      (crop_height > 0 && crop_width > 0)) << "Current implementation requires "
+      "crop_height and crop_width to be set at the same time.";
+
+  const string& source = protobuf_data_param.source();
+  LOG(INFO) << "Opening file " << source;
+  ReadProtoFromBinaryFile(source, &manifest_);
+  copy(manifest_.records().begin(), manifest_.records().end(),
+       back_inserter(records_));
+
+  if (protobuf_data_param.shuffle()) {
+    // randomly shuffle data
+    LOG(INFO) << "Shuffling data";
+    const unsigned int prefetch_rng_seed = caffe_rng_rand();
+    prefetch_rng_.reset(new Caffe::RNG(prefetch_rng_seed));
+    ShuffleProtobufs();
+  }
+  LOG(INFO) << "A total of " << records_.size() << " records.";
+
+  for (int i = 0; i < manifest_.label_defs_size(); ++i) {
+    const LabelDefinition& label_def = manifest_.label_defs(i);
+    label_def_map_[label_def.name()] = label_def;
+  }
+
+  const RepeatedPtrField<string>& labels = protobuf_data_param.labels();
+  int weight_index = 0;
+  for (int label_index = 0; label_index < labels.size(); ++label_index) {
+    const string& label = labels.Get(label_index);
+    label_map_.insert(make_pair(label, label_index));
+
+    if (label_def_map_.at(label).weights_size()) {
+      weight_map_.insert(make_pair(label, weight_index++));
+    }
+
+    LOG(INFO) << "Selected label " << label;
+  }
+
+  CHECK_EQ(label_map_.size() + weight_map_.size() + 1, top.size());
+
+  CHECK_LE(label_map_.size(), manifest_.label_defs_size());
+  num_labels_ = label_map_.size();
+
+  records_id_ = 0;
+  // Check if we would need to randomly skip a few data points
+  if (protobuf_data_param.rand_skip()) {
+    unsigned int skip = caffe_rng_rand() % protobuf_data_param.rand_skip();
+    LOG(INFO) << "Skipping first " << skip << " data points.";
+    CHECK_GT(records_.size(), skip) << "Not enough points to skip";
+    records_id_ = skip;
+  }
+  // image
+  const int batch_size = protobuf_data_param.batch_size();
+  top.at(0)->Reshape(batch_size, 3, crop_height, crop_width);
+  this->prefetch_data_.Reshape(batch_size, 3, crop_height, crop_width);
+  LOG(INFO) << "output data size: " << top.at(0)->num() << ","
+      << top.at(0)->channels() << "," << top.at(0)->height() << ","
+      << top.at(0)->width();
+  // label
+  this->prefetch_labels_.resize(num_labels_);
+  for (map<string, int>::const_iterator iter = label_map_.begin();
+      iter != label_map_.end(); ++iter) {
+    map<string, LabelDefinition>::const_iterator label_def_iter =
+        label_def_map_.find(iter->first);
+    CHECK(label_def_map_.end() != label_def_iter) << iter->first;
+    const LabelDefinition& label_def = label_def_iter->second;
+    CHECK(label_def.has_dim());
+    const int& dims = label_def.dim();
+    const int& label_index = iter->second;
+    LOG(INFO) << "Label: " << iter->first << " " << label_index << " " << dims;
+    top.at(label_index + 1)->Reshape(batch_size, dims, 1, 1);
+    LOG(INFO) << "output " << iter->first
+        << " size: " << top.at(label_index + 1)->num() << ","
+        << top.at(label_index + 1)->channels() << ","
+        << top.at(label_index + 1)->height() << ","
+        << top.at(label_index + 1)->width();
+    this->prefetch_labels_.at(label_index).reset(new Blob<Dtype>());
+    this->prefetch_labels_.at(label_index)->Reshape(batch_size, dims, 1, 1);
+
+    if (label_def.weights_size()) {
+      prefetch_weights_.resize(prefetch_weights_.size() + 1);
+      shared_ptr<Blob<Dtype> >& weights = prefetch_weights_.back();
+      weights.reset(new Blob<Dtype>());
+      weights->Reshape(batch_size, 1, 1, 1);
+      LOG(INFO) << "create " << weights->count();
+
+      top.at(prefetch_labels_.size() + prefetch_weights_.size())->Reshape(
+          batch_size, 1, 1, 1);
+    }
+  }
+}
+
+template <typename Dtype>
+void ProtobufDataLayer<Dtype>::ShuffleProtobufs() {
+  caffe::rng_t* prefetch_rng =
+      static_cast<caffe::rng_t*>(prefetch_rng_->generator());
+  shuffle(records_.begin(), records_.end(), prefetch_rng);
+}
+
+// This function is used to create a thread that prefetches the data.
+template <typename Dtype>
+void ProtobufDataLayer<Dtype>::InternalThreadEntry() {
+  Datum datum;
+  CHECK(this->prefetch_data_.count());
+  Dtype* top_data = this->prefetch_data_.mutable_cpu_data();
+  const ProtobufDataParameter& protobuf_data_param =
+      this->layer_param_.protobuf_data_param();
+  const int batch_size = protobuf_data_param.batch_size();
+  const int crop_height = protobuf_data_param.crop_height();
+  const int crop_width = protobuf_data_param.crop_width();
+
+#ifdef DEBUG_PROTO_DATA
+  const char* kDebugWindow = "protobuf debug";
+  cv::namedWindow(kDebugWindow, cv::WINDOW_AUTOSIZE);
+#endif
+
+  boost::uniform_int<> distribution(-1.0f, 1.0f);
+  boost::variate_generator<rng_t, boost::uniform_int<> >
+      pixel_prng(*caffe_rng(), distribution);
+
+  shared_ptr<DownloadManager> download_manager(download_manager_factory_());
+
+  size_t records_size = records_.size();
+  for (int item_id = 0; item_id < batch_size; ++item_id) {
+    int local_record_id = (records_id_ + item_id) % records_size;
+
+    // get a record
+    CHECK_GT(records_size, local_record_id);
+    const ProtobufRecord& record = records_.at(local_record_id);
+
+    CHECK(record.has_image_url());
+
+    const string& image_url = record.image_url();
+
+    download_manager->AddUrl(image_url);
+  }
+
+  download_manager->Download();
+
+  const vector<shared_ptr<stringstream> >& jpeg_streams =
+      download_manager->RetrieveResults();
+
+  // datum scales
+  DLOG(INFO) << "START";
+  for (int item_id = 0; item_id < batch_size; ++item_id) {
+    int local_record_id = (records_id_ + item_id) % records_size;
+
+    // get a record
+    CHECK_GT(records_size, local_record_id);
+    const ProtobufRecord& record = records_.at(local_record_id);
+    boost::shared_ptr<stringstream> stream = jpeg_streams.at(item_id);
+
+    const string& image_data_string = stream->str();
+    vector<unsigned char> image_data_vector(image_data_string.begin(),
+                                            image_data_string.end());
+    if (image_data_string.empty()) {
+      LOG(ERROR) << "Empty image " << record.image_url();
+      continue;
+    }
+
+#ifdef NO_TURBO_JPEG
+    cv::Mat image_data_mat(1, image_data_vector.size(), CV_8UC3,
+                           image_data_vector.data());
+    cv::Mat image = cv::imdecode(image_data_mat, CV_LOAD_IMAGE_COLOR);
+    if (image.empty()) {
+      LOG(ERROR) << "Failed to load " << record.image_url();
+      continue;
+    }
+#else
+    int jpeg_subsamp, image_width, image_height, jpeg_result;
+    tjDecompressHeader2(jpeg_decompressor_, image_data_vector.data(),
+                        image_data_vector.size(), &image_width, &image_height,
+                        &jpeg_subsamp);
+    cv::Mat image;
+    try {
+      image.create(image_height, image_width, CV_8UC3);
+    } catch (const cv::Exception & ex) {
+      LOG(ERROR) << ex.what() << " " << record.image_url()
+          << " " << image_height << " " << image_width;
+      continue;
+    }
+    jpeg_result = tjDecompress2(jpeg_decompressor_, image_data_vector.data(),
+                                image_data_vector.size(), image.ptr(),
+                                image_width, 0, image_height, TJPF_BGR,
+                                TJFLAG_FASTDCT);
+    if (jpeg_result) {
+      LOG(ERROR) << "Failed to load " << record.image_url();
+      continue;
+    }
+#endif
+
+    CHECK(record.has_crop_x1());
+    CHECK(record.has_crop_x2());
+    CHECK(record.has_crop_y1());
+    CHECK(record.has_crop_y2());
+
+    int height = record.crop_y2() - record.crop_y1() + 1;
+    int width = record.crop_x2() - record.crop_x1() + 1;
+
+    cv::Mat crop(height, width, CV_8UC4);
+    uchar* dst = crop.ptr();
+    for (int row = 0; row < height; ++row) {
+      const int src_row = record.crop_y1() + row;
+      uchar* src_scanline = image.ptr(src_row);
+      for (int col = 0; col < width; ++col) {
+        const int src_col = record.crop_x1() + col;
+        if (src_row >= 0 && src_row < image.rows &&
+            src_col >= 0 && src_col < image.cols) {
+          uchar* src = src_scanline + src_col * 3;
+          for (int c = 0; c < 3; ++c) {
+            *dst++ = *src++;
+          }
+          *dst++ = 255;
+        } else {
+          for (int c = 0; c < 4; ++c) {
+            *dst++ = 0;
+          }
+        }
+      }
+    }
+
+    cv::Mat resized_image;
+    cv::Size size(crop_width, crop_height);
+    cv::resize(crop, resized_image, size);
+
+#ifdef DEBUG_PROTO_DATA
+    LOG(INFO) << "DEBUG image " << image.size();
+    imshow(kDebugWindow, image);
+    cv::waitKey(0);
+
+    LOG(INFO) << "DEBUG crop " << crop.size();
+    imshow(kDebugWindow, crop);
+    cv::waitKey(0);
+
+    LOG(INFO) << "DEBUG resized " << resized_image.size();
+    imshow(kDebugWindow, resized_image);
+    cv::waitKey(0);
+#endif
+    Dtype* item_data = top_data + item_id * 3 * crop_height * crop_width;
+
+    for (int row = 0; row < crop_height; ++row) {
+      uchar* scanline = resized_image.ptr(row);
+      for (int col = 0; col < crop_width; ++col) {
+        uchar* pixel = scanline + col * 4;
+
+        Dtype * pixel_base = item_data + row * crop_width + col;
+
+        if (pixel[3] < 255) {
+          // random
+          for (int channel = 0; channel < 3; ++channel) {
+            pixel_base[channel * crop_height * crop_width] = pixel_prng();
+          }
+        } else {
+          // copy
+          for (int channel = 0; channel < 3; ++channel) {
+            pixel_base[channel * crop_height * crop_width] =
+                (pixel[channel] - 128.0f) / 128.0f;
+          }
+        }
+      }
+    }
+
+    const Reflection* record_reflection = record.GetReflection();
+    CHECK_NOTNULL(record_reflection);
+    for (map<string, int>::const_iterator iter = label_map_.begin();
+        iter != label_map_.end(); ++iter) {
+      const string& label_name = iter->first;
+      const int& label_index = iter->second;
+      Dtype* top_label = this->prefetch_labels_.at(label_index)
+          ->mutable_cpu_data();
+
+#ifdef WORKAROUND_PROTOBUF_FIND_EXTENSION
+      vector<const FieldDescriptor*> fields;
+      record_reflection->ListFields(record, &fields);
+      const FieldDescriptor* extension_field = 0;
+      for (int i = 0; i < fields.size(); ++i) {
+        if (fields.at(i)->name() == "parent") {
+          extension_field = fields.at(i);
+        }
+      }
+#else
+      const Descriptor* record_descriptor = record.GetDescriptor();
+      CHECK_NOTNULL(record_descriptor);
+      const FieldDescriptor* extension_field =
+          record_descriptor->FindFieldByName("parent");
+#endif
+      CHECK_NOTNULL(extension_field);
+
+      const Message& extension_message = record_reflection->GetMessage(record,
+          extension_field);
+      const Descriptor* descriptor = extension_message.GetDescriptor();
+      CHECK_NOTNULL(descriptor);
+      const FieldDescriptor* field = descriptor->FindFieldByName(label_name);
+      CHECK(NULL != field) << label_name;
+      const Reflection* extension_reflection =
+          extension_message.GetReflection();
+      CHECK_NOTNULL(extension_reflection);
+
+      const LabelDefinition& label_def = label_def_map_.at(label_name);
+      CHECK(label_def.has_dim());
+      int label_dim = label_def.dim();
+      Dtype* labels = top_label + item_id * label_dim;
+
+      switch (field->label()) {
+      case FieldDescriptor::LABEL_REPEATED: {
+          for (int i = 0; i < label_dim; ++i) {
+            switch (field->type()) {
+            case FieldDescriptor::TYPE_UINT32:
+              *labels = extension_reflection->GetRepeatedUInt32(
+                  extension_message, field, i);
+              break;
+            case FieldDescriptor::TYPE_FLOAT:
+              *labels = extension_reflection->GetRepeatedFloat(
+                  extension_message, field, i);
+              break;
+            default:
+              LOG(FATAL) << "label fields must be int32 or float";
+              break;
+            }
+            if (label_def.has_mean()) {
+              *labels -= label_def.mean();
+            }
+            if (label_def.has_stdev()) {
+              CHECK(label_def.has_mean());
+              *labels /= label_def.stdev();
+            }
+            ++labels;
+          }
+        }
+        break;
+      default: {
+          CHECK_EQ(1, label_dim);
+          switch (field->type()) {
+          case FieldDescriptor::TYPE_UINT32:
+            *labels = extension_reflection->GetUInt32(extension_message, field);
+            break;
+          case FieldDescriptor::TYPE_FLOAT:
+            *labels = extension_reflection->GetFloat(extension_message, field);
+            break;
+          default:
+            LOG(FATAL) << "label fields must be int32 or float";
+            break;
+          }
+          if (label_def.has_mean()) {
+            *labels -= label_def.mean();
+          }
+          if (label_def.has_stdev()) {
+            CHECK(label_def.has_mean());
+            *labels /= label_def.stdev();
+          }
+        }
+        break;
+      }
+
+      if (label_def.weights_size()) {
+        CHECK_EQ(1, label_dim);
+        const Dtype* labels = top_label + item_id;
+
+        int weight_index = weight_map_.at(label_name);
+        Dtype* top_weight = this->prefetch_weights_.at(weight_index)
+            ->mutable_cpu_data();
+
+        Dtype* weights = top_weight + item_id;
+
+        int label = *labels;
+
+        CHECK_GT(label_def.weights_size(), label);
+
+        float weight = label_def.weights(label);
+
+        *weights = weight;
+      }
+    }
+  }
+
+#ifdef DEBUG_PREFETCH_DATA
+  ofstream data("prefetch_data");
+  data.write(reinterpret_cast<const char*>(this->prefetch_data_.cpu_data()),
+      this->prefetch_data_.count() * sizeof(Dtype));
+  data.close();
+
+  for (int i = 0; i < num_labels_; ++i) {
+    const boost::shared_ptr<Blob<Dtype> > labels = this->prefetch_labels_.at(i);
+    stringstream filename;
+    filename << "prefetch_label" << i;
+    ofstream label(filename.str().c_str());
+    label.write(reinterpret_cast<const char*>(labels->cpu_data()),
+        labels->count() * sizeof(Dtype));
+    label.close();
+  }
+  cv::waitKey(0);
+  LOG(INFO) << "WAITING";
+#endif
+
+  // go to the next iter
+  records_id_ += batch_size;
+  if (records_id_ >= records_size) {
+    // We have reached the end. Restart from the first.
+    DLOG(INFO) << "Restarting data prefetching from start.";
+    records_id_ = 0;
+    if (protobuf_data_param.shuffle()) {
+      ShuffleProtobufs();
+    }
+  }
+  DLOG(INFO) << "END";
+}
+
+template <typename Dtype>
+void ProtobufDataLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  // First, join the thread
+  ptime tic = microsec_clock::local_time();
+  this->JoinPrefetchThread();
+  ptime toc = microsec_clock::local_time();
+  LOG(INFO) << "prefetch was behind by " << (toc - tic).total_milliseconds()
+      << " milliseconds";
+  // Copy the data
+  caffe_copy(this->prefetch_data_.count(), this->prefetch_data_.cpu_data(),
+             top.at(0)->mutable_cpu_data());
+  if (this->output_labels_) {
+    for (int i = 0; i < num_labels_; ++i) {
+      caffe_copy(prefetch_labels_.at(i)->count(),
+                 prefetch_labels_.at(i)->cpu_data(),
+                 top.at(i + 1)->mutable_cpu_data());
+    }
+
+    for (int i = 0; i < prefetch_weights_.size(); ++i) {
+      caffe_copy(prefetch_weights_.at(i)->count(),
+          prefetch_weights_.at(i)->cpu_data(),
+          top.at(i + num_labels_ + 1)->mutable_cpu_data());
+    }
+  }
+  // Start a new prefetch thread
+  this->CreatePrefetchThread();
+}
+
+#ifdef CPU_ONLY
+STUB_GPU_FORWARD(ProtobufDataLayer, Forward);
+#endif
+
+INSTANTIATE_CLASS(ProtobufDataLayer);
+REGISTER_LAYER_CLASS(PROTOBUF_DATA, ProtobufDataLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/protobuf_data_layer.cpp
+++ b/src/caffe/layers/protobuf_data_layer.cpp
@@ -294,6 +294,21 @@ void ProtobufDataLayer<Dtype>::InternalThreadEntry() {
     int height = y2 - y1 + 1;
     int width = x2 - x1 + 1;
 
+    if (protobuf_data_param.has_jitter()) {
+      int orig_height = height/(1.0 + 2.0*protobuf_data_param.jitter());
+      int orig_width = width/(1.0 + 2.0*protobuf_data_param.jitter());
+      int jitter_pixels_height = (height - orig_height) / 2;
+      int jitter_pixels_width = (width - orig_width) / 2;
+      int jitter_x = caffe_rng_rand() % jitter_pixels_width;
+      int jitter_y = caffe_rng_rand() % jitter_pixels_height;
+      x1 += jitter_x;
+      y1 += jitter_y;
+      x2 += jitter_x;
+      y2 += jitter_y;
+      height = y2 - y1 + 1;
+      width = x2 - x1 + 1;
+    }
+
     cv::Mat crop(height, width, CV_8UC4);
     uchar* dst = crop.ptr();
     for (int row = 0; row < height; ++row) {

--- a/src/caffe/layers/protobuf_data_layer.cpp
+++ b/src/caffe/layers/protobuf_data_layer.cpp
@@ -279,16 +279,28 @@ void ProtobufDataLayer<Dtype>::InternalThreadEntry() {
     CHECK(record.has_crop_y1());
     CHECK(record.has_crop_y2());
 
-    int height = record.crop_y2() - record.crop_y1() + 1;
-    int width = record.crop_x2() - record.crop_x1() + 1;
+    int x1 = record.crop_x1();
+    int x2 = record.crop_x2();
+    int y1 = record.crop_y1();
+    int y2 = record.crop_y2();
+
+    if (protobuf_data_param.no_crop()) {
+      x1 = 0;
+      x2 = image.cols - 1;
+      y1 = 0;
+      y2 = image.rows - 1;
+    }
+
+    int height = y2 - y1 + 1;
+    int width = x2 - x1 + 1;
 
     cv::Mat crop(height, width, CV_8UC4);
     uchar* dst = crop.ptr();
     for (int row = 0; row < height; ++row) {
-      const int src_row = record.crop_y1() + row;
+      const int src_row = y1 + row;
       uchar* src_scanline = image.ptr(src_row);
       for (int col = 0; col < width; ++col) {
-        const int src_col = record.crop_x1() + col;
+        const int src_col = x1 + col;
         if (src_row >= 0 && src_row < image.rows &&
             src_col >= 0 && src_col < image.cols) {
           uchar* src = src_scanline + src_col * 3;

--- a/src/caffe/layers/protobuf_data_layer.cu
+++ b/src/caffe/layers/protobuf_data_layer.cu
@@ -1,0 +1,39 @@
+#include <vector>
+
+#include "caffe/data_layers.hpp"
+#include "caffe/util/benchmark.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void ProtobufDataLayer<Dtype>::Forward_gpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  // First, join the thread
+  caffe::Timer timer;
+  timer.Start();
+  this->JoinPrefetchThread();
+  timer.Stop();
+  LOG(INFO) << "prefetch was behind by " << timer.MilliSeconds()
+      << " milliseconds";
+  // Copy the data
+  caffe_copy(this->prefetch_data_.count(), this->prefetch_data_.cpu_data(),
+      top.at(0)->mutable_gpu_data());
+  if (this->output_labels_) {
+    for (int i = 0; i < num_labels_; ++i) {
+      caffe_copy(prefetch_labels_.at(i)->count(),
+                 prefetch_labels_.at(i)->cpu_data(),
+                 top.at(i + 1)->mutable_gpu_data());
+    }
+    for (int i = 0; i < prefetch_weights_.size(); ++i) {
+      caffe_copy(prefetch_weights_.at(i)->count(),
+          prefetch_weights_.at(i)->cpu_data(),
+          top.at(i + num_labels_ + 1)->mutable_gpu_data());
+    }
+  }
+  // Start a new prefetch thread
+  this->CreatePrefetchThread();
+}
+
+INSTANTIATE_LAYER_GPU_FORWARD(ProtobufDataLayer);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -558,6 +558,7 @@ message ProtobufDataParameter {
   optional uint32 crop_width = 6;
   repeated string labels = 7;
   optional bool no_crop = 8 [default = false];
+  optional float jitter = 9;
 }
 
 // Message that stores parameters InfogainLossLayer

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -271,6 +271,7 @@ message LayerParameter {
     TANH = 23;
     WINDOW_DATA = 24;
     THRESHOLD = 31;
+    PROTOBUF_DATA = 999;
   }
   optional LayerType type = 5; // the layer type from the enum above
 
@@ -327,6 +328,7 @@ message LayerParameter {
   optional TanHParameter tanh_param = 37;
   optional ThresholdParameter threshold_param = 25;
   optional WindowDataParameter window_data_param = 20;
+  optional ProtobufDataParameter protobuf_data_param = 999;
 
   // Parameters for data pre-processing.
   optional TransformationParameter transform_param = 36;
@@ -545,6 +547,16 @@ message ImageDataParameter {
   // data.
   optional bool mirror = 6 [default = false];
   optional string root_folder = 12 [default = ""];
+}
+
+message ProtobufDataParameter {
+  optional string source = 1;
+  optional uint32 batch_size = 2;
+  optional uint32 rand_skip = 3 [default = 0];
+  optional bool shuffle = 4 [default = false];
+  optional uint32 crop_height = 5;
+  optional uint32 crop_width = 6;
+  repeated string labels = 7;
 }
 
 // Message that stores parameters InfogainLossLayer
@@ -816,4 +828,51 @@ message V0LayerParameter {
   optional uint32 concat_dim = 65 [default = 1];
 
   optional HDF5OutputParameter hdf5_output_param = 1001;
+}
+
+message LabelDefinition {
+  optional string name = 1;
+  optional uint32 dim = 2;
+  optional float mean = 3;
+  optional float stdev = 4;
+  repeated float weights = 5;
+}
+
+message ProtobufManifest {
+  repeated ProtobufRecord records = 1;
+  repeated LabelDefinition label_defs = 2;
+}
+
+message ProtobufRecord {
+  optional string image_url = 1;
+  optional int32 crop_x1 = 2;
+  optional int32 crop_x2 = 3;
+  optional int32 crop_y1 = 4;
+  optional int32 crop_y2 = 5;
+
+  extensions 100 to max;
+}
+
+message ClassificationRecord {
+  extend ProtobufRecord {
+    optional ClassificationRecord parent = 101;
+  }
+
+  optional uint32 class_id = 1;
+}
+
+message TestRecord {
+  extend ProtobufRecord {
+    optional TestRecord parent = 102;
+  }
+
+  optional uint32 single_int = 1;
+  optional float single_float = 2;
+  optional float single_float_sub = 3;
+  optional float single_float_sub_scale = 4;
+  optional float weighted = 5;
+  repeated uint32 multi_int = 6;
+  repeated float multi_float = 7;
+  repeated float multi_float_sub = 8;
+  repeated float multi_float_sub_scale = 9;
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -557,6 +557,7 @@ message ProtobufDataParameter {
   optional uint32 crop_height = 5;
   optional uint32 crop_width = 6;
   repeated string labels = 7;
+  optional bool no_crop = 8 [default = false];
 }
 
 // Message that stores parameters InfogainLossLayer

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -71,6 +71,7 @@ void Solver<Dtype>::InitTrainNet() {
   // precedence); then, merge in any NetState specified by the net_param itself;
   // finally, merge in any NetState specified by the train_state (highest
   // precedence).
+  Caffe::set_phase(Caffe::TRAIN);
   NetState net_state;
   net_state.set_phase(TRAIN);
   net_state.MergeFrom(net_param.state());
@@ -141,6 +142,7 @@ void Solver<Dtype>::InitTestNets() {
     // precedence); then, merge in any NetState specified by the net_param
     // itself; finally, merge in any NetState specified by the test_state
     // (highest precedence).
+    Caffe::set_phase(Caffe::TEST);
     NetState net_state;
     net_state.set_phase(TEST);
     net_state.MergeFrom(net_params[i].state());

--- a/src/caffe/test/test_protobuf_data_layer.cpp
+++ b/src/caffe/test/test_protobuf_data_layer.cpp
@@ -298,7 +298,7 @@ class ProtobufDataLayerTest : public MultiDeviceTest<TypeParam> {
               // TODO(kmatzen): Fix this test so that JPEG decompresses closer
               // to the exact value.  In fact, maybe replace jpeg decompressor
               // in the layer with a separate class that I can mock.
-              EXPECT_NEAR(target, 128.0 * *data++ + 128.0, 17.0)
+              EXPECT_NEAR(target, *data++ + 128.0, 17.0)
                   << channel << " " << height << " " << width;
             }
           }

--- a/src/caffe/test/test_protobuf_data_layer.cpp
+++ b/src/caffe/test/test_protobuf_data_layer.cpp
@@ -1,0 +1,337 @@
+#include <opencv2/opencv.hpp>
+
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/util/download_manager.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/vision_layers.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+#if CV_VERSION_MAJOR == 3
+const int CV_IMWRITE_JPEG_QUALITY = cv::IMWRITE_JPEG_QUALITY;
+#endif
+
+namespace caffe {
+
+class MockDownloadManager : public DownloadManager {
+ public:
+  void Download() {
+    LOG(INFO) << "MOCK DOWNLOAD";
+
+    cv::Mat image(640, 640, CV_8UC3);
+    image = 123;
+
+    for (int row = 120; row < 240; ++row) {
+      for (int col = 10; col < 40; ++col) {
+        cv::Vec3b& dst = image.at<cv::Vec3b>(row, col);
+        dst[0] = row;
+        dst[1] = col;
+        dst[2] = 200;
+      }
+    }
+
+    vector<uchar> jpeg;
+    vector<int> args;
+    args.push_back(CV_IMWRITE_JPEG_QUALITY);
+    args.push_back(100);
+    CHECK(cv::imencode(".jpg", image, jpeg, args));
+
+    for (vector<string>::const_iterator iter = urls_.begin();
+        iter != urls_.end(); ++iter) {
+      shared_ptr<stringstream> stream(new stringstream());
+      streams_.push_back(stream);
+
+      stream->write(reinterpret_cast<const char*>(jpeg.data()), jpeg.size());
+    }
+  }
+};
+
+DownloadManager* MockDownloadManagerFactory() {
+  return new MockDownloadManager();
+}
+
+template <typename TypeParam>
+class ProtobufDataLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  ProtobufDataLayerTest()
+      : blob_top_data_(new Blob<Dtype>()),
+        blob_top_single_int_(new Blob<Dtype>()),
+        blob_top_single_float_(new Blob<Dtype>()),
+        blob_top_single_float_sub_(new Blob<Dtype>()),
+        blob_top_single_float_sub_scale_(new Blob<Dtype>()),
+        blob_top_weighted_(new Blob<Dtype>()),
+        blob_top_multi_int_(new Blob<Dtype>()),
+        blob_top_multi_float_(new Blob<Dtype>()),
+        blob_top_multi_float_sub_(new Blob<Dtype>()),
+        blob_top_multi_float_sub_scale_(new Blob<Dtype>()),
+        blob_top_weights_(new Blob<Dtype>()),
+        random_test_seed_(1701) {
+  }
+
+  virtual void SetUp() {
+    filename_.reset(new string());
+    MakeTempFilename(filename_.get());
+    LOG(INFO) << *filename_;
+
+    blob_top_vec_.push_back(blob_top_data_.get());
+    blob_top_vec_.push_back(blob_top_single_int_.get());
+    blob_top_vec_.push_back(blob_top_single_float_.get());
+    blob_top_vec_.push_back(blob_top_single_float_sub_.get());
+    blob_top_vec_.push_back(blob_top_single_float_sub_scale_.get());
+    blob_top_vec_.push_back(blob_top_weighted_.get());
+    blob_top_vec_.push_back(blob_top_multi_int_.get());
+    blob_top_vec_.push_back(blob_top_multi_float_.get());
+    blob_top_vec_.push_back(blob_top_multi_float_sub_.get());
+    blob_top_vec_.push_back(blob_top_multi_float_sub_scale_.get());
+    blob_top_vec_.push_back(blob_top_weights_.get());
+  }
+
+  void BuildManifest() {
+    ProtobufManifest manifest;
+
+    LabelDefinition* label_def;
+
+    label_def = manifest.add_label_defs();
+    label_def->set_name("single_int");
+    label_def->set_dim(1);
+
+    label_def = manifest.add_label_defs();
+    label_def->set_name("single_float");
+    label_def->set_dim(1);
+
+    label_def = manifest.add_label_defs();
+    label_def->set_name("single_float_sub");
+    label_def->set_dim(1);
+    label_def->set_mean(1);
+
+    label_def = manifest.add_label_defs();
+    label_def->set_name("single_float_sub_scale");
+    label_def->set_dim(1);
+    label_def->set_mean(1);
+    label_def->set_stdev(2);
+
+    label_def = manifest.add_label_defs();
+    label_def->set_name("weighted");
+    label_def->set_dim(1);
+    label_def->add_weights(1);
+    label_def->add_weights(2);
+    label_def->add_weights(3);
+    label_def->add_weights(4);
+    label_def->add_weights(5);
+
+    label_def = manifest.add_label_defs();
+    label_def->set_name("multi_int");
+    label_def->set_dim(3);
+
+    label_def = manifest.add_label_defs();
+    label_def->set_name("multi_float");
+    label_def->set_dim(3);
+
+    label_def = manifest.add_label_defs();
+    label_def->set_name("multi_float_sub");
+    label_def->set_dim(3);
+    label_def->set_mean(1);
+
+    label_def = manifest.add_label_defs();
+    label_def->set_name("multi_float_sub_scale");
+    label_def->set_dim(3);
+    label_def->set_mean(1);
+    label_def->set_stdev(2);
+
+    for (int i = 0; i < 5; ++i) {
+      ProtobufRecord* record = manifest.add_records();
+
+      record->set_image_url("NOT_A_REAL_URL");
+
+      record->set_crop_x1(10);
+      record->set_crop_x2(40);
+
+      record->set_crop_y1(120);
+      record->set_crop_y2(240);
+
+      TestRecord* test_record = record->MutableExtension(TestRecord::parent);
+
+      test_record->set_single_int(i);
+      test_record->set_single_float(i);
+      test_record->set_single_float_sub(i);
+      test_record->set_single_float_sub_scale(i);
+      test_record->set_weighted(i);
+
+      for (int j = 0; j < 3; ++j) {
+        test_record->add_multi_int(i + j);
+        test_record->add_multi_float(i + j - 1);
+        test_record->add_multi_float_sub(i + j - 1);
+        test_record->add_multi_float_sub_scale(i + j - 1);
+      }
+    }
+
+    LOG(INFO) << manifest.DebugString();
+
+    WriteProtoToBinaryFile(manifest, *filename_);
+  }
+
+  void TestRead() {
+    LayerParameter param;
+    ProtobufDataParameter* protobuf_data_param =
+        param.mutable_protobuf_data_param();
+    protobuf_data_param->set_batch_size(5);
+    protobuf_data_param->set_source(filename_->c_str());
+    protobuf_data_param->add_labels("single_int");
+    protobuf_data_param->add_labels("single_float");
+    protobuf_data_param->add_labels("single_float_sub");
+    protobuf_data_param->add_labels("single_float_sub_scale");
+    protobuf_data_param->add_labels("weighted");
+    protobuf_data_param->add_labels("multi_int");
+    protobuf_data_param->add_labels("multi_float");
+    protobuf_data_param->add_labels("multi_float_sub");
+    protobuf_data_param->add_labels("multi_float_sub_scale");
+    protobuf_data_param->set_crop_height(4);
+    protobuf_data_param->set_crop_width(2);
+
+    ProtobufDataLayer<Dtype> layer(param, MockDownloadManagerFactory);
+    layer.SetUp(blob_bottom_vec_, blob_top_vec_);
+
+    EXPECT_EQ(5, blob_top_data_->num());
+    EXPECT_EQ(3, blob_top_data_->channels());
+    EXPECT_EQ(4, blob_top_data_->height());
+    EXPECT_EQ(2, blob_top_data_->width());
+
+    EXPECT_EQ(5, blob_top_single_int_->num());
+    EXPECT_EQ(1, blob_top_single_int_->channels());
+    EXPECT_EQ(1, blob_top_single_int_->height());
+    EXPECT_EQ(1, blob_top_single_int_->width());
+
+    EXPECT_EQ(5, blob_top_single_float_->num());
+    EXPECT_EQ(1, blob_top_single_float_->channels());
+    EXPECT_EQ(1, blob_top_single_float_->height());
+    EXPECT_EQ(1, blob_top_single_float_->width());
+
+    EXPECT_EQ(5, blob_top_single_float_sub_->num());
+    EXPECT_EQ(1, blob_top_single_float_sub_->channels());
+    EXPECT_EQ(1, blob_top_single_float_sub_->height());
+    EXPECT_EQ(1, blob_top_single_float_sub_->width());
+
+    EXPECT_EQ(5, blob_top_single_float_sub_scale_->num());
+    EXPECT_EQ(1, blob_top_single_float_sub_scale_->channels());
+    EXPECT_EQ(1, blob_top_single_float_sub_scale_->height());
+    EXPECT_EQ(1, blob_top_single_float_sub_scale_->width());
+
+    EXPECT_EQ(5, blob_top_weighted_->num());
+    EXPECT_EQ(1, blob_top_weighted_->channels());
+    EXPECT_EQ(1, blob_top_weighted_->height());
+    EXPECT_EQ(1, blob_top_weighted_->width());
+
+    EXPECT_EQ(5, blob_top_multi_int_->num());
+    EXPECT_EQ(3, blob_top_multi_int_->channels());
+    EXPECT_EQ(1, blob_top_multi_int_->height());
+    EXPECT_EQ(1, blob_top_multi_int_->width());
+
+    EXPECT_EQ(5, blob_top_multi_float_->num());
+    EXPECT_EQ(3, blob_top_multi_float_->channels());
+    EXPECT_EQ(1, blob_top_multi_float_->height());
+    EXPECT_EQ(1, blob_top_multi_float_->width());
+
+    EXPECT_EQ(5, blob_top_multi_float_sub_->num());
+    EXPECT_EQ(3, blob_top_multi_float_sub_->channels());
+    EXPECT_EQ(1, blob_top_multi_float_sub_->height());
+    EXPECT_EQ(1, blob_top_multi_float_sub_->width());
+
+    EXPECT_EQ(5, blob_top_multi_float_sub_scale_->num());
+    EXPECT_EQ(3, blob_top_multi_float_sub_scale_->channels());
+    EXPECT_EQ(1, blob_top_multi_float_sub_scale_->height());
+    EXPECT_EQ(1, blob_top_multi_float_sub_scale_->width());
+
+    EXPECT_EQ(5, blob_top_weights_->num());
+    EXPECT_EQ(1, blob_top_weights_->channels());
+    EXPECT_EQ(1, blob_top_weights_->height());
+    EXPECT_EQ(1, blob_top_weights_->width());
+
+
+    for (int iter = 0; iter < 100; ++iter) {
+      layer.Forward(blob_bottom_vec_, blob_top_vec_);
+
+      const Dtype* data = blob_top_data_->cpu_data();
+      for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(i, blob_top_single_int_->cpu_data()[i]);
+        EXPECT_EQ(i, blob_top_single_float_->cpu_data()[i]);
+        EXPECT_EQ(i - 1.0, blob_top_single_float_sub_->cpu_data()[i]);
+        EXPECT_EQ((i - 1.0) / 2.0,
+            blob_top_single_float_sub_scale_->cpu_data()[i]);
+        EXPECT_EQ(i, blob_top_weighted_->cpu_data()[i]);
+        EXPECT_EQ(i + 1, blob_top_weights_->cpu_data()[i]);
+
+        for (int j = 0; j < 3; ++j) {
+          EXPECT_EQ(i + j, blob_top_multi_int_->cpu_data()[3 * i + j])
+              << i << " " << j;
+          EXPECT_EQ(i + j - 1, blob_top_multi_float_->cpu_data()[3 * i + j])
+              << i << " " << j;
+          EXPECT_EQ(i + j - 2, blob_top_multi_float_sub_->cpu_data()[3 * i + j])
+              << i << " " << j;
+          EXPECT_EQ((i + j - 2) / 2.0,
+              blob_top_multi_float_sub_scale_->cpu_data()[3 * i + j])
+              << i << " " << j;
+        }
+
+        for (int channel = 0; channel < 3; ++channel) {
+          for (int height = 0; height < 4; ++height) {
+            for (int width = 0; width < 2; ++width) {
+              Dtype target;
+              switch (channel) {
+              case 0:
+                target = height * Dtype(40) + Dtype(120);
+                break;
+              case 1:
+                target = width * Dtype(30) + Dtype(10);
+                break;
+              case 2:
+                target = Dtype(200);
+                break;
+              }
+
+              // TODO(kmatzen): Fix this test so that JPEG decompresses closer
+              // to the exact value.  In fact, maybe replace jpeg decompressor
+              // in the layer with a separate class that I can mock.
+              EXPECT_NEAR(target, 128.0 * *data++ + 128.0, 17.0)
+                  << channel << " " << height << " " << width;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  shared_ptr<string> filename_;
+  shared_ptr<Blob<Dtype> > const blob_top_data_;
+  shared_ptr<Blob<Dtype> > const blob_top_single_int_;
+  shared_ptr<Blob<Dtype> > const blob_top_single_float_;
+  shared_ptr<Blob<Dtype> > const blob_top_single_float_sub_;
+  shared_ptr<Blob<Dtype> > const blob_top_single_float_sub_scale_;
+  shared_ptr<Blob<Dtype> > const blob_top_weighted_;
+  shared_ptr<Blob<Dtype> > const blob_top_multi_int_;
+  shared_ptr<Blob<Dtype> > const blob_top_multi_float_;
+  shared_ptr<Blob<Dtype> > const blob_top_multi_float_sub_;
+  shared_ptr<Blob<Dtype> > const blob_top_multi_float_sub_scale_;
+  shared_ptr<Blob<Dtype> > const blob_top_weights_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+  int random_test_seed_;
+};
+
+TYPED_TEST_CASE(ProtobufDataLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(ProtobufDataLayerTest, TestNothing) {
+}
+
+TYPED_TEST(ProtobufDataLayerTest, TestRead) {
+  this->BuildManifest();
+  this->TestRead();
+}
+
+}  // namespace caffe

--- a/src/caffe/util/download_manager.cpp
+++ b/src/caffe/util/download_manager.cpp
@@ -1,0 +1,130 @@
+#include <curlpp/Easy.hpp>
+#include <curlpp/Options.hpp>
+
+#include <string>
+#include <vector>
+
+#include "caffe/util/download_manager.hpp"
+
+#include "caffe/util/benchmark.hpp"
+
+namespace caffe {
+
+void DownloadManager::AddUrl(const string& url) {
+  DLOG(INFO) << url;
+
+  urls_.push_back(url);
+}
+
+void DownloadManager::Register(const string& url) {
+  DLOG(INFO) << "registering " << url;
+
+  curlpp::Easy *e = new curlpp::Easy;
+
+  stringstream* stream = new stringstream();
+  streams_.push_back(shared_ptr<stringstream>(stream));
+
+  e->setOpt(new curlpp::options::WriteStream(stream));
+  e->setOpt(new curlpp::Options::FollowLocation(true));
+  e->setOpt(new curlpp::Options::Url(url.c_str()));
+  e->setOpt(new curlpp::Options::Timeout(200));
+
+  curl_multi_.add(e);
+}
+
+void DownloadManager::Download() {
+  // TODO(kmatzen): Do I need this cleanup?  Read the cURLpp docs.
+  // curlpp::Cleanup cleanup;
+
+  const int kMaxHandles = 32;
+  int running_handles = -1;
+  fd_set read, write, exc;
+  int max_fd = -1;
+  int64_t timeout = -1;
+  timeval sel_timeout;
+
+  vector<string>::const_iterator url_iter = urls_.begin() + streams_.size();
+
+  DLOG(INFO) << "preparing requests...";
+  // TODO(kmatzen): I sort of manually enforce this, but can I tell cURLpp to
+  // do it for me?
+  // curl_multi_.setOpt(new curlpp::Options::MaxConnections(kMaxHandles));
+
+  for (int i = 0; i < kMaxHandles && url_iter != urls_.end(); ++url_iter, ++i) {
+    Register(*url_iter);
+  }
+
+  DLOG(INFO) << "BEGIN DOWNLOAD";
+  while (running_handles) {
+    while (!curl_multi_.perform(&running_handles)) {
+    }
+
+    if (!running_handles) {
+      break;
+    }
+
+    FD_ZERO(&read);
+    FD_ZERO(&write);
+    FD_ZERO(&exc);
+
+    curl_multi_.fdset(&read, &write, &exc, &max_fd);
+    // TODO(kmatzen): Figure out if curl needs to be configured with a timeout.
+    // Sometimes it seems to get stuck and I'd like to just skip those examples.
+    // curl_multi_.timeout(&timeout);
+
+    if (timeout == -1) {
+      timeout = 100;
+    }
+
+    if (max_fd == -1) {
+      usleep(timeout * 1000);
+    } else {
+      sel_timeout.tv_sec = timeout / 1000;
+      sel_timeout.tv_usec = (timeout % 1000) * 1000;
+
+      if (select(max_fd + 1, &read, &write, &exc, &sel_timeout) < 0) {
+        LOG(FATAL) << "select failed";
+      }
+    }
+
+    const curlpp::Multi::Msgs msgs = curl_multi_.info();
+    for (curlpp::Multi::Msgs::const_iterator msg = msgs.begin();
+         msg != msgs.end(); ++msg) {
+      if (msg->second.msg != CURLMSG_DONE) {
+        continue;
+      }
+
+      const curlpp::Easy* easy_handle = msg->first;
+
+      if (msg->second.code != CURLE_OK) {
+        curlpp::Options::Url option;
+        easy_handle->getOpt(option);
+        LOG(ERROR) << "curl failed " << msg->second.code << " " << option;
+      }
+
+      curl_multi_.remove(easy_handle);
+      delete easy_handle;
+
+      if (url_iter == urls_.end()) {
+        continue;
+      }
+
+      Register(*url_iter++);
+    }
+  }
+  DLOG(INFO) << running_handles;
+  DLOG(INFO) << "END DOWNLOAD";
+}
+
+const vector<shared_ptr<stringstream> >&
+    DownloadManager::RetrieveResults() const {
+  CHECK_EQ(urls_.size(), streams_.size());
+  return streams_;
+}
+
+void DownloadManager::Reset() {
+  streams_.clear();
+  urls_.clear();
+}
+
+}  // namespace caffe


### PR DESCRIPTION
I recently saw PR https://github.com/BVLC/caffe/pull/1239, so I figured I'd mention this one thing I've been working on to figure out whether or not it's useful for other people.  I feel this feature is related to https://github.com/BVLC/caffe/pull/1239 since one of the core aims is to use encoded images and preprocess them while training.  It differs in that it also supports multi-task datasets and it also reads images over HTTP rather than via a database or the local filesystem directly.

Here's my use case:
I do my training on EC2 and when I start up a new instance, I need to fetch my training data from S3.  Sometimes I just want to train for one epoch or less to help set learning rates and other parameters.  It's wasteful to download the full dataset to each machine if I'm not going to use all of it.  The disks on g2.2xlarge instances are only 60 GB, so I often can't fit my entire dataset on each anyway.

The second part of my use case is that I often vary the method by which I preprocess my training examples during development.  Therefore, the input here is not a set of pre-cropped and resized images, but instead original images along with cropping and resizing parameters.

Here's the feature:
It's a new data layer that takes as input a protobuf that enumerates training examples each with:
(1) A URL to a jpeg image.
(2) A crop region.
(3) A set of training labels.

Each minibatch of images is fetched together with libcurl-multi.  That way, if all of your images are stored in the same place, such as S3, then the DNS resolution will be reused between the requests.  The images are decoded with libjpeg-turbo which offers better performance than what's used by OpenCV (although you lose support for anything other than jpeg).  cv::resize is used, although it's pretty slow unless you use OpenCV 3 since 3 is built with IPP support.

Now, an alternative is to configure a set of EBS volumes with the training data and run NFS or GlusterFS to serve the data to the training machines.  I'm not saying one method is better than the other.  S3 is certainly easier to configure and in terms of price per storage per month, it's cheaper, but a private network file system might offer better performance.  This feature is meant to act as something to try and measure.  And it might be the case for online training that consuming resources from an HTTP server is easier.   

Here's what the input protobuf message definitions look like for some FooTask.  This example dataset has four sets of training labels for multitask learning.
```
message ProtobufManifest {
  repeated ProtobufRecord records = 1;
  repeated string labels = 2;
  repeated uint32 label_dims = 3;
}

message ProtobufRecord {
  optional string image_url = 1;
  optional int32 crop_x1 = 2;
  optional int32 crop_x2 = 3;
  optional int32 crop_y1 = 4;
  optional int32 crop_y2 = 5;

  extensions 100 to max;
}

message FooTaskRecord {
  extend ProtobufRecord {
    optional ClassificationRecord parent = 103;
  }

  optional uint32 classification_label = 1;
  optional float regression_target = 2;
  repeated uint32 classification_multilabel = 3;
  repeated float regression_multitarget = 4;
}
```

And here's what an input protobuf might look like (encoded with text_format for visualization).
```
records {
  image_url: "http://s3.amazonaws.com/footask/123.jpg"
  crop_x1: 10
  crop_x2: 20
  crop_y1: 15
  crop_y2: 25
  [caffe.FooTaskRecord.parent] {
    classification_label: 1
    regression_target: 1.5
    classification_multilabel: 1
    classification_multilabel: 2
    classification_multilabel: 3
    classification_multilabel: 4
    classification_multilabel: 5
    regression_multitarget: 1.2
    regression_multitarget: 3.4
    regression_multitarget: 5.6
  }
}
records {
  image_url: "http://s3.amazonaws.com/footask/456.jpg"
  crop_x1: 10
  crop_x2: 20
  crop_y1: 15
  crop_y2: 25
  [caffe.FooTaskRecord.parent] {
    classification_label: 1
    regression_target: 1.5
    classification_multilabel: 1
    classification_multilabel: 2
    classification_multilabel: 3
    classification_multilabel: 4
    classification_multilabel: 5
    regression_multitarget: 1.2
    regression_multitarget: 3.4
    regression_multitarget: 5.6
  }
}
labels: "classification_label"
labels: "regression_target"
labels: "classification_multilabel"
labels: "regression_multitarget"
label_dims: 1
label_dims: 1
label_dims: 5
label_dims: 3
```

Now say you're not interested in doing multi-task learning, but just want to do classification on the ```classification_label``` field.  In the network's protobuf definition, you can specify the following to select only the ```classification_label``` as output.
```
layers {
  top: "data"
  top: "classification_label"
  name: "train"
  type: PROTOBUF_DATA
  include {
    phase: TRAIN
  }
  protobuf_data_param {
    source: "my_manifest.protobuf"
    batch_size: 32
    shuffle: true
    crop_height: 224
    crop_width: 224
    labels: "classification_label"
  }
}
```

Or if you want both ```classification_label``` and ```regression_target``` for training, then you can specify both.  The size of top will always be N + 1 where N is the number of selected label outputs.
```
layers {
  top: "data"
  top: "classification_label"
  top: "regression_target"
  name: "train"
  type: PROTOBUF_DATA
  include {
    phase: TRAIN
  }
  protobuf_data_param {
    source: "my_manifest.protobuf"
    batch_size: 32
    shuffle: true
    crop_height: 224
    crop_width: 224
    labels: "classification_label"
    labels: "regression_target"
  }
}
```