### PR TITLE
Added Net Templates to easy definition of Nets

### DIFF
--- a/examples/templates/aux_classifier.template
+++ b/examples/templates/aux_classifier.template
@@ -1,0 +1,123 @@
+# Auxiliary Classifer Module
+# Requires: input
+layers {
+  bottom: "${input}"
+  top: "ave_pool"
+  name: "ave_pool"
+  type: POOLING
+  pooling_param {
+    pool: AVE
+    kernel_size: 5
+    stride: 3
+  }
+}
+layers {
+  bottom: "ave_pool"
+  top: "conv"
+  name: "conv"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.08
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv"
+  top: "conv"
+  name: "relu_conv"
+  type: RELU
+}
+layers {
+  bottom: "conv"
+  top: "fc"
+  name: "fc"
+  type: INNER_PRODUCT
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 1024
+    weight_filler {
+      type: "xavier"
+      std: 0.02
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "fc"
+  top: "fc"
+  name: "relu_fc"
+  type: RELU
+}
+layers {
+  bottom: "fc"
+  top: "fc"
+  name: "drop_fc"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.7
+  }
+}
+layers {
+  bottom: "fc"
+  top: "classifier"
+  name: "classifier"
+  type: INNER_PRODUCT
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 1000
+    weight_filler {
+      type: "xavier"
+      std: 0.0009765625
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers {
+  bottom: "classifier"
+  bottom: "../label"
+  name: "loss"
+  type: SOFTMAX_LOSS
+  loss_weight: 0.3
+  top: "loss1"
+}
+layers {
+  name: "top-1"
+  type: ACCURACY
+  bottom: "classifier"
+  bottom: "../label"
+  top: "top-1"
+  include: { phase: TEST }
+}
+layers {
+  name: "top-5"
+  type: ACCURACY
+  bottom: "classifier"
+  bottom: "../label"
+  top: "top-5"
+  accuracy_param: { top_k: 5 }
+  include: { phase: TEST }
+}

--- a/examples/templates/convolution_with_relu.template
+++ b/examples/templates/convolution_with_relu.template
@@ -1,0 +1,30 @@
+# Convolution with ReLU
+# Required: input, num_output, kernel_size
+layers: {
+  name: "convolution"
+  type: CONVOLUTION
+  bottom: "${input}"
+  top: "output"
+  blobs_lr: 1.
+  blobs_lr: 2.
+  weight_decay: 1.
+  weight_decay: 0.
+  convolution_param {
+    num_output: ${num_output}
+    kernel_size: ${kernel_size}
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers: {
+  name: "relu"
+  type: RELU
+  bottom: "output"
+  top: "output"
+}

--- a/examples/templates/example_net.template
+++ b/examples/templates/example_net.template
@@ -1,0 +1,58 @@
+name: "TemplateNetwork"
+layers: {
+  name: "data"
+  type: DUMMY_DATA
+  dummy_data_param {
+    num: 5
+    channels: 2
+    height: 3
+    width: 4
+    num: 5
+    channels: 1
+    height: 1
+    width: 1
+    data_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+  }
+  top: "data"
+  top: "label"
+}
+layers: {
+  name: "conv1"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/convolution_with_relu.template"
+    variable { name: "input" value: "/data" }
+    variable { name: "num_output" value: "10" }
+    variable { name: "kernel_size" value: "3" }
+  }
+}
+layers: {
+  name: "fc1"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/innerproduct_with_dropout.template"
+    variable { name: "input" value: "/conv1/output" }
+    variable { name: "num_output" value: "10" }
+    variable { name: "dropout_ratio" value: "0.5" }
+  } 
+}
+layers: {
+  name: "fc2"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/innerproduct_with_dropout.template"
+    variable { name: "input" value: "../fc1/output" }
+    variable { name: "num_output" value: "20" }
+    variable { name: "dropout_ratio" value: "0.0" }
+  }
+}
+layers: {
+  name: "loss"
+  type: SOFTMAX_LOSS
+  bottom: "fc2/output"
+  bottom: "label"
+  top: "top_loss"
+}

--- a/examples/templates/expand_net.sh
+++ b/examples/templates/expand_net.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+./build/tools/expand_net examples/templates/example_net.template examples/templates/example_net.prototxt
+./build/tools/expand_net examples/templates/googlenet.template examples/templates/googlenet.prototxt

--- a/examples/templates/googlenet.template
+++ b/examples/templates/googlenet.template
@@ -1,0 +1,411 @@
+name: "GoogleNet"
+layers {
+  name: "data"
+  type: DATA
+  top: "data"
+  top: "label"
+  data_param {
+    source: "examples/imagenet/ilsvrc12_train_lmdb"
+    backend: LMDB
+    batch_size: 32
+  }
+  transform_param {
+    crop_size: 224
+    mean_value: 104
+    mean_value: 117
+    mean_value: 123
+    mirror: true
+  }
+  include: { phase: TRAIN }
+}
+layers {
+  name: "data"
+  type: DATA
+  top: "data"
+  top: "label"
+  data_param {
+    source: "examples/imagenet/ilsvrc12_val_lmdb"
+    backend: LMDB
+    batch_size: 50
+  }
+  transform_param {
+    crop_size: 224
+    mean_value: 104
+    mean_value: 117
+    mean_value: 123
+    mirror: false
+  }
+  include: { phase: TEST }
+}
+layers {
+  bottom: "data"
+  top: "conv1/7x7_s2"
+  name: "conv1/7x7_s2"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 7
+    stride: 2
+    pad: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv1/7x7_s2"
+  top: "conv1/7x7_s2"
+  name: "conv1/relu_7x7"
+  type: RELU
+}
+layers {
+  bottom: "conv1/7x7_s2"
+  top: "pool1/3x3_s2"
+  name: "pool1/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool1/3x3_s2"
+  top: "pool1/norm1"
+  name: "pool1/norm1"
+  type: LRN
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+layers {
+  bottom: "pool1/norm1"
+  top: "conv2/3x3_reduce"
+  name: "conv2/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv2/3x3_reduce"
+  top: "conv2/3x3_reduce"
+  name: "conv2/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "conv2/3x3_reduce"
+  top: "conv2/3x3"
+  name: "conv2/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 192
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv2/3x3"
+  top: "conv2/3x3"
+  name: "conv2/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "conv2/3x3"
+  top: "conv2/norm2"
+  name: "conv2/norm2"
+  type: LRN
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+layers {
+  bottom: "conv2/norm2"
+  top: "pool2/3x3_s2"
+  name: "pool2/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+# Inception (3a)
+layers {
+  name: "inception_3a"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/inception.template"
+    variable { name: "input"      value: "/pool2/3x3_s2"}
+    variable { name: "1x1"        value: "64"}
+    variable { name: "3x3_reduce" value: "96"}
+    variable { name: "3x3"        value: "128"}
+    variable { name: "5x5_reduce" value: "16"}
+    variable { name: "5x5"        value: "32"}
+    variable { name: "pool_proj"  value: "32"}
+  }
+}
+# Inception (3b)
+layers {
+  name: "inception_3b"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/inception.template"
+    variable { name: "input"      value: "/inception_3a/output"}
+    variable { name: "1x1"        value: "128"}
+    variable { name: "3x3_reduce" value: "128"}
+    variable { name: "3x3"        value: "192"}
+    variable { name: "5x5_reduce" value: "32"}
+    variable { name: "5x5"        value: "96"}
+    variable { name: "pool_proj"  value: "64"}
+  }
+}
+layers {
+  bottom: "/inception_3b/output"
+  top: "pool3/3x3_s2"
+  name: "pool3/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+# Inception (4a)
+layers {
+  name: "inception_4a"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/inception.template"
+    variable { name: "input"      value: "/pool3/3x3_s2"}
+    variable { name: "1x1"        value: "192"}
+    variable { name: "3x3_reduce" value: "96"}
+    variable { name: "3x3"        value: "208"}
+    variable { name: "5x5_reduce" value: "16"}
+    variable { name: "5x5"        value: "48"}
+    variable { name: "pool_proj"  value: "64"}
+  }
+}
+# Loss 1
+layers {
+  name: "loss1"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/aux_classifier.template"
+    variable { name: "input" value: "/inception_4a/output"}
+  }
+}
+# Inception (4b)
+layers {
+  name: "inception_4b"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/inception.template"
+    variable { name: "input"      value: "/inception_4a/output"}
+    variable { name: "1x1"        value: "160"}
+    variable { name: "3x3_reduce" value: "112"}
+    variable { name: "3x3"        value: "224"}
+    variable { name: "5x5_reduce" value: "24"}
+    variable { name: "5x5"        value: "64"}
+    variable { name: "pool_proj"  value: "64"}
+  }
+}
+# Inception (4b)
+layers {
+  name: "inception_4c"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/inception.template"
+    variable { name: "input"      value: "/inception_4b/output"}
+    variable { name: "1x1"        value: "128"}
+    variable { name: "3x3_reduce" value: "128"}
+    variable { name: "3x3"        value: "256"}
+    variable { name: "5x5_reduce" value: "24"}
+    variable { name: "5x5"        value: "64"}
+    variable { name: "pool_proj"  value: "64"}
+  }
+}
+# Inception (4d)
+layers {
+  name: "inception_4d"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/inception.template"
+    variable { name: "input"      value: "/inception_4c/output"}
+    variable { name: "1x1"        value: "112"}
+    variable { name: "3x3_reduce" value: "144"}
+    variable { name: "3x3"        value: "288"}
+    variable { name: "5x5_reduce" value: "32"}
+    variable { name: "5x5"        value: "64"}
+    variable { name: "pool_proj"  value: "64"}
+  }
+}
+# Loss 2
+layers {
+  name: "loss2"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/aux_classifier.template"
+    variable { name: "input" value: "/inception_4d/output"}
+  }
+}
+# Inception (4e)
+layers {
+  name: "inception_4e"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/inception.template"
+    variable { name: "input"      value: "/inception_4d/output"}
+    variable { name: "1x1"        value: "256"}
+    variable { name: "3x3_reduce" value: "160"}
+    variable { name: "3x3"        value: "320"}
+    variable { name: "5x5_reduce" value: "32"}
+    variable { name: "5x5"        value: "128"}
+    variable { name: "pool_proj"  value: "128"}
+  }
+}
+layers {
+  bottom: "/inception_4e/output"
+  top: "pool4/3x3_s2"
+  name: "pool4/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+# Inception (5a)
+layers {
+  name: "inception_5a"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/inception.template"
+    variable { name: "input"      value: "/pool4/3x3_s2"}
+    variable { name: "1x1"        value: "256"}
+    variable { name: "3x3_reduce" value: "160"}
+    variable { name: "3x3"        value: "320"}
+    variable { name: "5x5_reduce" value: "32"}
+    variable { name: "5x5"        value: "128"}
+    variable { name: "pool_proj"  value: "128"}
+  }
+}
+# Inception (5b)
+layers {
+  name: "inception_5b"
+  type: TEMPLATE
+  template_param {
+    source: "examples/templates/inception.template"
+    variable { name: "input"      value: "/inception_5a/output"}
+    variable { name: "1x1"        value: "384"}
+    variable { name: "3x3_reduce" value: "192"}
+    variable { name: "3x3"        value: "384"}
+    variable { name: "5x5_reduce" value: "48"}
+    variable { name: "5x5"        value: "128"}
+    variable { name: "pool_proj"  value: "128"}
+  }
+}
+layers {
+  bottom: "/inception_5b/output"
+  top: "pool5/7x7_s1"
+  name: "pool5/7x7_s1"
+  type: POOLING
+  pooling_param {
+    pool: AVE
+    kernel_size: 7
+    stride: 1
+  }
+}
+layers {
+  bottom: "pool5/7x7_s1"
+  top: "pool5/7x7_s1"
+  name: "pool5/drop_7x7_s1"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.4
+  }
+}
+# Loss 3
+layers {
+  bottom: "pool5/7x7_s1"
+  top: "loss3/classifier"
+  name: "loss3/classifier"
+  type: INNER_PRODUCT
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 1000
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers {
+  bottom: "loss3/classifier"
+  bottom: "label"
+  name: "loss3/loss3"
+  type: SOFTMAX_LOSS
+  loss_weight: 1
+  top: "loss3/loss3"
+}
+layers {
+  name: "loss3/top-1"
+  type: ACCURACY
+  bottom: "loss3/classifier"
+  bottom: "label"
+  top: "loss3/top-1"
+  include: { phase: TEST }
+}
+layers {
+  name: "loss3/top-5"
+  type: ACCURACY
+  bottom: "loss3/classifier"
+  bottom: "label"
+  top: "loss3/top-5"
+  accuracy_param: { top_k: 5 }
+  include: { phase: TEST }
+}

--- a/examples/templates/inception.template
+++ b/examples/templates/inception.template
@@ -1,0 +1,194 @@
+# < Inception Module
+# Requires: input, 1x1, 3x3_reduce, 3x3, 5x5_reduce, 5x5, pool_proj
+layers {
+  bottom: "${input}"
+  top: "1x1"
+  name: "1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: ${1x1}
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "1x1"
+  top: "1x1"
+  name: "relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "${input}"
+  top: "3x3_reduce"
+  name: "3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: ${3x3_reduce}
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "3x3_reduce"
+  top: "3x3_reduce"
+  name: "relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "3x3_reduce"
+  top: "3x3"
+  name: "3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: ${3x3}
+    kernel_size: 3
+    pad: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "3x3"
+  top: "3x3"
+  name: "relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "${input}"
+  top: "5x5_reduce"
+  name: "5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: ${5x5_reduce}
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "5x5_reduce"
+  top: "5x5_reduce"
+  name: "relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "5x5_reduce"
+  top: "5x5"
+  name: "5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: ${5x5}
+    kernel_size: 5
+    pad: 2
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "5x5"
+  top: "5x5"
+  name: "relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "${input}"
+  top: "pool"
+  name: "pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "pool"
+  top: "pool_proj"
+  name: "pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: ${pool_proj}
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "pool_proj"
+  top: "pool_proj"
+  name: "relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "1x1"
+  bottom: "3x3"
+  bottom: "5x5"
+  bottom: "pool_proj"
+  top: "output"
+  name: "output"
+  type: CONCAT
+}
+# Inception Module >

--- a/examples/templates/innerproduct_with_dropout.template
+++ b/examples/templates/innerproduct_with_dropout.template
@@ -1,0 +1,32 @@
+# InnerProduct with dropout
+# Required: input, num_ouput, dropout_ratio
+layers: {
+  name: "innerproduct"
+  type: INNER_PRODUCT
+  bottom: "${input}"
+  top: "output"
+  blobs_lr: 1.
+  blobs_lr: 2.
+  weight_decay: 1.
+  weight_decay: 0.
+  inner_product_param {
+    num_output: ${num_output}
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers: {
+  name: "dropout"
+  type: DROPOUT
+  bottom: "output"
+  top: "output"
+  dropout_param {
+    dropout_ratio: ${dropout_ratio}
+  }
+}

--- a/include/caffe/util/expand_templates.hpp
+++ b/include/caffe/util/expand_templates.hpp
@@ -1,0 +1,20 @@
+#ifndef CAFFE_UTIL_EXPAND_TEMPLATES_H_
+#define CAFFE_UTIL_EXPAND_TEMPLATES_H_
+
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/proto/caffe_pretty_print.pb.h"
+
+namespace caffe {
+
+// Return true iff contains at least one TEMPLATE layer.
+bool NetContainsTemplates(const NetParameter& net_param);
+
+// Perform all necessary transformations to expand NetParameter containing
+// TEMPLATE layers into a NetParameter without them.
+// Doing all the string substitutions needed.
+void ExpandTemplatesNet(const NetParameter& in_net_param,
+                        NetParameter* out_net_param);
+
+}  // namespace caffe
+
+#endif   // CAFFE_UTIL_EXPAND_TEMPLATES_H_

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -88,6 +88,8 @@ inline void WriteProtoToBinaryFile(
   WriteProtoToBinaryFile(proto, filename.c_str());
 }
 
+bool ReadFileToString(const string& filename, string* content);
+
 bool ReadFileToDatum(const string& filename, const int label, Datum* datum);
 
 inline bool ReadFileToDatum(const string& filename, Datum* datum) {

--- a/python/expand_net.py
+++ b/python/expand_net.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+"""
+This is the python version of the script tools/expand_net
+which expands templates layers to generate a network proto_file
+
+Usage:
+    expand_net net_proto_file_in net_proto_file_out
+
+A template layer example:
+
+    layers {
+      name: "layer_name"
+      type: TEMPLATE
+      template_param {
+        source: "path/to/template/file"
+        variable { name: "id" value: "id_value" }
+      }
+    }
+
+In path/to/template/file
+    ${id} will be expanded to id_value
+    if no id_value is given, the line containing ${id} will be omitted
+
+    ${id = default_value} will expanded to id_value
+    or default_value if id_value is not given.
+"""
+import os
+import re
+from google.protobuf import text_format
+from caffe.proto import caffe_pb2
+
+ID_PATTERN = r'[_a-zA-Z][_a-zA-Z0-9]*'
+PATTERN_EXP = r"""
+(?:
+ \${
+    (?P<named>%(id)s)            # <named> group matches var id
+    (?:\ *=\ *(?P<default>.+?))? # <default> group matches default value of var
+ }
+)
+""" % {'id': ID_PATTERN}
+
+PATTERN = re.compile(PATTERN_EXP, re.VERBOSE)
+
+def substitute(template, mapping):
+    # TODO: Skip comments in prototxt
+    def convert(match_obj):
+        named = match_obj.group('named')
+        if named is not None:
+            # print '%s => %s' % (match_obj.group(), mapping[named])
+            try:
+                return '%s' % (mapping[named],)
+            except KeyError:
+                if match_obj.group('default') is not None:
+                    return match_obj.group('default').strip()
+                else:
+                    raise KeyError
+        return match_obj.group()
+    result = []
+    for line in template.splitlines(True):
+        try:
+            subtituted = PATTERN.sub(convert, line)
+            # print subtituted.rstrip()
+        except KeyError:
+            # remove the line if no value to the var is given
+            continue
+        result.append(subtituted)
+    return '\n'.join(result)
+
+def join_path(cwd, path):
+    result_path = os.path.normpath(os.path.join(cwd, path))
+    result_path = result_path.replace(os.sep, '/')
+    if result_path.startswith('/'):
+        result_path = result_path[1:]
+    return result_path
+
+def expand_template(net, cwd=''):
+    expanded_net = caffe_pb2.NetParameter()
+    expanded_net.CopyFrom(net)
+    expanded_net.ClearField('layers')
+    tmp_layer_counter = 0
+    for layer in net.layers:
+        if not layer.HasField('name'):
+            layer.name = 'temp_layer_%d' % tmp_layer_counter
+            tmp_layer_counter += 1
+        layer.name = join_path(cwd, layer.name)
+
+        if layer.type == layer.TEMPLATE:
+            if layer.HasField('template_param'):
+                # load template and fill it with values
+                with open(layer.template_param.source) as template_file:
+                    layer_template = template_file.read()
+                layer_template = substitute(layer_template,
+                                            {var.name:var.value for var in
+                                             layer.template_param.variable})
+                # generate real network from the specialized template network
+                sub_net = caffe_pb2.NetParameter()
+                text_format.Merge(layer_template, sub_net)
+                # TODO: Handle recursive definition
+                net = expand_template(sub_net, layer.name)
+                expanded_net.layers.MergeFrom(net.layers)
+                layer_template = None
+            else:
+                raise Exception
+        else:
+            # change relative names into absolute ones
+            for i, bottom in enumerate(layer.bottom):
+                layer.bottom[i] = join_path(cwd, bottom)
+            for i, top in enumerate(layer.top):
+                layer.top[i] = join_path(cwd, top)
+
+            expanded_net.layers.add().CopyFrom(layer)
+
+    return expanded_net
+
+def main(argv):
+    if len(argv) != 3:
+        print 'Usage: %s expand_net net_proto_file_in net_proto_file_out' % \
+                os.path.basename(sys.argv[0])
+    else:
+        net = caffe_pb2.NetParameter()
+        text_format.Merge(open(sys.argv[1]).read(), net)
+        net = expand_template(net)
+        print 'Expanding net to %s' % sys.argv[2]
+        with open(sys.argv[2], 'w') as net_file:
+            net_file.write(text_format.MessageToString(net))
+
+if __name__ == '__main__':
+    import sys
+    main(sys.argv)

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -271,6 +271,7 @@ message LayerParameter {
     TANH = 23;
     WINDOW_DATA = 24;
     THRESHOLD = 31;
+    TEMPLATE = 1000;
   }
   optional LayerType type = 5; // the layer type from the enum above
 
@@ -331,6 +332,9 @@ message LayerParameter {
   // Parameters for data pre-processing.
   optional TransformationParameter transform_param = 36;
 
+  // Parameters for templates.
+  optional TemplateParameter template_param = 1000;
+
   // Note: certain layers may have more than one computational engine
   // for their implementation. These layers include an Engine type and
   // engine parameter for selecting the implementation.
@@ -340,6 +344,20 @@ message LayerParameter {
   // This should never be used by any code except to upgrade to the new
   // LayerParameter specification.
   optional V0LayerParameter layer = 1;
+}
+
+message NameValue {
+   required string name = 1;
+   required string value = 2;
+}
+
+// Message that stores parameters used by TemplateLayer
+message TemplateParameter {
+    // Proto file containing the template
+    optional string source = 1;
+    // Variable names to replace after expanding the template. Variables can
+    // be used in the template file in this format: ${name}
+    repeated NameValue variable = 2;
 }
 
 // Message that stores parameters used to apply transformation

--- a/src/caffe/proto/caffe_pretty_print.proto
+++ b/src/caffe/proto/caffe_pretty_print.proto
@@ -12,7 +12,8 @@ import "caffe.proto";
 message NetParameterPrettyPrint {
   optional string name = 1;
   optional bool force_backward = 2 [default = false];
-  repeated string input = 3;
-  repeated int32 input_dim = 4;
-  repeated LayerParameter layers = 5;
+  optional NetState state = 3;
+  repeated string input = 4;
+  repeated int32 input_dim = 5;
+  repeated LayerParameter layers = 6;
 }

--- a/src/caffe/util/expand_templates.cpp
+++ b/src/caffe/util/expand_templates.cpp
@@ -1,0 +1,98 @@
+#include <boost/algorithm/string.hpp>
+#include <google/protobuf/text_format.h>
+
+#include <string>
+
+#include "caffe/util/expand_templates.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/upgrade_proto.hpp"
+
+namespace caffe {
+
+string ResolveTemplateNames(const string& path, const string& pwd) {
+  CHECK(!boost::starts_with(pwd, "/") && !boost::ends_with(pwd, "/"));
+  if (boost::starts_with(path, "/"))
+    return path.substr(1, path.size() - 1);
+  string cpath = path;
+  string cpwd = pwd;
+  while (boost::starts_with(cpath, "../")) {
+    cpath = cpath.substr(3, cpath.size() - 3);
+    size_t i = cpwd.find_last_of('/');
+    cpwd = i == string::npos ? "" : cpwd.substr(0, i);
+  }
+  if (!cpwd.size())
+    return cpath;
+  if (!cpath.size() || cpath == ".")
+    return cpwd;
+  return cpwd + '/' + cpath;
+}
+
+void ExpandTemplates(const NetParameter& source, NetParameter* target,
+    const string& pwd) {
+  for (int i = 0; i < source.layers_size(); ++i) {
+    if (source.layers(i).type() == LayerParameter_LayerType_TEMPLATE) {
+      const LayerParameter& layer = source.layers(i);
+      CHECK(layer.has_template_param()) << "Missing template_param";
+      const TemplateParameter& template_param = layer.template_param();
+      string proto;
+      if (ReadFileToString(template_param.source(), &proto)) {
+        // Replace variables and references
+        for (int j = 0; j < template_param.variable_size(); ++j) {
+          const NameValue& p = template_param.variable(j);
+          boost::replace_all(proto, "${" + p.name() + "}", p.value());
+        }
+        NetParameter net;
+        CHECK(google::protobuf::TextFormat::ParseFromString(proto, &net))
+            << "Failed to parse Template file: " << template_param.source();
+        CHECK(layer.has_name() && layer.name().length() > 0)
+            << "Template layer must have a name";
+        std::size_t found = pwd.find(layer.name());
+        if (found != std::string::npos) {
+          LOG(FATAL) << "Recursion in " << template_param.source()
+            << " due to layer " << layer.name();
+        } else {
+          ExpandTemplates(net, target,
+                          ResolveTemplateNames(layer.name(), pwd));
+        }
+      } else {
+        LOG(ERROR) << "Failed to read Template file: "
+          << template_param.source();
+      }
+    } else {
+      LayerParameter *t = target->add_layers();
+      t->CopyFrom(source.layers(i));
+      t->set_name(ResolveTemplateNames(t->name(), pwd));
+      for (int j = 0; j < source.layers(i).top_size(); ++j)
+        t->set_top(j,
+          ResolveTemplateNames(source.layers(i).top(j), pwd));
+      for (int j = 0; j < source.layers(i).bottom_size(); ++j)
+        t->set_bottom(j,
+          ResolveTemplateNames(source.layers(i).bottom(j), pwd));
+    }
+  }
+}
+
+// Return true iff contains at least one TEMPLATE layer.
+bool NetContainsTemplates(const NetParameter& net_param) {
+  for (int i = 0; i < net_param.layers_size(); ++i) {
+    if (net_param.layers(i).type() == LayerParameter_LayerType_TEMPLATE) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ExpandTemplatesNet(const NetParameter& in_net_param,
+                        NetParameter* out_net_param) {
+  out_net_param->CopyFrom(in_net_param);
+  if (NetContainsTemplates(in_net_param)) {
+    out_net_param->clear_layers();
+    ExpandTemplates(in_net_param, out_net_param, "");
+  } else {
+    LOG(WARNING) << "Net doesn't contain any Templates";
+  }
+}
+
+}  // namespace caffe
+
+

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -65,6 +65,20 @@ void WriteProtoToBinaryFile(const Message& proto, const char* filename) {
   CHECK(proto.SerializeToOstream(&output));
 }
 
+bool ReadFileToString(const string& filename, string* contents) {
+  std::ifstream in(filename.c_str(), ios::in | ios::binary | ios::ate);
+  if (in.is_open()) {
+    contents->resize(in.tellg());
+    in.seekg(0, ios::beg);
+    in.read(&(*contents)[0], contents->size());
+    in.close();
+    return true;
+  } else {
+    LOG(ERROR) << "Could not open or find file " << filename;
+    return false;
+  }
+}
+
 cv::Mat ReadImageToCVMat(const string& filename,
     const int height, const int width, const bool is_color) {
   cv::Mat cv_img;
@@ -97,15 +111,8 @@ bool ReadImageToDatum(const string& filename, const int label,
 
 bool ReadFileToDatum(const string& filename, const int label,
     Datum* datum) {
-  std::streampos size;
-
-  fstream file(filename.c_str(), ios::in|ios::binary|ios::ate);
-  if (file.is_open()) {
-    size = file.tellg();
-    std::string buffer(size, ' ');
-    file.seekg(0, ios::beg);
-    file.read(&buffer[0], size);
-    file.close();
+  std::string buffer;
+  if (ReadFileToString(filename, &buffer)) {
     datum->set_data(buffer);
     datum->set_label(label);
     datum->set_encoded(true);

--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -584,6 +584,9 @@ void NetParameterToPrettyPrint(const NetParameter& param,
   if (param.has_force_backward()) {
     pretty_param->set_force_backward(param.force_backward());
   }
+  if (param.has_state()) {
+    pretty_param->mutable_state()->CopyFrom(param.state());
+  }
   for (int i = 0; i < param.input_size(); ++i) {
     pretty_param->add_input(param.input(i));
   }

--- a/tools/expand_net.cpp
+++ b/tools/expand_net.cpp
@@ -1,0 +1,42 @@
+// This is a script expand templates layers to generate a network proto_file
+// Usage:
+//    expand_net net_proto_file_in net_proto_file_out
+
+#include <cstring>
+#include <fstream>  // NOLINT(readability/streams)
+#include <iostream>  // NOLINT(readability/streams)
+
+#include "caffe/caffe.hpp"
+#include "caffe/util/expand_templates.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/upgrade_proto.hpp"
+
+using std::ofstream;
+
+using namespace caffe;  // NOLINT(build/namespaces)
+
+int main(int argc, char** argv) {
+  ::google::InitGoogleLogging(argv[0]);
+  if (argc != 3) {
+    LOG(ERROR) << "Usage: "
+        << "expand_net net_proto_file_in net_proto_file_out";
+    return 1;
+  }
+
+  NetParameter in_param;
+  ReadNetParamsFromTextFileOrDie(argv[1], &in_param);
+
+  NetParameter expanded(in_param);
+  ExpandTemplatesNet(in_param, &expanded);
+
+  // Convert to a NetParameterPrettyPrint to print fields in desired
+  // order.
+  NetParameterPrettyPrint net_param_pretty;
+  NetParameterToPrettyPrint(expanded, &net_param_pretty);
+
+  // Save new format prototxt.
+  WriteProtoToTextFile(net_param_pretty, argv[2]);
+
+  LOG(INFO) << "Wrote expanded NetParameter text proto to " << argv[2];
+  return 0;
+}


### PR DESCRIPTION
This PR is inspired by #1290 and the discussion there. This PR also reuse parts of the code done by @cypof.

Instead of modifying `Net.Init()` this PR provides a new tool `./build/tools/expand_net` that is able to expand templates and do the need string substitutions. 
Usage: 
```
expand_net net_proto_file_in net_proto_file_out
```
For some template examples look at `examples/templates/'
```
./build/tools/expand_net examples/templates/example_net.template examples/templates/example_net.prototxt
```