### PR TITLE
Reshape single input batches for inputs of varying dimension

### DIFF
--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -61,6 +61,9 @@ void BasePrefetchingDataLayer<Dtype>::Forward_cpu(
   // First, join the thread
   JoinPrefetchThread();
   DLOG(INFO) << "Thread joined";
+  // Reshape to loaded data.
+  top[0]->Reshape(this->prefetch_data_.num(), this->prefetch_data_.channels(),
+      this->prefetch_data_.height(), this->prefetch_data_.width());
   // Copy the data
   caffe_copy(prefetch_data_.count(), prefetch_data_.cpu_data(),
              top[0]->mutable_cpu_data());

--- a/src/caffe/layers/base_data_layer.cu
+++ b/src/caffe/layers/base_data_layer.cu
@@ -9,6 +9,9 @@ void BasePrefetchingDataLayer<Dtype>::Forward_gpu(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   // First, join the thread
   JoinPrefetchThread();
+  // Reshape to loaded data.
+  top[0]->Reshape(this->prefetch_data_.num(), this->prefetch_data_.channels(),
+      this->prefetch_data_.height(), this->prefetch_data_.width());
   // Copy the data
   caffe_copy(prefetch_data_.count(), prefetch_data_.cpu_data(),
       top[0]->mutable_gpu_data());

--- a/src/caffe/test/test_image_data_layer.cpp
+++ b/src/caffe/test/test_image_data_layer.cpp
@@ -25,17 +25,24 @@ class ImageDataLayerTest : public MultiDeviceTest<TypeParam> {
         blob_top_data_(new Blob<Dtype>()),
         blob_top_label_(new Blob<Dtype>()) {}
   virtual void SetUp() {
-    MakeTempFilename(&filename_);
     blob_top_vec_.push_back(blob_top_data_);
     blob_top_vec_.push_back(blob_top_label_);
     Caffe::set_random_seed(seed_);
-    // Create a Vector of files with labels
+    // Create test input file.
+    MakeTempFilename(&filename_);
     std::ofstream outfile(filename_.c_str(), std::ofstream::out);
     LOG(INFO) << "Using temporary file " << filename_;
     for (int i = 0; i < 5; ++i) {
       outfile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << i;
     }
     outfile.close();
+    // Create test input file for images of distinct sizes.
+    MakeTempFilename(&filename_reshape_);
+    std::ofstream reshapefile(filename_reshape_.c_str(), std::ofstream::out);
+    LOG(INFO) << "Using temporary file " << filename_reshape_;
+    reshapefile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << 0;
+    reshapefile << EXAMPLES_SOURCE_DIR "images/fish-bike.jpg " << 1;
+    reshapefile.close();
   }
 
   virtual ~ImageDataLayerTest() {
@@ -45,6 +52,7 @@ class ImageDataLayerTest : public MultiDeviceTest<TypeParam> {
 
   int seed_;
   string filename_;
+  string filename_reshape_;
   Blob<Dtype>* const blob_top_data_;
   Blob<Dtype>* const blob_top_label_;
   vector<Blob<Dtype>*> blob_bottom_vec_;
@@ -105,6 +113,33 @@ TYPED_TEST(ImageDataLayerTest, TestResize) {
       EXPECT_EQ(i, this->blob_top_label_->cpu_data()[i]);
     }
   }
+}
+
+TYPED_TEST(ImageDataLayerTest, TestReshape) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter param;
+  ImageDataParameter* image_data_param = param.mutable_image_data_param();
+  image_data_param->set_batch_size(1);
+  image_data_param->set_source(this->filename_reshape_.c_str());
+  image_data_param->set_shuffle(false);
+  ImageDataLayer<Dtype> layer(param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  EXPECT_EQ(this->blob_top_label_->num(), 1);
+  EXPECT_EQ(this->blob_top_label_->channels(), 1);
+  EXPECT_EQ(this->blob_top_label_->height(), 1);
+  EXPECT_EQ(this->blob_top_label_->width(), 1);
+  // cat.jpg
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  EXPECT_EQ(this->blob_top_data_->num(), 1);
+  EXPECT_EQ(this->blob_top_data_->channels(), 3);
+  EXPECT_EQ(this->blob_top_data_->height(), 360);
+  EXPECT_EQ(this->blob_top_data_->width(), 480);
+  // fish-bike.jpg
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  EXPECT_EQ(this->blob_top_data_->num(), 1);
+  EXPECT_EQ(this->blob_top_data_->channels(), 3);
+  EXPECT_EQ(this->blob_top_data_->height(), 323);
+  EXPECT_EQ(this->blob_top_data_->width(), 481);
 }
 
 TYPED_TEST(ImageDataLayerTest, TestShuffle) {


### PR DESCRIPTION
To feed inputs of varying dimension, the DATA layer reshapes its prefetch and top blobs when the batch size is 1. This is useful for models of variable input size, such as fully-convolutional models.

By the grace of #594 this is a simple change.

- [x] simplify to reshape always (there's no cost)
- [x] make compatible with crop thanks to @philkr 
- [x] test data layer reshaping