### PR TITLE
Added extract_keys with labels tool

### DIFF
--- a/tools/extract_keys.cpp
+++ b/tools/extract_keys.cpp
@@ -1,0 +1,94 @@
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <fstream>  // NOLINT(readability/streams)
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "caffe/dataset_factory.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/io.hpp"
+
+using caffe::Dataset;
+using caffe::Datum;
+using std::pair;
+using std::vector;
+
+
+DEFINE_string(backend, "lmdb", "The backend for containing the images");
+DEFINE_int32(max_iter, 0, "Max number of iterations (0 means extract all)");
+
+int main(int argc, char** argv) {
+  ::google::InitGoogleLogging(argv[0]);
+
+#ifndef GFLAGS_GFLAGS_H_
+  namespace gflags = google;
+#endif
+
+  gflags::SetUsageMessage("Extract keys and labels from a leveldb/lmdb \n"
+        "Usage:\n"
+        "    extract_keys [FLAGS] INPUT_DB [OUTPUT_FILE]\n");
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (argc < 2 || argc > 3) {
+    gflags::ShowUsageWithFlagsRestrict(argv[0], "tools/extract_keys");
+    return 1;
+  }
+
+  std::string db_backend = FLAGS_backend;
+  const int max_iter = FLAGS_max_iter;
+
+  caffe::shared_ptr<Dataset<std::string, Datum> > dataset =
+      caffe::DatasetFactory<std::string, Datum>(db_backend);
+
+  // Open db
+  CHECK(dataset->open(argv[1], Dataset<std::string, Datum>::ReadOnly));
+
+  int count = 0;
+  // load first datum
+  Dataset<std::string, Datum>::const_iterator iter = dataset->begin();
+  LOG(INFO) << "Starting Iteration";
+  std::vector<pair<std::string, int> > keys_label;
+  for (Dataset<std::string, Datum>::const_iterator iter = dataset->begin();
+      iter != dataset->end(); ++iter) {
+    std::string key = iter->key;
+    Datum datum = iter->value;
+    int label = datum.label();
+    keys_label.push_back(std::make_pair(key, label));
+    ++count;
+    if (count % 10000 == 0) {
+      LOG(INFO) << "Processed " << count << " items.";
+    }
+    if (max_iter > 0 && count >= max_iter) {
+      break;
+    }
+  }
+
+  if (count % 10000 != 0) {
+    LOG(INFO) << "Processed " << count << " items.";
+  }
+
+  // Write to disk
+  if (argc == 3) {
+    LOG(INFO) << "Writting to " << argv[2];
+    std::ofstream outfile(argv[2]);
+    for (int i = 0; i < keys_label.size(); ++i) {
+      outfile << keys_label[i].first << " " << keys_label[i].second
+        << std::endl;
+    }
+    outfile.close();
+  } else {
+    // Write to cout
+    for (int i = 0; i < keys_label.size(); ++i) {
+      std::cout << keys_label[i].first << " " << keys_label[i].second
+        << std::endl;
+    }
+  }
+
+  // Clean up
+  dataset->close();
+  return 0;
+}


### PR DESCRIPTION
Just added a simple tool to extract the keys (with associated labels) from a leveldb/lmdb dataset.
```
Usage:
    extract_keys [FLAGS] INPUT_DB [OUTPUT_FILE]

  Flags from tools/extract_keys.cpp:
    -backend (The backend for containing the images) type: string
      default: "lmdb"
    -max_iter (Max number of iterations (0 means extract all)) type: int32 default: 0
```
Example:
```
./build/tools/extract_keys -max_iter 10 ~/Data/caffe-train-lmdb
I1031 15:59:14.982887 12299 extract_keys.cpp:53] Starting Iteration
I1031 15:59:14.983891 12299 extract_keys.cpp:71] Processed 10 items.
00000000_n03891251/n03891251_402.JPEG 703
00000001_n07697313/n07697313_4046.JPEG 933
00000002_n01560419/n01560419_3918.JPEG 16
00000003_n03933933/n03933933_59123.JPEG 718
00000004_n02097298/n02097298_12209.JPEG 199
00000005_n03649909/n03649909_16243.JPEG 621
00000006_n02504013/n02504013_2796.JPEG 385
00000007_n03355925/n03355925_15226.JPEG 557
00000008_n01833805/n01833805_2266.JPEG 94
00000009_n03538406/n03538406_4090.JPEG 603
```