### PR TITLE
shuffle data from hdf5 datasets

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -177,6 +177,8 @@ class HDF5DataLayer : public Layer<Dtype> {
   unsigned int current_file_;
   hsize_t current_row_;
   std::vector<shared_ptr<Blob<Dtype> > > hdf_blobs_;
+  std::vector<unsigned int> data_permutation_;
+  std::vector<unsigned int> file_permutation_;
 };
 
 /**

--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -52,7 +52,20 @@ void HDF5DataLayer<Dtype>::LoadHDF5FileData(const char* filename) {
   for (int i = 1; i < top_size; ++i) {
     CHECK_EQ(hdf_blobs_[i]->num(), num);
   }
-  DLOG(INFO) << "Successully loaded " << hdf_blobs_[0]->num() << " rows";
+  //  permutation in file is identity by default
+  data_permutation_.clear();
+  data_permutation_.resize(hdf_blobs_[0]->num());
+  for (int i = 0; i < hdf_blobs_[0]->num(); i++)
+    data_permutation_[i] = i;
+
+  //  shuffle data when asked
+  if (this->layer_param_.hdf5_data_param().shuffle()) {
+    std::random_shuffle(data_permutation_.begin(), data_permutation_.end());
+    DLOG(INFO) << "Successully loaded " << hdf_blobs_[0]->num()
+    << " rows (shuffled)";
+  } else {
+    DLOG(INFO) << "Successully loaded " << hdf_blobs_[0]->num() << " rows";
+  }
 }
 
 template <typename Dtype>
@@ -76,9 +89,23 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   current_file_ = 0;
   LOG(INFO) << "Number of HDF5 files: " << num_files_;
 
+  file_permutation_.clear();
+  file_permutation_.resize(num_files_);
+  // default order-permutation is identity permutation
+  for (int i = 0; i < num_files_; i++)
+    file_permutation_[i] = i;
+
+  //  only change order, when asked
+  if (this->layer_param_.hdf5_data_param().shuffle()) {
+    std::random_shuffle(file_permutation_.begin(), file_permutation_.end());
+  }
+
   // Load the first HDF5 file and initialize the line counter.
-  LoadHDF5FileData(hdf_filenames_[current_file_].c_str());
+  LoadHDF5FileData(hdf_filenames_[file_permutation_[current_file_]].c_str());
   current_row_ = 0;
+  if (this->layer_param_.hdf5_data_param().shuffle()) {
+    std::random_shuffle(file_permutation_.begin(), file_permutation_.end());
+  }
 
   // Reshape blobs.
   const int batch_size = this->layer_param_.hdf5_data_param().batch_size();
@@ -99,17 +126,23 @@ void HDF5DataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
         ++current_file_;
         if (current_file_ == num_files_) {
           current_file_ = 0;
+          if (this->layer_param_.hdf5_data_param().shuffle())
+            std::random_shuffle(file_permutation_.begin(),
+              file_permutation_.end());
           DLOG(INFO) << "Looping around to first file.";
         }
-        LoadHDF5FileData(hdf_filenames_[current_file_].c_str());
+        LoadHDF5FileData(hdf_filenames_[file_permutation_[current_file_]].
+          c_str());
       }
       current_row_ = 0;
+      if (this->layer_param_.hdf5_data_param().shuffle())
+        std::random_shuffle(data_permutation_.begin(), data_permutation_.end());
     }
     for (int j = 0; j < this->layer_param_.top_size(); ++j) {
       int data_dim = top[j]->count() / top[j]->num();
       caffe_copy(data_dim,
-          &hdf_blobs_[j]->cpu_data()[current_row_ * data_dim],
-          &top[j]->mutable_cpu_data()[i * data_dim]);
+          &hdf_blobs_[j]->cpu_data()[data_permutation_[current_row_]
+            * data_dim], &top[j]->mutable_cpu_data()[i * data_dim]);
     }
   }
 }

--- a/src/caffe/layers/hdf5_data_layer.cu
+++ b/src/caffe/layers/hdf5_data_layer.cu
@@ -26,17 +26,23 @@ void HDF5DataLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
         current_file_ += 1;
         if (current_file_ == num_files_) {
           current_file_ = 0;
+          if (this->layer_param_.hdf5_data_param().shuffle())
+            std::random_shuffle(file_permutation_.begin(),
+              file_permutation_.end());
           DLOG(INFO) << "Looping around to first file.";
         }
-        LoadHDF5FileData(hdf_filenames_[current_file_].c_str());
+        LoadHDF5FileData(hdf_filenames_[file_permutation_[current_file_]]
+          .c_str());
       }
       current_row_ = 0;
+      if (this->layer_param_.hdf5_data_param().shuffle())
+        std::random_shuffle(data_permutation_.begin(), data_permutation_.end());
     }
     for (int j = 0; j < this->layer_param_.top_size(); ++j) {
       int data_dim = top[j]->count() / top[j]->num();
       caffe_copy(data_dim,
-          &hdf_blobs_[j]->cpu_data()[current_row_ * data_dim],
-          &top[j]->mutable_gpu_data()[i * data_dim]);
+          &hdf_blobs_[j]->cpu_data()[data_permutation_[current_row_]
+            * data_dim], &top[j]->mutable_gpu_data()[i * data_dim]);
     }
   }
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -499,6 +499,8 @@ message HDF5DataParameter {
   optional string source = 1;
   // Specify the batch size.
   optional uint32 batch_size = 2;
+  // Specify shuffling the order of training data
+  optional bool shuffle = 3 [default = false];
 }
 
 // Message that stores parameters used by HDF5OutputLayer


### PR DESCRIPTION
The order of read HDF5 files and the order of the entries of the HDF5 files can be shuffled when setting the flag `shuffle` in the hdf5data layer