### PR TITLE
Give back to layer what is layer's, and to factory what is factory's

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -7,9 +7,6 @@
 
 namespace caffe {
 
-// GetLayer() defines the overall layer factory. The Get*Layer() functions
-// define factories for layers with multiple computational engines.
-
 // Get convolution layer according to engine.
 template <typename Dtype>
 Layer<Dtype>* GetConvolutionLayer(
@@ -31,6 +28,8 @@ Layer<Dtype>* GetConvolutionLayer(
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
   }
 }
+
+REGISTER_LAYER_CREATOR(CONVOLUTION, GetConvolutionLayer);
 
 // Get pooling layer according to engine.
 template <typename Dtype>
@@ -60,6 +59,8 @@ Layer<Dtype>* GetPoolingLayer(const LayerParameter& param) {
   }
 }
 
+REGISTER_LAYER_CREATOR(POOLING, GetPoolingLayer);
+
 // Get relu layer according to engine.
 template <typename Dtype>
 Layer<Dtype>* GetReLULayer(const LayerParameter& param) {
@@ -80,6 +81,8 @@ Layer<Dtype>* GetReLULayer(const LayerParameter& param) {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
   }
 }
+
+REGISTER_LAYER_CREATOR(RELU, GetReLULayer);
 
 // Get sigmoid layer according to engine.
 template <typename Dtype>
@@ -102,26 +105,7 @@ Layer<Dtype>* GetSigmoidLayer(const LayerParameter& param) {
   }
 }
 
-// Get tanh layer according to engine.
-template <typename Dtype>
-Layer<Dtype>* GetTanHLayer(const LayerParameter& param) {
-  TanHParameter_Engine engine = param.tanh_param().engine();
-  if (engine == TanHParameter_Engine_DEFAULT) {
-    engine = TanHParameter_Engine_CAFFE;
-#ifdef USE_CUDNN
-    engine = TanHParameter_Engine_CUDNN;
-#endif
-  }
-  if (engine == TanHParameter_Engine_CAFFE) {
-    return new TanHLayer<Dtype>(param);
-#ifdef USE_CUDNN
-  } else if (engine == TanHParameter_Engine_CUDNN) {
-    return new CuDNNTanHLayer<Dtype>(param);
-#endif
-  } else {
-    LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
-  }
-}
+REGISTER_LAYER_CREATOR(SIGMOID, GetSigmoidLayer);
 
 // Get softmax layer according to engine.
 template <typename Dtype>
@@ -144,46 +128,31 @@ Layer<Dtype>* GetSoftmaxLayer(const LayerParameter& param) {
   }
 }
 
-// Layers that have a specific creator function.
-REGISTER_LAYER_CREATOR(CONVOLUTION, GetConvolutionLayer);
-REGISTER_LAYER_CREATOR(POOLING, GetPoolingLayer);
-REGISTER_LAYER_CREATOR(RELU, GetReLULayer);
-REGISTER_LAYER_CREATOR(SIGMOID, GetSigmoidLayer);
 REGISTER_LAYER_CREATOR(SOFTMAX, GetSoftmaxLayer);
+
+// Get tanh layer according to engine.
+template <typename Dtype>
+Layer<Dtype>* GetTanHLayer(const LayerParameter& param) {
+  TanHParameter_Engine engine = param.tanh_param().engine();
+  if (engine == TanHParameter_Engine_DEFAULT) {
+    engine = TanHParameter_Engine_CAFFE;
+#ifdef USE_CUDNN
+    engine = TanHParameter_Engine_CUDNN;
+#endif
+  }
+  if (engine == TanHParameter_Engine_CAFFE) {
+    return new TanHLayer<Dtype>(param);
+#ifdef USE_CUDNN
+  } else if (engine == TanHParameter_Engine_CUDNN) {
+    return new CuDNNTanHLayer<Dtype>(param);
+#endif
+  } else {
+    LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+  }
+}
+
 REGISTER_LAYER_CREATOR(TANH, GetTanHLayer);
 
