### PR TITLE
Check both lower and upper bounds in SoftmaxLossLayer

### DIFF
--- a/src/caffe/layers/softmax_loss_layer.cpp
+++ b/src/caffe/layers/softmax_loss_layer.cpp
@@ -44,8 +44,8 @@ void SoftmaxWithLossLayer<Dtype>::Forward_cpu(
   for (int i = 0; i < num; ++i) {
     for (int j = 0; j < spatial_dim; j++) {
       const int label_value = static_cast<int>(label[i * spatial_dim + j]);
-      CHECK_GE(label_value, 0);
-      CHECK_GT(dim, label_value * spatial_dim);
+      DCHECK_GE(label_value, 0);
+      DCHECK_GT(dim, label_value * spatial_dim);
       loss -= log(std::max(prob_data[i * dim +
           label_value * spatial_dim + j],
                            Dtype(FLT_MIN)));


### PR DESCRIPTION
If we're going to do bounds checking, may as well check all the bounds. I've already run into this while accidentally using uninitialized labels.
