### PR TITLE
caffe_set now works in GPU mode

### DIFF
--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -58,7 +58,20 @@ void caffe_set(const int N, const Dtype alpha, Dtype* Y) {
   if (alpha == 0) {
     memset(Y, 0, sizeof(Dtype) * N);  // NOLINT(caffe/alt_fn)
     return;
+    if (Caffe::mode() == Caffe::GPU) {
+#ifndef CPU_ONLY
+      // NOLINT_NEXT_LINE(caffe/alt_fn)
+      CUDA_CHECK(cudaMemset(Y, 0, sizeof(Dtype) * N));
+      return;
+#else
+      NO_GPU;
+#endif
+    } else {
+      memset(Y, 0, sizeof(Dtype) * N);  // NOLINT(caffe/alt_fn)
+      return;
+    }
   }
+
   for (int i = 0; i < N; ++i) {
     Y[i] = alpha;
   }


### PR DESCRIPTION
caffe_set for GPU mode.

I'm not sure this works when `alpha != 0`, I've not at the moment a gpu to test it. My doubt is that when the vector `Y` is gpu data, could not be directly accessible.
If I have no directions in the next two days, I'll try to test it with a gpu.