-// Layers that use their constructor as their default creator.
-REGISTER_LAYER_CLASS(ACCURACY, AccuracyLayer);
-REGISTER_LAYER_CLASS(ABSVAL, AbsValLayer);
-REGISTER_LAYER_CLASS(ARGMAX, ArgMaxLayer);
-REGISTER_LAYER_CLASS(BNLL, BNLLLayer);
-REGISTER_LAYER_CLASS(CONCAT, ConcatLayer);
-REGISTER_LAYER_CLASS(CONTRASTIVE_LOSS, ContrastiveLossLayer);
-REGISTER_LAYER_CLASS(DATA, DataLayer);
-REGISTER_LAYER_CLASS(DROPOUT, DropoutLayer);
-REGISTER_LAYER_CLASS(DUMMY_DATA, DummyDataLayer);
-REGISTER_LAYER_CLASS(EUCLIDEAN_LOSS, EuclideanLossLayer);
-REGISTER_LAYER_CLASS(ELTWISE, EltwiseLayer);
-REGISTER_LAYER_CLASS(EXP, ExpLayer);
-REGISTER_LAYER_CLASS(FLATTEN, FlattenLayer);
-REGISTER_LAYER_CLASS(HDF5_DATA, HDF5DataLayer);
-REGISTER_LAYER_CLASS(HDF5_OUTPUT, HDF5OutputLayer);
-REGISTER_LAYER_CLASS(HINGE_LOSS, HingeLossLayer);
-REGISTER_LAYER_CLASS(IMAGE_DATA, ImageDataLayer);
-REGISTER_LAYER_CLASS(IM2COL, Im2colLayer);
-REGISTER_LAYER_CLASS(INFOGAIN_LOSS, InfogainLossLayer);
-REGISTER_LAYER_CLASS(INNER_PRODUCT, InnerProductLayer);
-REGISTER_LAYER_CLASS(LRN, LRNLayer);
-REGISTER_LAYER_CLASS(MEMORY_DATA, MemoryDataLayer);
-REGISTER_LAYER_CLASS(MVN, MVNLayer);
-REGISTER_LAYER_CLASS(MULTINOMIAL_LOGISTIC_LOSS, MultinomialLogisticLossLayer);
-REGISTER_LAYER_CLASS(POWER, PowerLayer);
-REGISTER_LAYER_CLASS(SILENCE, SilenceLayer);
-REGISTER_LAYER_CLASS(SIGMOID_CROSS_ENTROPY_LOSS, SigmoidCrossEntropyLossLayer);
-REGISTER_LAYER_CLASS(SLICE, SliceLayer);
-REGISTER_LAYER_CLASS(SOFTMAX_LOSS, SoftmaxWithLossLayer);
-REGISTER_LAYER_CLASS(SPLIT, SplitLayer);
-REGISTER_LAYER_CLASS(THRESHOLD, ThresholdLayer);
-REGISTER_LAYER_CLASS(WINDOW_DATA, WindowDataLayer);
-
+// Layers that use their constructor as their default creator should be
+// registered in their corresponding cpp files. Do not registere them here.
 }  // namespace caffe

--- a/src/caffe/layers/absval_layer.cpp
+++ b/src/caffe/layers/absval_layer.cpp
@@ -41,6 +41,5 @@ STUB_GPU(AbsValLayer);
 #endif
 
 INSTANTIATE_CLASS(AbsValLayer);
-
-
+REGISTER_LAYER_CLASS(ABSVAL, AbsValLayer);
 }  // namespace caffe

--- a/src/caffe/layers/accuracy_layer.cpp
+++ b/src/caffe/layers/accuracy_layer.cpp
@@ -64,5 +64,5 @@ void AccuracyLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 }
 
 INSTANTIATE_CLASS(AccuracyLayer);
-
+REGISTER_LAYER_CLASS(ACCURACY, AccuracyLayer);
 }  // namespace caffe

--- a/src/caffe/layers/argmax_layer.cpp
+++ b/src/caffe/layers/argmax_layer.cpp
@@ -58,5 +58,6 @@ void ArgMaxLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 }
 
 INSTANTIATE_CLASS(ArgMaxLayer);
+REGISTER_LAYER_CLASS(ARGMAX, ArgMaxLayer);
 
 }  // namespace caffe

