### PR TITLE
Minor updates in tutorial files

### DIFF
--- a/docs/tutorial/forward_backward.md
+++ b/docs/tutorial/forward_backward.md
@@ -15,7 +15,7 @@ This pass goes from bottom to top.
 
 <img src="fig/forward.jpg" alt="Forward pass" width="320">
 
-The data $x$ is passed through an inner product layer for $g(x)$ then through a softmax for $h(g(x))$ and softmax loss to give $f_W(x)$.
+The data $$x$$ is passed through an inner product layer for $$g(x)$$ then through a softmax for $$h(g(x))$$ and softmax loss to give $$f_W(x)$$.
 
 The **backward** pass computes the gradient given the loss for learning.
 In backward Caffe reverse-composes the gradient of each layer to compute the gradient of the whole model by automatic differentiation.
@@ -24,7 +24,7 @@ This pass goes from top to bottom.
 
 <img src="fig/backward.jpg" alt="Backward pass" width="320">
 
-The backward pass begins with the loss and computes the gradient with respect to the output $\frac{\partial f_W}{\partial h}$. The gradient with respect to the rest of the model is computed layer-by-layer through the chain rule. Layers with parameters, like the `INNER_PRODUCT` layer, compute the gradient with respect to their parameters $\frac{\partial f_W}{\partial W_{\text{ip}}}$ during the backward step.
+The backward pass begins with the loss and computes the gradient with respect to the output $$\frac{\partial f_W}{\partial h}$$. The gradient with respect to the rest of the model is computed layer-by-layer through the chain rule. Layers with parameters, like the `INNER_PRODUCT` layer, compute the gradient with respect to their parameters $$\frac{\partial f_W}{\partial W_{\text{ip}}}$$ during the backward step.
 
 These computations follow immediately from defining the model: Caffe plans and carries out the forward and backward passes for you.
 

--- a/docs/tutorial/interfaces.md
+++ b/docs/tutorial/interfaces.md
@@ -9,7 +9,13 @@ Caffe has command line, Python, and MATLAB interfaces for day-to-day usage, inte
 
 The command line interface -- cmdcaffe -- is the `caffe` tool for model training, scoring, and diagnostics. Run `caffe` without any arguments for help. This tool and others are found in caffe/build/tools. (The following example calls require completing the LeNet / MNIST example first.)
 
-**Training**: `caffe train` learns models from scratch, resumes learning from saved snapshots, and fine-tunes models to new data and tasks. All training requires a solver configuration through the `-solver solver.prototxt` argument. Resuming requires the `-snapshot model_iter_1000.solverstate` argument to load the solver snapshot. Fine-tuning requires the `-weights model.caffemodel` argument for the model initialization.
+**Training**: `caffe train` learns models from scratch, resumes learning from saved snapshots, and fine-tunes models to new data and tasks:
+
+* All training requires a solver configuration through the `-solver solver.prototxt` argument. 
+* Resuming requires the `-snapshot model_iter_1000.solverstate` argument to load the solver snapshot. 
+* Fine-tuning requires the `-weights model.caffemodel` argument for the model initialization.
+
+For example, you can run:
 
     # train LeNet
     caffe train -solver examples/mnist/lenet_solver.prototxt
@@ -26,17 +32,19 @@ For a full example of fine-tuning, see examples/finetuning_on_flickr_style, but 
 **Testing**: `caffe test` scores models by running them in the test phase and reports the net output as its score. The net architecture must be properly defined to output an accuracy measure or loss as its output. The per-batch score is reported and then the grand average is reported last.
 
     #
-    # score the learned LeNet model on the validation set as defined in the model architeture lenet_train_test.prototxt
-    caffe test -model examples/mnist/lenet_train_test.prototxt -weights examples/mnist/lenet_iter_10000 -gpu 0 -iterations 100
+    # score the learned LeNet model on the validation set as defined in the 
+    # model architeture lenet_train_test.prototxt
+    caffe test -model examples/mnist/lenet_train_test.prototxt -weights examples/mnist/lenet_iter_10000.caffemodel -gpu 0 -iterations 100
 
 **Benchmarking**: `caffe time` benchmarks model execution layer-by-layer through timing and synchronization. This is useful to check system performance and measure relative execution times for models.
 
     # (These example calls require you complete the LeNet / MNIST example first.)
     # time LeNet training on CPU for 10 iterations
     caffe time -model examples/mnist/lenet_train_test.prototxt -iterations 10
