### PR TITLE
Load weights from multiple caffemodels.

### DIFF
--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "boost/algorithm/string.hpp"
 #include "caffe/caffe.hpp"
 
 using caffe::Blob;
@@ -76,6 +77,19 @@ int device_query() {
 }
 RegisterBrewFunction(device_query);
 
+// Load the weights from the specified caffemodel(s) into the train- and
+// test-nets.
+void CopyLayers(caffe::Solver<float>& solver, const std::string& model_list) {
+  std::vector<std::string> model_names;
+  boost::split(model_names, model_list, boost::is_any_of(",") );
+  for(int i = 0; i < model_names.size(); ++i) {
+    LOG(INFO) << "Finetuning from " << model_names[i];
+    solver.net()->CopyTrainedLayersFrom(model_names[i]);
+    for( int j = 0; j < solver.test_nets().size(); ++j ) {
+      solver.test_nets()[j]->CopyTrainedLayersFrom(model_names[i]);
+    }
+  }
+}
 
 // Train / Finetune a model.
 int train() {
@@ -112,8 +126,7 @@ int train() {
     LOG(INFO) << "Resuming from " << FLAGS_snapshot;
     solver->Solve(FLAGS_snapshot);
   } else if (FLAGS_weights.size()) {
-    LOG(INFO) << "Finetuning from " << FLAGS_weights;
-    solver->net()->CopyTrainedLayersFrom(FLAGS_weights);
+    CopyLayers(*solver, FLAGS_weights);
     solver->Solve();
   } else {
     solver->Solve();

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -79,14 +79,14 @@ RegisterBrewFunction(device_query);
 
 // Load the weights from the specified caffemodel(s) into the train- and
 // test-nets.
-void CopyLayers(caffe::Solver<float>& solver, const std::string& model_list) {
+void CopyLayers(caffe::Solver<float>* solver, const std::string& model_list) {
   std::vector<std::string> model_names;
   boost::split(model_names, model_list, boost::is_any_of(",") );
-  for(int i = 0; i < model_names.size(); ++i) {
+  for (int i = 0; i < model_names.size(); ++i) {
     LOG(INFO) << "Finetuning from " << model_names[i];
-    solver.net()->CopyTrainedLayersFrom(model_names[i]);
-    for( int j = 0; j < solver.test_nets().size(); ++j ) {
-      solver.test_nets()[j]->CopyTrainedLayersFrom(model_names[i]);
+    solver->net()->CopyTrainedLayersFrom(model_names[i]);
+    for (int j = 0; j < solver->test_nets().size(); ++j) {
+      solver->test_nets()[j]->CopyTrainedLayersFrom(model_names[i]);
     }
   }
 }
@@ -126,7 +126,7 @@ int train() {
     LOG(INFO) << "Resuming from " << FLAGS_snapshot;
     solver->Solve(FLAGS_snapshot);
   } else if (FLAGS_weights.size()) {
-    CopyLayers(*solver, FLAGS_weights);
+    CopyLayers(&*solver, FLAGS_weights);
     solver->Solve();
   } else {
     solver->Solve();


### PR DESCRIPTION
At least one use case requiring this is doing layerwise or "stacked" autoencoder training: First I train the newly-added encoder and decoder layers by themselves (using features extracted from the net having only the previously-trained layers). Then when I begin to train the combined network, it needs to pull weights from two different caffemodel files.  So this change allows the `--weights` parameter to be a comma-separated list of caffemodels instead of just a single caffemodel. 

The other code change is that the test nets are also initialized from the provided caffemodels, not just the train net. So if the trained net is a subset of the test net, then some of the test nets' layers' weights would be uninitialized, whereas with this change they are initialized from the specified models.