--- a/src/caffe/layers/bnll_layer.cpp
+++ b/src/caffe/layers/bnll_layer.cpp
@@ -43,6 +43,5 @@ STUB_GPU(BNLLLayer);
 #endif
 
 INSTANTIATE_CLASS(BNLLLayer);
-
-
+REGISTER_LAYER_CLASS(BNLL, BNLLLayer);
 }  // namespace caffe

--- a/src/caffe/layers/concat_layer.cpp
+++ b/src/caffe/layers/concat_layer.cpp
@@ -105,5 +105,5 @@ STUB_GPU(ConcatLayer);
 #endif
 
 INSTANTIATE_CLASS(ConcatLayer);
-
+REGISTER_LAYER_CLASS(CONCAT, ConcatLayer);
 }  // namespace caffe

--- a/src/caffe/layers/contrastive_loss_layer.cpp
+++ b/src/caffe/layers/contrastive_loss_layer.cpp
@@ -97,5 +97,5 @@ STUB_GPU(ContrastiveLossLayer);
 #endif
 
 INSTANTIATE_CLASS(ContrastiveLossLayer);
-
+REGISTER_LAYER_CLASS(CONTRASTIVE_LOSS, ContrastiveLossLayer);
 }  // namespace caffe

--- a/src/caffe/layers/conv_layer.cpp
+++ b/src/caffe/layers/conv_layer.cpp
@@ -267,5 +267,4 @@ STUB_GPU(ConvolutionLayer);
 #endif
 
 INSTANTIATE_CLASS(ConvolutionLayer);
-
 }  // namespace caffe

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -204,5 +204,5 @@ void DataLayer<Dtype>::InternalThreadEntry() {
 }
 
 INSTANTIATE_CLASS(DataLayer);
-
+REGISTER_LAYER_CLASS(DATA, DataLayer);
 }  // namespace caffe

--- a/src/caffe/layers/dropout_layer.cpp
+++ b/src/caffe/layers/dropout_layer.cpp
@@ -73,6 +73,5 @@ STUB_GPU(DropoutLayer);
 #endif
 
 INSTANTIATE_CLASS(DropoutLayer);
-
-
+REGISTER_LAYER_CLASS(DROPOUT, DropoutLayer);
 }  // namespace caffe

--- a/src/caffe/layers/dummy_data_layer.cpp
+++ b/src/caffe/layers/dummy_data_layer.cpp
@@ -93,5 +93,5 @@ void DummyDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 }
 
 INSTANTIATE_CLASS(DummyDataLayer);
-
+REGISTER_LAYER_CLASS(DUMMY_DATA, DummyDataLayer);
 }  // namespace caffe

--- a/src/caffe/layers/eltwise_layer.cpp
+++ b/src/caffe/layers/eltwise_layer.cpp
@@ -163,6 +163,5 @@ STUB_GPU(EltwiseLayer);
 #endif
 
 INSTANTIATE_CLASS(EltwiseLayer);
-
-
+REGISTER_LAYER_CLASS(ELTWISE, EltwiseLayer);
 }  // namespace caffe

--- a/src/caffe/layers/euclidean_loss_layer.cpp
+++ b/src/caffe/layers/euclidean_loss_layer.cpp
@@ -54,5 +54,5 @@ STUB_GPU(EuclideanLossLayer);
 #endif
 
 INSTANTIATE_CLASS(EuclideanLossLayer);
-
+REGISTER_LAYER_CLASS(EUCLIDEAN_LOSS, EuclideanLossLayer);
 }  // namespace caffe

--- a/src/caffe/layers/exp_layer.cpp
+++ b/src/caffe/layers/exp_layer.cpp
@@ -64,6 +64,5 @@ STUB_GPU(ExpLayer);
 #endif
 
 INSTANTIATE_CLASS(ExpLayer);
-
-
+REGISTER_LAYER_CLASS(EXP, ExpLayer);
 }  // namespace caffe

--- a/src/caffe/layers/flatten_layer.cpp
+++ b/src/caffe/layers/flatten_layer.cpp
@@ -34,5 +34,5 @@ STUB_GPU(FlattenLayer);
 #endif
 
 INSTANTIATE_CLASS(FlattenLayer);
-
+REGISTER_LAYER_CLASS(FLATTEN, FlattenLayer);
 }  // namespace caffe