-    # time a model architecture with the given weights on the first GPU for 10 iterations
     # time LeNet training on GPU for the default 50 iterations
     caffe time -model examples/mnist/lenet_train_test.prototxt -gpu 0
+    # time a model architecture with the given weights on the first GPU for 10 iterations
+    caffe time -model examples/mnist/lenet_train_test.prototxt -weights examples/mnist/lenet_iter_10000.caffemodel -gpu 0 -iterations 10
 
 **Diagnostics**: `caffe device_query` reports GPU details for reference and checking device ordinals for running on a given device in multi-GPU machines.
 

--- a/docs/tutorial/layers.md
+++ b/docs/tutorial/layers.md
@@ -11,7 +11,7 @@ TODO complete list of layers linking to headings
 
 ### Vision Layers
 
-* Header: `./include/caffe/vision_layers.hpp`
+* Header: `$CAFFE_ROOT/include/caffe/vision_layers.hpp`
 
 Vision layers usually take *images* as input and produce other *images* as output.
 A typical "image" in the real-world may have one color channel ($$c = 1$$), as in a grayscale image, or three color channels ($$c = 3$$) as in an RGB (red, green, blue) image.
@@ -24,8 +24,8 @@ In contrast, other layers (with few exceptions) ignore the spatial structure of 
 #### Convolution
 
 * LayerType: `CONVOLUTION`
-* CPU implementation: `./src/caffe/layers/convolution_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/convolution_layer.cu`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/convolution_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/convolution_layer.cu`
 * Parameters (`ConvolutionParameter convolution_param`)
     - Required
         - `num_output` (`c_o`): the number of filters
@@ -72,8 +72,8 @@ The `CONVOLUTION` layer convolves the input image with a set of learnable filter
 #### Pooling
 
 * LayerType: `POOLING`
-* CPU implementation: `./src/caffe/layers/pooling_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/pooling_layer.cu`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/pooling_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/pooling_layer.cu`
 * Parameters (`PoolingParameter pooling_param`)
     - Required
         - `kernel_size` (or `kernel_h` and `kernel_w`): specifies height and width of each filter
@@ -102,8 +102,8 @@ The `CONVOLUTION` layer convolves the input image with a set of learnable filter
 #### Local Response Normalization (LRN)
 
 * LayerType: `LRN`
-* CPU Implementation: `./src/caffe/layers/lrn_layer.cpp`
-* CUDA GPU Implementation: `./src/caffe/layers/lrn_layer.cu`
+* CPU Implementation: `$CAFFE_ROOT/src/caffe/layers/lrn_layer.cpp`
+* CUDA GPU Implementation: `$CAFFE_ROOT/src/caffe/layers/lrn_layer.cu`
 * Parameters (`LRNParameter lrn_param`)
     - Optional
         - `local_size` [default 5]: the number of channels to sum over (for cross channel LRN) or the side length of the square region to sum over (for within channel LRN)
@@ -124,19 +124,23 @@ Loss drives learning by comparing an output to a target and assigning cost to mi
 #### Softmax
 
 * LayerType: `SOFTMAX_LOSS`
