### PR TITLE
Modular model definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT := caffe
 
-CONFIG_FILE := Makefile.config
+CONFIG_FILE ?= Makefile.config
 include $(CONFIG_FILE)
 
 BUILD_DIR_LINK := $(BUILD_DIR)

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -147,7 +147,8 @@ class Caffe {
   inline static void set_mode(Brew mode) { Get().mode_ = mode; }
   // Sets the phase.
   inline static void set_phase(Phase phase) { Get().phase_ = phase; }
-  // Sets the random seed of both boost and curand
+  // Random seed of both boost and curand
+  static unsigned int get_random_seed();
   static void set_random_seed(const unsigned int seed);
   // Sets the device. Since we have cublas and curand stuff, set device also
   // requires us to reset those values.
@@ -161,6 +162,7 @@ class Caffe {
   curandGenerator_t curand_generator_;
 #endif
   shared_ptr<RNG> random_generator_;
+  unsigned int random_generator_seed_;
 
   Brew mode_;
   Phase phase_;

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -5,7 +5,10 @@
 #include <utility>
 #include <vector>
 
-#include "boost/scoped_ptr.hpp"
+#include "boost/weak_ptr.hpp"
+#include "boost/random/mersenne_twister.hpp"
+#include "boost/random/uniform_real.hpp"
+#include "boost/random/variate_generator.hpp"
 #include "hdf5.h"
 
 #include "caffe/blob.hpp"
@@ -16,8 +19,14 @@
 #include "caffe/internal_thread.hpp"
 #include "caffe/layer.hpp"
 #include "caffe/proto/caffe.pb.h"
+#include "caffe/util/blocking_queue.hpp"
 
 namespace caffe {
+
+using boost::weak_ptr;
+using boost::mt19937;
+using boost::uniform_real;
+using boost::variate_generator;
 
 /**
  * @brief Provides base for data layers that feed blobs to the Net.
@@ -53,11 +62,16 @@ class BaseDataLayer : public Layer<Dtype> {
 };
 
 template <typename Dtype>
+class Batch {
+ public:
+  Blob<Dtype> data_, label_;
+};
+
+template <typename Dtype>
 class BasePrefetchingDataLayer :
     public BaseDataLayer<Dtype>, public InternalThread {
  public:
-  explicit BasePrefetchingDataLayer(const LayerParameter& param)
-      : BaseDataLayer<Dtype>(param) {}
+  explicit BasePrefetchingDataLayer(const LayerParameter& param);
   virtual ~BasePrefetchingDataLayer() {}
   // LayerSetUp: implements common data layer setup functionality, and calls
   // DataLayerSetUp to do special data layer setup for individual layer types.
@@ -70,22 +84,64 @@ class BasePrefetchingDataLayer :
   virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
 
-  virtual void CreatePrefetchThread();
-  virtual void JoinPrefetchThread();
-  // The thread's function
-  virtual void InternalThreadEntry() {}
+  // Prefetches batches (asynchronously if to GPU memory)
+  static const int PREFETCH_COUNT = 3;
 
  protected:
-  Blob<Dtype> prefetch_data_;
-  Blob<Dtype> prefetch_label_;
+  virtual void InternalThreadEntry();
+  virtual void load_batch(Batch<Dtype>* batch) = 0;
+
+  Batch<Dtype> prefetch_[PREFETCH_COUNT];
+  blocking_queue<Batch<Dtype>*> prefetch_free_;
+  blocking_queue<Batch<Dtype>*> prefetch_full_;
+  int device_;
+
   Blob<Dtype> transformed_data_;
 };
 
-template <typename Dtype>
-class DataLayer : public BasePrefetchingDataLayer<Dtype> {
+// Prefetches datums to host memory that can be read by multiple data layers.
+class DataLoader {
  public:
-  explicit DataLayer(const LayerParameter& param)
-      : BasePrefetchingDataLayer<Dtype>(param) {}
+  DataLoader(const DataParameter& param, int index);
+  ~DataLoader();
+
+  inline blocking_queue<Datum*>& free() {
+    return body_.get()->free_;
+  }
+  inline blocking_queue<Datum*>& full() {
+    return body_.get()->full_;
+  }
+
+ protected:
+  class Body: public InternalThread {
+   public:
+    Body(const DataParameter& param, int index);
+    ~Body();
+
+    void InternalThreadEntry();
+
+    shared_ptr<Dataset<string, Datum> > dataset_;
+    Dataset<string, Datum>::const_iterator iter_;
+
+    blocking_queue<Datum*> free_;
+    blocking_queue<Datum*> full_;
+
+    DISABLE_COPY_AND_ASSIGN(Body);
+  };
+
+  static map<string, weak_ptr<Body> > instances_;
+  static boost::mutex instances_mutex_;
+
+  const string source_;
+  shared_ptr<Body> body_;
+
+  DISABLE_COPY_AND_ASSIGN(DataLoader);
+};
+
+template <typename Dtype>
+class DataLayer: public BasePrefetchingDataLayer<Dtype> {
+ public:
+  explicit DataLayer(const LayerParameter& param);
   virtual ~DataLayer();
   virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
@@ -98,10 +154,12 @@ class DataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual inline int MaxTopBlobs() const { return 2; }
 
  protected:
-  virtual void InternalThreadEntry();
+  virtual void load_batch(Batch<Dtype>* batch);
+  DataLoader* next_loader();
 
-  shared_ptr<Dataset<string, Datum> > dataset_;
-  Dataset<string, Datum>::const_iterator iter_;
+  vector<shared_ptr<DataLoader> > loaders_;
+  mt19937 rand_engine_;
+  uniform_real<float> rand_;
 };
 
 /**
@@ -244,7 +302,7 @@ class ImageDataLayer : public BasePrefetchingDataLayer<Dtype> {
  protected:
   shared_ptr<Caffe::RNG> prefetch_rng_;
   virtual void ShuffleImages();
-  virtual void InternalThreadEntry();
+  virtual void load_batch(Batch<Dtype>* batch);
 
   vector<std::pair<std::string, int> > lines_;
   int lines_id_;
@@ -317,7 +375,7 @@ class WindowDataLayer : public BasePrefetchingDataLayer<Dtype> {
 
  protected:
   virtual unsigned int PrefetchRand();
-  virtual void InternalThreadEntry();
+  virtual void load_batch(Batch<Dtype>* batch);
 
   shared_ptr<Caffe::RNG> prefetch_rng_;
   vector<std::pair<std::string, vector<int> > > image_database_;

--- a/include/caffe/internal_thread.hpp
+++ b/include/caffe/internal_thread.hpp
@@ -15,6 +15,7 @@ class Thread {
   Thread(Callable func, A1 a1);
   void join();
   bool joinable();
+  void interrupt();
  private:
   void* thread_;
 };
@@ -26,16 +27,20 @@ class Thread {
  */
 class InternalThread {
  public:
-  InternalThread() : thread_(NULL) {}
+  InternalThread() : thread_(NULL), must_stop_() {}
   virtual ~InternalThread();
 
   /** Returns true if the thread was successfully started. **/
   bool StartInternalThread();
 
   /** Will not return until the internal thread has exited. */
-  bool WaitForInternalThreadToExit();
+  bool StopInternalThread();
 
   bool is_started() const { return thread_ != NULL && thread_->joinable(); }
+
+  bool must_stop() {
+    return must_stop_;
+  }
 
  protected:
   /* Implement this method in your subclass
@@ -43,6 +48,7 @@ class InternalThread {
   virtual void InternalThreadEntry() {}
 
   caffe::Thread* thread_;
+  bool must_stop_;
 };
 
 }  // namespace caffe

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -56,6 +56,10 @@ class SyncedMemory {
   SyncedHead head() { return head_; }
   size_t size() { return size_; }
 
+#ifndef CPU_ONLY
+  void async_gpu_push(const cudaStream_t& stream);
+#endif
+
  private:
   void to_cpu();
   void to_gpu();

--- a/include/caffe/util/blocking_queue.hpp
+++ b/include/caffe/util/blocking_queue.hpp
@@ -1,0 +1,84 @@
+#ifndef CAFFE_UTIL_BLOCKING_QUEUE_H_
+#define CAFFE_UTIL_BLOCKING_QUEUE_H_
+
+#include <queue>
+#include "boost/thread.hpp"
+
+namespace caffe {
+
+template<typename T>
+class blocking_queue {
+ public:
+  blocking_queue()
+      : last_wait_log_(time(0)),
+        pops_() {
+  }
+
+  void push(const T& t) {
+    boost::mutex::scoped_lock lock(mutex_);
+    queue_.push(t);
+    lock.unlock();
+    condition_.notify_one();
+  }
+
+  bool empty() const {
+    boost::mutex::scoped_lock lock(mutex_);
+    return queue_.empty();
+  }
+
+  bool try_pop(T& t) {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    if (queue_.empty())
+      return false;
+
+    t = queue_.front();
+    queue_.pop();
+    return true;
+  }
+
+  T pop(const string& log_on_wait = "") {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    while (queue_.empty()) {
+      if (!log_on_wait.empty()) {
+        time_t now = time(0);
+        if (now - last_wait_log_ > 5) {
+          last_wait_log_ = now;
+          LOG(INFO) << log_on_wait;
+        }
+      }
+      condition_.wait(lock);
+    }
+
+    T t = queue_.front();
+    queue_.pop();
+    pops_++;
+    return t;
+  }
+
+  // Return element without removing it
+  T peek() {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    while (queue_.empty())
+      condition_.wait(lock);
+
+    return queue_.front();
+  }
+
+  inline uint64_t pops() {
+    return pops_;
+  }
+
+ private:
+  std::queue<T> queue_;
+  mutable boost::mutex mutex_;
+  boost::condition_variable condition_;
+  time_t last_wait_log_;
+  uint64_t pops_;
+};
+
+}  // namespace caffe
+
+#endif

--- a/include/caffe/util/thread.hpp
+++ b/include/caffe/util/thread.hpp
@@ -20,6 +20,10 @@ bool Thread::joinable() {
   return static_cast<boost::thread*>(this->thread_)->joinable();
 }
 
+void Thread::interrupt() {
+  static_cast<boost::thread*>(this->thread_)->interrupt();
+}
+
 }  // namespace caffe
 
 #endif

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -108,6 +108,10 @@ Caffe::~Caffe() {
   }
 }
 
+unsigned int Caffe::get_random_seed() {
+  return Get().random_generator_seed_;
+}
+
 void Caffe::set_random_seed(const unsigned int seed) {
   // Curand seed
   static bool g_curand_availability_logged = false;
@@ -124,6 +128,7 @@ void Caffe::set_random_seed(const unsigned int seed) {
   }
   // RNG seed
   Get().random_generator_.reset(new RNG(seed));
+  Get().random_generator_seed_ = seed;
 }
 
 void Caffe::SetDevice(const int device_id) {

--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -27,51 +27,93 @@ void BaseDataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
 }
 
 template <typename Dtype>
+BasePrefetchingDataLayer<Dtype>::BasePrefetchingDataLayer(
+    const LayerParameter& param)
+    : BaseDataLayer<Dtype>(param),
+      prefetch_free_(), prefetch_full_(), device_() {
+  for(int i = 0; i < PREFETCH_COUNT; ++i)
+    prefetch_free_.push(&prefetch_[i]);
+}
+
+template <typename Dtype>
 void BasePrefetchingDataLayer<Dtype>::LayerSetUp(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   BaseDataLayer<Dtype>::LayerSetUp(bottom, top);
-  // Now, start the prefetch thread. Before calling prefetch, we make two
-  // cpu_data calls so that the prefetch thread does not accidentally make
-  // simultaneous cudaMalloc calls when the main thread is running. In some
-  // GPUs this seems to cause failures if we do not so.
-  this->prefetch_data_.mutable_cpu_data();
-  if (this->output_labels_) {
-    this->prefetch_label_.mutable_cpu_data();
+
+  // Before starting the prefetch thread, we make cpu_data and gpu_data
+  // calls so that the prefetch thread does not accidentally make simultaneous
+  // cudaMalloc calls when the main thread is running. In some GPUs this
+  // seems to cause failures if we do not so.
+  for(int i = 0; i < PREFETCH_COUNT; ++i) {
+    prefetch_[i].data_.mutable_cpu_data();
+    if (this->output_labels_) {
+      prefetch_[i].label_.mutable_cpu_data();
+    }
   }
+  switch (Caffe::mode()) {
+    case Caffe::CPU:
+      device_ = -1;
+      break;
+    case Caffe::GPU:
+#ifndef CPU_ONLY
+      for(int i = 0; i < PREFETCH_COUNT; ++i) {
+        prefetch_[i].data_.mutable_gpu_data();
+        if (this->output_labels_) {
+          prefetch_[i].label_.mutable_gpu_data();
+        }
+      }
+      CUDA_CHECK(cudaGetDevice(&device_));
+#endif
+      break;
+  }
+
   DLOG(INFO) << "Initializing prefetch";
-  this->CreatePrefetchThread();
+  this->phase_ = Caffe::phase();
+  this->data_transformer_.InitRand();
+  CHECK(StartInternalThread()) << "Thread execution failed";
   DLOG(INFO) << "Prefetch initialized.";
 }
 
 template <typename Dtype>
-void BasePrefetchingDataLayer<Dtype>::CreatePrefetchThread() {
-  this->phase_ = Caffe::phase();
-  this->data_transformer_.InitRand();
-  CHECK(StartInternalThread()) << "Thread execution failed";
-}
+void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
+#ifndef CPU_ONLY
+  cudaStream_t stream;
+  if(device_ >= 0) {
+    CUDA_CHECK(cudaSetDevice(device_));
+    cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
+  }
+#endif
 
-template <typename Dtype>
-void BasePrefetchingDataLayer<Dtype>::JoinPrefetchThread() {
-  CHECK(WaitForInternalThreadToExit()) << "Thread joining failed";
+  try {
+    while(!must_stop()) {
+      Batch<Dtype>* batch = prefetch_free_.pop();
+      load_batch(batch);
+#ifndef CPU_ONLY
+      if(device_ >= 0) {
+        batch->data_.data().get()->async_gpu_push(stream);
+        cudaStreamSynchronize(stream);
+      }
+#endif
+      prefetch_full_.push(batch);
+    }
+  } catch (boost::thread_interrupted&) {
+    // Interrupted exception is expected on shutdown
+  }
 }
 
 template <typename Dtype>
 void BasePrefetchingDataLayer<Dtype>::Forward_cpu(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
-  // First, join the thread
-  JoinPrefetchThread();
-  DLOG(INFO) << "Thread joined";
-  // Copy the data
-  caffe_copy(prefetch_data_.count(), prefetch_data_.cpu_data(),
-             top[0]->mutable_cpu_data());
-  DLOG(INFO) << "Prefetch copied";
+  Batch<Dtype>* batch = prefetch_full_.pop("Data layer prefetch queue empty");
+
+  caffe_copy(batch->data_.count(), batch->data_.cpu_data(),
+      top[0]->mutable_cpu_data());
   if (this->output_labels_) {
-    caffe_copy(prefetch_label_.count(), prefetch_label_.cpu_data(),
-               top[1]->mutable_cpu_data());
+    caffe_copy(batch->label_.count(), batch->label_.cpu_data(),
+        top[1]->mutable_cpu_data());
   }
-  // Start a new prefetch thread
-  DLOG(INFO) << "CreatePrefetchThread";
-  CreatePrefetchThread();
+
+  prefetch_free_.push(batch);
 }
 
 #ifdef CPU_ONLY
@@ -79,6 +121,7 @@ STUB_GPU_FORWARD(BasePrefetchingDataLayer, Forward);
 #endif
 
 INSTANTIATE_CLASS(BaseDataLayer);
+INSTANTIATE_CLASS(Batch);
 INSTANTIATE_CLASS(BasePrefetchingDataLayer);
 
 }  // namespace caffe

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -1,9 +1,11 @@
 #include <opencv2/core/core.hpp>
 
 #include <stdint.h>
+#include <sys/stat.h>
 
 #include <string>
 #include <vector>
+#include <map>
 
 #include "caffe/common.hpp"
 #include "caffe/data_layers.hpp"
@@ -17,28 +19,40 @@
 
 namespace caffe {
 
-template <typename Dtype>
-DataLayer<Dtype>::~DataLayer<Dtype>() {
-  this->JoinPrefetchThread();
-  // clean up the dataset resources
-  dataset_->close();
+map<string, weak_ptr<DataLoader::Body> > DataLoader::instances_;
+boost::mutex DataLoader::instances_mutex_;
+
+DataLoader::DataLoader(const DataParameter& param, int index):
+    source_(param.source(index)) {
+  // Makes sure create only one body per source
+  boost::mutex::scoped_lock lock(instances_mutex_);
+  weak_ptr<Body> body = instances_[source_];
+  body_ = body.lock();
+  if (!body_) {
+    body_.reset(new Body(param, index));
+    instances_[source_] = weak_ptr<Body>(body_);
+  }
 }
 
-template <typename Dtype>
-void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top) {
+DataLoader::~DataLoader() {
+  boost::mutex::scoped_lock lock(instances_mutex_);
+  body_.reset();
+  if (instances_[source_].expired())
+    instances_.erase(source_);
+}
+
+DataLoader::Body::Body(const DataParameter& param, int index) {
   // Initialize DB
-  dataset_ = DatasetFactory<string, Datum>(
-      this->layer_param_.data_param().backend());
-  const string& source = this->layer_param_.data_param().source();
-  LOG(INFO) << "Opening dataset " << source;
-  CHECK(dataset_->open(source, Dataset<string, Datum>::ReadOnly));
+  DataParameter_DB backend = param.backend_size() ?
+      param.backend(index) : DataParameter::LEVELDB;
+  dataset_ = DatasetFactory<string, Datum>(backend);
+  LOG(INFO) << "Opening dataset " << param.source(index);
+  CHECK(dataset_->open(param.source(index), Dataset<string, Datum>::ReadOnly));
   iter_ = dataset_->begin();
 
-  // Check if we would need to randomly skip a few data points
-  if (this->layer_param_.data_param().rand_skip()) {
-    unsigned int skip = caffe_rng_rand() %
-                        this->layer_param_.data_param().rand_skip();
+  // Check if we need to randomly skip a few data points
+  if (param.rand_skip()) {
+    unsigned int skip = caffe_rng_rand() % param.rand_skip();
     LOG(INFO) << "Skipping first " << skip << " data points.";
     while (skip-- > 0) {
       if (++iter_ == dataset_->end()) {
@@ -46,63 +60,152 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       }
     }
   }
-  // Read a data point, and use it to initialize the top blob.
-  CHECK(iter_ != dataset_->end());
-  Datum datum = iter_->value;
 
-  if (DecodeDatum(&datum)) {
+  // Add prefetch datums to layer free queue
+  int prefetch = param.prefetch() * param.batch_size();
+  for(int i = 0; i < prefetch; ++i) {
+    free_.push(new Datum());
+  }
+
+  CHECK(StartInternalThread()) << "DataLoader thread start failed";
+}
+
+DataLoader::Body::~Body() {
+  CHECK(StopInternalThread()) << "DataLoader thread stop failed";
+  Datum* datum;
+  while(free_.try_pop(datum)) {
+    delete datum;
+  }
+  while(full_.try_pop(datum)) {
+    delete datum;
+  }
+  // clean up the dataset resources
+  dataset_->close();
+}
+
+void DataLoader::Body::InternalThreadEntry() {
+  try {
+    while(!must_stop()) {
+      CHECK(iter_ != dataset_->end());
+
+      Datum* datum = free_.pop();
+      // TODO deserialize in-place instead of copy?
+      datum->CopyFrom(iter_->value);
+      full_.push(datum);
+
+      ++iter_;
+      if (iter_ == dataset_->end()) {
+        iter_ = dataset_->begin();
+      }
+    }
+  } catch (boost::thread_interrupted&) {
+    // Interrupted exception is expected on shutdown
+  }
+}
+
+static unsigned int get_datalayer_specific_random_seed() {
+  unsigned int seed = Caffe::get_random_seed();
+  if(!seed) {
+    seed = caffe_rng_rand();
+  }
+  return seed + 87267527;
+}
+
+template <typename Dtype>
+DataLayer<Dtype>::DataLayer(const LayerParameter& param)
+  : BasePrefetchingDataLayer<Dtype>(param),
+    rand_engine_(get_datalayer_specific_random_seed()) {
+  const DataParameter& data = param.data_param();
+  if (data.backend_size()) {
+    CHECK(data.source().size() == data.backend().size())
+      << "Invalid DataParameter, there should be one backend per source";
+  }
+  if (data.probability_size()) {
+    CHECK(data.source().size() == data.backend().size())
+      << "Invalid DataParameter, there should be one probability per source";
+    float sum = 0;
+    for(int i = 0; i < data.probability().size(); ++i) {
+      sum += data.probability(i);
+    }
+    CHECK(fabsf(sum - 1.0f) < 1e-6f)
+      << "Invalid DataParameter, probabilities do not sum to 1";
+  }
+  for(int i = 0; i < data.source().size(); ++i) {
+    DataLoader* ld = new DataLoader(data, i);
+    loaders_.push_back(shared_ptr<DataLoader>(ld));
+  }
+}
+
+template <typename Dtype>
+DataLayer<Dtype>::~DataLayer() {
+  CHECK(this->StopInternalThread()) << "Stop thread failed";
+}
+
+template <typename Dtype>
+void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+
+  // Look at first data point to initialize the top blob.
+  Datum* datum = loaders_[0].get()->full().peek();
+
+  if (DecodeDatum(datum)) {
     LOG(INFO) << "Decoding Datum";
   }
   // image
-  int crop_size = this->layer_param_.transform_param().crop_size();
+  const int crop_size = this->layer_param_.transform_param().crop_size();
+  const int batch_size = this->layer_param_.data_param().batch_size();
   if (crop_size > 0) {
-    top[0]->Reshape(this->layer_param_.data_param().batch_size(),
-                       datum.channels(), crop_size, crop_size);
-    this->prefetch_data_.Reshape(this->layer_param_.data_param().batch_size(),
-        datum.channels(), crop_size, crop_size);
-    this->transformed_data_.Reshape(1, datum.channels(), crop_size, crop_size);
+    top[0]->Reshape(batch_size, datum->channels(), crop_size, crop_size);
+    for(int i = 0; i < this->PREFETCH_COUNT; ++i) {
+	    this->prefetch_[i].data_.Reshape(batch_size, datum->channels(),
+	        crop_size, crop_size);
+	  }
+    this->transformed_data_.Reshape(1, datum->channels(),
+        crop_size, crop_size);
   } else {
-    top[0]->Reshape(
-        this->layer_param_.data_param().batch_size(), datum.channels(),
-        datum.height(), datum.width());
-    this->prefetch_data_.Reshape(this->layer_param_.data_param().batch_size(),
-        datum.channels(), datum.height(), datum.width());
-    this->transformed_data_.Reshape(1, datum.channels(),
-      datum.height(), datum.width());
+    top[0]->Reshape(batch_size, datum->channels(),
+        datum->height(), datum->width());
+    for(int i = 0; i < this->PREFETCH_COUNT; ++i) {
+    	this->prefetch_[i].data_.Reshape(batch_size, datum->channels(),
+    	    datum->height(), datum->width());
+    }
+    this->transformed_data_.Reshape(1, datum->channels(),
+        datum->height(), datum->width());
   }
   LOG(INFO) << "output data size: " << top[0]->num() << ","
       << top[0]->channels() << "," << top[0]->height() << ","
       << top[0]->width();
   // label
   if (this->output_labels_) {
-    top[1]->Reshape(this->layer_param_.data_param().batch_size(), 1, 1, 1);
-    this->prefetch_label_.Reshape(this->layer_param_.data_param().batch_size(),
-        1, 1, 1);
+    top[1]->Reshape(batch_size, 1, 1, 1);
+    for(int i = 0; i < this->PREFETCH_COUNT; ++i) {
+      this->prefetch_[i].label_.Reshape(batch_size, 1, 1, 1);
+    }
   }
 }
 
-// This function is used to create a thread that prefetches the data.
+// This function is called on prefetch thread
 template <typename Dtype>
-void DataLayer<Dtype>::InternalThreadEntry() {
+void DataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
   CPUTimer batch_timer;
   batch_timer.Start();
   double read_time = 0;
   double trans_time = 0;
   CPUTimer timer;
-  CHECK(this->prefetch_data_.count());
+  CHECK(batch->data_.count());
   CHECK(this->transformed_data_.count());
-  Dtype* top_data = this->prefetch_data_.mutable_cpu_data();
+  Dtype* top_data = batch->data_.mutable_cpu_data();
   Dtype* top_label = NULL;  // suppress warnings about uninitialized variables
 
   if (this->output_labels_) {
-    top_label = this->prefetch_label_.mutable_cpu_data();
+    top_label = batch->label_.mutable_cpu_data();
   }
+
   const int batch_size = this->layer_param_.data_param().batch_size();
   for (int item_id = 0; item_id < batch_size; ++item_id) {
     timer.Start();
-    // get a blob
-    CHECK(iter_ != dataset_->end());
-    const Datum& datum = iter_->value;
+    DataLoader* loader = next_loader();
+    const Datum& datum = *(loader->full().pop("Waiting on data loader"));
 
     cv::Mat cv_img;
     if (datum.encoded()) {
@@ -112,7 +215,7 @@ void DataLayer<Dtype>::InternalThreadEntry() {
     timer.Start();
 
     // Apply data transformations (mirror, scale, crop...)
-    int offset = this->prefetch_data_.offset(item_id);
+    int offset = batch->data_.offset(item_id);
     this->transformed_data_.set_cpu_data(top_data + offset);
     if (datum.encoded()) {
       this->data_transformer_.Transform(cv_img, &(this->transformed_data_));
@@ -123,16 +226,40 @@ void DataLayer<Dtype>::InternalThreadEntry() {
       top_label[item_id] = datum.label();
     }
     trans_time += timer.MicroSeconds();
-    // go to the next iter
-    ++iter_;
-    if (iter_ == dataset_->end()) {
-      iter_ = dataset_->begin();
-    }
+
+    loader->free().push((Datum*) &datum);
   }
   batch_timer.Stop();
   DLOG(INFO) << "Prefetch batch: " << batch_timer.MilliSeconds() << " ms.";
   DLOG(INFO) << "     Read time: " << read_time / 1000 << " ms.";
   DLOG(INFO) << "Transform time: " << trans_time / 1000 << " ms.";
+}
+
+// This function is called on prefetch thread
+template <typename Dtype>
+DataLoader* DataLayer<Dtype>::next_loader() {
+  const DataParameter& data = this->layer_param().data_param();
+  // Default case without probabilities, try to find a loader with
+  // data ready, or return first one
+  if (data.probability_size() == 0) {
+    for(int i = 0; i < loaders_.size(); ++i) {
+      DataLoader* loader = loaders_[i].get();
+      if(!loader->full().empty()) {
+        return loader;
+      }
+    }
+  } else {
+    // Pick loader randomly with probability
+    float rand = rand_(rand_engine_);
+    for(int i = 0; i < data.probability().size(); ++i) {
+      rand -= data.probability(i);
+      if(rand < 0) {
+        return loaders_[i].get();
+      }
+    }
+  }
+  // If no data ready, or rounding error on probabilities
+  return loaders_[0].get();
 }
 
 INSTANTIATE_CLASS(DataLayer);

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -17,7 +17,7 @@ namespace caffe {
 
 template <typename Dtype>
 ImageDataLayer<Dtype>::~ImageDataLayer<Dtype>() {
-  this->JoinPrefetchThread();
+  CHECK(this->StopInternalThread()) << "Stop thread failed";
 }
 
 template <typename Dtype>
@@ -70,11 +70,14 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   const int batch_size = this->layer_param_.image_data_param().batch_size();
   if (crop_size > 0) {
     top[0]->Reshape(batch_size, channels, crop_size, crop_size);
-    this->prefetch_data_.Reshape(batch_size, channels, crop_size, crop_size);
+    for(int i = 0; i < this->PREFETCH_COUNT; ++i)
+	    this->prefetch_[i].data_.Reshape(batch_size, channels,
+	        crop_size, crop_size);
     this->transformed_data_.Reshape(1, channels, crop_size, crop_size);
   } else {
     top[0]->Reshape(batch_size, channels, height, width);
-    this->prefetch_data_.Reshape(batch_size, channels, height, width);
+    for(int i = 0; i < this->PREFETCH_COUNT; ++i)
+	    this->prefetch_[i].data_.Reshape(batch_size, channels, height, width);
     this->transformed_data_.Reshape(1, channels, height, width);
   }
   LOG(INFO) << "output data size: " << top[0]->num() << ","
@@ -82,7 +85,8 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       << top[0]->width();
   // label
   top[1]->Reshape(batch_size, 1, 1, 1);
-  this->prefetch_label_.Reshape(batch_size, 1, 1, 1);
+  for(int i = 0; i < this->PREFETCH_COUNT; ++i)
+    this->prefetch_[i].label_.Reshape(batch_size, 1, 1, 1);
 }
 
 template <typename Dtype>
@@ -92,18 +96,18 @@ void ImageDataLayer<Dtype>::ShuffleImages() {
   shuffle(lines_.begin(), lines_.end(), prefetch_rng);
 }
 
-// This function is used to create a thread that prefetches the data.
+// This function is called on prefetch thread
 template <typename Dtype>
-void ImageDataLayer<Dtype>::InternalThreadEntry() {
+void ImageDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
   CPUTimer batch_timer;
   batch_timer.Start();
   double read_time = 0;
   double trans_time = 0;
   CPUTimer timer;
-  CHECK(this->prefetch_data_.count());
+  CHECK(batch->data_.count());
   CHECK(this->transformed_data_.count());
-  Dtype* top_data = this->prefetch_data_.mutable_cpu_data();
-  Dtype* top_label = this->prefetch_label_.mutable_cpu_data();
+  Dtype* top_data = batch->data_.mutable_cpu_data();
+  Dtype* top_label = batch->label_.mutable_cpu_data();
   ImageDataParameter image_data_param = this->layer_param_.image_data_param();
   const int batch_size = image_data_param.batch_size();
   const int new_height = image_data_param.new_height();
@@ -125,7 +129,7 @@ void ImageDataLayer<Dtype>::InternalThreadEntry() {
     read_time += timer.MicroSeconds();
     timer.Start();
     // Apply transformations (mirror, crop...) to the image
-    int offset = this->prefetch_data_.offset(item_id);
+    int offset = batch->data_.offset(item_id);
     this->transformed_data_.set_cpu_data(top_data + offset);
     this->data_transformer_.Transform(cv_img, &(this->transformed_data_));
     trans_time += timer.MicroSeconds();

--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -30,7 +30,7 @@ namespace caffe {
 
 template <typename Dtype>
 WindowDataLayer<Dtype>::~WindowDataLayer<Dtype>() {
-  this->JoinPrefetchThread();
+  CHECK(this->StopInternalThread()) << "Stop thread failed";
 }
 
 template <typename Dtype>
@@ -174,14 +174,16 @@ void WindowDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   CHECK_GT(crop_size, 0);
   const int batch_size = this->layer_param_.window_data_param().batch_size();
   top[0]->Reshape(batch_size, channels, crop_size, crop_size);
-  this->prefetch_data_.Reshape(batch_size, channels, crop_size, crop_size);
+  for(int i = 0; i < this->PREFETCH_COUNT; ++i)
+    this->prefetch_[i].data_.Reshape(batch_size, channels, crop_size, crop_size);
 
   LOG(INFO) << "output data size: " << top[0]->num() << ","
       << top[0]->channels() << "," << top[0]->height() << ","
       << top[0]->width();
   // label
   top[1]->Reshape(batch_size, 1, 1, 1);
-  this->prefetch_label_.Reshape(batch_size, 1, 1, 1);
+  for(int i = 0; i < this->PREFETCH_COUNT; ++i)
+    this->prefetch_[i].label_.Reshape(batch_size, 1, 1, 1);
 
   // data mean
   has_mean_file_ = this->transform_param_.has_mean_file();
@@ -219,9 +221,9 @@ unsigned int WindowDataLayer<Dtype>::PrefetchRand() {
   return (*prefetch_rng)();
 }
 
-// Thread fetching the data
+// This function is called on prefetch thread
 template <typename Dtype>
-void WindowDataLayer<Dtype>::InternalThreadEntry() {
+void WindowDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
   // At each iteration, sample N windows where N*p are foreground (object)
   // windows and N*(1-p) are background (non-object) windows
   CPUTimer batch_timer;
@@ -229,8 +231,8 @@ void WindowDataLayer<Dtype>::InternalThreadEntry() {
   double read_time = 0;
   double trans_time = 0;
   CPUTimer timer;
-  Dtype* top_data = this->prefetch_data_.mutable_cpu_data();
-  Dtype* top_label = this->prefetch_label_.mutable_cpu_data();
+  Dtype* top_data = batch->data_.mutable_cpu_data();
+  Dtype* top_label = batch->label_.mutable_cpu_data();
   const Dtype scale = this->layer_param_.window_data_param().scale();
   const int batch_size = this->layer_param_.window_data_param().batch_size();
   const int context_pad = this->layer_param_.window_data_param().context_pad();
@@ -254,7 +256,7 @@ void WindowDataLayer<Dtype>::InternalThreadEntry() {
   bool use_square = (crop_mode == "square") ? true : false;
 
   // zero out batch
-  caffe_set(this->prefetch_data_.count(), Dtype(0), top_data);
+  caffe_set(batch->data_.count(), Dtype(0), top_data);
 
   const int num_fg = static_cast<int>(static_cast<float>(batch_size)
       * fg_fraction);

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -417,13 +417,14 @@ message ConvolutionParameter {
 }
 
 // Message that stores parameters used by DataLayer
+// next available ID: 11 (last added: probability)
 message DataParameter {
   enum DB {
     LEVELDB = 0;
     LMDB = 1;
   }
   // Specify the data source.
-  optional string source = 1;
+  repeated string source = 1;
   // Specify the batch size.
   optional uint32 batch_size = 4;
   // The rand_skip variable is for the data layer to skip a few data points
@@ -431,7 +432,7 @@ message DataParameter {
   // point would be set as rand_skip * rand(0,1). Note that rand_skip should not
   // be larger than the number of keys in the database.
   optional uint32 rand_skip = 7 [default = 0];
-  optional DB backend = 8 [default = LEVELDB];
+  repeated DB backend = 8;
   // DEPRECATED. See TransformationParameter. For data pre-processing, we can do
   // simple scaling and subtracting the data mean, if provided. Note that the
   // mean subtraction is always carried out before scaling.
@@ -443,6 +444,14 @@ message DataParameter {
   // DEPRECATED. See TransformationParameter. Specify if we want to randomly mirror
   // data.
   optional bool mirror = 6 [default = false];
+  // Prefetch queue (Number of batches to prefetch to host memory
+  // from each source, increase if read bandwidth has glitches).
+  optional uint32 prefetch = 9 [default = 4];
+  // If multiple sources are given, a probability can be set on each source.
+  // Samples will be picked from it with given probability, and the label will
+  // be set to the source index. This allows experimenting with different
+  // class ratios at runtime without rebuilding datasets.
+  repeated float probability = 10;
 }
 
 // Message that stores parameters used by DropoutLayer

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -108,6 +108,17 @@ void* SyncedMemory::mutable_gpu_data() {
 #endif
 }
 
+#ifndef CPU_ONLY
+void SyncedMemory::async_gpu_push(const cudaStream_t& stream) {
+  CHECK(head_ == HEAD_AT_CPU);
+  if (gpu_ptr_ == NULL) {
+    CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
+  }
+  CUDA_CHECK(cudaMemcpyAsync(gpu_ptr_, cpu_ptr_, size_, cudaMemcpyHostToDevice, stream));
+  // Assume caller will synchronize on the stream before use
+  head_ = SYNCED;
+}
+#endif
 
 }  // namespace caffe
 

--- a/src/caffe/test/test_data_layer.cpp
+++ b/src/caffe/test/test_data_layer.cpp
@@ -21,14 +21,16 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
 
  protected:
   DataLayerTest()
-      : backend_(DataParameter_DB_LEVELDB),
-        blob_top_data_(new Blob<Dtype>()),
+      : blob_top_data_(new Blob<Dtype>()),
         blob_top_label_(new Blob<Dtype>()),
         seed_(1701) {}
   virtual void SetUp() {
-    filename_.reset(new string());
-    MakeTempDir(filename_.get());
-    *filename_ += "/db";
+    for (int i = 0; i < BACKENDS_COUNT; ++i) {
+      backends_[i] = DataParameter_DB_LEVELDB,
+      filenames_[i].reset(new string());
+      MakeTempDir(filenames_[i].get());
+      *filenames_[i] += "/db";
+    }
     blob_top_vec_.push_back(blob_top_data_);
     blob_top_vec_.push_back(blob_top_label_);
   }
@@ -36,13 +38,13 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
   // Fill the LevelDB with data: if unique_pixels, each pixel is unique but
   // all images are the same; else each image is unique but all pixels within
   // an image are the same.
-  void Fill(const bool unique_pixels, DataParameter_DB backend) {
-    backend_ = backend;
-    LOG(INFO) << "Using temporary dataset " << *filename_;
+  void Fill(const bool unique_pixels, DataParameter_DB backend, int index = 0) {
+    backends_[index] = backend;
+    LOG(INFO) << "Using temporary dataset " << *(filenames_[index]);
     shared_ptr<Dataset<string, Datum> > dataset =
-        DatasetFactory<string, Datum>(backend_);
-    CHECK(dataset->open(*filename_, Dataset<string, Datum>::New));
-    for (int i = 0; i < 5; ++i) {
+        DatasetFactory<string, Datum>(backend);
+    CHECK(dataset->open(*(filenames_[index]), Dataset<string, Datum>::New));
+    for (int i = 0; i < BATCH_SIZE; ++i) {
       Datum datum;
       datum.set_label(i);
       datum.set_channels(2);
@@ -65,9 +67,9 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
     const Dtype scale = 3;
     LayerParameter param;
     DataParameter* data_param = param.mutable_data_param();
-    data_param->set_batch_size(5);
-    data_param->set_source(filename_->c_str());
-    data_param->set_backend(backend_);
+    data_param->set_batch_size(BATCH_SIZE);
+    data_param->add_source(filenames_[0]->c_str());
+    data_param->add_backend(backends_[0]);
 
     TransformationParameter* transform_param =
         param.mutable_transform_param();
@@ -86,10 +88,10 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
 
     for (int iter = 0; iter < 100; ++iter) {
       layer.Forward(blob_bottom_vec_, blob_top_vec_);
-      for (int i = 0; i < 5; ++i) {
+      for (int i = 0; i < BATCH_SIZE; ++i) {
         EXPECT_EQ(i, blob_top_label_->cpu_data()[i]);
       }
-      for (int i = 0; i < 5; ++i) {
+      for (int i = 0; i < BATCH_SIZE; ++i) {
         for (int j = 0; j < 24; ++j) {
           EXPECT_EQ(scale * i, blob_top_data_->cpu_data()[i * 24 + j])
               << "debug: iter " << iter << " i " << i << " j " << j;
@@ -100,13 +102,14 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
 
   void TestReadCrop() {
     const Dtype scale = 3;
+    const int batch = BATCH_SIZE;
     LayerParameter param;
     Caffe::set_random_seed(1701);
 
     DataParameter* data_param = param.mutable_data_param();
-    data_param->set_batch_size(5);
-    data_param->set_source(filename_->c_str());
-    data_param->set_backend(backend_);
+    data_param->set_batch_size(batch);
+    data_param->add_source(filenames_[0]->c_str());
+    data_param->add_backend(backends_[0]);
 
     TransformationParameter* transform_param =
         param.mutable_transform_param();
@@ -115,22 +118,22 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
 
     DataLayer<Dtype> layer(param);
     layer.SetUp(blob_bottom_vec_, blob_top_vec_);
-    EXPECT_EQ(blob_top_data_->num(), 5);
+    EXPECT_EQ(blob_top_data_->num(), batch);
     EXPECT_EQ(blob_top_data_->channels(), 2);
     EXPECT_EQ(blob_top_data_->height(), 1);
     EXPECT_EQ(blob_top_data_->width(), 1);
-    EXPECT_EQ(blob_top_label_->num(), 5);
+    EXPECT_EQ(blob_top_label_->num(), batch);
     EXPECT_EQ(blob_top_label_->channels(), 1);
     EXPECT_EQ(blob_top_label_->height(), 1);
     EXPECT_EQ(blob_top_label_->width(), 1);
 
     for (int iter = 0; iter < 2; ++iter) {
       layer.Forward(blob_bottom_vec_, blob_top_vec_);
-      for (int i = 0; i < 5; ++i) {
+      for (int i = 0; i < batch; ++i) {
         EXPECT_EQ(i, blob_top_label_->cpu_data()[i]);
       }
       int num_with_center_value = 0;
-      for (int i = 0; i < 5; ++i) {
+      for (int i = 0; i < batch; ++i) {
         for (int j = 0; j < 2; ++j) {
           const Dtype center_value = scale * (j ? 17 : 5);
           num_with_center_value +=
@@ -154,9 +157,9 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
   void TestReadCropTrainSequenceSeeded() {
     LayerParameter param;
     DataParameter* data_param = param.mutable_data_param();
-    data_param->set_batch_size(5);
-    data_param->set_source(filename_->c_str());
-    data_param->set_backend(backend_);
+    data_param->set_batch_size(BATCH_SIZE);
+    data_param->add_source(filenames_[0]->c_str());
+    data_param->add_backend(backends_[0]);
 
     TransformationParameter* transform_param =
         param.mutable_transform_param();
@@ -171,11 +174,11 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
       layer1.SetUp(blob_bottom_vec_, blob_top_vec_);
       for (int iter = 0; iter < 2; ++iter) {
         layer1.Forward(blob_bottom_vec_, blob_top_vec_);
-        for (int i = 0; i < 5; ++i) {
+        for (int i = 0; i < BATCH_SIZE; ++i) {
           EXPECT_EQ(i, blob_top_label_->cpu_data()[i]);
         }
         vector<Dtype> iter_crop_sequence;
-        for (int i = 0; i < 5; ++i) {
+        for (int i = 0; i < BATCH_SIZE; ++i) {
           for (int j = 0; j < 2; ++j) {
             iter_crop_sequence.push_back(
                 blob_top_data_->cpu_data()[i * 2 + j]);
@@ -192,10 +195,10 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
     layer2.SetUp(blob_bottom_vec_, blob_top_vec_);
     for (int iter = 0; iter < 2; ++iter) {
       layer2.Forward(blob_bottom_vec_, blob_top_vec_);
-      for (int i = 0; i < 5; ++i) {
+      for (int i = 0; i < BATCH_SIZE; ++i) {
         EXPECT_EQ(i, blob_top_label_->cpu_data()[i]);
       }
-      for (int i = 0; i < 5; ++i) {
+      for (int i = 0; i < BATCH_SIZE; ++i) {
         for (int j = 0; j < 2; ++j) {
           EXPECT_EQ(crop_sequence[iter][i * 2 + j],
                     blob_top_data_->cpu_data()[i * 2 + j])
@@ -208,9 +211,9 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
   void TestReadCropTrainSequenceUnseeded() {
     LayerParameter param;
     DataParameter* data_param = param.mutable_data_param();
-    data_param->set_batch_size(5);
-    data_param->set_source(filename_->c_str());
-    data_param->set_backend(backend_);
+    data_param->set_batch_size(BATCH_SIZE);
+    data_param->add_source(filenames_[0]->c_str());
+    data_param->add_backend(backends_[0]);
 
     TransformationParameter* transform_param =
         param.mutable_transform_param();
@@ -226,11 +229,11 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
       layer1.SetUp(blob_bottom_vec_, blob_top_vec_);
       for (int iter = 0; iter < 2; ++iter) {
         layer1.Forward(blob_bottom_vec_, blob_top_vec_);
-        for (int i = 0; i < 5; ++i) {
+        for (int i = 0; i < BATCH_SIZE; ++i) {
           EXPECT_EQ(i, blob_top_label_->cpu_data()[i]);
         }
         vector<Dtype> iter_crop_sequence;
-        for (int i = 0; i < 5; ++i) {
+        for (int i = 0; i < BATCH_SIZE; ++i) {
           for (int j = 0; j < 2; ++j) {
             iter_crop_sequence.push_back(
                 blob_top_data_->cpu_data()[i * 2 + j]);
@@ -247,11 +250,11 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
     layer2.SetUp(blob_bottom_vec_, blob_top_vec_);
     for (int iter = 0; iter < 2; ++iter) {
       layer2.Forward(blob_bottom_vec_, blob_top_vec_);
-      for (int i = 0; i < 5; ++i) {
+      for (int i = 0; i < BATCH_SIZE; ++i) {
         EXPECT_EQ(i, blob_top_label_->cpu_data()[i]);
       }
       int num_sequence_matches = 0;
-      for (int i = 0; i < 5; ++i) {
+      for (int i = 0; i < BATCH_SIZE; ++i) {
         for (int j = 0; j < 2; ++j) {
           num_sequence_matches += (crop_sequence[iter][i * 2 + j] ==
                                    blob_top_data_->cpu_data()[i * 2 + j]);
@@ -261,10 +264,90 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
     }
   }
 
+  void TestProbabilities() {
+    LayerParameter param;
+    DataParameter* data_param = param.mutable_data_param();
+    data_param->set_batch_size(BATCH_SIZE);
+    for (int i = 0; i < BACKENDS_COUNT; ++i) {
+      data_param->add_source(filenames_[i]->c_str());
+      data_param->add_backend(
+          i % 2 ? DataParameter_DB_LEVELDB : DataParameter_DB_LMDB);
+      data_param->add_probability(0);
+    }
+
+    Caffe::set_random_seed(544432);
+    int counts[BACKENDS_COUNT];
+
+    // Balanced two
+    data_param->set_probability(0, .5f);
+    data_param->set_probability(1, .5f);
+    memset(counts, 0, sizeof(counts));
+    probabilities_run(param, counts);
+    EXPECT_EQ(58, counts[0]);
+    EXPECT_EQ(57, counts[1]);
+    EXPECT_EQ(0, counts[2]);
+
+    // Balanced three
+    data_param->set_probability(0, .33333333f);
+    data_param->set_probability(1, .33333333f);
+    data_param->set_probability(2, .33333333f);
+    memset(counts, 0, sizeof(counts));
+    probabilities_run(param, counts);
+    EXPECT_EQ(43, counts[0]);
+    EXPECT_EQ(27, counts[1]);
+    EXPECT_EQ(45, counts[2]);
+
+    // Only one
+    data_param->set_probability(0, 0);
+    data_param->set_probability(1, 0);
+    data_param->set_probability(2, 1);
+    memset(counts, 0, sizeof(counts));
+    probabilities_run(param, counts);
+    EXPECT_EQ(0, counts[0]);
+    EXPECT_EQ(0, counts[1]);
+    EXPECT_EQ(115, counts[2]);
+  }
+
+  void probabilities_run(LayerParameter param, int* counts) {
+    const int batch = BATCH_SIZE;
+    DataLayer<Dtype> layer(param);
+    layer.SetUp(blob_bottom_vec_, blob_top_vec_);
+    EXPECT_EQ(blob_top_data_->num(), batch);
+    EXPECT_EQ(blob_top_data_->channels(), 2);
+    EXPECT_EQ(blob_top_data_->height(), 3);
+    EXPECT_EQ(blob_top_data_->width(), 4);
+    EXPECT_EQ(blob_top_label_->num(), batch);
+    EXPECT_EQ(blob_top_label_->channels(), 1);
+    EXPECT_EQ(blob_top_label_->height(), 1);
+    EXPECT_EQ(blob_top_label_->width(), 1);
+
+    const int examples = 100;
+    for (int iter = 0; iter < examples / batch; ++iter) {
+      layer.Forward(blob_bottom_vec_, blob_top_vec_);
+    }
+
+    for(;;) {
+      int total = 0;
+      for (int i = 0; i < BACKENDS_COUNT; ++i) {
+        DataLoader loader(param.data_param(), i);
+        counts[i] = loader.full().pops();
+        total += counts[i];
+      }
+      // Wait until prefetch queue refills, for reproducibility
+      const int prefetch = BasePrefetchingDataLayer<TypeParam>::PREFETCH_COUNT;
+      if(total == examples + prefetch * batch) {
+        break;
+      }
+      usleep(1000);
+    }
+  }
+
   virtual ~DataLayerTest() { delete blob_top_data_; delete blob_top_label_; }
 
-  DataParameter_DB backend_;
-  shared_ptr<string> filename_;
+  static const int BATCH_SIZE = 5;
+  static const int BACKENDS_COUNT = 3;
+  DataParameter_DB backends_[BACKENDS_COUNT];
+  shared_ptr<string> filenames_[BACKENDS_COUNT];
   Blob<Dtype>* const blob_top_data_;
   Blob<Dtype>* const blob_top_label_;
   vector<Blob<Dtype>*> blob_bottom_vec_;
@@ -348,6 +431,15 @@ TYPED_TEST(DataLayerTest, TestReadCropTestLMDB) {
   const bool unique_pixels = true;  // all images the same; pixels different
   this->Fill(unique_pixels, DataParameter_DB_LMDB);
   this->TestReadCrop();
+}
+
+TYPED_TEST(DataLayerTest, TestTwoProbabilities) {
+  Caffe::set_phase(Caffe::TEST);
+  const bool unique_pixels = true;  // all images the same; pixels different
+  this->Fill(unique_pixels, DataParameter_DB_LMDB, 0);
+  this->Fill(unique_pixels, DataParameter_DB_LEVELDB, 1);
+  this->Fill(unique_pixels, DataParameter_DB_LMDB, 2);
+  this->TestProbabilities();
 }
 
 }  // namespace caffe

--- a/src/caffe/test/test_internal_thread.cpp
+++ b/src/caffe/test/test_internal_thread.cpp
@@ -15,7 +15,7 @@ TEST_F(InternalThreadTest, TestStartAndExit) {
   EXPECT_FALSE(thread.is_started());
   EXPECT_TRUE(thread.StartInternalThread());
   EXPECT_TRUE(thread.is_started());
-  EXPECT_TRUE(thread.WaitForInternalThreadToExit());
+  EXPECT_TRUE(thread.StopInternalThread());
   EXPECT_FALSE(thread.is_started());
 }
 

--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -295,7 +295,7 @@ bool UpgradeLayerParameter(const LayerParameter& v0_layer_connection,
     }
     if (v0_layer_param.has_source()) {
       if (type == "data") {
-        layer_param->mutable_data_param()->set_source(v0_layer_param.source());
+        layer_param->mutable_data_param()->add_source(v0_layer_param.source());
       } else if (type == "hdf5_data") {
         layer_param->mutable_hdf5_data_param()->set_source(
             v0_layer_param.source());


### PR DESCRIPTION
A way to import a protobuf model into another one, by specifying a layer of type IMPORT. We went for a file system analogy, to allow referencing layers and blobs from different parts of the model:

* Imports are renamed to “name of the import layer/name”, e.g. “conv_pool1/relu”.
* Imported layers can reference layers and blobs from the importing network as a parent folder, e.g. “../data”, or using an absolute path: “/data”.
* By default names are relative references, so existing network definitions are fine. They will resolve all objects in the root folder.

Imports can be configured using ${variables}, that are applied during load using simple string replace.

We modified mnist/lenet_train_test.prototxt as an example, by exporting the Conv/Pool part as a module that is imported twice.

In lenet_train_test.prototxt:

<pre><code>
...
layers {
  name: "cp1"
  type: IMPORT
  import_param {
    net: "examples/mnist/lenet_conv_pool.prototxt"
    var { name: "bottom" value: "/data" }
    var { name: "num_output" value: "20" }
  }
}
layers {
  name: "cp2"
  type: IMPORT
  import_param {
    net: "examples/mnist/lenet_conv_pool.prototxt"
    var { name: "bottom" value: "../cp1/pool" }
    var { name: "num_output" value: "50" }
  }
}
…
</pre></code>

lenet_conv_pool.prototxt:

<pre><code>
layers {
  name: "conv"
  type: CONVOLUTION
  bottom: "${bottom}"
  top: "conv"
  blobs_lr: 1
  blobs_lr: 2
  convolution_param {
    num_output: ${num_output}
    kernel_size: 5
    stride: 1
    weight_filler {
      type: "xavier"
    }
    bias_filler {
      type: "constant"
    }
  }
}
layers {
  name: "pool"
  type: POOLING
  bottom: "conv"
  top: "pool"
  pooling_param {
    pool: MAX
    kernel_size: 2
    stride: 2
  }
}
</pre></code>