--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -119,5 +119,5 @@ STUB_GPU_FORWARD(HDF5DataLayer, Forward);
 #endif
 
 INSTANTIATE_CLASS(HDF5DataLayer);
-
+REGISTER_LAYER_CLASS(HDF5_DATA, HDF5DataLayer);
 }  // namespace caffe

--- a/src/caffe/layers/hdf5_output_layer.cpp
+++ b/src/caffe/layers/hdf5_output_layer.cpp
@@ -70,5 +70,5 @@ STUB_GPU(HDF5OutputLayer);
 #endif
 
 INSTANTIATE_CLASS(HDF5OutputLayer);
-
+REGISTER_LAYER_CLASS(HDF5_OUTPUT, HDF5OutputLayer);
 }  // namespace caffe

--- a/src/caffe/layers/hinge_loss_layer.cpp
+++ b/src/caffe/layers/hinge_loss_layer.cpp
@@ -77,5 +77,5 @@ void HingeLossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
 }
 
 INSTANTIATE_CLASS(HingeLossLayer);
-
+REGISTER_LAYER_CLASS(HINGE_LOSS, HingeLossLayer);
 }  // namespace caffe

--- a/src/caffe/layers/im2col_layer.cpp
+++ b/src/caffe/layers/im2col_layer.cpp
@@ -88,5 +88,5 @@ STUB_GPU(Im2colLayer);
 #endif
 
 INSTANTIATE_CLASS(Im2colLayer);
-
+REGISTER_LAYER_CLASS(IM2COL, Im2colLayer);
 }  // namespace caffe

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -131,5 +131,5 @@ void ImageDataLayer<Dtype>::InternalThreadEntry() {
 }
 
 INSTANTIATE_CLASS(ImageDataLayer);
-
+REGISTER_LAYER_CLASS(IMAGE_DATA, ImageDataLayer);
 }  // namespace caffe

--- a/src/caffe/layers/infogain_loss_layer.cpp
+++ b/src/caffe/layers/infogain_loss_layer.cpp
@@ -106,5 +106,5 @@ void InfogainLossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
 }
 
 INSTANTIATE_CLASS(InfogainLossLayer);
-
+REGISTER_LAYER_CLASS(INFOGAIN_LOSS, InfogainLossLayer);
 }  // namespace caffe

--- a/src/caffe/layers/inner_product_layer.cpp
+++ b/src/caffe/layers/inner_product_layer.cpp
@@ -104,5 +104,5 @@ STUB_GPU(InnerProductLayer);
 #endif
 
 INSTANTIATE_CLASS(InnerProductLayer);
-
+REGISTER_LAYER_CLASS(INNER_PRODUCT, InnerProductLayer);
 }  // namespace caffe

--- a/src/caffe/layers/lrn_layer.cpp
+++ b/src/caffe/layers/lrn_layer.cpp
@@ -252,6 +252,5 @@ STUB_GPU_BACKWARD(LRNLayer, CrossChannelBackward);
 #endif
 
 INSTANTIATE_CLASS(LRNLayer);
-
-
+REGISTER_LAYER_CLASS(LRN, LRNLayer);
 }  // namespace caffe

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -72,5 +72,5 @@ void MemoryDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 }
 
 INSTANTIATE_CLASS(MemoryDataLayer);
-
+REGISTER_LAYER_CLASS(MEMORY_DATA, MemoryDataLayer);
 }  // namespace caffe

--- a/src/caffe/layers/multinomial_logistic_loss_layer.cpp
+++ b/src/caffe/layers/multinomial_logistic_loss_layer.cpp
@@ -62,5 +62,5 @@ void MultinomialLogisticLossLayer<Dtype>::Backward_cpu(
 }
 
 INSTANTIATE_CLASS(MultinomialLogisticLossLayer);
-
+REGISTER_LAYER_CLASS(MULTINOMIAL_LOGISTIC_LOSS, MultinomialLogisticLossLayer);
 }  // namespace caffe

--- a/src/caffe/layers/mvn_layer.cpp
+++ b/src/caffe/layers/mvn_layer.cpp
@@ -159,6 +159,5 @@ STUB_GPU(MVNLayer);
 #endif
 
 INSTANTIATE_CLASS(MVNLayer);