+* CPU implemntation: `$CAFFE_ROOT/src/caffe/layers/softmax_loss_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/softmax_loss_layer.cu`
 
 The softmax loss layer computes the multinomial logistic loss of the softmax of its inputs. It's conceptually identical to a softmax layer followed by a multinomial logistic loss layer, but provides a more numerically stable gradient.
 
 #### Sum-of-Squares / Euclidean
 
 * LayerType: `EUCLIDEAN_LOSS`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/euclidean_loss_layer.cpp`
+* GPU GPU implementation: `$CAFFE_ROOT/src/caffe/layers/euclidean_loss_layer.cu`
 
 The Euclidean loss layer computes the sum of squares of differences of its two inputs, $$\frac 1 {2N} \sum_{i=1}^N \| x^1_i - x^2_i \|_2^2$$.
 
 #### Hinge / Margin
 
 * LayerType: `HINGE_LOSS`
-* CPU implementation: `./src/caffe/layers/hinge_loss_layer.cpp`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/hinge_loss_layer.cpp`
 * CUDA GPU implementation: none yet
 * Parameters (`HingeLossParameter hinge_loss_param`)
     - Optional
@@ -172,11 +176,15 @@ The hinge loss layer computes a one-vs-all hinge or squared hinge loss.
 
 #### Sigmoid Cross-Entropy
 
-`SIGMOID_CROSS_ENTROPY_LOSS`
+* LayerType: `SIGMOID_CROSS_ENTROPY_LOSS`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/sigmoid_cross_entropy_loss_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/sigmoid_cross_entropy_loss_layer.cu`
 
 #### Infogain
 
-`INFOGAIN_LOSS`
+* LayerType: `INFOGAIN_LOSS`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/infogain_loss_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/infogain_loss_layer.cu`
 
 #### Accuracy and Top-k
 
@@ -194,8 +202,8 @@ In general, activation / Neuron layers are element-wise operators, taking one bo
 #### ReLU / Rectified-Linear and Leaky-ReLU
 
 * LayerType: `RELU`
