### PR TITLE
Preserve shape of extracted features

### DIFF
--- a/tools/extract_features.cpp
+++ b/tools/extract_features.cpp
@@ -146,9 +146,9 @@ int feature_extraction_pipeline(int argc, char** argv) {
       int dim_features = feature_blob->count() / batch_size;
       const Dtype* feature_blob_data;
       for (int n = 0; n < batch_size; ++n) {
-        datum.set_height(dim_features);
-        datum.set_width(1);
-        datum.set_channels(1);
+        datum.set_height(feature_blob->height());
+        datum.set_width(feature_blob->width());
+        datum.set_channels(feature_blob->channels());
         datum.clear_data();
         datum.clear_float_data();
         feature_blob_data = feature_blob->cpu_data() +


### PR DESCRIPTION
Is there a reason why extract_features changes the shape of a feature datum from channels x height x width to 1 x channels*height*width x 1? This caused a problem where I extracted features to use as the training data for the next stacked encoder/decoder pair of layers. I was unable to train with them because their shape was lost: the convolutional layer needs to know the correct width and height of its input, and it had been lost. I couldn't find a way to tell the net to reshape the training data back to the correct feature dimensions. The simplest solution appears to me to just not mangle the dimensions in the first place. 