### PR TITLE
Switch layer

### DIFF
--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -488,9 +488,9 @@ class SliceLayer : public Layer<Dtype> {
 };
 
 /**
- * @brief Takes some inputs Blob%s and a selector and outputs the data
- *        based on the value of the selector blob.
- *        If selector is < 0 or > num_inputs then it fills with zeros
+ * @brief Takes some inputs Blob%s and a selector and copies the data
+ *        based on the value of the selector blob to the top blob.
+ *        The selector values should integer and within [0,n-1]
  */
 template <typename Dtype>
 class SwitchLayer : public Layer<Dtype> {

--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -488,8 +488,9 @@ class SliceLayer : public Layer<Dtype> {
 };
 
 /**
- * @brief Takes three Blob%s and outputs the second or third blob based on
- *        the value of the first blob (second if 0, third if 1).
+ * @brief Takes some inputs Blob%s and a selector and outputs the data
+ *        based on the value of the selector blob.
+ *        If selector is < 0 or > num_inputs then it fills with zeros
  */
 template <typename Dtype>
 class SwitchLayer : public Layer<Dtype> {
@@ -505,7 +506,7 @@ class SwitchLayer : public Layer<Dtype> {
   virtual inline LayerParameter_LayerType type() const {
     return LayerParameter_LayerType_SWITCH;
   }
-  virtual inline int MinBottomBlobs() const { return 3; }
+  virtual inline int MinBottomBlobs() const { return 2; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
 
  protected:

--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -498,10 +498,9 @@ class SwitchLayer : public Layer<Dtype> {
       : Layer<Dtype>(param) {}
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-  /*
+
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-  */
 
   virtual inline LayerParameter_LayerType type() const {
     return LayerParameter_LayerType_SWITCH;
@@ -519,13 +518,6 @@ class SwitchLayer : public Layer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-
-  Blob<Dtype> col_bob_;
-  int count_;
-  int num_;
-  int channels_;
-  int height_;
-  int width_;
 };
 
 }  // namespace caffe

--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -487,6 +487,47 @@ class SliceLayer : public Layer<Dtype> {
   vector<int> slice_point_;
 };
 
+/**
+ * @brief Takes three Blob%s and outputs the second or third blob based on
+ *        the value of the first blob (second if 0, third if 1).
+ */
+template <typename Dtype>
+class SwitchLayer : public Layer<Dtype> {
+ public:
+  explicit SwitchLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  /*
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  */
+
+  virtual inline LayerParameter_LayerType type() const {
+    return LayerParameter_LayerType_SWITCH;
+  }
+  virtual inline int MinBottomBlobs() const { return 3; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  Blob<Dtype> col_bob_;
+  int count_;
+  int num_;
+  int channels_;
+  int height_;
+  int width_;
+};
+
 }  // namespace caffe
 
 #endif  // CAFFE_COMMON_LAYERS_HPP_

--- a/src/caffe/layers/switch_layer.cpp
+++ b/src/caffe/layers/switch_layer.cpp
@@ -5,26 +5,69 @@
 
 namespace caffe {
 
+// Let's move the selector to the last bottom
 template <typename Dtype>
 void SwitchLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+  // Check that the dimensions of bottoms are all the same
+  for (int i = 0; i < bottom.size() - 1; ++i) {
+    CHECK_EQ(bottom[i]->num(),  bottom[0]->num());
+    CHECK_EQ(bottom[i]->channels(), bottom[0]->channels());
+    CHECK_EQ(bottom[i]->height(), bottom[0]->height());
+    CHECK_EQ(bottom[i]->width(), bottom[0]->width());
+  }
+  // Check the selector dimensions
+  // It could be generalized to have more channels, one per top
+  const int selector_ind = bottom.size() - 1;
+  CHECK_EQ(bottom[selector_ind]->num(), bottom[0]->num());
+  CHECK_EQ(bottom[selector_ind]->channels(), 1);
+  CHECK_EQ(bottom[selector_ind]->height(), 1);
+  CHECK_EQ(bottom[selector_ind]->width(), 1);
+}
+
+template <typename Dtype>
+void SwitchLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  // Initialize with the first blob.
+  top[0]->Reshape(bottom[0]->num(), bottom[0]->channels(),
+    bottom[0]->height(), bottom[0]->width());
+  CHECK_EQ(bottom[0]->count(), top[0]->count());
 }
 
 template <typename Dtype>
 void SwitchLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+  const int selector_ind = bottom.size() - 1;
   Dtype* top_data = top[0]->mutable_cpu_data();
-  const Dtype* select = bottom[0]->cpu_data();
-  int num_elem = bottom[0]->count();
-  for (int i = 0; i < num_elem; i++) {
-    top_data[i] = bottom[select[i]+1]->cpu_data()[i];
+  const int num_elem = top[0]->channels() * top[0]->height() * top[0]->width();
+
+  for (int n = 0; n < bottom[selector_ind]->num(); n++) {
+    int index = static_cast<int>(bottom[selector_ind]->data_at(n, 0 , 0, 0));
+    if (index >= 0 && index < selector_ind) {
+      const Dtype* bottom_data = bottom[index]->cpu_data();
+      caffe_copy(num_elem, bottom_data+bottom[index]->offset(n),
+            top_data+top[0]->offset(n));
+    } else {
+      caffe_set(num_elem, Dtype(0), top_data+top[0]->offset(n));
+    }
   }
 }
 
 template <typename Dtype>
 void SwitchLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  // don't need to implement yet
+  const int selector_ind = bottom.size() - 1;
+  const int num_elem = top[0]->channels() * top[0]->height() * top[0]->width();
+  const Dtype* top_diff = top[0]->cpu_diff();
+
+  for (int n = 0; n < bottom[selector_ind]->num(); n++) {
+    int index = static_cast<int>(bottom[selector_ind]->data_at(n, 0 , 0, 0));
+    if (index >= 0 && index < selector_ind) {
+      Dtype* bottom_diff = bottom[index]->mutable_cpu_diff();
+      caffe_copy(num_elem, top_diff+top[0]->offset(n),
+          bottom_diff + bottom[index]->offset(n));
+    }
+  }
 }
 
 #ifdef CPU_ONLY
@@ -32,5 +75,5 @@ STUB_GPU(SwitchLayer);
 #endif
 
 INSTANTIATE_CLASS(SwitchLayer);
-//REGISTER_LAYER_CLASS(SWITCH, SwitchLayer);
+REGISTER_LAYER_CLASS(SWITCH, SwitchLayer);
 }  // namespace caffe

--- a/src/caffe/layers/switch_layer.cpp
+++ b/src/caffe/layers/switch_layer.cpp
@@ -1,0 +1,36 @@
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void SwitchLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+}
+
+template <typename Dtype>
+void SwitchLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  const Dtype* select = bottom[0]->cpu_data();
+  int num_elem = bottom[0]->count();
+  for (int i = 0; i < num_elem; i++) {
+    top_data[i] = bottom[select[i]+1]->cpu_data()[i];
+  }
+}
+
+template <typename Dtype>
+void SwitchLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  // don't need to implement yet
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(SwitchLayer);
+#endif
+
+INSTANTIATE_CLASS(SwitchLayer);
+//REGISTER_LAYER_CLASS(SWITCH, SwitchLayer);
+}  // namespace caffe

