### PR TITLE
Thresholded ReLU

### DIFF
--- a/src/caffe/layers/cudnn_relu_layer.cu
+++ b/src/caffe/layers/cudnn_relu_layer.cu
@@ -15,6 +15,11 @@ void CuDNNReLULayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     return ReLULayer<Dtype>::Forward_gpu(bottom, top);
   }
 
+  // Fallback to standard Caffe for thresholded RELU (TREC).
+  if (ReLULayer<Dtype>::layer_param_.relu_param().has_theta()) {
+    return ReLULayer<Dtype>::Forward_gpu(bottom, top);
+  }
+
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
   CUDNN_CHECK(cudnnActivationForward(this->handle_,
@@ -32,6 +37,11 @@ void CuDNNReLULayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
 
   // Fallback to standard Caffe for leaky ReLU.
   if (ReLULayer<Dtype>::layer_param_.relu_param().negative_slope() != 0) {
+    return ReLULayer<Dtype>::Backward_gpu(top, propagate_down, bottom);
+  }
+
+  // Fallback to standard Caffe for thresholded ReLU (TRec).
+  if (ReLULayer<Dtype>::layer_param.relu_param().has_theta()) {
     return ReLULayer<Dtype>::Backward_gpu(top, propagate_down, bottom);
   }
 

--- a/src/caffe/layers/relu_layer.cpp
+++ b/src/caffe/layers/relu_layer.cpp
@@ -13,9 +13,28 @@ void ReLULayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   Dtype* top_data = top[0]->mutable_cpu_data();
   const int count = bottom[0]->count();
   Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
-  for (int i = 0; i < count; ++i) {
-    top_data[i] = std::max(bottom_data[i], Dtype(0))
-        + negative_slope * std::min(bottom_data[i], Dtype(0));
+
+  // Threshholded RELU (TREC) has zero output in the TRAIN phase when the
+  // input does not exceed the threshold theta.
+  if ( Caffe::phase() == Caffe::TRAIN &&
+       this->layer_param_.relu_param().has_theta() ) {
+    Dtype theta = this->layer_param_.relu_param().theta();
+    for (int i = 0; i < count; ++i) {
+      Dtype input = bottom_data[i];
+      // TRec output is non-zero only when the magnitude of the input
+      // exceeds the threshold theta.
+      if (std::abs(input) > theta) {
+        top_data[i] = std::max(bottom_data[i], Dtype(0))
+          + negative_slope * std::min(bottom_data[i], Dtype(0));
+      } else {
+        top_data[i] = Dtype(0.0);
+      }
+    }
+  } else {
+    for (int i = 0; i < count; ++i) {
+      top_data[i] = std::max(bottom_data[i], Dtype(0))
+          + negative_slope * std::min(bottom_data[i], Dtype(0));
+    }
   }
 }
 
@@ -29,13 +48,31 @@ void ReLULayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
     const int count = bottom[0]->count();
     Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
-    for (int i = 0; i < count; ++i) {
-      bottom_diff[i] = top_diff[i] * ((bottom_data[i] > 0)
-          + negative_slope * (bottom_data[i] <= 0));
+
+    // Threshholded RELU (TREC) has zero output in the TRAIN phase when the
+    // input does not exceed the threshold theta.
+    if ( Caffe::phase() == Caffe::TRAIN &&
+         this->layer_param_.relu_param().has_theta() ) {
+      for (int i = 0; i < count; ++i) {
+        Dtype theta = this->layer_param_.relu_param().theta();
+        Dtype input = bottom_data[i];
+        // TREC derivative is non-zero only when the magnitude of the input
+        // exceeds the threshold theta.
+        if (std::abs(input) > theta) {
+          bottom_diff[i] = top_diff[i] * ((input > 0)
+              + negative_slope * (input <= 0));
+        } else {
+          bottom_diff[i] = Dtype(0.0);
+        }
+      }
+    } else {
+      for (int i = 0; i < count; ++i) {
+        bottom_diff[i] = top_diff[i] * ((bottom_data[i] > 0)
+            + negative_slope * (bottom_data[i] <= 0));
+      }
     }
   }
 }
-
 
 #ifdef CPU_ONLY
 STUB_GPU(ReLULayer);

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -643,6 +643,11 @@ message ReLUParameter {
     CUDNN = 2;
   }
   optional Engine engine = 2 [default = DEFAULT];
+  // Allow a thresholded RELU as described in:
+  // R. Memisevic et al, "Zero-bias autoencoders and the benefits of
+  // co-adapting features". When training, input to unit must have magnitude
+  // exceeding theta for the output to be non-zero.
+  optional float theta = 3 [default = 0];
 }
 
 // Message that stores parameters used by SigmoidLayer


### PR DESCRIPTION
Extend the ReLU unit to allow thresholded ReLU (AKA TRec) as presented in [Memisevic et al](http://arxiv.org/pdf/1402.3337v2.pdf).

Adds an optional parameter "theta" to the ReLUParameter. Specify its value in order to get the thresholded ReLU ("TRec") behavior. I think you can also get the "TLin" behavior by also specifying a negative_slope = 1.0.  The goal is that by using this along with bias_term=false on the INNER_PRODUCT or CONVOLUTION layer, and no weight decay, you'd get the zero-bias autoencoder described in the paper.  I'm guessing you'd want to have at least mean-subtracted image inputs, if not PCA and whitened inputs as in the paper, if you run with no biases.  

There's not any higher math involved in the implementation, but my understanding of it is a bit tenuous so I'm hoping someone can look at this and the paper and see if it's implemented correctly. 