### PR TITLE
Fix CMake lint for out of tree build

### DIFF
--- a/CMakeScripts/lint.cmake
+++ b/CMakeScripts/lint.cmake
@@ -1,6 +1,5 @@
-
-set(CMAKE_SOURCE_DIR ../)
-set(LINT_COMMAND ${CMAKE_SOURCE_DIR}/scripts/cpp_lint.py)
+set(PROJECT_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR}/../)
+set(LINT_COMMAND ${PROJECT_ROOT_DIR}/scripts/cpp_lint.py)
 set(SRC_FILE_EXTENSIONS h hpp hu c cpp cu cc)
 set(EXCLUDE_FILE_EXTENSTIONS pb.h pb.cc)
 set(LINT_DIRS include src/caffe examples tools python matlab)
@@ -8,14 +7,14 @@ set(LINT_DIRS include src/caffe examples tools python matlab)
 # find all files of interest
 foreach(ext ${SRC_FILE_EXTENSIONS})
     foreach(dir ${LINT_DIRS})
-        file(GLOB_RECURSE FOUND_FILES ${CMAKE_SOURCE_DIR}/${dir}/*.${ext})
+        file(GLOB_RECURSE FOUND_FILES ${PROJECT_ROOT_DIR}/${dir}/*.${ext})
         set(LINT_SOURCES ${LINT_SOURCES} ${FOUND_FILES})
     endforeach()
 endforeach()
 
 # find all files that should be excluded
 foreach(ext ${EXCLUDE_FILE_EXTENSTIONS})
-    file(GLOB_RECURSE FOUND_FILES ${CMAKE_SOURCE_DIR}/*.${ext})
+    file(GLOB_RECURSE FOUND_FILES ${PROJECT_ROOT_DIR}/*.${ext})
     set(EXCLUDED_FILES ${EXCLUDED_FILES} ${FOUND_FILES})
 endforeach()
 


### PR DESCRIPTION
The `../` is relative to build dir, so it only works for building from `${root}/build` cases, and breaks when building really away from source tree. Now `../` is relative to `lint.cmake`, and so it's tied to place.