### PR TITLE
Filter layer

### DIFF
--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -190,7 +190,7 @@ class EltwiseLayer : public Layer<Dtype> {
 };
 
 /**
- * @brief Takes two+ Blobs, interprets first Blob as a selector and
+ * @brief Takes two+ Blobs, interprets last Blob as a selector and
  *  filter remaining Blobs accordingly with selector data (0 means that
  * the corresponding item has to be filtered, non-zero means that corresponding
  * item needs to stay).
@@ -214,13 +214,13 @@ class FilterLayer : public Layer<Dtype> {
  protected:
   /**
    * @param bottom input Blob vector (length 2+)
-   *   -# @f$ (N \times 1 \times 1 \times 1) @f$
-   *      the selector blob
    *   -# @f$ (N \times C \times H \times W) @f$
    *      the inputs to be filtered @f$ x_1 @f$
    *   -# ...
    *   -# @f$ (N \times C \times H \times W) @f$
    *      the inputs to be filtered @f$ x_K @f$
+   *   -# @f$ (N \times 1 \times 1 \times 1) @f$
+   *      the selector blob
    * @param top output Blob vector (length 1+)
    *   -# @f$ (S \times C \times H \times W) @f$ () 
    *        the filtered output @f$ x_1 @f$ 

--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -190,9 +190,10 @@ class EltwiseLayer : public Layer<Dtype> {
 };
 
 /**
- * @brief Takes two Blob%s, computes the argmax of the IF bottom blob,
- *  and allow or block the successive forward pass depending on whether
- *  the argmax is equal or different form conditional index, respectively
+ * @brief Takes two+ Blobs, interprets first Blob as a selector and
+ *  filter remaining Blobs accordingly with selector data (0 means that
+ * the corresponding item has to be filtered, non-zero means that corresponding
+ * item needs to stay).
  */
 template <typename Dtype>
 class FilterLayer : public Layer<Dtype> {
@@ -213,7 +214,7 @@ class FilterLayer : public Layer<Dtype> {
  protected:
   /**
    * @param bottom input Blob vector (length 2+)
-   *   -# @f$ (N \times C \times H \times W) @f$
+   *   -# @f$ (N \times 1 \times 1 \times 1) @f$
    *      the selector blob
    *   -# @f$ (N \times C \times H \times W) @f$
    *      the inputs to be filtered @f$ x_1 @f$
@@ -250,7 +251,7 @@ class FilterLayer : public Layer<Dtype> {
     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
   bool first_reshape_;
-  vector<Dtype> indices_to_forward_;
+  vector<int> indices_to_forward_;
   vector<int> need_back_prop_;
 };
 

--- a/src/caffe/layers/filter_layer.cpp
+++ b/src/caffe/layers/filter_layer.cpp
@@ -1,0 +1,123 @@
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void FilterLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  first_reshape_ = true;
+  CHECK_EQ(top.size(), bottom.size()-1) <<
+        "Top.size() should be equal to bottom.size() - 1";
+}
+
+template <typename Dtype>
+void FilterLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  // bottom[0] is the "SELECTOR_blob"
+  // bottom[1+] are the blobs to filter
+  int num_items = bottom[0]->num();
+  
+  CHECK_EQ(bottom[0]->channels(), 1) <<
+        "Selector blob (bottom[0]) must have channels == 1";
+  CHECK_EQ(bottom[0]->width(), 1) <<
+        "Selector blob (bottom[0]) must have width == 1";
+  CHECK_EQ(bottom[0]->height(), 1) <<
+        "Selector blob (bottom[0]) must have height == 1";
+  for(int i = 1; i < bottom.size(); i++) {
+    CHECK_EQ(num_items, bottom[i]->num()) <<
+        "Each bottom should have the same dimension as bottom[0]";
+  }
+
+  const Dtype* bottom_data_SELECTOR = bottom[0]->cpu_data();
+  indices_to_forward_.clear();
+
+  // look for non-zero elements in bottom[0]. Items of each bottom that
+  // have the same index as the items in bottom[0] with value == non-zero
+  // will be forwarded
+  for (size_t item_id = 0; item_id < num_items; ++item_id) {
+    //we don't need an offset because item size == 1
+    const Dtype* tmp_data_SELECTOR = bottom_data_SELECTOR + item_id;
+    if(*tmp_data_SELECTOR != 0) {
+      indices_to_forward_.push_back(item_id);
+    }
+  }
+
+  // only filtered items will be forwarded
+  int new_tops_num = indices_to_forward_.size();
+  // init
+  if (first_reshape_) {
+    new_tops_num = bottom[1]->num();
+    first_reshape_ = false;
+  }
+
+  for(size_t t = 0; t < top.size(); t++) {
+    top[t]->Reshape(new_tops_num,
+        bottom[t+1]->channels(),
+        bottom[t+1]->height(),
+        bottom[t+1]->width());
+  }
+}
+
+template <typename Dtype>
+void FilterLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  int new_tops_num = indices_to_forward_.size();
+  // forward all filtered items for all bottoms but the Selector (bottom[0])
+  for(size_t b = 1; b < bottom.size(); b++) {
+    const Dtype* bottom_data = bottom[b]->cpu_data();
+    Dtype* top_data = top[b-1]->mutable_cpu_data();
+    size_t size_single_item = bottom[b]->count()/bottom[b]->num();
+
+    for (size_t n = 0; n < new_tops_num; n++) {
+      int offset = indices_to_forward_[n];
+      int data_offset_top = size_single_item*n;
+      int data_offset_bottom = size_single_item*offset;
+
+      caffe_copy(size_single_item, bottom_data+data_offset_bottom,
+          top_data+data_offset_top);
+    }
+  }
+}
+
+template <typename Dtype>
+void FilterLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  LOG(ERROR) << "propagate_down.size(): " << propagate_down.size();
+  LOG(ERROR) << "bottom.size(): " << bottom.size();
+  LOG(ERROR) << "top.size(): " << top.size();
+  for(size_t i = 0; i < propagate_down.size(); i++) {
+    if (propagate_down[i]) {/*
+      const int size_single_batch = top[1]->count()/top[1]->num();
+      int index_top = 0;
+      std::vector<double> zeros(size_single_batch, 0.0);
+      for (size_t n = 0; n < bottom[1]->num(); n++) {
+        int offset = indices_to_forward_[n];
+        int data_offset_bottom = size_single_batch*n;
+        if (n != offset) {  // this data was not been forwarded
+          caffe_copy(size_single_batch,
+              reinterpret_cast<Dtype*>(&zeros[0]),
+              bottom[1]->mutable_cpu_diff() + data_offset_bottom);
+        } else {  // this data was been forwarded
+          int data_offset_top = size_single_batch*index_top;
+          index_top++;
+          caffe_copy(size_single_batch,
+              top[1]->mutable_cpu_diff() + data_offset_top,
+              bottom[1]->mutable_cpu_diff() + data_offset_bottom);
+        }
+      }
+    */}
+  }
+    
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(FilterLayer);
+#endif
+
+INSTANTIATE_CLASS(FilterLayer);
+REGISTER_LAYER_CLASS(FILTER, FilterLayer);
+}  // namespace caffe

--- a/src/caffe/layers/filter_layer.cpp
+++ b/src/caffe/layers/filter_layer.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <vector>
 
 #include "caffe/layer.hpp"
@@ -28,15 +29,14 @@ void FilterLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   // bottom[0] is the "SELECTOR_blob"
   // bottom[1+] are the blobs to filter
-  int num_items = bottom[0]->num();
-  
   CHECK_EQ(bottom[0]->channels(), 1) <<
         "Selector blob (bottom[0]) must have channels == 1";
   CHECK_EQ(bottom[0]->width(), 1) <<
         "Selector blob (bottom[0]) must have width == 1";
   CHECK_EQ(bottom[0]->height(), 1) <<
         "Selector blob (bottom[0]) must have height == 1";
