### PR TITLE
Update CIFAR-10 example

### DIFF
--- a/examples/cifar10/create_cifar10.sh
+++ b/examples/cifar10/create_cifar10.sh
@@ -1,24 +1,30 @@
 #!/usr/bin/env sh
-# This script converts the cifar data into leveldb format.
+# This script converts the cifar data into leveldb or lmdb format.
 
 EXAMPLE=examples/cifar10
 DATA=data/cifar10
-BUILD=build/examples/cifar10
-TOOLS=build/tools
+BUILD=./build/examples/cifar10
+TOOLS=./build/tools
 
-# At this time, only leveldb is available for CIFAR-10
+# DBLIST contains the available DB types for the CIFAR-10 dataset.
+# Update the list if more DB types are supported.
+DBLIST=(lmdb leveldb)
+# DBTYPE that is choosen. Can be leveldb or lmdb.
 DBTYPE=leveldb
 
 echo "Creating $DBTYPE..."
 
-rm -rf $EXAMPLE/cifar10_train_$DBTYPE 
-rm -rf $EXAMPLE/cifar10_test_$DBTYPE
+for type in "${DBLIST[@]}"
+do
+  rm -rf $EXAMPLE/cifar10_train_$type
+  rm -rf $EXAMPLE/cifar10_test_$type
+done
 
-$BUILD/convert_cifar_data.bin $DATA $EXAMPLE $DTYPE
+$BUILD/convert_cifar_data.bin $DATA $EXAMPLE $DBTYPE
 
 echo "Computing image mean..."
 
-$TOOLS/compute_image_mean.bin  $EXAMPLE/cifar10_train_$DBTYPE \
-  $EXAMPLE/mean.binaryproto $DBTYPE
+$TOOLS/compute_image_mean.bin -backend=$DBTYPE $EXAMPLE/cifar10_train_$DBTYPE \
+  $EXAMPLE/mean.binaryproto
 
 echo "Done."

--- a/examples/cifar10/create_cifar10.sh
+++ b/examples/cifar10/create_cifar10.sh
@@ -3,17 +3,22 @@
 
 EXAMPLE=examples/cifar10
 DATA=data/cifar10
-DBTYPE=lmdb
+BUILD=build/examples/cifar10
+TOOLS=build/tools
+
+# At this time, only leveldb is available for CIFAR-10
+DBTYPE=leveldb
 
 echo "Creating $DBTYPE..."
 
-rm -rf $EXAMPLE/cifar10_train_$DBTYPE $EXAMPLE/cifar10_test_$DBTYPE
+rm -rf $EXAMPLE/cifar10_train_$DBTYPE 
+rm -rf $EXAMPLE/cifar10_test_$DBTYPE
 
-./build/examples/cifar10/convert_cifar_data.bin $DATA $EXAMPLE $DBTYPE
+$BUILD/convert_cifar_data.bin $DATA $EXAMPLE $DTYPE
 
 echo "Computing image mean..."
 
-./build/tools/compute_image_mean -backend=$DBTYPE \
-  $EXAMPLE/cifar10_train_$DBTYPE $EXAMPLE/mean.binaryproto
+$TOOLS/compute_image_mean.bin  $EXAMPLE/cifar10_train_$DBTYPE \
+  $EXAMPLE/mean.binaryproto $DBTYPE
 
 echo "Done."

--- a/examples/cifar10/readme.md
+++ b/examples/cifar10/readme.md
@@ -24,10 +24,18 @@ You will first need to download and convert the data format from the [CIFAR-10 w
 
     cd $CAFFE_ROOT/data/cifar10
     ./get_cifar10.sh
-    cd $CAFFE_ROOT/examples/cifar10
-    ./create_cifar10.sh
 
-If it complains that `wget` or `gunzip` are not installed, you need to install them respectively. After running the script there should be the dataset, `./cifar10-leveldb`, and the data set image mean `./mean.binaryproto`.
+or
+
+    cd $CAFFE_ROOT
+    ./data/cifar10/get_cifar10.sh
+
+to download and unzip the data files (if it complains that `wget` or `gunzip` are not installed, you need to install them respectively), and then:
+
+    cd $CAFFE_ROOT
+    ./examples/cifar10/create_cifar10.sh
+
+to create the dataset, `./cifar10_leveldb`, and the data set image mean `./mean.binaryproto`, in `$CAFFE_ROOT/examples/cifar10`. Currently only `leveldb` is supported for CIFAR-10.
 
 The Model
 ---------
@@ -39,8 +47,8 @@ Training and Testing the "Quick" Model
 
 Training the model is simple after you have written the network definition protobuf and solver protobuf files (refer to [MNIST Tutorial](../examples/mnist.html)). Simply run `train_quick.sh`, or the following command directly:
 
-    cd $CAFFE_ROOT/examples/cifar10
-    ./train_quick.sh
+    cd $CAFFE_ROOT
+    ./examples/cifar10/train_quick.sh
 
 `train_quick.sh` is a simple script, so have a look inside. The main tool for training is `caffe` with the `train` action, and the solver protobuf text file as its argument.
 


### PR DESCRIPTION
I made some changes to `create_cifar10.sh`. I couldn't get it run with the `lmdb` option so I changed it to `leveldb`; it seemed that `convert_cifar_data.bin` cannot accept `lmdb` as an argument.

Moreover, `compute_image_mean.bin`'s output was:

    Computing image mean...
    F1101 06:29:56.293719  5732 compute_image_mean.cpp:67] Unknown db backend examples/cifar10/mean.binaryproto
    *** Check failure stack trace: ***
        @     0x7f36c1f08daa  (unknown)
        @     0x7f36c1f08ce4  (unknown)
        @     0x7f36c1f086e6  (unknown)
        @     0x7f36c1f0b687  (unknown)
        @           0x409e18  main
        @     0x7f36bea00ec5  (unknown)
        @           0x4090f9  (unknown)
        @              (nil)  (unknown)
    Aborted (core dumped)

I don't know whether this problem is only mine, but I made the changes, so they might be useful to someone else.

I also fixed the paths in `readme.md`.
