### PR TITLE
Data augmentation via random rotations

### DIFF
--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -47,6 +47,7 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
   const int crop_size = param_.crop_size();
   const Dtype scale = param_.scale();
   const bool do_mirror = param_.mirror() && Rand(2);
+  const int rotation_count = (param_.rotate()) ? Rand(4) : 0;
   const bool has_mean_file = param_.has_mean_file();
   const bool has_uint8 = data.size() > 0;
   const bool has_mean_values = mean_values_.size() > 0;
@@ -75,6 +76,10 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
 
   int height = datum_height;
   int width = datum_width;
+  if (param_.rotate()) {
+    CHECK(height == width) <<
+        "If random rotation is enabled, the data must be square";
+  }
 
   int h_off = 0;
   int w_off = 0;
@@ -97,11 +102,25 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
     for (int h = 0; h < height; ++h) {
       for (int w = 0; w < width; ++w) {
         data_index = (c * datum_height + h_off + h) * datum_width + w_off + w;
+        int h_idx = h;
+        int w_idx = w;
         if (do_mirror) {
-          top_index = (c * height + h) * width + (width - 1 - w);
-        } else {
-          top_index = (c * height + h) * width + w;
+          w_idx = width - 1 - w;
         }
+        if (rotation_count == 1) {
+          int temp = w_idx;
+          w_idx = height - 1 - h_idx;
+          h_idx = temp;
+        } else if (rotation_count == 2) {
+          w_idx = width - 1 - w_idx;
+          h_idx = height - 1 - h_idx;
+        } else if (rotation_count == 3) {
+          int temp = h_idx;
+          h_idx = width - 1 - w_idx;
+          w_idx = temp;
+        }
+        top_index = (c * height + h_idx) * width + w_idx;
+
         if (has_uint8) {
           datum_element =
             static_cast<Dtype>(static_cast<uint8_t>(data[data_index]));
@@ -381,7 +400,7 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
 
 template <typename Dtype>
 void DataTransformer<Dtype>::InitRand() {
-  const bool needs_rand = param_.mirror() ||
+  const bool needs_rand = param_.mirror() || param_.rotate() ||
       (phase_ == Caffe::TRAIN && param_.crop_size());
   if (needs_rand) {
     const unsigned int rng_seed = caffe_rng_rand();

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -359,6 +359,9 @@ message TransformationParameter {
   // or can be repeated the same number of times as channels
   // (would subtract them from the corresponding channel)
   repeated float mean_value = 5;
+  // Specify if we want to randomly rotate data by an integer multiple of
+  // 90 degrees
+  optional bool rotate = 6 [default = false];
 }
 
 // Message that stores parameters used by AccuracyLayer

--- a/src/caffe/test/test_data_transformer.cpp
+++ b/src/caffe/test/test_data_transformer.cpp
@@ -227,6 +227,40 @@ TYPED_TEST(DataTransformTest, TestMirrorTest) {
   EXPECT_LT(num_matches, size * this->num_iter_);
 }
 
+TYPED_TEST(DataTransformTest, TestRotateTrain) {
+  TransformationParameter transform_param;
+  const bool unique_pixels = true;  // pixels are consecutive ints [0,size]
+  const int label = 0;
+  const int channels = 3;
+  const int height = 5;
+  const int width = 5;
+  const int size = channels * height * width;
+
+  transform_param.set_rotate(true);
+  Datum datum;
+  FillDatum(label, channels, height, width, unique_pixels, &datum);
+  Caffe::set_phase(Caffe::TRAIN);
+  int num_matches = this->NumSequenceMatches(transform_param, datum);
+  EXPECT_LT(num_matches, size * this->num_iter_);
+}
+
+TYPED_TEST(DataTransformTest, TestRotateTest) {
+  TransformationParameter transform_param;
+  const bool unique_pixels = true;  // pixels are consecutive ints [0,size]
+  const int label = 0;
+  const int channels = 3;
+  const int height = 5;
+  const int width = 5;
+  const int size = channels * height * width;
+
+  transform_param.set_rotate(true);
+  Datum datum;
+  FillDatum(label, channels, height, width, unique_pixels, &datum);
+  Caffe::set_phase(Caffe::TEST);
+  int num_matches = this->NumSequenceMatches(transform_param, datum);
+  EXPECT_LT(num_matches, size * this->num_iter_);
+}
+
 TYPED_TEST(DataTransformTest, TestCropMirrorTrain) {
   TransformationParameter transform_param;
   const bool unique_pixels = true;  // pixels are consecutive ints [0,size]


### PR DESCRIPTION
Some datasets are indifferent to which direction in the image is "up" and therefore can be augmented with random rotations. This PR implements a `rotate` option in the `TransformationParameter` message which operates analogously to `mirror`. It's `false` by default; setting it to `true` causes images to be randomly rotated by an integer multiple of 90 degrees. If `mirror` is also enabled, there are 8 possibilities for the randomly transformed output image.

An error is thrown if the input data is not square (i.e., if `datum.height() != datum.width()`); the logic for dealing with square rotations is easier to start with, and I believe that `transformed_data` is expected to have the same shape as the input data.

I added unit tests to `test_data_transformer.cpp` by copying and pasting some pre-existing mirroring unit tests; the tests show that this transformation runs, but they don't prove that it does what I expect it to do (i.e., rotate an image properly). I'm not a pro at Caffe unit tests, so if anyone can suggest how to write a unit test that confirms that the rotation is working properly, I'd be happy to implement it. I can (and probably will) copy the logic to a little test script in Matlab to convince myself that the logic is working, but that's not really good enough as a unit test.

~~I have not yet tried to train a network using the `rotate` parameter but that's next on my list. In the mean time, eyeballs on my rotation (and generalized mirroring) logic are welcome.~~

*Update:* I've trained a network using the random rotations and it worked just fine (if not necessarily any better than when random rotations were disabled).
