### PR TITLE
Cherry-pick add option to save multiple data in HDF5Output

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -199,7 +199,7 @@ class HDF5OutputLayer : public Layer<Dtype> {
     return LayerParameter_LayerType_HDF5_OUTPUT;
   }
   // TODO: no limit on the number of blobs
-  virtual inline int ExactNumBottomBlobs() const { return 2; }
+  virtual inline int MinBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 0; }
 
   inline std::string file_name() const { return file_name_; }
@@ -213,12 +213,13 @@ class HDF5OutputLayer : public Layer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-  virtual void SaveBlobs();
+  // virtual void SaveBlobs();
 
   std::string file_name_;
   hid_t file_id_;
   Blob<Dtype> data_blob_;
   Blob<Dtype> label_blob_;
+  int current_batch_;
 };
 
 /**

--- a/src/caffe/layers/hdf5_output_layer.cpp
+++ b/src/caffe/layers/hdf5_output_layer.cpp
@@ -19,6 +19,7 @@ HDF5OutputLayer<Dtype>::HDF5OutputLayer(const LayerParameter& param)
   file_id_ = H5Fcreate(file_name_.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT,
                        H5P_DEFAULT);
   CHECK_GE(file_id_, 0) << "Failed to open HDF5 file" << file_name_;
+  current_batch_ = 0;
 }
 
 template <typename Dtype>
@@ -27,36 +28,52 @@ HDF5OutputLayer<Dtype>::~HDF5OutputLayer<Dtype>() {
   CHECK_GE(status, 0) << "Failed to close HDF5 file " << file_name_;
 }
 
-template <typename Dtype>
-void HDF5OutputLayer<Dtype>::SaveBlobs() {
-  // TODO: no limit on the number of blobs
-  LOG(INFO) << "Saving HDF5 file " << file_name_;
-  CHECK_EQ(data_blob_.num(), label_blob_.num()) <<
-      "data blob and label blob must have the same batch size";
-  hdf5_save_nd_dataset(file_id_, HDF5_DATA_DATASET_NAME, data_blob_);
-  hdf5_save_nd_dataset(file_id_, HDF5_DATA_LABEL_NAME, label_blob_);
-  LOG(INFO) << "Successfully saved " << data_blob_.num() << " rows";
-}
+// template <typename Dtype>
+// void HDF5OutputLayer<Dtype>::SaveBlobs() {
+//   // TODO: no limit on the number of blobs
+//   LOG(INFO) << "Saving batch " << current_batch_
+//     << " to HDF5 file " << file_name_;
+//   CHECK_EQ(data_blob_.num(), label_blob_.num()) <<
+//       "data blob and label blob must have the same batch size";
+//   stringstream batch_id;
+//   batch_id << "_" << current_batch_;
+//   hdf5_save_nd_dataset(file_id_, HDF5_DATA_DATASET_NAME + batch_id.str(),
+//     data_blob_);
+//   hdf5_save_nd_dataset(file_id_, HDF5_DATA_LABEL_NAME + batch_id.str(),
+//     label_blob_);
+//   LOG(INFO) << "Successfully saved " << data_blob_.num() << " rows";
+//   current_batch_++;
+// }
 
 template <typename Dtype>
 void HDF5OutputLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-  CHECK_GE(bottom.size(), 2);
-  CHECK_EQ(bottom[0]->num(), bottom[1]->num());
-  data_blob_.Reshape(bottom[0]->num(), bottom[0]->channels(),
-                     bottom[0]->height(), bottom[0]->width());
-  label_blob_.Reshape(bottom[1]->num(), bottom[1]->channels(),
-                     bottom[1]->height(), bottom[1]->width());
-  const int data_datum_dim = bottom[0]->count() / bottom[0]->num();
-  const int label_datum_dim = bottom[1]->count() / bottom[1]->num();
-
-  for (int i = 0; i < bottom[0]->num(); ++i) {
-    caffe_copy(data_datum_dim, &bottom[0]->cpu_data()[i * data_datum_dim],
-        &data_blob_.mutable_cpu_data()[i * data_datum_dim]);
-    caffe_copy(label_datum_dim, &bottom[1]->cpu_data()[i * label_datum_dim],
-        &label_blob_.mutable_cpu_data()[i * label_datum_dim]);
+  for (int i = 0; i < bottom.size(); ++i) {
+    std::string bottom_name = this->layer_param_.bottom(i);
+    stringstream batch_id;
+    batch_id << "_" << current_batch_;
+    LOG(INFO) << "Saving batch " << bottom_name + batch_id.str()
+      << " to HDF5 file " << file_name_;
+    hdf5_save_nd_dataset(file_id_, bottom_name + batch_id.str(), *bottom[i]);
   }
-  SaveBlobs();
+  current_batch_++;
+
+  // CHECK_GE(bottom.size(), 2);
+  // CHECK_EQ(bottom[0]->num(), bottom[1]->num());
+  // data_blob_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+  //                    bottom[0]->height(), bottom[0]->width());
+  // label_blob_.Reshape(bottom[1]->num(), bottom[1]->channels(),
+  //                    bottom[1]->height(), bottom[1]->width());
+  // const int data_datum_dim = bottom[0]->count() / bottom[0]->num();
+  // const int label_datum_dim = bottom[1]->count() / bottom[1]->num();
+
+  // for (int i = 0; i < bottom[0]->num(); ++i) {
+  //   caffe_copy(data_datum_dim, &bottom[0]->cpu_data()[i * data_datum_dim],
+  //       &data_blob_.mutable_cpu_data()[i * data_datum_dim]);
+  //   caffe_copy(label_datum_dim, &bottom[1]->cpu_data()[i * label_datum_dim],
+  //       &label_blob_.mutable_cpu_data()[i * label_datum_dim]);
+  // }
+  // SaveBlobs();
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/hdf5_output_layer.cpp
+++ b/src/caffe/layers/hdf5_output_layer.cpp
@@ -28,52 +28,18 @@ HDF5OutputLayer<Dtype>::~HDF5OutputLayer<Dtype>() {
   CHECK_GE(status, 0) << "Failed to close HDF5 file " << file_name_;
 }
 
-// template <typename Dtype>
-// void HDF5OutputLayer<Dtype>::SaveBlobs() {
-//   // TODO: no limit on the number of blobs
-//   LOG(INFO) << "Saving batch " << current_batch_
-//     << " to HDF5 file " << file_name_;
-//   CHECK_EQ(data_blob_.num(), label_blob_.num()) <<
-//       "data blob and label blob must have the same batch size";
-//   stringstream batch_id;
-//   batch_id << "_" << current_batch_;
-//   hdf5_save_nd_dataset(file_id_, HDF5_DATA_DATASET_NAME + batch_id.str(),
-//     data_blob_);
-//   hdf5_save_nd_dataset(file_id_, HDF5_DATA_LABEL_NAME + batch_id.str(),
-//     label_blob_);
-//   LOG(INFO) << "Successfully saved " << data_blob_.num() << " rows";
-//   current_batch_++;
-// }
-
 template <typename Dtype>
 void HDF5OutputLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+  CHECK_EQ(this->layer_param_.bottom_size(), bottom.size());
   for (int i = 0; i < bottom.size(); ++i) {
-    std::string bottom_name = this->layer_param_.bottom(i);
     stringstream batch_id;
-    batch_id << "_" << current_batch_;
-    LOG(INFO) << "Saving batch " << bottom_name + batch_id.str()
-      << " to HDF5 file " << file_name_;
-    hdf5_save_nd_dataset(file_id_, bottom_name + batch_id.str(), *bottom[i]);
+    batch_id << this->layer_param_.bottom(i) << "_" << current_batch_;
+    LOG_FIRST_N(INFO, bottom.size()) << "Saving batch " << batch_id.str()
+        << " to HDF5 file " << file_name_;
+    hdf5_save_nd_dataset(file_id_, batch_id.str(), *bottom[i]);
   }
   current_batch_++;
-
-  // CHECK_GE(bottom.size(), 2);
-  // CHECK_EQ(bottom[0]->num(), bottom[1]->num());
-  // data_blob_.Reshape(bottom[0]->num(), bottom[0]->channels(),
-  //                    bottom[0]->height(), bottom[0]->width());
-  // label_blob_.Reshape(bottom[1]->num(), bottom[1]->channels(),
-  //                    bottom[1]->height(), bottom[1]->width());
-  // const int data_datum_dim = bottom[0]->count() / bottom[0]->num();
-  // const int label_datum_dim = bottom[1]->count() / bottom[1]->num();
-
-  // for (int i = 0; i < bottom[0]->num(); ++i) {
-  //   caffe_copy(data_datum_dim, &bottom[0]->cpu_data()[i * data_datum_dim],
-  //       &data_blob_.mutable_cpu_data()[i * data_datum_dim]);
-  //   caffe_copy(label_datum_dim, &bottom[1]->cpu_data()[i * label_datum_dim],
-  //       &label_blob_.mutable_cpu_data()[i * label_datum_dim]);
-  // }
-  // SaveBlobs();
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/hdf5_output_layer.cu
+++ b/src/caffe/layers/hdf5_output_layer.cu
@@ -15,22 +15,6 @@ template <typename Dtype>
 void HDF5OutputLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   Forward_cpu(bottom, top);
-  // CHECK_GE(bottom.size(), 2);
-  // CHECK_EQ(bottom[0]->num(), bottom[1]->num());
-  // data_blob_.Reshape(bottom[0]->num(), bottom[0]->channels(),
-  //                    bottom[0]->height(), bottom[0]->width());
-  // label_blob_.Reshape(bottom[1]->num(), bottom[1]->channels(),
-  //                    bottom[1]->height(), bottom[1]->width());
-  // const int data_datum_dim = bottom[0]->count() / bottom[0]->num();
-  // const int label_datum_dim = bottom[1]->count() / bottom[1]->num();
-
-  // for (int i = 0; i < bottom[0]->num(); ++i) {
-  //   caffe_copy(data_datum_dim, &bottom[0]->gpu_data()[i * data_datum_dim],
-  //       &data_blob_.mutable_cpu_data()[i * data_datum_dim]);
-  //   caffe_copy(label_datum_dim, &bottom[1]->gpu_data()[i * label_datum_dim],
-  //       &label_blob_.mutable_cpu_data()[i * label_datum_dim]);
-  // }
-  // SaveBlobs();
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/hdf5_output_layer.cu
+++ b/src/caffe/layers/hdf5_output_layer.cu
@@ -14,22 +14,23 @@ namespace caffe {
 template <typename Dtype>
 void HDF5OutputLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-  CHECK_GE(bottom.size(), 2);
-  CHECK_EQ(bottom[0]->num(), bottom[1]->num());
-  data_blob_.Reshape(bottom[0]->num(), bottom[0]->channels(),
-                     bottom[0]->height(), bottom[0]->width());
-  label_blob_.Reshape(bottom[1]->num(), bottom[1]->channels(),
-                     bottom[1]->height(), bottom[1]->width());
-  const int data_datum_dim = bottom[0]->count() / bottom[0]->num();
-  const int label_datum_dim = bottom[1]->count() / bottom[1]->num();
+  Forward_cpu(bottom, top);
+  // CHECK_GE(bottom.size(), 2);
+  // CHECK_EQ(bottom[0]->num(), bottom[1]->num());
+  // data_blob_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+  //                    bottom[0]->height(), bottom[0]->width());
+  // label_blob_.Reshape(bottom[1]->num(), bottom[1]->channels(),
+  //                    bottom[1]->height(), bottom[1]->width());
+  // const int data_datum_dim = bottom[0]->count() / bottom[0]->num();
+  // const int label_datum_dim = bottom[1]->count() / bottom[1]->num();
 
-  for (int i = 0; i < bottom[0]->num(); ++i) {
-    caffe_copy(data_datum_dim, &bottom[0]->gpu_data()[i * data_datum_dim],
-        &data_blob_.mutable_cpu_data()[i * data_datum_dim]);
-    caffe_copy(label_datum_dim, &bottom[1]->gpu_data()[i * label_datum_dim],
-        &label_blob_.mutable_cpu_data()[i * label_datum_dim]);
-  }
-  SaveBlobs();
+  // for (int i = 0; i < bottom[0]->num(); ++i) {
+  //   caffe_copy(data_datum_dim, &bottom[0]->gpu_data()[i * data_datum_dim],
+  //       &data_blob_.mutable_cpu_data()[i * data_datum_dim]);
+  //   caffe_copy(label_datum_dim, &bottom[1]->gpu_data()[i * label_datum_dim],
+  //       &label_blob_.mutable_cpu_data()[i * label_datum_dim]);
+  // }
+  // SaveBlobs();
 }
 
 template <typename Dtype>

--- a/src/caffe/test/test_hdf5_output_layer.cpp
+++ b/src/caffe/test/test_hdf5_output_layer.cpp
@@ -88,6 +88,8 @@ TYPED_TEST(HDF5OutputLayerTest, TestForward) {
 
   LayerParameter param;
   param.mutable_hdf5_output_param()->set_file_name(this->output_file_name_);
+  param.add_bottom("data");
+  param.add_bottom("label");
   // This code block ensures that the layer is deconstructed and
   //   the output hdf5 file is closed.
   {
@@ -103,13 +105,11 @@ TYPED_TEST(HDF5OutputLayerTest, TestForward) {
           this->input_file_name_;
 
   Blob<Dtype>* blob_data = new Blob<Dtype>();
-  hdf5_load_nd_dataset(file_id, HDF5_DATA_DATASET_NAME, 0, 4,
-                       blob_data);
+  hdf5_load_nd_dataset(file_id, "data_0", 0, 4, blob_data);
   this->CheckBlobEqual(*(this->blob_data_), *blob_data);
 
   Blob<Dtype>* blob_label = new Blob<Dtype>();
-  hdf5_load_nd_dataset(file_id, HDF5_DATA_LABEL_NAME, 0, 4,
-                       blob_label);
+  hdf5_load_nd_dataset(file_id, "label_0", 0, 4, blob_label);
   this->CheckBlobEqual(*(this->blob_label_), *blob_label);
 
   status = H5Fclose(file_id);


### PR DESCRIPTION
This PR allows the HDF5Output layer to save multiple blobs, as many a bottoms, and during multiple batches, each one numbered consecutively. 

This example would save `fc7` and `fc8` features plus the `label`. If there are split layers the names would be changed accordingly. Each forward pass will increment the `batch_id` and append it to the `dataset_name`
```
layers {
  name: "hdf5_output"
  type: HDF5_OUTPUT
  bottom: "fc7"
  bottom: "fc8"
  bottom: "label"
  hdf5_output_param { file_name: "temp.hdf5" }
}
```