### PR TITLE
absval nan fix: define gradient at zero to be zero

### DIFF
--- a/src/caffe/layers/absval_layer.cpp
+++ b/src/caffe/layers/absval_layer.cpp
@@ -26,12 +26,11 @@ template <typename Dtype>
 void AbsValLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
   const int count = top[0]->count();
-  const Dtype* top_data = top[0]->cpu_data();
   const Dtype* top_diff = top[0]->cpu_diff();
   if (propagate_down[0]) {
     const Dtype* bottom_data = bottom[0]->cpu_data();
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
-    caffe_div(count, top_data, bottom_data, bottom_diff);
+    caffe_cpu_sign(count, bottom_data, bottom_diff);
     caffe_mul(count, bottom_diff, top_diff, bottom_diff);
   }
 }

--- a/src/caffe/layers/absval_layer.cu
+++ b/src/caffe/layers/absval_layer.cu
@@ -23,7 +23,7 @@ void AbsValLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   if (propagate_down[0]) {
     const Dtype* bottom_data = bottom[0]->gpu_data();
     Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
-    caffe_gpu_div(count, top_data, bottom_data, bottom_diff);
+    caffe_gpu_sign(count, bottom_data, bottom_diff);
     caffe_gpu_mul(count, bottom_diff, top_diff, bottom_diff);
   }
 }


### PR DESCRIPTION
@rodrigob @jeffdonahue @shelhamer Here is a PR to fix issue #1230.

The bug probably slipped under the radar because the kink at zero is avoided by the gradient checker, and the filler is Gaussian. Can someone outline the right way to implement a test for that?

Absolute value is not differentiable at zero. There are a couple of ways around this. Here I just define the gradient to be zero at zero. This is practical but maybe something like this would be better:

f(x) = (x^2 + eps)^(1/2)
