### PR TITLE
net.cpp now allows zero-sized batches

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -58,6 +58,13 @@ class Net {
   string Forward(const string& input_blob_protos, Dtype* loss = NULL);
 
   /**
+   * If a bottom blob has num == 0, then the forward is not allowed and a top
+   * blob of the layer must be reshaped with num = 0, so all the subsequent
+   * layers will not have their forward allowed, too.
+   */
+  bool ForwardIsAllowed(int i);
+
+  /**
    * The network backward should take no input and output, since it solely
    * computes the gradient w.r.t the parameters, and the data has already been
    * provided during the forward pass.
@@ -66,6 +73,12 @@ class Net {
   void BackwardFromTo(int start, int end);
   void BackwardFrom(int start);
   void BackwardTo(int end);
+
+  /**
+   * If a top blob has num == 0, then the forward on this layer was been
+   * denied, so we don't need to backpropagate
+   */
+  bool BackwardIsAllowed(int i);
 
   /**
    * @brief Reshape all layers from bottom to top.


### PR DESCRIPTION
Implemented a way to allow zero-sized batches as discussed in #1448 with @sguada and @longjon (point 5).
The net now checks, before forwarding or backwarding anything, if some blob has *num == 0*, if so forward and backward are denyied and all subsequent layers are reshaped to avoid forward and bacward to those, too.
Actually the net doesn't allow a batch to have 0 size, but this could happen because #1482