### PR TITLE
Test cases used incorrect ParseFromString

### DIFF
--- a/src/caffe/test/test_mvn_layer.cpp
+++ b/src/caffe/test/test_mvn_layer.cpp
@@ -1,3 +1,5 @@
+#include <google/protobuf/text_format.h>
+
 #include <cmath>
 #include <cstring>
 #include <vector>
@@ -73,7 +75,8 @@ TYPED_TEST(MVNLayerTest, TestForward) {
 TYPED_TEST(MVNLayerTest, TestForwardMeanOnly) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  layer_param.ParseFromString("mvn_param{normalize_variance: false}");
+  CHECK(google::protobuf::TextFormat::ParseFromString(
+      "mvn_param{normalize_variance: false}", &layer_param));
   MVNLayer<Dtype> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -105,7 +108,8 @@ TYPED_TEST(MVNLayerTest, TestForwardMeanOnly) {
 TYPED_TEST(MVNLayerTest, TestForwardAcrossChannels) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  layer_param.ParseFromString("mvn_param{across_channels: true}");
+  CHECK(google::protobuf::TextFormat::ParseFromString(
+      "mvn_param{across_channels: true}", &layer_param));
   MVNLayer<Dtype> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -149,7 +153,8 @@ TYPED_TEST(MVNLayerTest, TestGradient) {
 TYPED_TEST(MVNLayerTest, TestGradientMeanOnly) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  layer_param.ParseFromString("mvn_param{normalize_variance: false}");
+  CHECK(google::protobuf::TextFormat::ParseFromString(
+      "mvn_param{normalize_variance: false}", &layer_param));
   MVNLayer<Dtype> layer(layer_param);
   GradientChecker<Dtype> checker(1e-2, 1e-3);
   checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
@@ -159,7 +164,8 @@ TYPED_TEST(MVNLayerTest, TestGradientMeanOnly) {
 TYPED_TEST(MVNLayerTest, TestGradientAcrossChannels) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  layer_param.ParseFromString("mvn_param{across_channels: true}");
+  CHECK(google::protobuf::TextFormat::ParseFromString(
+      "mvn_param{across_channels: true}", &layer_param));
   MVNLayer<Dtype> layer(layer_param);
   GradientChecker<Dtype> checker(1e-2, 1e-3);
   checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,

--- a/src/caffe/test/test_neuron_layer.cpp
+++ b/src/caffe/test/test_neuron_layer.cpp
@@ -1,3 +1,5 @@
+#include <google/protobuf/text_format.h>
+
 #include <cstring>
 #include <vector>
 
@@ -152,7 +154,8 @@ TYPED_TEST(NeuronLayerTest, TestReLUGradient) {
 TYPED_TEST(NeuronLayerTest, TestReLUWithNegativeSlope) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  layer_param.ParseFromString("relu_param{negative_slope:0.01}");
+  CHECK(google::protobuf::TextFormat::ParseFromString(
+      "relu_param{negative_slope:0.01}", &layer_param));
   ReLULayer<Dtype> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -168,7 +171,8 @@ TYPED_TEST(NeuronLayerTest, TestReLUWithNegativeSlope) {
 TYPED_TEST(NeuronLayerTest, TestReLUGradientWithNegativeSlope) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  layer_param.ParseFromString("relu_param{negative_slope:0.01}");
+  CHECK(google::protobuf::TextFormat::ParseFromString(
+      "relu_param{negative_slope:0.01}", &layer_param));
   ReLULayer<Dtype> layer(layer_param);
   GradientChecker<Dtype> checker(1e-2, 1e-3, 1701, 0., 0.01);
   checker.CheckGradientEltwise(&layer, this->blob_bottom_vec_,
@@ -437,7 +441,8 @@ TYPED_TEST(CuDNNNeuronLayerTest, TestReLUGradientCuDNN) {
 TYPED_TEST(CuDNNNeuronLayerTest, TestReLUWithNegativeSlopeCuDNN) {
   Caffe::set_mode(Caffe::GPU);
   LayerParameter layer_param;
-  layer_param.ParseFromString("relu_param{negative_slope:0.01}");
+  CHECK(google::protobuf::TextFormat::ParseFromString(
+      "relu_param{negative_slope:0.01}", &layer_param));
   CuDNNReLULayer<TypeParam> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -453,7 +458,8 @@ TYPED_TEST(CuDNNNeuronLayerTest, TestReLUWithNegativeSlopeCuDNN) {
 TYPED_TEST(CuDNNNeuronLayerTest, TestReLUGradientWithNegativeSlopeCuDNN) {
   Caffe::set_mode(Caffe::GPU);
   LayerParameter layer_param;
-  layer_param.ParseFromString("relu_param{negative_slope:0.01}");
+  CHECK(google::protobuf::TextFormat::ParseFromString(
+      "relu_param{negative_slope:0.01}", &layer_param));
   CuDNNReLULayer<TypeParam> layer(layer_param);
   GradientChecker<TypeParam> checker(1e-2, 1e-3, 1701, 0., 0.01);
   checker.CheckGradientEltwise(&layer, this->blob_bottom_vec_,


### PR DESCRIPTION
Some test cases used the binary format ParseFromString rather than the TextFormat version.  If you CHECK these calls, the return values indicate failure.  When you switch to the correct ParseFromString, the test cases fail.  These tests need to be fixed.

```
[  PASSED  ] 1139 tests.
[  FAILED  ] 18 tests, listed below:
[  FAILED  ] NeuronLayerTest/0.TestReLUWithNegativeSlope, where TypeParam = caffe::FloatCPU
[  FAILED  ] NeuronLayerTest/1.TestReLUWithNegativeSlope, where TypeParam = caffe::DoubleCPU
[  FAILED  ] NeuronLayerTest/2.TestReLUWithNegativeSlope, where TypeParam = caffe::FloatGPU
[  FAILED  ] NeuronLayerTest/3.TestReLUWithNegativeSlope, where TypeParam = caffe::DoubleGPU
[  FAILED  ] CuDNNNeuronLayerTest/0.TestReLUWithNegativeSlopeCuDNN, where TypeParam = float
[  FAILED  ] CuDNNNeuronLayerTest/1.TestReLUWithNegativeSlopeCuDNN, where TypeParam = double
[  FAILED  ] MVNLayerTest/0.TestGradientMeanOnly, where TypeParam = caffe::FloatCPU
[  FAILED  ] MVNLayerTest/0.TestForwardAcrossChannels, where TypeParam = caffe::FloatCPU
[  FAILED  ] MVNLayerTest/0.TestGradientAcrossChannels, where TypeParam = caffe::FloatCPU
[  FAILED  ] MVNLayerTest/1.TestForwardAcrossChannels, where TypeParam = caffe::DoubleCPU
[  FAILED  ] MVNLayerTest/1.TestGradientMeanOnly, where TypeParam = caffe::DoubleCPU
[  FAILED  ] MVNLayerTest/1.TestGradientAcrossChannels, where TypeParam = caffe::DoubleCPU
[  FAILED  ] MVNLayerTest/2.TestGradientAcrossChannels, where TypeParam = caffe::FloatGPU
[  FAILED  ] MVNLayerTest/2.TestForwardAcrossChannels, where TypeParam = caffe::FloatGPU
[  FAILED  ] MVNLayerTest/2.TestGradientMeanOnly, where TypeParam = caffe::FloatGPU
[  FAILED  ] MVNLayerTest/3.TestForwardAcrossChannels, where TypeParam = caffe::DoubleGPU
[  FAILED  ] MVNLayerTest/3.TestGradientMeanOnly, where TypeParam = caffe::DoubleGPU
[  FAILED  ] MVNLayerTest/3.TestGradientAcrossChannels, where TypeParam = caffe::DoubleGPU

18 FAILED TESTS
  YOU HAVE 2 DISABLED TESTS
```