### PR TITLE
Fix matcaffe build on OS X with XCode 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,6 +417,11 @@ mat$(PROJECT): mat
 
 mat: $(MAT$(PROJECT)_SO)
 
+ifeq ($(OSX), 1)
+  OSXCXXLIBS = "/usr/lib/libstdc++.dylib"
+else
+  OSXCXXLIBS = ""
+endif
 $(MAT$(PROJECT)_SO): $(MAT$(PROJECT)_SRC) $(STATIC_NAME)
 	@ if [ -z "$(MATLAB_DIR)" ]; then \
 		echo "MATLAB_DIR must be specified in $(CONFIG_FILE)" \
@@ -426,7 +431,7 @@ $(MAT$(PROJECT)_SO): $(MAT$(PROJECT)_SRC) $(STATIC_NAME)
 	$(MATLAB_DIR)/bin/mex $(MAT$(PROJECT)_SRC) \
 			CXX="$(CXX)" \
 			CXXFLAGS="\$$CXXFLAGS $(MATLAB_CXXFLAGS)" \
-			CXXLIBS="\$$CXXLIBS $(STATIC_LINK_COMMAND) $(LDFLAGS) /usr/lib/libstdc++.dylib" -output $@
+			CXXLIBS="\$$CXXLIBS $(STATIC_LINK_COMMAND) $(LDFLAGS) $(OSXCXXLIBS)" -output $@
 	@ echo
 
 runtest: $(TEST_ALL_BIN) $(TEST_ALL_DYNLINK_BIN)


### PR DESCRIPTION
Fixes `vecLib` and `boost`/`string` issues in https://github.com/BVLC/caffe/issues/1212

The explicit reference to `/usr/lib/libstdc++.dylib` in the Makefile is potentially brittle if `libstdc++.dylib` is installed to a non-standard location; perhaps there's a more elegant way to make this change?

Tested on:
## Mac
- OS X 10.9.5
- XCode 6.0.1
- Matlab R2014a

```
$pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
package-id: com.apple.pkg.CLTools_Executables
version: 6.0.0.0.1.1410400753
volume: /
location: /
install-time: 1412278538
groups: com.apple.FindSystemFiles.pkg-group com.apple.DevToolsBoth.pkg-group com.apple.DevToolsNonRelocatableShared.pkg-group
```
## Ubuntu
- Ubuntu 14.04
- g++ 4.6
- Matlab R2014a
