### PR TITLE
fix matcaffe prepare_batch indexing

### DIFF
--- a/matlab/caffe/prepare_batch.m
+++ b/matlab/caffe/prepare_batch.m
@@ -13,7 +13,7 @@ end
 IMAGE_DIM = 256;
 CROPPED_DIM = 227;
 indices = [0 IMAGE_DIM-CROPPED_DIM] + 1;
-center = floor(indices(2) / 2)+1;
+center = floor(indices(2) / 2);
 
 num_images = length(image_files);
 images = zeros(CROPPED_DIM,CROPPED_DIM,3,batch_size,'single');


### PR DESCRIPTION
The data_transformer.cpp code crops centers according to the formula

     floor((image_dim - cropped_dim) / 2) 

However, the matlab code crops centers according to the formula:

     floor((image_dim - cropped_dim + 1) / 2) + 1

where the additional +1's are for matlab's indexing at 1. However, you only need one +1. Right now, this causes matcaffe to crop centers one pixel off from the data_transformer.cpp, which makes the extracted features different. I think you should remove one of the +1s so that matcaffe matches data_transformer.cpp exactly.