### PR TITLE
Fix compile error in convert_mnist_siamese_data.cpp

### DIFF
--- a/examples/siamese/convert_mnist_siamese_data.cpp
+++ b/examples/siamese/convert_mnist_siamese_data.cpp
@@ -36,7 +36,7 @@ void convert_dataset(const char* image_filename, const char* label_filename,
   std::ifstream image_file(image_filename, std::ios::in | std::ios::binary);
   std::ifstream label_file(label_filename, std::ios::in | std::ios::binary);
   CHECK(image_file) << "Unable to open file " << image_filename;
-  CHECK(label_file) << "Unable to open file " << label_file;
+  CHECK(label_file) << "Unable to open file " << label_filename;
   // Read the magic and the meta data
   uint32_t magic;
   uint32_t num_items;


### PR DESCRIPTION
We can not print label_file which is a std::ifstream. So, we need replace label_file by label_filename.