--- a/src/caffe/layers/switch_layer.cu
+++ b/src/caffe/layers/switch_layer.cu
@@ -1,0 +1,39 @@
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void SwitchForward(const int n, const Dtype* select, 
+    const Dtype* in0, const Dtype* in1, Dtype* out) {
+  CUDA_KERNEL_LOOP(index, n) {
+    out[index] = select[index] ? in1[index] : in0[index];
+  }
+}
+
+template <typename Dtype>
+void SwitchLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  //Dtype* top_data = (*top)[0]->mutable_gpu_data();
+  Dtype* top_data = top[0]->mutable_gpu_data();
+  const Dtype* select = bottom[0]->gpu_data();
+  const Dtype* in0 = bottom[1]->gpu_data();
+  const Dtype* in1 = bottom[2]->gpu_data();
+  const int num_elem = bottom[0]->count();
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  SwitchForward<Dtype><<<CAFFE_GET_BLOCKS(num_elem), CAFFE_CUDA_NUM_THREADS>>>(
+      num_elem, select, in0, in1, top_data);
+  CUDA_POST_KERNEL_CHECK;
+}
+
+template <typename Dtype>
+void SwitchLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  // don't need to implement yet
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(SwitchLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/switch_layer.cu
+++ b/src/caffe/layers/switch_layer.cu
@@ -15,13 +15,13 @@ void SwitchLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 
   for (int n = 0; n < bottom[selector_ind]->num(); n++) {
     int index = static_cast<int>(bottom[selector_ind]->data_at(n, 0 , 0, 0));
-    if (index >= 0 && index < selector_ind) {
-      const Dtype* bottom_data = bottom[index]->gpu_data();
-      caffe_copy(num_elem, bottom_data+bottom[index]->offset(n),
-            top_data+top[0]->offset(n));
-    } else {
-      caffe_set(num_elem, Dtype(0), top_data+top[0]->offset(n));
-    }
+    DCHECK(floor(index) == index) << "Index should be an integer";
+    DCHECK_GE(index, 0) << "Index should be greater than 0";
+    DCHECK_LT(index, selector_ind)
+        << "Index should be less than " << selector_ind;
+    const Dtype* bottom_data = bottom[index]->gpu_data();
+    caffe_copy(num_elem, bottom_data+bottom[index]->offset(n),
+          top_data+top[0]->offset(n));
   }
 }
 