-  for(int i = 1; i < bottom.size(); i++) {
+  int num_items = bottom[0]->num();
+  for (int i = 1; i < bottom.size(); i++) {
     CHECK_EQ(num_items, bottom[i]->num()) <<
         "Each bottom should have the same dimension as bottom[0]";
   }
@@ -48,9 +48,9 @@ void FilterLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   // have the same index as the items in bottom[0] with value == non-zero
   // will be forwarded
   for (size_t item_id = 0; item_id < num_items; ++item_id) {
-    //we don't need an offset because item size == 1
+    // we don't need an offset because item size == 1
     const Dtype* tmp_data_SELECTOR = bottom_data_SELECTOR + item_id;
-    if(*tmp_data_SELECTOR != 0) {
+    if (*tmp_data_SELECTOR != 0) {
       indices_to_forward_.push_back(item_id);
     }
   }
@@ -63,7 +63,7 @@ void FilterLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
     first_reshape_ = false;
   }
 
-  for(size_t t = 0; t < top.size(); t++) {
+  for (size_t t = 0; t < top.size(); t++) {
     top[t]->Reshape(new_tops_num,
         bottom[t+1]->channels(),
         bottom[t+1]->height(),
@@ -76,7 +76,7 @@ void FilterLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   int new_tops_num = indices_to_forward_.size();
   // forward all filtered items for all bottoms but the Selector (bottom[0])
-  for(size_t b = 1; b < bottom.size(); b++) {
+  for (size_t b = 1; b < bottom.size(); b++) {
     const Dtype* bottom_data = bottom[b]->cpu_data();
     Dtype* top_data = top[b-1]->mutable_cpu_data();
     size_t dim = bottom[b]->count()/bottom[b]->num();
@@ -95,7 +95,7 @@ void FilterLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void FilterLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  for(size_t i = 1; i < propagate_down.size(); i++) {
+  for (size_t i = 1; i < propagate_down.size(); i++) {
     // bottom[0] is the selector and never needs backpropagation
     // so we can start from i = 1 and index each top with i-1
     if (propagate_down[i] && need_back_prop_[i-1]) {
@@ -117,7 +117,6 @@ void FilterLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       }
     }
   }
-    
 }
 
 #ifdef CPU_ONLY

--- a/src/caffe/layers/filter_layer.cpp
+++ b/src/caffe/layers/filter_layer.cpp
@@ -27,7 +27,7 @@ void FilterLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void FilterLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-  // bottom[0] is the "SELECTOR_blob"
+  // bottom[0] is the "selector_blob"
   // bottom[1+] are the blobs to filter
   CHECK_EQ(bottom[0]->channels(), 1) <<
         "Selector blob (bottom[0]) must have channels == 1";
@@ -41,16 +41,16 @@ void FilterLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
         "Each bottom should have the same dimension as bottom[0]";
   }
 
-  const Dtype* bottom_data_SELECTOR = bottom[0]->cpu_data();
+  const Dtype* bottom_data_selector = bottom[0]->cpu_data();
   indices_to_forward_.clear();
 
   // look for non-zero elements in bottom[0]. Items of each bottom that
   // have the same index as the items in bottom[0] with value == non-zero
   // will be forwarded
-  for (size_t item_id = 0; item_id < num_items; ++item_id) {
+  for (int item_id = 0; item_id < num_items; ++item_id) {
     // we don't need an offset because item size == 1
-    const Dtype* tmp_data_SELECTOR = bottom_data_SELECTOR + item_id;
-    if (*tmp_data_SELECTOR != 0) {
+    const Dtype* tmp_data_selector = bottom_data_selector + item_id;
+    if (*tmp_data_selector) {
       indices_to_forward_.push_back(item_id);
     }
   }
@@ -63,7 +63,7 @@ void FilterLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
     first_reshape_ = false;
   }
 
-  for (size_t t = 0; t < top.size(); t++) {
+  for (int t = 0; t < top.size(); t++) {
     top[t]->Reshape(new_tops_num,
         bottom[t+1]->channels(),
         bottom[t+1]->height(),
@@ -76,15 +76,15 @@ void FilterLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   int new_tops_num = indices_to_forward_.size();
   // forward all filtered items for all bottoms but the Selector (bottom[0])
-  for (size_t b = 1; b < bottom.size(); b++) {
+  for (int b = 1; b < bottom.size(); b++) {
     const Dtype* bottom_data = bottom[b]->cpu_data();
     Dtype* top_data = top[b-1]->mutable_cpu_data();
-    size_t dim = bottom[b]->count()/bottom[b]->num();
+    int dim = bottom[b]->count() / bottom[b]->num();
 
-    for (size_t n = 0; n < new_tops_num; n++) {
+    for (int n = 0; n < new_tops_num; n++) {
       int offset = indices_to_forward_[n];
-      int data_offset_top = dim*n;
-      int data_offset_bottom = dim*offset;
+      int data_offset_top = top[b-1]->offset(n);
+      int data_offset_bottom =  bottom[b]->offset(indices_to_forward_[n]);
 
       caffe_copy(dim, bottom_data+data_offset_bottom,
           top_data+data_offset_top);
@@ -95,24 +95,34 @@ void FilterLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void FilterLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  for (size_t i = 1; i < propagate_down.size(); i++) {
+  for (int i = 1; i < propagate_down.size(); i++) {
     // bottom[0] is the selector and never needs backpropagation
     // so we can start from i = 1 and index each top with i-1
     if (propagate_down[i] && need_back_prop_[i-1]) {
-      const int dim = top[i-1]->count()/top[i-1]->num();
-      int index_top = 0;
-      std::vector<double> zeros(dim, 0.0);
-      for (size_t n = 0; n < bottom[i]->num(); n++) {
-        int offset = indices_to_forward_[n];
-        int data_offset_bottom = dim*n;
-        if (n != offset) {  // this data was not been forwarded
-          caffe_copy(dim, reinterpret_cast<Dtype*>(&zeros[0]),
+      const int dim = top[i-1]->count() / top[i-1]->num();
+      int next_to_backward_offset = 0;
+      int batch_offset = 0;
+      int data_offset_bottom = 0;
+      int data_offset_top = 0;
+      for (int n = 0; n < bottom[i]->num(); n++) {
+        if (next_to_backward_offset >= indices_to_forward_.size()) {
+          // we already visited all items that were been forwarded, so
+          // just set to zero remaining ones
+          data_offset_bottom = top[i-1]->offset(n);
+          caffe_set(dim, Dtype(0),
               bottom[i]->mutable_cpu_diff() + data_offset_bottom);
-        } else {  // this data was been forwarded
-          int data_offset_top = dim*index_top;
-          index_top++;
-          caffe_copy(dim, top[i-1]->mutable_cpu_diff() + data_offset_top,
-              bottom[i]->mutable_cpu_diff() + data_offset_bottom);
+        } else {
+          batch_offset = indices_to_forward_[next_to_backward_offset];
+          data_offset_bottom = top[i-1]->offset(n);
+          if (n != batch_offset) {  // this data was not been forwarded
+            caffe_set(dim, Dtype(0),
+                bottom[i]->mutable_cpu_diff() + data_offset_bottom);
+          } else {  // this data was been forwarded
+            data_offset_top = top[i-1]->offset(next_to_backward_offset);
+            next_to_backward_offset++;  // point to next forwarded item index
+            caffe_copy(dim, top[i-1]->mutable_cpu_diff() + data_offset_top,
+                bottom[i]->mutable_cpu_diff() + data_offset_bottom);
+          }
         }
       }
     }

--- a/src/caffe/layers/filter_layer.cpp
+++ b/src/caffe/layers/filter_layer.cpp
@@ -82,7 +82,6 @@ void FilterLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     int dim = bottom[b]->count() / bottom[b]->num();
 
     for (int n = 0; n < new_tops_num; n++) {
-      int offset = indices_to_forward_[n];
       int data_offset_top = top[b-1]->offset(n);
       int data_offset_bottom =  bottom[b]->offset(indices_to_forward_[n]);
 

--- a/src/caffe/layers/filter_layer.cpp
+++ b/src/caffe/layers/filter_layer.cpp
@@ -9,9 +9,18 @@ namespace caffe {
 template <typename Dtype>
 void FilterLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-  first_reshape_ = true;
   CHECK_EQ(top.size(), bottom.size()-1) <<
-        "Top.size() should be equal to bottom.size() - 1";
+      "Top.size() should be equal to bottom.size() - 1";
+  const FilterParameter& filter_param = this->layer_param_.filter_param();
+  first_reshape_ = true;
+  need_back_prop_.clear();
+  std::copy(filter_param.need_back_prop().begin(),
+      filter_param.need_back_prop().end(),
+      std::back_inserter(need_back_prop_));
+  CHECK_NE(0, need_back_prop_.size()) <<
+      "need_back_prop param needs to be specified";
+  CHECK_EQ(top.size(), need_back_prop_.size()) <<
+      "need_back_prop.size() needs to be equal to top.size()";
 }
 
 template <typename Dtype>
@@ -70,14 +79,14 @@ void FilterLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   for(size_t b = 1; b < bottom.size(); b++) {
     const Dtype* bottom_data = bottom[b]->cpu_data();
     Dtype* top_data = top[b-1]->mutable_cpu_data();
-    size_t size_single_item = bottom[b]->count()/bottom[b]->num();
+    size_t dim = bottom[b]->count()/bottom[b]->num();
 
     for (size_t n = 0; n < new_tops_num; n++) {
       int offset = indices_to_forward_[n];
-      int data_offset_top = size_single_item*n;
-      int data_offset_bottom = size_single_item*offset;
+      int data_offset_top = dim*n;
+      int data_offset_bottom = dim*offset;
 
-      caffe_copy(size_single_item, bottom_data+data_offset_bottom,
+      caffe_copy(dim, bottom_data+data_offset_bottom,
           top_data+data_offset_top);
     }
   }
@@ -86,30 +95,27 @@ void FilterLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void FilterLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  LOG(ERROR) << "propagate_down.size(): " << propagate_down.size();
-  LOG(ERROR) << "bottom.size(): " << bottom.size();
-  LOG(ERROR) << "top.size(): " << top.size();
-  for(size_t i = 0; i < propagate_down.size(); i++) {
-    if (propagate_down[i]) {/*
-      const int size_single_batch = top[1]->count()/top[1]->num();
+  for(size_t i = 1; i < propagate_down.size(); i++) {
+    // bottom[0] is the selector and never needs backpropagation
+    // so we can start from i = 1 and index each top with i-1
+    if (propagate_down[i] && need_back_prop_[i-1]) {
+      const int dim = top[i-1]->count()/top[i-1]->num();
       int index_top = 0;
-      std::vector<double> zeros(size_single_batch, 0.0);
-      for (size_t n = 0; n < bottom[1]->num(); n++) {
+      std::vector<double> zeros(dim, 0.0);
+      for (size_t n = 0; n < bottom[i]->num(); n++) {
         int offset = indices_to_forward_[n];
-        int data_offset_bottom = size_single_batch*n;
+        int data_offset_bottom = dim*n;
         if (n != offset) {  // this data was not been forwarded
-          caffe_copy(size_single_batch,
-              reinterpret_cast<Dtype*>(&zeros[0]),
-              bottom[1]->mutable_cpu_diff() + data_offset_bottom);
+          caffe_copy(dim, reinterpret_cast<Dtype*>(&zeros[0]),
+              bottom[i]->mutable_cpu_diff() + data_offset_bottom);
         } else {  // this data was been forwarded
-          int data_offset_top = size_single_batch*index_top;
+          int data_offset_top = dim*index_top;
           index_top++;
-          caffe_copy(size_single_batch,
-              top[1]->mutable_cpu_diff() + data_offset_top,
-              bottom[1]->mutable_cpu_diff() + data_offset_bottom);
+          caffe_copy(dim, top[i-1]->mutable_cpu_diff() + data_offset_top,
+              bottom[i]->mutable_cpu_diff() + data_offset_bottom);
         }
       }
-    */}
+    }
   }
     
 }

--- a/src/caffe/layers/filter_layer.cu
+++ b/src/caffe/layers/filter_layer.cu
@@ -43,13 +43,13 @@ void FilterLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
           // we already visited all items that were been forwarded, so
           // just set to zero remaining ones
           data_offset_bottom = top[i-1]->offset(n);
-          caffe_set(dim, Dtype(0),
+          caffe_gpu_set(dim, Dtype(0),
               bottom[i]->mutable_gpu_diff() + data_offset_bottom);
         } else {
           batch_offset = indices_to_forward_[next_to_backward_offset];
           data_offset_bottom = top[i-1]->offset(n);
           if (n != batch_offset) {  // this data was not been forwarded
-            caffe_set(dim, Dtype(0),
+            caffe_gpu_set(dim, Dtype(0),
                 bottom[i]->mutable_gpu_diff() + data_offset_bottom);
           } else {  // this data was been forwarded
             data_offset_top = top[i-1]->offset(next_to_backward_offset);

--- a/src/caffe/layers/filter_layer.cu
+++ b/src/caffe/layers/filter_layer.cu
@@ -11,7 +11,7 @@ void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   int new_tops_num = indices_to_forward_.size();
   // forward all filtered items for all bottoms but the Selector (bottom[0])
-  for(size_t b = 1; b < bottom.size(); b++) {
+  for (size_t b = 1; b < bottom.size(); b++) {
     const Dtype* bottom_data = bottom[b]->gpu_data();
     Dtype* top_data = top[b-1]->mutable_gpu_data();
     size_t dim = bottom[b]->count()/bottom[b]->num();
@@ -30,7 +30,7 @@ void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void FilterLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  for(size_t i = 1; i < propagate_down.size(); i++) {
+  for (size_t i = 1; i < propagate_down.size(); i++) {
     // bottom[0] is the selector and never needs backpropagation
     // so we can start from i = 1 and index each top with i-1
     if (propagate_down[i] && need_back_prop_[i-1]) {
@@ -52,8 +52,8 @@ void FilterLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
       }
     }
   }
-    
 }
+
 INSTANTIATE_LAYER_GPU_FUNCS(FilterLayer);
 
 }  // namespace caffe

--- a/src/caffe/layers/filter_layer.cu
+++ b/src/caffe/layers/filter_layer.cu
@@ -10,14 +10,14 @@ template <typename Dtype>
 void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   int new_tops_num = indices_to_forward_.size();
-  // forward all filtered items for all bottoms but the Selector (bottom[0])
-  for (int b = 1; b < bottom.size(); b++) {
-    const Dtype* bottom_data = bottom[b]->gpu_data();
-    Dtype* top_data = top[b-1]->mutable_gpu_data();
-    int dim = bottom[b]->count() / bottom[b]->num();
+  // forward all filtered items for all bottoms but the Selector (bottom[last])
+  for (int t = 0; t < top.size(); t++) {
+    const Dtype* bottom_data = bottom[t]->gpu_data();
+    Dtype* top_data = top[t]->mutable_gpu_data();
+    int dim = bottom[t]->count() / bottom[t]->num();
     for (int n = 0; n < new_tops_num; n++) {
-      int data_offset_top = top[b-1]->offset(n);
-      int data_offset_bottom =  bottom[b]->offset(indices_to_forward_[n]);
+      int data_offset_top = top[t]->offset(n);
+      int data_offset_bottom =  bottom[t]->offset(indices_to_forward_[n]);
       caffe_copy(dim, bottom_data + data_offset_bottom,
           top_data + data_offset_top);
     }
@@ -27,11 +27,10 @@ void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void FilterLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  for (int i = 1; i < propagate_down.size(); i++) {
-    // bottom[0] is the selector and never needs backpropagation
-    // so we can start from i = 1 and index each top with i-1
-    if (propagate_down[i] && need_back_prop_[i-1]) {
-      const int dim = top[i-1]->count() / top[i-1]->num();
+  for (int i = 0; i < top.size(); i++) {
+    // bottom[last] is the selector and never needs backpropagation
+    if (propagate_down[i] && need_back_prop_[i]) {
+      const int dim = top[i]->count() / top[i]->num();
       int next_to_backward_offset = 0;
       int batch_offset = 0;
       int data_offset_bottom = 0;
@@ -40,19 +39,19 @@ void FilterLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
         if (next_to_backward_offset >= indices_to_forward_.size()) {
           // we already visited all items that were been forwarded, so
           // just set to zero remaining ones
-          data_offset_bottom = top[i-1]->offset(n);
+          data_offset_bottom = top[i]->offset(n);
           caffe_gpu_set(dim, Dtype(0),
               bottom[i]->mutable_gpu_diff() + data_offset_bottom);
         } else {
           batch_offset = indices_to_forward_[next_to_backward_offset];
-          data_offset_bottom = top[i-1]->offset(n);
+          data_offset_bottom = top[i]->offset(n);
           if (n != batch_offset) {  // this data was not been forwarded
             caffe_gpu_set(dim, Dtype(0),
                 bottom[i]->mutable_gpu_diff() + data_offset_bottom);
           } else {  // this data was been forwarded
-            data_offset_top = top[i-1]->offset(next_to_backward_offset);
+            data_offset_top = top[i]->offset(next_to_backward_offset);
             next_to_backward_offset++;  // point to next forwarded item index
-            caffe_copy(dim, top[i-1]->mutable_gpu_diff() + data_offset_top,
+            caffe_copy(dim, top[i]->mutable_gpu_diff() + data_offset_top,
                 bottom[i]->mutable_gpu_diff() + data_offset_bottom);
           }
         }

--- a/src/caffe/layers/filter_layer.cu
+++ b/src/caffe/layers/filter_layer.cu
@@ -1,0 +1,62 @@
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  int new_tops_num = indices_to_forward_.size();
+  // forward all filtered items for all bottoms but the Selector (bottom[0])
+  for(size_t b = 1; b < bottom.size(); b++) {
+    const Dtype* bottom_data = bottom[b]->gpu_data();
+    Dtype* top_data = top[b-1]->mutable_gpu_data();
+    size_t size_single_item = bottom[b]->count()/bottom[b]->num();
+
+    for (size_t n = 0; n < new_tops_num; n++) {
+      int offset = indices_to_forward_[n];
+      int data_offset_top = size_single_item*n;
+      int data_offset_bottom = size_single_item*offset;
+
+      caffe_copy(size_single_batch, bottom_data+data_offset_bottom,
+          top_data+data_offset_top);
+    }
+  }
+}
+
+template <typename Dtype>
+void FilterLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  LOG(ERROR) << "propagate_down.size(): " << propagate_down.size();
+  LOG(ERROR) << "bottom.size(): " << bottom.size();
+  LOG(ERROR) << "top.size(): " << top.size();
+  for(size_t i = 0; i < propagate_down.size(); i++) {
+    if (propagate_down[i]) {/*
+      const int size_single_batch = top[1]->count()/top[1]->num();
+      int index_top = 0;
+      std::vector<double> zeros(size_single_batch, 0.0);
+      for (size_t n = 0; n < bottom[1]->num(); n++) {
+        int offset = indices_to_forward_[n];
+        int data_offset_bottom = size_single_batch*n;
+        if (n != offset) {  // this data was not been forwarded
+          caffe_copy(size_single_batch,
+              reinterpret_cast<Dtype*>(&zeros[0]),
+              bottom[1]->mutable_gpu_diff() + data_offset_bottom);
+        } else {  // this data was been forwarded
+          int data_offset_top = size_single_batch*index_top;
+          index_top++;
+          caffe_copy(size_single_batch,
+              top[1]->mutable_gpu_diff() + data_offset_top,
+              bottom[1]->mutable_gpu_diff() + data_offset_bottom);
+        }
+      }
+    */}
+  }
+    
+}
+INSTANTIATE_LAYER_GPU_FUNCS(FilterLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/filter_layer.cu
+++ b/src/caffe/layers/filter_layer.cu
@@ -11,15 +11,15 @@ void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   int new_tops_num = indices_to_forward_.size();
   // forward all filtered items for all bottoms but the Selector (bottom[0])
-  for (size_t b = 1; b < bottom.size(); b++) {
+  for (int b = 1; b < bottom.size(); b++) {
     const Dtype* bottom_data = bottom[b]->gpu_data();
     Dtype* top_data = top[b-1]->mutable_gpu_data();
-    size_t dim = bottom[b]->count()/bottom[b]->num();
+    int dim = bottom[b]->count() / bottom[b]->num();
 
-    for (size_t n = 0; n < new_tops_num; n++) {
+    for (int n = 0; n < new_tops_num; n++) {
       int offset = indices_to_forward_[n];
-      int data_offset_top = dim*n;
-      int data_offset_bottom = dim*offset;
+      int data_offset_top = top[b-1]->offset(n);
+      int data_offset_bottom =  bottom[b]->offset(indices_to_forward_[n]);
 
       caffe_copy(dim, bottom_data+data_offset_bottom,
           top_data+data_offset_top);
@@ -30,24 +30,34 @@ void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void FilterLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  for (size_t i = 1; i < propagate_down.size(); i++) {
+  for (int i = 1; i < propagate_down.size(); i++) {
     // bottom[0] is the selector and never needs backpropagation
     // so we can start from i = 1 and index each top with i-1
     if (propagate_down[i] && need_back_prop_[i-1]) {
-      const int dim = top[i-1]->count()/top[i-1]->num();
-      int index_top = 0;
-      std::vector<double> zeros(dim, 0.0);
-      for (size_t n = 0; n < bottom[i]->num(); n++) {
-        int offset = indices_to_forward_[n];
-        int data_offset_bottom = dim*n;
-        if (n != offset) {  // this data was not been forwarded
-          caffe_copy(dim, reinterpret_cast<Dtype*>(&zeros[0]),
+      const int dim = top[i-1]->count() / top[i-1]->num();
+      int next_to_backward_offset = 0;
+      int batch_offset = 0;
+      int data_offset_bottom = 0;
+      int data_offset_top = 0;
+      for (int n = 0; n < bottom[i]->num(); n++) {
+        if (next_to_backward_offset >= indices_to_forward_.size()) {
+          // we already visited all items that were been forwarded, so
+          // just set to zero remaining ones
+          data_offset_bottom = top[i-1]->offset(n);
+          caffe_set(dim, Dtype(0),
               bottom[i]->mutable_gpu_diff() + data_offset_bottom);
-        } else {  // this data was been forwarded
-          int data_offset_top = dim*index_top;
-          index_top++;
-          caffe_copy(dim, top[i-1]->mutable_gpu_diff() + data_offset_top,
-              bottom[i]->mutable_gpu_diff() + data_offset_bottom);
+        } else {
+          batch_offset = indices_to_forward_[next_to_backward_offset];
+          data_offset_bottom = top[i-1]->offset(n);
+          if (n != batch_offset) {  // this data was not been forwarded
+            caffe_set(dim, Dtype(0),
+                bottom[i]->mutable_gpu_diff() + data_offset_bottom);
+          } else {  // this data was been forwarded
+            data_offset_top = top[i-1]->offset(next_to_backward_offset);
+            next_to_backward_offset++;  // point to next forwarded item index
+            caffe_copy(dim, top[i-1]->mutable_gpu_diff() + data_offset_top,
+                bottom[i]->mutable_gpu_diff() + data_offset_bottom);
+          }
         }
       }
     }

--- a/src/caffe/layers/filter_layer.cu
+++ b/src/caffe/layers/filter_layer.cu
@@ -15,13 +15,11 @@ void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const Dtype* bottom_data = bottom[b]->gpu_data();
     Dtype* top_data = top[b-1]->mutable_gpu_data();
     int dim = bottom[b]->count() / bottom[b]->num();
-
     for (int n = 0; n < new_tops_num; n++) {
       int data_offset_top = top[b-1]->offset(n);
       int data_offset_bottom =  bottom[b]->offset(indices_to_forward_[n]);
-
-      caffe_copy(dim, bottom_data+data_offset_bottom,
-          top_data+data_offset_top);
+      caffe_copy(dim, bottom_data + data_offset_bottom,
+          top_data + data_offset_top);
     }
   }
 }

--- a/src/caffe/layers/filter_layer.cu
+++ b/src/caffe/layers/filter_layer.cu
@@ -17,7 +17,6 @@ void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     int dim = bottom[b]->count() / bottom[b]->num();
 
     for (int n = 0; n < new_tops_num; n++) {
-      int offset = indices_to_forward_[n];
       int data_offset_top = top[b-1]->offset(n);
       int data_offset_bottom =  bottom[b]->offset(indices_to_forward_[n]);
 

--- a/src/caffe/layers/filter_layer.cu
+++ b/src/caffe/layers/filter_layer.cu
@@ -14,14 +14,14 @@ void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   for(size_t b = 1; b < bottom.size(); b++) {
     const Dtype* bottom_data = bottom[b]->gpu_data();
     Dtype* top_data = top[b-1]->mutable_gpu_data();
-    size_t size_single_item = bottom[b]->count()/bottom[b]->num();
+    size_t dim = bottom[b]->count()/bottom[b]->num();
 
     for (size_t n = 0; n < new_tops_num; n++) {
       int offset = indices_to_forward_[n];
-      int data_offset_top = size_single_item*n;
-      int data_offset_bottom = size_single_item*offset;
+      int data_offset_top = dim*n;
+      int data_offset_bottom = dim*offset;
 
-      caffe_copy(size_single_batch, bottom_data+data_offset_bottom,
+      caffe_copy(dim, bottom_data+data_offset_bottom,
           top_data+data_offset_top);
     }
   }
@@ -30,30 +30,27 @@ void FilterLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void FilterLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  LOG(ERROR) << "propagate_down.size(): " << propagate_down.size();
-  LOG(ERROR) << "bottom.size(): " << bottom.size();
-  LOG(ERROR) << "top.size(): " << top.size();
-  for(size_t i = 0; i < propagate_down.size(); i++) {
-    if (propagate_down[i]) {/*
-      const int size_single_batch = top[1]->count()/top[1]->num();
+  for(size_t i = 1; i < propagate_down.size(); i++) {
+    // bottom[0] is the selector and never needs backpropagation
+    // so we can start from i = 1 and index each top with i-1
+    if (propagate_down[i] && need_back_prop_[i-1]) {
+      const int dim = top[i-1]->count()/top[i-1]->num();
       int index_top = 0;
-      std::vector<double> zeros(size_single_batch, 0.0);
-      for (size_t n = 0; n < bottom[1]->num(); n++) {
+      std::vector<double> zeros(dim, 0.0);
+      for (size_t n = 0; n < bottom[i]->num(); n++) {
         int offset = indices_to_forward_[n];
-        int data_offset_bottom = size_single_batch*n;
+        int data_offset_bottom = dim*n;
         if (n != offset) {  // this data was not been forwarded
-          caffe_copy(size_single_batch,
-              reinterpret_cast<Dtype*>(&zeros[0]),
-              bottom[1]->mutable_gpu_diff() + data_offset_bottom);
+          caffe_copy(dim, reinterpret_cast<Dtype*>(&zeros[0]),
+              bottom[i]->mutable_gpu_diff() + data_offset_bottom);
         } else {  // this data was been forwarded
-          int data_offset_top = size_single_batch*index_top;
+          int data_offset_top = dim*index_top;
           index_top++;
-          caffe_copy(size_single_batch,
-              top[1]->mutable_gpu_diff() + data_offset_top,
-              bottom[1]->mutable_gpu_diff() + data_offset_bottom);
+          caffe_copy(dim, top[i-1]->mutable_gpu_diff() + data_offset_top,
+              bottom[i]->mutable_gpu_diff() + data_offset_bottom);
         }
       }
-    */}
+    }
   }
     
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -206,7 +206,7 @@ message NetStateRule {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available ID: 42 (last added: exp_param)
+// LayerParameter next available ID: 43 (last added: filter_param)
 message LayerParameter {
   repeated string bottom = 2; // the name of the bottom blobs
   repeated string top = 3; // the name of the top blobs
@@ -310,6 +310,7 @@ message LayerParameter {
   optional DummyDataParameter dummy_data_param = 26;
   optional EltwiseParameter eltwise_param = 24;
   optional ExpParameter exp_param = 41;
+  optional FilterParameter filter_param = 42;
   optional HDF5DataParameter hdf5_data_param = 13;
   optional HDF5OutputParameter hdf5_output_param = 14;
   optional HingeLossParameter hinge_loss_param = 29;
@@ -492,6 +493,12 @@ message ExpParameter {
   optional float base = 1 [default = -1.0];
   optional float scale = 2 [default = 1.0];
   optional float shift = 3 [default = 0.0];
+}
+
+// Message that stores parameters used by FilterLayer
+message FilterParameter {
+  // specify which blobs need to be backpropagated and which not
+  repeated uint32 need_back_prop = 1 [packed = true];
 }
 
 // Message that stores parameters used by HDF5DataLayer

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -227,7 +227,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 39 (last added: EXP)
+  // LayerType next available ID: 40 (last added: FILTER)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if
@@ -246,6 +246,7 @@ message LayerParameter {
     EUCLIDEAN_LOSS = 7;
     ELTWISE = 25;
     EXP = 38;
+    FILTER = 39;
     FLATTEN = 8;
     HDF5_DATA = 9;
     HDF5_OUTPUT = 10;

--- a/src/caffe/test/test_filter_layer.cpp
+++ b/src/caffe/test/test_filter_layer.cpp
@@ -20,45 +20,45 @@ class FilterLayerTest : public MultiDeviceTest<TypeParam> {
 
  protected:
   FilterLayerTest()
-      : blob_bottom_SELECTOR_(new Blob<Dtype>(4, 1, 1, 1)),
-        blob_bottom_DATA_(new Blob<Dtype>(4, 14, 5, 7)),
-        blob_bottom_LABELS_(new Blob<Dtype>(4, 1, 1, 1)),
-        blob_top_DATA_(new Blob<Dtype>()),
-        blob_top_LABELS_(new Blob<Dtype>()) {}
+      : blob_bottom_selector_(new Blob<Dtype>(4, 1, 1, 1)),
+        blob_bottom_data_(new Blob<Dtype>(4, 3, 6, 4)),
+        blob_bottom_labels_(new Blob<Dtype>(4, 1, 1, 1)),
+        blob_top_data_(new Blob<Dtype>()),
+        blob_top_labels_(new Blob<Dtype>()) {}
   virtual void SetUp() {
     // fill the values
     Caffe::set_random_seed(1890);
     FillerParameter filler_param;
     GaussianFiller<Dtype> filler(filler_param);
     // fill the selector blob
-    Dtype* bottom_data_SELECTOR_ = blob_bottom_SELECTOR_->mutable_cpu_data();
-    *(bottom_data_SELECTOR_) = 0;
-    *(bottom_data_SELECTOR_ + 1) = 1;
-    *(bottom_data_SELECTOR_ + 2) = 1;
-    *(bottom_data_SELECTOR_ + 3) = 0;
+    Dtype* bottom_data_selector_ = blob_bottom_selector_->mutable_cpu_data();
+    *(bottom_data_selector_) = 0;
+    *(bottom_data_selector_ + 1) = 1;
+    *(bottom_data_selector_ + 2) = 1;
+    *(bottom_data_selector_ + 3) = 0;
     // fill the othre bottom blobs
-    filler.Fill(blob_bottom_DATA_);
-    filler.Fill(blob_bottom_LABELS_);
-    blob_bottom_vec_.push_back(blob_bottom_SELECTOR_);
-    blob_bottom_vec_.push_back(blob_bottom_DATA_);
-    blob_bottom_vec_.push_back(blob_bottom_LABELS_);
-    blob_top_vec_.push_back(blob_top_DATA_);
-    blob_top_vec_.push_back(blob_top_LABELS_);
+    filler.Fill(blob_bottom_data_);
+    filler.Fill(blob_bottom_labels_);
+    blob_bottom_vec_.push_back(blob_bottom_selector_);
+    blob_bottom_vec_.push_back(blob_bottom_data_);
+    blob_bottom_vec_.push_back(blob_bottom_labels_);
+    blob_top_vec_.push_back(blob_top_data_);
+    blob_top_vec_.push_back(blob_top_labels_);
   }
   virtual ~FilterLayerTest() {
-    delete blob_bottom_SELECTOR_;
-    delete blob_bottom_DATA_;
-    delete blob_bottom_LABELS_;
-    delete blob_top_DATA_;
-    delete blob_top_LABELS_;
+    delete blob_bottom_selector_;
+    delete blob_bottom_data_;
+    delete blob_bottom_labels_;
+    delete blob_top_data_;
+    delete blob_top_labels_;
   }
 
-  Blob<Dtype>* const blob_bottom_SELECTOR_;
-  Blob<Dtype>* const blob_bottom_DATA_;
-  Blob<Dtype>* const blob_bottom_LABELS_;
+  Blob<Dtype>* const blob_bottom_selector_;
+  Blob<Dtype>* const blob_bottom_data_;
+  Blob<Dtype>* const blob_bottom_labels_;
   // blobs for the top of FilterLayer
-  Blob<Dtype>* const blob_top_DATA_;
-  Blob<Dtype>* const blob_top_LABELS_;
+  Blob<Dtype>* const blob_top_data_;
+  Blob<Dtype>* const blob_top_labels_;
   vector<Blob<Dtype>*> blob_bottom_vec_;
   vector<Blob<Dtype>*> blob_top_vec_;
 };
@@ -80,24 +80,24 @@ TYPED_TEST(FilterLayerTest, TestReshape) {
   layer.Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
   // In the test first and last items should have been filtered
   // so we just expect 2 remaining items
-  EXPECT_EQ(this->blob_top_DATA_->num(), 2);
-  EXPECT_EQ(this->blob_top_LABELS_->num(), 2);
-  EXPECT_GT(this->blob_bottom_DATA_->num(),
-      this->blob_top_DATA_->num());
-  EXPECT_GT(this->blob_bottom_LABELS_->num(),
-      this->blob_top_LABELS_->num());
-  EXPECT_EQ(this->blob_bottom_LABELS_->channels(),
-      this->blob_top_LABELS_->channels());
-  EXPECT_EQ(this->blob_bottom_LABELS_->width(),
-      this->blob_top_LABELS_->width());
-  EXPECT_EQ(this->blob_bottom_LABELS_->height(),
-      this->blob_top_LABELS_->height());
-  EXPECT_EQ(this->blob_bottom_DATA_->channels(),
-      this->blob_top_DATA_->channels());
-  EXPECT_EQ(this->blob_bottom_DATA_->width(),
-      this->blob_top_DATA_->width());
-  EXPECT_EQ(this->blob_bottom_DATA_->height(),
-      this->blob_top_DATA_->height());
+  EXPECT_EQ(this->blob_top_data_->num(), 2);
+  EXPECT_EQ(this->blob_top_labels_->num(), 2);
+  EXPECT_GT(this->blob_bottom_data_->num(),
+      this->blob_top_data_->num());
+  EXPECT_GT(this->blob_bottom_labels_->num(),
+      this->blob_top_labels_->num());
+  EXPECT_EQ(this->blob_bottom_labels_->channels(),
+      this->blob_top_labels_->channels());
+  EXPECT_EQ(this->blob_bottom_labels_->width(),
+      this->blob_top_labels_->width());
+  EXPECT_EQ(this->blob_bottom_labels_->height(),
+      this->blob_top_labels_->height());
+  EXPECT_EQ(this->blob_bottom_data_->channels(),
+      this->blob_top_data_->channels());
+  EXPECT_EQ(this->blob_bottom_data_->width(),
+      this->blob_top_data_->width());
+  EXPECT_EQ(this->blob_bottom_data_->height(),
+      this->blob_top_data_->height());
 }
 
 
@@ -114,45 +114,42 @@ TYPED_TEST(FilterLayerTest, TestForward) {
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   layer.Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
-  EXPECT_EQ(this->blob_top_LABELS_->data_at(0, 0, 0, 0),
-      this->blob_bottom_LABELS_->data_at(1, 0, 0, 0));
-  EXPECT_EQ(this->blob_top_LABELS_->data_at(1, 0, 0, 0),
-      this->blob_bottom_LABELS_->data_at(2, 0, 0, 0));
+  EXPECT_EQ(this->blob_top_labels_->data_at(0, 0, 0, 0),
+      this->blob_bottom_labels_->data_at(1, 0, 0, 0));
+  EXPECT_EQ(this->blob_top_labels_->data_at(1, 0, 0, 0),
+      this->blob_bottom_labels_->data_at(2, 0, 0, 0));
 
-  int dim = this->blob_top_DATA_->count() /
-      this->blob_top_DATA_->num();
-  const Dtype* top_DATA = this->blob_top_DATA_->cpu_data();
-  const Dtype* bottom_DATA = this->blob_bottom_DATA_->cpu_data();
+  int dim = this->blob_top_data_->count() /
+      this->blob_top_data_->num();
+  const Dtype* top_data = this->blob_top_data_->cpu_data();
+  const Dtype* bottom_data = this->blob_bottom_data_->cpu_data();
   // selector is 0 1 1 0, so we need to compare bottom(1,c,h,w)
   // with top(0,c,h,w) and bottom(2,c,h,w) with top(1,c,h,w)
-  bottom_DATA += dim;  // bottom(1,c,h,w)
+  bottom_data += dim;  // bottom(1,c,h,w)
   for (size_t n = 0; n < dim; n++)
-    EXPECT_EQ(*(top_DATA+n), *(bottom_DATA+n));
+    EXPECT_EQ(*(top_data+n), *(bottom_data+n));
 
-  bottom_DATA += dim;  // bottom(2,c,h,w)
-  top_DATA += dim;  // top(1,c,h,w)
+  bottom_data += dim;  // bottom(2,c,h,w)
+  top_data += dim;  // top(1,c,h,w)
   for (size_t n = 0; n < dim; n++)
-    EXPECT_EQ(*(top_DATA+n), *(bottom_DATA+n));
+    EXPECT_EQ(*(top_data+n), *(bottom_data+n));
 }
 
 
 
 TYPED_TEST(FilterLayerTest, TestGradient) {
   typedef typename TypeParam::Dtype Dtype;
-  if (Caffe::mode() == Caffe::CPU || sizeof(Dtype) == 4) {
-    LayerParameter layer_param;
-    FilterParameter* f_param = layer_param.mutable_filter_param();
-    // we need to forward the data blob
-    f_param->add_need_back_prop(1);
-    // we don't need to forward the labels blob
-    f_param->add_need_back_prop(0);
-    FilterLayer<Dtype> layer(layer_param);
-    GradientChecker<Dtype> checker(1e-2, 1e-3);
-    checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
-        this->blob_top_vec_, 0);
-  } else {
-    LOG(ERROR) << "Skipping test due to old architecture.";
-  }
+
+  LayerParameter layer_param;
+  FilterParameter* f_param = layer_param.mutable_filter_param();
+  // we need to forward the data blob
+  f_param->add_need_back_prop(1);
+  // we don't need to forward the labels blob
+  f_param->add_need_back_prop(0);
+  FilterLayer<Dtype> layer(layer_param);
+  GradientChecker<Dtype> checker(1e-2, 1e-3);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 1);
 }
 
 

--- a/src/caffe/test/test_filter_layer.cpp
+++ b/src/caffe/test/test_filter_layer.cpp
@@ -41,22 +41,22 @@ class FilterLayerTest : public MultiDeviceTest<TypeParam> {
     for (int i = 0; i < blob_bottom_labels_->count(); ++i) {
       blob_bottom_labels_->mutable_cpu_data()[i] = caffe_rng_rand() % 5;
     }
-    blob_bottom_vec_.push_back(blob_bottom_selector_);
     blob_bottom_vec_.push_back(blob_bottom_data_);
     blob_bottom_vec_.push_back(blob_bottom_labels_);
+    blob_bottom_vec_.push_back(blob_bottom_selector_);
     blob_top_vec_.push_back(blob_top_data_);
     blob_top_vec_.push_back(blob_top_labels_);
   }
   virtual ~FilterLayerTest() {
-    delete blob_bottom_selector_;
     delete blob_bottom_data_;
     delete blob_bottom_labels_;
+    delete blob_bottom_selector_;
     delete blob_top_data_;
     delete blob_top_labels_;
   }
-  Blob<Dtype>* const blob_bottom_selector_;
   Blob<Dtype>* const blob_bottom_data_;
   Blob<Dtype>* const blob_bottom_labels_;
+  Blob<Dtype>* const blob_bottom_selector_;
   // blobs for the top of FilterLayer
   Blob<Dtype>* const blob_top_data_;
   Blob<Dtype>* const blob_top_labels_;
@@ -144,7 +144,7 @@ TYPED_TEST(FilterLayerTest, TestGradient) {
   FilterLayer<Dtype> layer(layer_param);
   GradientChecker<Dtype> checker(1e-2, 1e-3);
   checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
-      this->blob_top_vec_, 1);
+      this->blob_top_vec_, 0);
 }
 
 }  // namespace caffe

--- a/src/caffe/test/test_filter_layer.cpp
+++ b/src/caffe/test/test_filter_layer.cpp
@@ -139,12 +139,7 @@ TYPED_TEST(FilterLayerTest, TestForward) {
 
 TYPED_TEST(FilterLayerTest, TestGradient) {
   typedef typename TypeParam::Dtype Dtype;
-  bool IS_VALID_CUDA = false;
-#ifndef CPU_ONLY
-  IS_VALID_CUDA = CAFFE_TEST_CUDA_PROP.major >= 2;
-#endif
-  if (Caffe::mode() == Caffe::CPU ||
-      sizeof(Dtype) == 4 || IS_VALID_CUDA) {
+  if (Caffe::mode() == Caffe::CPU || sizeof(Dtype) == 4) {
     LayerParameter layer_param;
     FilterParameter* f_param = layer_param.mutable_filter_param();
     // we need to forward the data blob

--- a/src/caffe/test/test_filter_layer.cpp
+++ b/src/caffe/test/test_filter_layer.cpp
@@ -32,13 +32,15 @@ class FilterLayerTest : public MultiDeviceTest<TypeParam> {
     GaussianFiller<Dtype> filler(filler_param);
     // fill the selector blob
     Dtype* bottom_data_selector_ = blob_bottom_selector_->mutable_cpu_data();
-    *(bottom_data_selector_) = 0;
-    *(bottom_data_selector_ + 1) = 1;
-    *(bottom_data_selector_ + 2) = 1;
-    *(bottom_data_selector_ + 3) = 0;
-    // fill the othre bottom blobs
+    bottom_data_selector_[0] = 0;
+    bottom_data_selector_[1] = 1;
+    bottom_data_selector_[2] = 1;
+    bottom_data_selector_[3] = 0;
+    // fill the other bottom blobs
     filler.Fill(blob_bottom_data_);
-    filler.Fill(blob_bottom_labels_);
+    for (int i = 0; i < blob_bottom_labels_->count(); ++i) {
+      blob_bottom_labels_->mutable_cpu_data()[i] = caffe_rng_rand() % 5;
+    }
     blob_bottom_vec_.push_back(blob_bottom_selector_);
     blob_bottom_vec_.push_back(blob_bottom_data_);
     blob_bottom_vec_.push_back(blob_bottom_labels_);
@@ -52,7 +54,6 @@ class FilterLayerTest : public MultiDeviceTest<TypeParam> {
     delete blob_top_data_;
     delete blob_top_labels_;
   }
-
   Blob<Dtype>* const blob_bottom_selector_;
   Blob<Dtype>* const blob_bottom_data_;
   Blob<Dtype>* const blob_bottom_labels_;
@@ -100,7 +101,6 @@ TYPED_TEST(FilterLayerTest, TestReshape) {
       this->blob_top_data_->height());
 }
 
-
 TYPED_TEST(FilterLayerTest, TestForward) {
   typedef typename TypeParam::Dtype Dtype;
 
@@ -127,15 +127,13 @@ TYPED_TEST(FilterLayerTest, TestForward) {
   // with top(0,c,h,w) and bottom(2,c,h,w) with top(1,c,h,w)
   bottom_data += dim;  // bottom(1,c,h,w)
   for (size_t n = 0; n < dim; n++)
-    EXPECT_EQ(*(top_data+n), *(bottom_data+n));
+    EXPECT_EQ(top_data[n], bottom_data[n]);
 
   bottom_data += dim;  // bottom(2,c,h,w)
   top_data += dim;  // top(1,c,h,w)
   for (size_t n = 0; n < dim; n++)
-    EXPECT_EQ(*(top_data+n), *(bottom_data+n));
+    EXPECT_EQ(top_data[n], bottom_data[n]);
 }
-
-
 
 TYPED_TEST(FilterLayerTest, TestGradient) {
   typedef typename TypeParam::Dtype Dtype;
@@ -151,7 +149,5 @@ TYPED_TEST(FilterLayerTest, TestGradient) {
   checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
       this->blob_top_vec_, 1);
 }
-
-
 
 }  // namespace caffe

--- a/src/caffe/test/test_filter_layer.cpp
+++ b/src/caffe/test/test_filter_layer.cpp
@@ -1,0 +1,165 @@
+#include <cstring>
+#include <limits>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/vision_layers.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+namespace caffe {
+
+template <typename TypeParam>
+class FilterLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  FilterLayerTest()
+      : blob_bottom_SELECTOR_(new Blob<Dtype>(4, 1, 1, 1)),
+        blob_bottom_DATA_(new Blob<Dtype>(4, 14, 5, 7)),
+        blob_bottom_LABELS_(new Blob<Dtype>(4, 1, 1, 1)),
+        blob_top_DATA_(new Blob<Dtype>()),
+        blob_top_LABELS_(new Blob<Dtype>()) {}
+  virtual void SetUp() {
+    // fill the values
+    Caffe::set_random_seed(1890);
+    FillerParameter filler_param;
+    GaussianFiller<Dtype> filler(filler_param);
+    // fill the selector blob
+    Dtype* bottom_data_SELECTOR_ = blob_bottom_SELECTOR_->mutable_cpu_data();
+    *(bottom_data_SELECTOR_) = 0;
+    *(bottom_data_SELECTOR_ + 1) = 1;
+    *(bottom_data_SELECTOR_ + 2) = 1;
+    *(bottom_data_SELECTOR_ + 3) = 0;
+    // fill the othre bottom blobs
+    filler.Fill(blob_bottom_DATA_);
+    filler.Fill(blob_bottom_LABELS_);
+    blob_bottom_vec_.push_back(blob_bottom_SELECTOR_);
+    blob_bottom_vec_.push_back(blob_bottom_DATA_);
+    blob_bottom_vec_.push_back(blob_bottom_LABELS_);
+    blob_top_vec_.push_back(blob_top_DATA_);
+    blob_top_vec_.push_back(blob_top_LABELS_);
+  }
+  virtual ~FilterLayerTest() {
+    delete blob_bottom_SELECTOR_;
+    delete blob_bottom_DATA_;
+    delete blob_bottom_LABELS_;
+    delete blob_top_DATA_;
+    delete blob_top_LABELS_;
+  }
+
+  Blob<Dtype>* const blob_bottom_SELECTOR_;
+  Blob<Dtype>* const blob_bottom_DATA_;
+  Blob<Dtype>* const blob_bottom_LABELS_;
+  // blobs for the top of FilterLayer
+  Blob<Dtype>* const blob_top_DATA_;
+  Blob<Dtype>* const blob_top_LABELS_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(FilterLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(FilterLayerTest, TestReshape) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  LayerParameter layer_param;
+  FilterParameter* f_param = layer_param.mutable_filter_param();
+  // we need to forward the data blob
+  f_param->add_need_back_prop(1);
+  // we don't need to forward the labels blob
+  f_param->add_need_back_prop(0);
+  FilterLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
+  // In the test first and last items should have been filtered
+  // so we just expect 2 remaining items
+  EXPECT_EQ(this->blob_top_DATA_->num(), 2);
+  EXPECT_EQ(this->blob_top_LABELS_->num(), 2);
+  EXPECT_GT(this->blob_bottom_DATA_->num(),
+      this->blob_top_DATA_->num());
+  EXPECT_GT(this->blob_bottom_LABELS_->num(),
+      this->blob_top_LABELS_->num());
+  EXPECT_EQ(this->blob_bottom_LABELS_->channels(),
+      this->blob_top_LABELS_->channels());
+  EXPECT_EQ(this->blob_bottom_LABELS_->width(),
+      this->blob_top_LABELS_->width());
+  EXPECT_EQ(this->blob_bottom_LABELS_->height(),
+      this->blob_top_LABELS_->height());
+  EXPECT_EQ(this->blob_bottom_DATA_->channels(),
+      this->blob_top_DATA_->channels());
+  EXPECT_EQ(this->blob_bottom_DATA_->width(),
+      this->blob_top_DATA_->width());
+  EXPECT_EQ(this->blob_bottom_DATA_->height(),
+      this->blob_top_DATA_->height());
+}
+
+
+TYPED_TEST(FilterLayerTest, TestForward) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  LayerParameter layer_param;
+  FilterParameter* f_param = layer_param.mutable_filter_param();
+  // we need to forward the data blob
+  f_param->add_need_back_prop(1);
+  // we don't need to forward the labels blob
+  f_param->add_need_back_prop(0);
+  FilterLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  EXPECT_EQ(this->blob_top_LABELS_->data_at(0, 0, 0, 0),
+      this->blob_bottom_LABELS_->data_at(1, 0, 0, 0));
+  EXPECT_EQ(this->blob_top_LABELS_->data_at(1, 0, 0, 0),
+      this->blob_bottom_LABELS_->data_at(2, 0, 0, 0));
+
+  int dim = this->blob_top_DATA_->count() /
+      this->blob_top_DATA_->num();
+  const Dtype* top_DATA = this->blob_top_DATA_->cpu_data();
+  const Dtype* bottom_DATA = this->blob_bottom_DATA_->cpu_data();
+  // selector is 0 1 1 0, so we need to compare bottom(1,c,h,w)
+  // with top(0,c,h,w) and bottom(2,c,h,w) with top(1,c,h,w)
+  bottom_DATA += dim;  // bottom(1,c,h,w)
+  for (size_t n = 0; n < dim; n++)
+    EXPECT_EQ(*(top_DATA+n), *(bottom_DATA+n));
+
+  bottom_DATA += dim;  // bottom(2,c,h,w)
+  top_DATA += dim;  // top(1,c,h,w)
+  for (size_t n = 0; n < dim; n++)
+    EXPECT_EQ(*(top_DATA+n), *(bottom_DATA+n));
+}
+
+
+
+TYPED_TEST(FilterLayerTest, TestGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  bool IS_VALID_CUDA = false;
+#ifndef CPU_ONLY
+  IS_VALID_CUDA = CAFFE_TEST_CUDA_PROP.major >= 2;
+#endif
+  if (Caffe::mode() == Caffe::CPU ||
+      sizeof(Dtype) == 4 || IS_VALID_CUDA) {
+    LayerParameter layer_param;
+    FilterParameter* f_param = layer_param.mutable_filter_param();
+    // we need to forward the data blob
+    f_param->add_need_back_prop(1);
+    // we don't need to forward the labels blob
+    f_param->add_need_back_prop(0);
+    FilterLayer<Dtype> layer(layer_param);
+    GradientChecker<Dtype> checker(1e-2, 1e-3);
+    checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+        this->blob_top_vec_, 0);
+  } else {
+    LOG(ERROR) << "Skipping test due to old architecture.";
+  }
+}
+
+
+
+}  // namespace caffe

--- a/src/caffe/test/test_filter_layer.cpp
+++ b/src/caffe/test/test_filter_layer.cpp
@@ -17,7 +17,6 @@ namespace caffe {
 template <typename TypeParam>
 class FilterLayerTest : public MultiDeviceTest<TypeParam> {
   typedef typename TypeParam::Dtype Dtype;
-
  protected:
   FilterLayerTest()
       : blob_bottom_selector_(new Blob<Dtype>(4, 1, 1, 1)),
@@ -68,7 +67,6 @@ TYPED_TEST_CASE(FilterLayerTest, TestDtypesAndDevices);
 
 TYPED_TEST(FilterLayerTest, TestReshape) {
   typedef typename TypeParam::Dtype Dtype;
-
   LayerParameter layer_param;
   FilterParameter* f_param = layer_param.mutable_filter_param();
   // we need to forward the data blob
@@ -103,7 +101,6 @@ TYPED_TEST(FilterLayerTest, TestReshape) {
 
 TYPED_TEST(FilterLayerTest, TestForward) {
   typedef typename TypeParam::Dtype Dtype;
-
   LayerParameter layer_param;
   FilterParameter* f_param = layer_param.mutable_filter_param();
   // we need to forward the data blob
@@ -137,7 +134,6 @@ TYPED_TEST(FilterLayerTest, TestForward) {
 
 TYPED_TEST(FilterLayerTest, TestGradient) {
   typedef typename TypeParam::Dtype Dtype;
-
   LayerParameter layer_param;
   FilterParameter* f_param = layer_param.mutable_filter_param();
   // we need to forward the data blob

--- a/src/caffe/test/test_filter_layer.cpp
+++ b/src/caffe/test/test_filter_layer.cpp
@@ -17,6 +17,7 @@ namespace caffe {
 template <typename TypeParam>
 class FilterLayerTest : public MultiDeviceTest<TypeParam> {
   typedef typename TypeParam::Dtype Dtype;
+
  protected:
   FilterLayerTest()
       : blob_bottom_selector_(new Blob<Dtype>(4, 1, 1, 1)),


### PR DESCRIPTION
Filter_layer developed as discussed in #1448, implemented following the suggestions by @sguada and @longjon (paragraph 2(i)).

This layer accepts 2+ bottom blobs, the first blob acts as a selector, so it should be a vector s={0,1,2, .. n} in [0,1], and the remaining blobs are blobs to be filtered. Each value of 1 in the selector vector means that the items at the corresponding indices int the bottom_blobs[1+] will be kept, on the contrary a values of 0 means the items with corresponding symbols will be filtered out.
So only non-filtered items will be forwarded and afterwards will receive backpropagation. 

As param the filter_layer needs a *need_back_prop vector*. This is needed because some blob could contains labels, and therefore will not need backpropagation. The need_back_prop vector as the same size as the top vector, and accepts 1s and 0s depending on whether it should be backpropagated or not.

This PR needs #1483 and #1484