-
-
+REGISTER_LAYER_CLASS(MVN, MVNLayer);
 }  // namespace caffe

--- a/src/caffe/layers/power_layer.cpp
+++ b/src/caffe/layers/power_layer.cpp
@@ -99,6 +99,5 @@ STUB_GPU(PowerLayer);
 #endif
 
 INSTANTIATE_CLASS(PowerLayer);
-
-
+REGISTER_LAYER_CLASS(POWER, PowerLayer);
 }  // namespace caffe

--- a/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cpp
+++ b/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cpp
@@ -75,6 +75,5 @@ STUB_GPU(SigmoidCrossEntropyLossLayer);
 #endif
 
 INSTANTIATE_CLASS(SigmoidCrossEntropyLossLayer);
-
-
+REGISTER_LAYER_CLASS(SIGMOID_CROSS_ENTROPY_LOSS, SigmoidCrossEntropyLossLayer);
 }  // namespace caffe

--- a/src/caffe/layers/silence_layer.cpp
+++ b/src/caffe/layers/silence_layer.cpp
@@ -22,5 +22,5 @@ STUB_GPU(SilenceLayer);
 #endif
 
 INSTANTIATE_CLASS(SilenceLayer);
-
+REGISTER_LAYER_CLASS(SILENCE, SilenceLayer);
 }  // namespace caffe

--- a/src/caffe/layers/slice_layer.cpp
+++ b/src/caffe/layers/slice_layer.cpp
@@ -137,5 +137,5 @@ STUB_GPU(SliceLayer);
 #endif
 
 INSTANTIATE_CLASS(SliceLayer);
-
+REGISTER_LAYER_CLASS(SLICE, SliceLayer);
 }  // namespace caffe

--- a/src/caffe/layers/softmax_layer.cpp
+++ b/src/caffe/layers/softmax_layer.cpp
@@ -92,6 +92,4 @@ STUB_GPU(SoftmaxLayer);
 #endif
 
 INSTANTIATE_CLASS(SoftmaxLayer);
-
-
 }  // namespace caffe

--- a/src/caffe/layers/softmax_loss_layer.cpp
+++ b/src/caffe/layers/softmax_loss_layer.cpp
@@ -90,6 +90,5 @@ STUB_GPU(SoftmaxWithLossLayer);
 #endif
 
 INSTANTIATE_CLASS(SoftmaxWithLossLayer);
-
-
+REGISTER_LAYER_CLASS(SOFTMAX_LOSS, SoftmaxWithLossLayer);
 }  // namespace caffe

--- a/src/caffe/layers/split_layer.cpp
+++ b/src/caffe/layers/split_layer.cpp
@@ -56,5 +56,5 @@ STUB_GPU(SplitLayer);
 #endif
 
 INSTANTIATE_CLASS(SplitLayer);
-
+REGISTER_LAYER_CLASS(SPLIT, SplitLayer);
 }  // namespace caffe

--- a/src/caffe/layers/threshold_layer.cpp
+++ b/src/caffe/layers/threshold_layer.cpp
@@ -29,5 +29,5 @@ STUB_GPU_FORWARD(ThresholdLayer, Forward);
 #endif
 
 INSTANTIATE_CLASS(ThresholdLayer);
-
+REGISTER_LAYER_CLASS(THRESHOLD, ThresholdLayer);
 }  // namespace caffe

--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -402,5 +402,5 @@ void WindowDataLayer<Dtype>::InternalThreadEntry() {
 }
 
 INSTANTIATE_CLASS(WindowDataLayer);
-
+REGISTER_LAYER_CLASS(WINDOW_DATA, WindowDataLayer);
 }  // namespace caffe


### PR DESCRIPTION
This PR puts all registration code near where they are defined. This would allow us to hopefully make layers more modular. For example, if we want to disable a layer, simply put an #ifdef around its cpp file (as well as its declaration).

I don't know where to put all those Creator functions, so they are still inside layer_factory.cpp. Ideally we could also create separate cpp files like conv_layer_factory.cpp and so on, but given the fact that they are all core layers, maybe it's an overkill to separate them anyway.