@@ -32,18 +32,14 @@ void SwitchLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   const int num_elem = top[0]->channels() * top[0]->height() * top[0]->width();
   const Dtype* top_diff = top[0]->gpu_diff();
 
-  if (propagate_down[selector_ind]) {
-    LOG(FATAL) << this->type_name()
-               << " Layer cannot backpropagate to selector inputs.";
-  }
+  CHECK(!propagate_down[selector_ind]) << this->type_name()
+        << " Layer cannot backpropagate to selector inputs.";
 
   for (int n = 0; n < bottom[selector_ind]->num(); n++) {
     int index = static_cast<int>(bottom[selector_ind]->data_at(n, 0 , 0, 0));
-    if (index >= 0 && index < selector_ind && propagate_down[index]) {
-      Dtype* bottom_diff = bottom[index]->mutable_gpu_diff();
-      caffe_copy(num_elem, top_diff+top[0]->offset(n),
-          bottom_diff + bottom[index]->offset(n));
-    }
+    Dtype* bottom_diff = bottom[index]->mutable_gpu_diff();
+    caffe_copy(num_elem, top_diff+top[0]->offset(n),
+        bottom_diff + bottom[index]->offset(n));
   }
 }
 

--- a/src/caffe/layers/switch_layer.cu
+++ b/src/caffe/layers/switch_layer.cu
@@ -32,9 +32,14 @@ void SwitchLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   const int num_elem = top[0]->channels() * top[0]->height() * top[0]->width();
   const Dtype* top_diff = top[0]->gpu_diff();
 
