### PR TITLE
Link with atlas on centos 7.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,8 @@ ifeq ($(BLAS), mkl)
 else ifeq ($(BLAS), open)
 	# OpenBLAS
 	LIBRARIES += openblas
+else ifeq ($(BLAS), atlas-centos7)
+	LIBRARIES += tatlas
 else
 	# ATLAS
 	ifeq ($(LINUX), 1)

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,7 @@ else ifeq ($(BLAS), open)
 	# OpenBLAS
 	LIBRARIES += openblas
 else ifeq ($(BLAS), atlas-centos7)
+	# On centos 7 atlas and cblas are compiled together into a single library called tatlas.
 	LIBRARIES += tatlas
 else
 	# ATLAS

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -28,7 +28,7 @@ CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
 		#-gencode arch=compute_50,code=compute_50
 
 # BLAS choice:
-# atlas for ATLAS (default)
+# atlas for ATLAS (default) (on centos 7 use atlas-centos7)
 # mkl for MKL
 # open for OpenBlas
 BLAS := atlas


### PR DESCRIPTION
On centos 7 atlas and cblas are compiled together into a single library called tatlas (there is also satlas which is a single threaded version).  This commit adds a new BLAS choice that links against this differently named library.