### PR TITLE
LMDB read-only transaction limit fix

### DIFF
--- a/include/caffe/dataset.hpp
+++ b/include/caffe/dataset.hpp
@@ -170,7 +170,6 @@ class Dataset {
     iterator(const Dataset* parent, shared_ptr<DatasetState> state)
         : parent_(parent),
           state_(state) { }
-    ~iterator() { }
 
     iterator(const iterator& other)
         : parent_(other.parent_),

--- a/include/caffe/leveldb_dataset.hpp
+++ b/include/caffe/leveldb_dataset.hpp
@@ -61,12 +61,11 @@ class LeveldbDataset : public Dataset<K, V, KCoder, VCoder> {
     shared_ptr<DatasetState> clone() {
       shared_ptr<leveldb::Iterator> new_iter;
 
-      if (iter_.get()) {
-        new_iter.reset(db_->NewIterator(leveldb::ReadOptions()));
-        CHECK(iter_->Valid());
-        new_iter->Seek(iter_->key());
-        CHECK(new_iter->Valid());
-      }
+      CHECK(iter_.get());
+      new_iter.reset(db_->NewIterator(leveldb::ReadOptions()));
+      CHECK(iter_->Valid());
+      new_iter->Seek(iter_->key());
+      CHECK(new_iter->Valid());
 
       return shared_ptr<DatasetState>(new LeveldbState(db_, new_iter));
     }

--- a/src/caffe/test/test_dataset.cpp
+++ b/src/caffe/test/test_dataset.cpp
@@ -751,6 +751,44 @@ TYPED_TEST(DatasetTest, TestReadOnlyGetNoCommitFails) {
   EXPECT_FALSE(dataset->get(key, &new_value));
 }
 
+TYPED_TEST(DatasetTest, TestCreateManyItersShortScope) {
+  UNPACK_TYPES;
+
+  string name = this->DBName();
+  shared_ptr<Dataset<string, value_type> > dataset =
+      DatasetFactory<string, value_type>(backend);
+  EXPECT_TRUE(dataset->open(name, Dataset<string, value_type>::New));
+
+  string key = this->TestKey();
+  value_type value = this->TestValue();
+  EXPECT_TRUE(dataset->put(key, value));
+  EXPECT_TRUE(dataset->commit());
+
+  for (int i = 0; i < 1000; ++i) {
+    typename Dataset<string, value_type>::const_iterator iter =
+        dataset->begin();
+  }
+}
+
+TYPED_TEST(DatasetTest, TestCreateManyItersLongScope) {
+  UNPACK_TYPES;
+
+  string name = this->DBName();
+  shared_ptr<Dataset<string, value_type> > dataset =
+      DatasetFactory<string, value_type>(backend);
+  EXPECT_TRUE(dataset->open(name, Dataset<string, value_type>::New));
+
+  string key = this->TestKey();
+  value_type value = this->TestValue();
+  EXPECT_TRUE(dataset->put(key, value));
+  EXPECT_TRUE(dataset->commit());
+
+  vector<typename Dataset<string, value_type>::const_iterator> iters;
+  for (int i = 0; i < 1000; ++i) {
+    iters.push_back(dataset->begin());
+  }
+}
+
 #undef UNPACK_TYPES
 
 }  // namespace caffe


### PR DESCRIPTION
I incorrectly assumed that you could have many concurrent read-only transactions with LMDB.  This preallocates a single read-only transaction that can be reused until commit has been called.

This still leaks cursors.  I need to find out whether or not those are automatically cleaned up when a transaction aborts or commits.

New test cases included.