+  if (propagate_down[selector_ind]) {
+    LOG(FATAL) << this->type_name()
+               << " Layer cannot backpropagate to selector inputs.";
+  }
+
   for (int n = 0; n < bottom[selector_ind]->num(); n++) {
     int index = static_cast<int>(bottom[selector_ind]->data_at(n, 0 , 0, 0));
-    if (index >= 0 && index < selector_ind) {
+    if (index >= 0 && index < selector_ind && propagate_down[index]) {
       Dtype* bottom_diff = bottom[index]->mutable_gpu_diff();
       caffe_copy(num_elem, top_diff+top[0]->offset(n),
           bottom_diff + bottom[index]->offset(n));

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -227,7 +227,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 39 (last added: EXP)
+  // LayerType next available ID: 40 (last added: SWITCH)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if
@@ -267,6 +267,7 @@ message LayerParameter {
     SOFTMAX = 20;
     SOFTMAX_LOSS = 21;
     SPLIT = 22;
+    SWITCH = 39;
     SLICE = 33;
     TANH = 23;
     WINDOW_DATA = 24;

--- a/src/caffe/test/test_switch_layer.cpp
+++ b/src/caffe/test/test_switch_layer.cpp
@@ -1,0 +1,98 @@
+#include <cstring>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/vision_layers.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+namespace caffe {
+
+template <typename TypeParam>
+class SwitchLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  SwitchLayerTest()
+      : blob_bottom_0(new Blob<Dtype>(6, 3, 2, 5)),
+        blob_bottom_1(new Blob<Dtype>(6, 3, 2, 5)),
+        blob_selector(new Blob<Dtype>(6, 1, 1, 1)),
+        blob_top_(new Blob<Dtype>()) {}
+  virtual void SetUp() {
+    // fill the values
+    FillerParameter filler_param;
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_0);
+    filler.Fill(this->blob_bottom_1);
+    // Initialize the selector with 0s and 1s
+    Dtype* selector_data = blob_selector->mutable_cpu_data();
+    for (int i = 0; i < blob_selector->count(); ++i) {
+      selector_data[i] = i % 2;
+    }
+    blob_bottom_vec.push_back(blob_bottom_0);
+    blob_bottom_vec.push_back(blob_bottom_1);
+    blob_bottom_vec.push_back(blob_selector);
+    blob_top_vec_.push_back(blob_top_);
+  }
+
+  virtual ~SwitchLayerTest() {
+    delete blob_bottom_0; delete blob_bottom_1;
+    delete blob_selector; delete blob_top_;
+  }
+
+  Blob<Dtype>* const blob_bottom_0;
+  Blob<Dtype>* const blob_bottom_1;
+  Blob<Dtype>* const blob_selector;
+  Blob<Dtype>* const blob_top_;
+  vector<Blob<Dtype>*> blob_bottom_vec;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(SwitchLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(SwitchLayerTest, TestSetup) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  SwitchLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec, this->blob_top_vec_);
+  EXPECT_EQ(this->blob_top_->num(), this->blob_bottom_0->num());
+  EXPECT_EQ(this->blob_top_->channels(), this->blob_bottom_0->channels());
+  EXPECT_EQ(this->blob_top_->height(), this->blob_bottom_0->height());
+  EXPECT_EQ(this->blob_top_->width(), this->blob_bottom_0->width());
+}
+
+TYPED_TEST(SwitchLayerTest, TestForward) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  SwitchLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec, this->blob_top_vec_);
+  for (int n = 0; n < this->blob_top_->num(); ++n) {
+    int index = this->blob_selector->data_at(n, 0, 0, 0);
+    EXPECT_TRUE(index == 0 || index == 1);
+    for (int c = 0; c < this->blob_top_->channels(); ++c) {
+      for (int h = 0; h < this->blob_top_->height(); ++h) {
+        for (int w = 0; w < this->blob_top_->width(); ++w) {
+          EXPECT_EQ(this->blob_top_->data_at(n, c, h, w),
+            this->blob_bottom_vec[index]->data_at(n, c, h, w));
+        }
+      }
+    }
+  }
+}
+
+TYPED_TEST(SwitchLayerTest, TestGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  SwitchLayer<Dtype> layer(layer_param);
+  GradientChecker<Dtype> checker(1e-2, 1e-2, 1701);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec,
+    this->blob_top_vec_, 0);
+}
+
+}  // namespace caffe

--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -504,6 +504,8 @@ LayerParameter_LayerType UpgradeV0LayerType(const string& type) {
     return LayerParameter_LayerType_SOFTMAX_LOSS;
   } else if (type == "split") {
     return LayerParameter_LayerType_SPLIT;
+  } else if (type == "switch") {
+    return LayerParameter_LayerType_SWITCH;
   } else if (type == "tanh") {
     return LayerParameter_LayerType_TANH;
   } else if (type == "window_data") {


### PR DESCRIPTION
This layers allows to have multiple input blobs and a selector (last blob) which will select from which input the data will be copied into the top.
All the inputs (bottoms 0 to n-2) should have the same shape, and the last bottom (n-1) contain n indices between 0 and n-2 to fill the top. 
Currently if the index is out of range it will fill the corresponding part of top with zeros, this allows to do block dropout, but just passing one input bottom and a selector with 0s and 1s (the blocks corresponding with 1s will be replaced with zeros)
@longjon do you think the logic about indices out of range is confusing?