### PR TITLE
Display individual losses when forwarding net

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -38,7 +38,8 @@ class Net {
    *
    * You can get the input blobs using input_blobs().
    */
-  const vector<Blob<Dtype>*>& ForwardPrefilled(Dtype* loss = NULL);
+  const vector<Blob<Dtype>*>& ForwardPrefilled(Dtype* loss = NULL,
+          std::vector<std::pair<std::string, Dtype> >* loss_table = NULL);
 
   /**
    * The From and To variants of Forward and Backward operate on the
@@ -48,17 +49,22 @@ class Net {
    * the middle may be incorrect if all of the layers of a fan-in are not
    * included.
    */
-  Dtype ForwardFromTo(int start, int end);
-  Dtype ForwardFrom(int start);
-  Dtype ForwardTo(int end);
+  Dtype ForwardFromTo(int start, int end,
+          std::vector<std::pair<std::string, Dtype> >* loss_table = NULL);
+  Dtype ForwardFrom(int start,
+          std::vector<std::pair<std::string, Dtype> >* loss_table = NULL);
+  Dtype ForwardTo(int end,
+          std::vector<std::pair<std::string, Dtype> >* loss_table = NULL);
   /// @brief Run forward using a set of bottom blobs, and return the result.
   const vector<Blob<Dtype>*>& Forward(const vector<Blob<Dtype>* > & bottom,
-      Dtype* loss = NULL);
+      Dtype* loss = NULL,
+      std::vector<std::pair<std::string, Dtype> >* loss_table = NULL);
   /**
    * @brief Run forward using a serialized BlobProtoVector and return the
    *        result as a serialized BlobProtoVector
    */
-  string Forward(const string& input_blob_protos, Dtype* loss = NULL);
+  string Forward(const string& input_blob_protos, Dtype* loss = NULL,
+      std::vector<std::pair<std::string, Dtype> >* loss_table = NULL);
 
   /**
    * The network backward should take no input and output, since it solely
@@ -78,13 +84,14 @@ class Net {
    */
   void Reshape();
 
-  Dtype ForwardBackward(const vector<Blob<Dtype>* > & bottom) {
+  Dtype ForwardBackward(const vector<Blob<Dtype>* > & bottom,
+      std::vector<std::pair<std::string, Dtype> >* loss_table = NULL) {
     #ifdef TIMING
     Timer timer;
     timer.Start();
     #endif
     Dtype loss;
-    Forward(bottom, &loss);
+    Forward(bottom, &loss, loss_table);
     Backward();
     #ifdef TIMING
     LOG(INFO) << "ForwardBackward Time: " << timer.MilliSeconds() << "ms.";


### PR DESCRIPTION
When there are multiple loss layers, the solver will display the total loss as well as the individual losses to allow easier inspection.

Very useful if there are multiple loss layers because there can be a lot of problems. The different loss layers may reduce at vastly different speed, or certain type of loss dominates the total such that other layers are basically ignored, etc.

Sample output

```
I1016 14:38:03.321640 21826 solver.cpp:275] Iteration 0, Testing net (#0)
I1016 14:38:11.277034 21826 solver.cpp:326]     Test net output #0: accuracy = 0.00195312
I1016 14:38:11.370230 21826 solver.cpp:213] Iteration 0, loss = 9.92332
I1016 14:38:11.370256 21826 solver.cpp:217]     Layer "loss": 5.29832
I1016 14:38:11.370275 21826 solver.cpp:217]     Layer "intermediate_loss": 4.62499
I1016 14:38:11.370292 21826 solver.cpp:456] Iteration 0, lr = 0.03
I1016 14:38:16.585816 21826 solver.cpp:213] Iteration 20, loss = 8.80078
I1016 14:38:16.585873 21826 solver.cpp:217]     Layer "loss": 5.28885
I1016 14:38:16.585891 21826 solver.cpp:217]     Layer "intermediate_loss": 3.51193
I1016 14:38:16.585901 21826 solver.cpp:456] Iteration 20, lr = 0.03
I1016 14:38:21.799321 21826 solver.cpp:213] Iteration 40, loss = 8.25201
I1016 14:38:21.799370 21826 solver.cpp:217]     Layer "loss": 5.26909
I1016 14:38:21.799386 21826 solver.cpp:217]     Layer "intermediate_loss": 2.98292
```