-* CPU implementation: `./src/caffe/layers/relu_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/relu_layer.cu`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/relu_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/relu_layer.cu`
 * Parameters (`ReLUParameter relu_param`)
     - Optional
         - `negative_slope` [default 0]: specifies whether to leak the negative part by multiplying it with the slope value rather than setting it to 0.
@@ -213,9 +221,9 @@ Given an input value x, The `RELU` layer computes the output as x if x > 0 and n
 #### Sigmoid
 
 * LayerType: `SIGMOID`
-* CPU implementation: `./src/caffe/layers/sigmoid_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/sigmoid_layer.cu`
-* Sample (as seen in `./examples/imagenet/mnist_autoencoder.prototxt`)
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/sigmoid_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/sigmoid_layer.cu`
+* Sample (as seen in `$CAFFE_ROOT/examples/imagenet/mnist_autoencoder.prototxt`)
 
       layers {
         name: "encode1neuron"
@@ -229,8 +237,8 @@ The `SIGMOID` layer computes the output as sigmoid(x) for each input element x.
 #### TanH / Hyperbolic Tangent
 
 * LayerType: `TANH`
-* CPU implementation: `./src/caffe/layers/tanh_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/tanh_layer.cu`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/tanh_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/tanh_layer.cu`
 * Sample
 
       layers {
@@ -245,8 +253,8 @@ The `TANH` layer computes the output as tanh(x) for each input element x.
 #### Absolute Value
 
 * LayerType: `ABSVAL`
-* CPU implementation: `./src/caffe/layers/absval_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/absval_layer.cu`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/absval_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/absval_layer.cu`
 * Sample
 
       layers {
@@ -261,8 +269,8 @@ The `ABSVAL` layer computes the output as abs(x) for each input element x.
 #### Power
 
 * LayerType: `POWER`
-* CPU implementation: `./src/caffe/layers/power_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/power_layer.cu`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/power_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/power_layer.cu`
 * Parameters (`PowerParameter power_param`)
     - Optional
         - `power` [default 1]
@@ -287,8 +295,8 @@ The `POWER` layer computes the output as (shift + scale * x) ^ power for each in
 #### BNLL
 
 * LayerType: `BNLL`
-* CPU implementation: `./src/caffe/layers/bnll_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/bnll_layer.cu`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/bnll_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/bnll_layer.cu`
 * Sample
 
       layers {
@@ -310,6 +318,8 @@ Common input preprocessing (mean subtraction, scaling, random cropping, and mirr
 #### Database
 
 * LayerType: `DATA`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/data_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/data_layer.cu`
 * Parameters
     - Required
         - `source`: the name of the directory containing the database
@@ -323,6 +333,8 @@ Common input preprocessing (mean subtraction, scaling, random cropping, and mirr
 #### In-Memory
 
 * LayerType: `MEMORY_DATA`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/memory_data_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/memory_data_layer.cu`
 * Parameters
     - Required
         - `batch_size`, `channels`, `height`, `width`: specify the size of input chunks to read from memory
@@ -332,6 +344,8 @@ The memory data layer reads data directly from memory, without copying it. In or
 #### HDF5 Input
 
 * LayerType: `HDF5_DATA`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/hdf5_data_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/hdf5_data_layer.cu`
 * Parameters
     - Required
         - `source`: the name of the file to read from
@@ -340,6 +354,8 @@ The memory data layer reads data directly from memory, without copying it. In or
 #### HDF5 Output
 
 * LayerType: `HDF5_OUTPUT`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/hdf5_output_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/hdf5_output_layer.cu`
 * Parameters
     - Required
         - `file_name`: name of file to write to
@@ -349,6 +365,8 @@ The HDF5 output layer performs the opposite function of the other layers in this
 #### Images
 
 * LayerType: `IMAGE_DATA`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/image_data.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/image_data.cu`
 * Parameters
     - Required
         - `source`: name of a text file, with each line giving an image filename and label
@@ -360,7 +378,9 @@ The HDF5 output layer performs the opposite function of the other layers in this
 
 #### Windows
 
-`WINDOW_DATA`
+* LayerType: `WINDOW_DATA`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/window_data_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/window_data_layer.cu`
 
 #### Dummy
 
@@ -371,8 +391,8 @@ The HDF5 output layer performs the opposite function of the other layers in this
 #### Inner Product
 
 * LayerType: `INNER_PRODUCT`
-* CPU implementation: `./src/caffe/layers/inner_product_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/inner_product_layer.cu`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/inner_product_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/inner_product_layer.cu`
 * Parameters (`InnerProductParameter inner_product_param`)
     - Required
         - `num_output` (`c_o`): the number of filters
@@ -422,8 +442,8 @@ The `FLATTEN` layer is a utility layer that flattens an input of shape `n * c * 
 #### Concatenation
 
 * LayerType: `CONCAT`
-* CPU implementation: `./src/caffe/layers/concat_layer.cpp`
-* CUDA GPU implementation: `./src/caffe/layers/concat_layer.cu`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/layers/concat_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/layers/concat_layer.cu`
 * Parameters (`ConcatParameter concat_param`)
     - Optional
         - `concat_dim` [default 1]: 0 for concatenation along num and 1 for channels.
@@ -453,16 +473,24 @@ The `SLICE` layer is a utility layer that slices an input layer to multiple outp
 
 #### Elementwise Operations
 
-`ELTWISE`
+* LayerType: `ELTWISE`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/eltwise_layer.cpp`
+* CUDA GPU imlementation: `$CAFFE_ROOT/src/caffe/eltwise_layer.cu`
 
 #### Argmax
 
-`ARGMAX`
+* LayerType: `ARGMAX`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/argmax_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/argmax_layer.cu`
 
 #### Softmax
 
-`SOFTMAX`
+* LayerType: `SOFTMAX`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/softmax_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/softmax_layer.cu`
 
 #### Mean-Variance Normalization
 
-`MVN`
+* LayerType: `MVN`
+* CPU implementation: `$CAFFE_ROOT/src/caffe/mvn_layer.cpp`
+* CUDA GPU implementation: `$CAFFE_ROOT/src/caffe/mvn_layer.cu

--- a/docs/tutorial/net_layer_blob.md
+++ b/docs/tutorial/net_layer_blob.md
@@ -11,15 +11,15 @@ We will go over the details of these components in more detail.
 
 ## Blob storage and communication
 
-A Blob is a wrapper over the actual data being processed and passed along by Caffe, and also under the hood provides synchronization capability between the CPU and the GPU. Mathematically, a blob is a 4-dimensional array that stores things in the order of (Num, Channels, Height and Width), from major to minor, and stored in a C-contiguous fashion.  The main reason for putting Num (the name is due to legacy reasons, and is equivalent to the notation of "batch" as in minibatch SGD).
+A Blob is a wrapper over the actual data being processed and passed along by Caffe, and also under the hood provides synchronization capability between the CPU and the GPU. Mathematically, a blob is a 4-dimensional array that stores things in the order of (Num, Channels, Height and Width), from major to minor, and stored in a C-contiguous fashion.  The main reason for putting Num (the name is due to legacy reasons, and is equivalent to the notation of "batch" as in minibatch SGD), is to enable Num number of 3-dimensional arrays (for example, images) to be processed simultaionusly as a batch.
 
 Caffe stores and communicates data in 4-dimensional arrays called blobs. Blobs provide a unified memory interface, holding data e.g. batches of images, model parameters, and derivatives for optimization.
 
 Blobs conceal the computational and mental overhead of mixed CPU/GPU operation by synchronizing from the CPU host to the GPU device as needed. Memory on the host and device is allocated on demand (lazily) for efficient memory usage.
 
-The conventional blob dimensions for data are number N x channel K x height H x width W. Blob memory is row-major in layout so the last / rightmost dimension changes fastest. For example, the value at index (n, k, h, w) is physically located at index ((n * K + k) * H + h) * W + w.
+The conventional blob dimensions for data are: number N x channel K x height H x width W. Blob memory is row-major in layout so the last / rightmost dimension changes fastest. For example, the value at index (n, k, h, w) is physically located at index ((n * K + k) * H + h) * W + w.
 
-- Number / N is the batch size of the data. Batch processing achieves better throughput for communication and device processing. For an ImageNet training batch of 256 images B = 256.
+- Number / N is the batch size of the data. Batch processing achieves better throughput for communication and device processing. For an ImageNet training batch of 256 images N = 256.
 - Channel / K is the feature dimension e.g. for RGB images K = 3.
 
 Note that although we have designed blobs with its dimensions corresponding to image applications, they are named purely for notational purpose and it is totally valid for you to do non-image applications. For example, if you simply need fully-connected networks like the conventional multi-layer perceptron, use blobs of dimensions (Num, Channels, 1, 1) and call the InnerProductLayer (which we will cover soon).
@@ -121,6 +121,8 @@ is defined by
       bottom: "label"
       top: "loss"
     }
+
+It is easily to understand that this `.prototxt` file, creates a network (named `LogReg`), with three layers. Furthermore, it defines network's DAG by using the `top:` and `bottom:` definitions in every layer. The only exception is in the `DATA` layer, where there is no `bottom:` definition, and `source:` is used to import our data into the network. In this case, our input data are located in a leveldb (key-value pair) database, and we only need to specify our `source:`'s name in the `data_param` part of layer's definition.
 
 Model initialization is handled by `Net::Init()`. The initialization mainly does two things: scaffolding the overall DAG by creating the blobs and layers (for C++ geeks: the network will retain ownership of the blobs and layers during its lifetime), and calls the layers' `SetUp()` function. It also does a set of other bookkeeping things, such as validating the correctness of the overall network architecture. Also, during initialization the Net explains its initialization by logging to INFO as it goes:
 


### PR DESCRIPTION
I have made some changes-updates to:
* docs/tutorial/net_layer_blob.md file:
  * Complete the last sentence of the first paragraph in `Blob storage and communication`.
  * Add an explanation for the `.prototxt` file. I do not know whether you like it or not.

* docs/tutorial/interfaces.md file:
  * Change the style in the `Training` part.
  * Add the .caffemodel suffix.
  * Add a missing (?) example (at line 37 on the old file).

* docs/tutorial/forward_backward.md file:
  * Fix LaTeX code.

* docs/tutorial/layers.md file:
  * Update and add paths to be relative to `$CAFFE_ROOT`.