### PR TITLE
Persistent transformations

### DIFF
--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -30,6 +30,17 @@ class DataTransformer {
   void InitRand();
 
   /**
+   * @brief Reset Transformation state. This would cause to generate random params
+   *    the next Transform is called
+   */
+  void ResetState();
+
+  /**
+   * @brief Tells if the Transformation is persistent or not
+   */
+  inline bool IsPersistent() { return state_.persistent; }
+
+  /**
    * @brief Applies the transformation defined in the data layer's
    * transform_param block to the data.
    *
@@ -92,15 +103,28 @@ class DataTransformer {
    */
   virtual int Rand(int n);
 
+  struct TransformState {
+    bool persistent;
+    bool reset;
+    bool do_mirror;
+    int h_off;
+    int w_off;
+    int height;
+    int width;
+  };
+
   void Transform(const Datum& datum, Dtype* transformed_data);
+
+  void UpdateState(const int height, const int width);
+
   // Tranformation parameters
   TransformationParameter param_;
-
 
   shared_ptr<Caffe::RNG> rng_;
   Caffe::Phase phase_;
   Blob<Dtype> data_mean_;
   vector<Dtype> mean_values_;
+  TransformState state_;
 };
 
 }  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -359,6 +359,9 @@ message TransformationParameter {
   // or can be repeated the same number of times as channels
   // (would subtract them from the corresponding channel)
   repeated float mean_value = 5;
+  // if true it would compute the random parameters the first time and reuse
+  // them for following transfomration until Reset() is called.
+  optional bool persistent = 6 [default = false];
 }
 
 // Message that stores parameters used by AccuracyLayer


### PR DESCRIPTION
This improvement to DataTransform allows us to have a persistent state, which allows to apply the same transformation (cropping, mirror) to multiple images. There is a `ResetState` to reset the state and compute a new transformation for the next image.

@longjon Could you take a look and let me know your opinion?