### PR TITLE
Added first_key and last_key to dataset

### DIFF
--- a/include/caffe/dataset.hpp
+++ b/include/caffe/dataset.hpp
@@ -135,6 +135,8 @@ class Dataset {
   virtual bool open(const string& filename, Mode mode) = 0;
   virtual bool put(const K& key, const V& value) = 0;
   virtual bool get(const K& key, V* value) = 0;
+  virtual bool first_key(K* key) = 0;
+  virtual bool last_key(K* key) = 0;
   virtual bool commit() = 0;
   virtual void close() = 0;
 

--- a/include/caffe/leveldb_dataset.hpp
+++ b/include/caffe/leveldb_dataset.hpp
@@ -29,6 +29,8 @@ class LeveldbDataset : public Dataset<K, V, KCoder, VCoder> {
   bool open(const string& filename, Mode mode);
   bool put(const K& key, const V& value);
   bool get(const K& key, V* value);
+  bool first_key(K* key);
+  bool last_key(K* key);
   bool commit();
   void close();
 

--- a/include/caffe/lmdb_dataset.hpp
+++ b/include/caffe/lmdb_dataset.hpp
@@ -33,6 +33,8 @@ class LmdbDataset : public Dataset<K, V, KCoder, VCoder> {
   bool open(const string& filename, Mode mode);
   bool put(const K& key, const V& value);
   bool get(const K& key, V* value);
+  bool first_key(K* key);
+  bool last_key(K* key);
   bool commit();
   void close();
 

--- a/src/caffe/leveldb_dataset.cpp
+++ b/src/caffe/leveldb_dataset.cpp
@@ -107,6 +107,30 @@ bool LeveldbDataset<K, V, KCoder, VCoder>::get(const K& key, V* value) {
 }
 
 template <typename K, typename V, typename KCoder, typename VCoder>
+bool LeveldbDataset<K, V, KCoder, VCoder>::first_key(K* key) {
+  DLOG(INFO) << "LevelDB: First key";
+
+  CHECK_NOTNULL(db_.get());
+  shared_ptr<leveldb::Iterator> iter(db_->NewIterator(leveldb::ReadOptions()));
+  iter->SeekToFirst();
+  CHECK(iter->Valid());
+  const leveldb::Slice& key_slice = iter->key();
+  return KCoder::deserialize(key_slice.data(), key_slice.size(), key);
+}
+
+template <typename K, typename V, typename KCoder, typename VCoder>
+bool LeveldbDataset<K, V, KCoder, VCoder>::last_key(K* key) {
+  DLOG(INFO) << "LevelDB: Last key";
+
+  CHECK_NOTNULL(db_.get());
+  shared_ptr<leveldb::Iterator> iter(db_->NewIterator(leveldb::ReadOptions()));
+  iter->SeekToLast();
+  CHECK(iter->Valid());
+  const leveldb::Slice& key_slice = iter->key();
+  return KCoder::deserialize(key_slice.data(), key_slice.size(), key);
+}
+
+template <typename K, typename V, typename KCoder, typename VCoder>
 bool LeveldbDataset<K, V, KCoder, VCoder>::commit() {
   DLOG(INFO) << "LevelDB: Commit";
 

--- a/src/caffe/test/test_dataset.cpp
+++ b/src/caffe/test/test_dataset.cpp
@@ -277,6 +277,120 @@ TYPED_TEST(DatasetTest, TestKeys) {
   EXPECT_FALSE(this->equals(keys.at(0), keys.at(1)));
 }
 
+TYPED_TEST(DatasetTest, TestFirstKey) {
+  UNPACK_TYPES;
+
+  string name = this->DBName();
+  shared_ptr<Dataset<string, value_type> > dataset =
+      DatasetFactory<string, value_type>(backend);
+  EXPECT_TRUE(dataset->open(name, Dataset<string, value_type>::New));
+
+  value_type value = this->TestValue();
+
+  string key1 = "01";
+  EXPECT_TRUE(dataset->put(key1, value));
+
+  string key2 = "02";
+  EXPECT_TRUE(dataset->put(key2, value));
+
+  string key3 = "03";
+  EXPECT_TRUE(dataset->put(key3, value));
+
+  EXPECT_TRUE(dataset->commit());
+
+  string first_key;
+  dataset->first_key(&first_key);
+
+  EXPECT_TRUE(this->equals(first_key, key1));
+}
+
+TYPED_TEST(DatasetTest, TestLastKey) {
+  UNPACK_TYPES;
+
+  string name = this->DBName();
+  shared_ptr<Dataset<string, value_type> > dataset =
+      DatasetFactory<string, value_type>(backend);
+  EXPECT_TRUE(dataset->open(name, Dataset<string, value_type>::New));
+
+  value_type value = this->TestValue();
+
+  string key1 = "01";
+  EXPECT_TRUE(dataset->put(key1, value));
+
+  string key2 = "02";
+  EXPECT_TRUE(dataset->put(key2, value));
+
+  string key3 = "03";
+  EXPECT_TRUE(dataset->put(key3, value));
+
+  EXPECT_TRUE(dataset->commit());
+
+  string last_key;
+  dataset->last_key(&last_key);
+
+  EXPECT_TRUE(this->equals(last_key, key3));
+}
+
+TYPED_TEST(DatasetTest, TestFirstLastKeys) {
+  UNPACK_TYPES;
+
+  string name = this->DBName();
+  shared_ptr<Dataset<string, value_type> > dataset =
+      DatasetFactory<string, value_type>(backend);
+  EXPECT_TRUE(dataset->open(name, Dataset<string, value_type>::New));
+
+  value_type value = this->TestValue();
+
+  string key1 = "01";
+  EXPECT_TRUE(dataset->put(key1, value));
+
+  string key2 = "02";
+  EXPECT_TRUE(dataset->put(key2, value));
+
+  string key3 = "03";
+  EXPECT_TRUE(dataset->put(key3, value));
+
+  EXPECT_TRUE(dataset->commit());
+
+  string first_key;
+  dataset->first_key(&first_key);
+  string last_key;
+  dataset->last_key(&last_key);
+
+  EXPECT_TRUE(this->equals(first_key, key1));
+  EXPECT_TRUE(this->equals(last_key, key3));
+}
+
+TYPED_TEST(DatasetTest, TestFirstLastKeysUnOrdered) {
+  UNPACK_TYPES;
+
+  string name = this->DBName();
+  shared_ptr<Dataset<string, value_type> > dataset =
+      DatasetFactory<string, value_type>(backend);
+  EXPECT_TRUE(dataset->open(name, Dataset<string, value_type>::New));
+
+  value_type value = this->TestValue();
+
+  string key3 = "03";
+  EXPECT_TRUE(dataset->put(key3, value));
+
+  string key1 = "01";
+  EXPECT_TRUE(dataset->put(key1, value));
+
+  string key2 = "02";
+  EXPECT_TRUE(dataset->put(key2, value));
+
+  EXPECT_TRUE(dataset->commit());
+
+  string first_key;
+  dataset->first_key(&first_key);
+  string last_key;
+  dataset->last_key(&last_key);
+
+  EXPECT_TRUE(this->equals(first_key, key1));
+  EXPECT_TRUE(this->equals(last_key, key3));
+}
+
 TYPED_TEST(DatasetTest, TestKeysNoCommit) {
   UNPACK_TYPES;
 


### PR DESCRIPTION
This PR depends on #1238.

Just added two more methods to `dataset` to be able to know which is the first_key and last_key. This would be very useful when the keys are generated sequentially.

@kmatzen Could you take a look?
