### PR TITLE
Abstraction and unification of data input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ PROTO_OBJS := ${PROTO_GEN_CC:.cc=.o}
 OBJ_BUILD_DIR := $(BUILD_DIR)/src/$(PROJECT)
 LAYER_BUILD_DIR := $(OBJ_BUILD_DIR)/layers
 UTIL_BUILD_DIR := $(OBJ_BUILD_DIR)/util
+DATA_SOURCES_BUILD_DIR := $(OBJ_BUILD_DIR)/data_sources
 OBJS := $(PROTO_OBJS) $(CXX_OBJS) $(CU_OBJS)
 # tool, example, and test objects
 TOOL_OBJS := $(addprefix $(BUILD_DIR)/, ${TOOL_SRCS:.cpp=.o})
@@ -185,7 +186,7 @@ endif
 
 ALL_BUILD_DIRS := $(sort \
 		$(BUILD_DIR) $(LIB_BUILD_DIR) $(OBJ_BUILD_DIR) \
-		$(LAYER_BUILD_DIR) $(UTIL_BUILD_DIR) $(TOOL_BUILD_DIR) \
+		$(LAYER_BUILD_DIR) $(UTIL_BUILD_DIR) $(DATA_SOURCES_BUILD_DIR) $(TOOL_BUILD_DIR) \
 		$(TEST_BUILD_DIR) $(TEST_BIN_DIR) $(GTEST_BUILD_DIR) \
 		$(EXAMPLE_BUILD_DIRS) \
 		$(LINT_OUTPUT_DIR) \
@@ -539,6 +540,12 @@ $(PROTO_BUILD_DIR)/%.pb.o: $(PROTO_BUILD_DIR)/%.pb.cc $(PROTO_GEN_HEADER) \
 	@ echo
 
 $(UTIL_BUILD_DIR)/%.o: src/$(PROJECT)/util/%.cpp $(HXX_SRCS) | $(UTIL_BUILD_DIR)
+	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+		|| (cat $@.$(WARNS_EXT); exit 1)
+	@ cat $@.$(WARNS_EXT)
+	@ echo
+
+$(DATA_SOURCES_BUILD_DIR)/%.o: src/$(PROJECT)/data_sources/%.cpp $(HXX_SRCS) | $(DATA_SOURCES_BUILD_DIR)
 	$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
 		|| (cat $@.$(WARNS_EXT); exit 1)
 	@ cat $@.$(WARNS_EXT)

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -350,6 +350,10 @@ class DataMappingLayer : public Layer<Dtype> {
                             const vector<Blob<Dtype>*>& bottom) {
     NOT_IMPLEMENTED;
   }
+
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+                       const vector<Blob<Dtype>*>& top);
+
  private:
   shared_ptr<DataSource<Dtype> > data_source_;
   uint32_t data_length_;
@@ -372,10 +376,14 @@ class DataSequenceLayer : public Layer<Dtype> {
                             const vector<Blob<Dtype>*>& bottom) {
     NOT_IMPLEMENTED;
   }
+
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+                       const vector<Blob<Dtype>*>& top);
+
  private:
   shared_ptr<DataSource<Dtype> > data_source_;
   std::vector<index_type> indices_;
-  int cursor;
+  int cursor_;
   unsigned int batch_size_;
   unsigned int data_length_;
 };

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -10,7 +10,6 @@
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
-#include "caffe/data_sources.hpp"
 #include "caffe/data_transformer.hpp"
 #include "caffe/dataset.hpp"
 #include "caffe/filler.hpp"
@@ -333,11 +332,18 @@ class WindowDataLayer : public BasePrefetchingDataLayer<Dtype> {
   vector<std::pair<std::string, Datum > > image_database_cache_;
 };
 
+// Forward declaration
+template <typename Dtype>
+class DataSource;
+
 template <typename Dtype>
 class DataMappingLayer : public Layer<Dtype> {
  public:
   explicit DataMappingLayer(const LayerParameter& param)
     : Layer<Dtype>(param) {}
+
+  DataMappingLayer(const LayerParameter& param,
+                   shared_ptr<DataSource<Dtype> > source);
 
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
                           const vector<Blob<Dtype>*>& top);
@@ -356,7 +362,7 @@ class DataMappingLayer : public Layer<Dtype> {
 
  private:
   shared_ptr<DataSource<Dtype> > data_source_;
-  uint32_t data_length_;
+  unsigned int data_length_;
 };
 
 template <typename Dtype>
@@ -365,6 +371,9 @@ class DataSequenceLayer : public Layer<Dtype> {
   explicit DataSequenceLayer(const LayerParameter& param)
     : Layer<Dtype>(param) {}
 
+  DataSequenceLayer(const LayerParameter& param,
+                    shared_ptr<DataSource<Dtype> > source);
+
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
                           const vector<Blob<Dtype>*>& top);
 
@@ -382,7 +391,7 @@ class DataSequenceLayer : public Layer<Dtype> {
 
  private:
   shared_ptr<DataSource<Dtype> > data_source_;
-  std::vector<index_type> indices_;
+  std::vector<int> indices_;
   int cursor_;
   unsigned int batch_size_;
   unsigned int data_length_;

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -10,6 +10,7 @@
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
+#include "caffe/data_sources.hpp"
 #include "caffe/data_transformer.hpp"
 #include "caffe/dataset.hpp"
 #include "caffe/filler.hpp"
@@ -330,6 +331,53 @@ class WindowDataLayer : public BasePrefetchingDataLayer<Dtype> {
   bool has_mean_values_;
   bool cache_images_;
   vector<std::pair<std::string, Datum > > image_database_cache_;
+};
+
+template <typename Dtype>
+class DataMappingLayer : public Layer<Dtype> {
+ public:
+  explicit DataMappingLayer(const LayerParameter& param)
+    : Layer<Dtype>(param) {}
+
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+                          const vector<Blob<Dtype>*>& top);
+
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+                           const vector<Blob<Dtype>*>& top);
+
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+                            const vector<bool>& propagate_down,
+                            const vector<Blob<Dtype>*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+ private:
+  shared_ptr<DataSource<Dtype> > data_source_;
+  uint32_t data_length_;
+};
+
+template <typename Dtype>
+class DataSequenceLayer : public Layer<Dtype> {
+ public:
+  explicit DataSequenceLayer(const LayerParameter& param)
+    : Layer<Dtype>(param) {}
+
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+                          const vector<Blob<Dtype>*>& top);
+
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+                           const vector<Blob<Dtype>*>& top);
+
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+                            const vector<bool>& propagate_down,
+                            const vector<Blob<Dtype>*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+ private:
+  shared_ptr<DataSource<Dtype> > data_source_;
+  std::vector<index_type> indices_;
+  int cursor;
+  unsigned int batch_size_;
+  unsigned int data_length_;
 };
 
 }  // namespace caffe

--- a/include/caffe/data_sources.hpp
+++ b/include/caffe/data_sources.hpp
@@ -1,0 +1,37 @@
+#ifndef CAFFE_DATA_SOURCES_HPP_
+#define CAFFE_DATA_SOURCES_HPP_
+
+#include <vector>
+
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+typedef int index_type;
+typedef int length_type;
+
+template <typename Dtype>
+class DataSource {
+ public:
+  explicit DataSource(const DataSourceParameter& param)
+    : data_source_param_(param) {}
+
+  const DataSourceParameter& data_source_param() const {
+    return data_source_param_;
+  }
+
+  virtual ~DataSource() {}
+
+  virtual length_type retrieve(index_type index,
+                               Dtype* buffer,
+                               length_type buffer_length) = 0;
+
+  virtual std::vector<index_type> indices() = 0;
+
+ private:
+  DataSourceParameter data_source_param_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_DATA_SOURCES_HPP_

--- a/include/caffe/data_sources.hpp
+++ b/include/caffe/data_sources.hpp
@@ -33,11 +33,11 @@ class DataSource {
    * @brief indices
    * @return a list of indicies that this source accepts
    *
-   * This default implementation returns a single {0}.
+   * This default implementation returns a single {0}. The return value is
+   * not guaranteed to be sorted.
    *
    * Subclass may allow retrieval of data at indices
-   * other than those in the return value of this function.
-   * It is especially true for pseudo sources, e.g. ConstantDataSource.
+   * other than those specified by this function.
    */
   virtual std::vector<index_type> indices() {
     return std::vector<index_type>(1, 0);

--- a/include/caffe/data_sources.hpp
+++ b/include/caffe/data_sources.hpp
@@ -1,6 +1,8 @@
 #ifndef CAFFE_DATA_SOURCES_HPP_
 #define CAFFE_DATA_SOURCES_HPP_
 
+#include <boost/unordered_map.hpp>
+
 #include <vector>
 
 #include "caffe/proto/caffe.pb.h"
@@ -31,6 +33,61 @@ class DataSource {
  private:
   DataSourceParameter data_source_param_;
 };
+
+template <typename Dtype>
+class ConstantDataSource : public DataSource<Dtype> {
+ public:
+  explicit ConstantDataSource(const DataSourceParameter& param)
+    : DataSource<Dtype>(param) {
+    constant_ = param.constant_param().constant();
+  }
+
+  virtual std::vector<index_type> indices() {
+    return std::vector<index_type>(1, 0);
+  }
+
+  virtual length_type retrieve(index_type index,
+                                 Dtype* buffer,
+                                 length_type buffer_length) {
+    if (buffer_length > 0)
+      *buffer = constant_;
+    return 1;
+  }
+
+ private:
+  Dtype constant_;
+};
+
+template <typename Dtype>
+class CSVDataSource : public DataSource<Dtype> {
+ public:
+  explicit CSVDataSource(const DataSourceParameter& param);
+
+  virtual ~CSVDataSource();
+
+  virtual length_type retrieve(index_type index,
+                               Dtype* buffer,
+                               length_type buffer_length);
+
+  virtual std::vector<index_type> indices();
+
+ private:
+  boost::unordered_map<index_type, std::vector<Dtype> > data_;
+};
+
+template <typename Dtype>
+DataSource<Dtype>* create_data_source(const DataSourceParameter& param) {
+  switch (param.type()) {
+  case DataSourceParameter_DataSourceType_CONSTANT:
+    return new ConstantDataSource<Dtype>(param);
+  case DataSourceParameter_DataSourceType_CSV:
+    return new CSVDataSource<Dtype>(param);
+  default:
+    LOG(FATAL) << "Unknown or unimplemented data source type "
+               << static_cast<int>(param.type());
+  }
+  return NULL;
+}
 
 }  // namespace caffe
 

--- a/include/caffe/data_sources.hpp
+++ b/include/caffe/data_sources.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/unordered_map.hpp>
 
+#include <algorithm>
 #include <vector>
 
 #include "caffe/proto/caffe.pb.h"
@@ -28,7 +29,19 @@ class DataSource {
                                Dtype* buffer,
                                length_type buffer_length) = 0;
 
-  virtual std::vector<index_type> indices() = 0;
+  /**
+   * @brief indices
+   * @return a list of indicies that this source accepts
+   *
+   * This default implementation returns a single {0}.
+   *
+   * Subclass may allow retrieval of data at indices
+   * other than those in the return value of this function.
+   * It is especially true for pseudo sources, e.g. ConstantDataSource.
+   */
+  virtual std::vector<index_type> indices() {
+    return std::vector<index_type>(1, 0);
+  }
 
  private:
   DataSourceParameter data_source_param_;
@@ -42,16 +55,11 @@ class ConstantDataSource : public DataSource<Dtype> {
     constant_ = param.constant_param().constant();
   }
 
-  virtual std::vector<index_type> indices() {
-    return std::vector<index_type>(1, 0);
-  }
-
   virtual length_type retrieve(index_type index,
                                  Dtype* buffer,
                                  length_type buffer_length) {
-    if (buffer_length > 0)
-      *buffer = constant_;
-    return 1;
+    std::fill(buffer, buffer + buffer_length, constant_);
+    return buffer_length;
   }
 
  private:

--- a/src/caffe/data_sources/csv_data_source.cpp
+++ b/src/caffe/data_sources/csv_data_source.cpp
@@ -1,0 +1,74 @@
+#include <boost/lexical_cast.hpp>
+#include <boost/tokenizer.hpp>
+#include <boost/unordered_map.hpp>
+
+#include <algorithm>
+#include <fstream>  // NOLINT(readability/streams)
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/data_sources.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+CSVDataSource<Dtype>::CSVDataSource(const DataSourceParameter& param)
+  : DataSource<Dtype>(param) {
+  std::ifstream input(param.filename().c_str());
+  CHECK(input) << "Opening file " << param.filename() << " failed";
+
+  std::string line;
+  typedef boost::char_separator<char> separator_type;
+  typedef boost::tokenizer<separator_type> tokenizer_type;
+  typedef typename tokenizer_type::iterator iterator_type;
+
+  try {
+    separator_type separator(", \t");
+    while (std::getline(input, line)) {
+      tokenizer_type tokenizer(line, separator);
+      iterator_type it = tokenizer.begin();
+      if (it != tokenizer.end()) {
+        index_type index = boost::lexical_cast<index_type>(*it);
+        std::vector<Dtype>* current_data = &data_[index];
+        CHECK(current_data->empty()) << "Duplicate index " << index;
+
+        while (++it != tokenizer.end()) {
+          current_data->push_back(boost::lexical_cast<Dtype>(*it));
+        }
+      }
+    }
+  } catch (const boost::bad_lexical_cast& e) {
+    LOG(FATAL) << e.what();
+  }
+}
+
+template <typename Dtype>
+CSVDataSource<Dtype>::~CSVDataSource() {}
+
+template <typename Dtype>
+length_type CSVDataSource<Dtype>::retrieve(index_type index,
+                                           Dtype* buffer,
+                                           length_type buffer_length) {
+  const std::vector<Dtype>& current_data = data_[index];
+  length_type copy_length =
+      std::min<length_type>(current_data.size(), buffer_length);
+  std::copy(current_data.begin(), current_data.begin() + copy_length, buffer);
+  return current_data.size();
+}
+
+template <typename Dtype>
+std::vector<index_type> CSVDataSource<Dtype>::indices() {
+  std::vector<index_type> result;
+  result.reserve(data_.size());
+  for (typename boost::unordered_map<index_type, std::vector<Dtype> >::iterator
+       it = data_.begin(); it != data_.end(); ++it) {
+    result.push_back(it->first);
+  }
+  return result;
+}
+
+INSTANTIATE_CLASS(CSVDataSource);
+
+}  // namespace caffe

--- a/src/caffe/layers/data_mapping_layer.cpp
+++ b/src/caffe/layers/data_mapping_layer.cpp
@@ -1,0 +1,57 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/data_layers.hpp"
+#include "caffe/data_sources.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void DataMappingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+                                         const vector<Blob<Dtype>*>& top) {
+  CHECK_EQ(bottom.size(), top.size());
+  for (int i = 0; i < bottom.size(); ++i) {
+    CHECK_EQ(bottom[i]->channels(), 1);
+    CHECK_EQ(bottom[i]->height(), 1);
+    CHECK_EQ(bottom[i]->width(), 1);
+  }
+  const DataMappingParameter& param = this->layer_param().data_mapping_param();
+  this->data_length_ = param.channels() * param.height() * param.width();
+}
+
+template <typename Dtype>
+void DataMappingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+                                   const vector<Blob<Dtype>*>& top) {
+  for (int i = 0; i < bottom.size(); ++i) {
+    int num = bottom[i]->num();
+    const Blob<Dtype>* b = bottom[i];
+    Blob<Dtype>* t = top[i];
+    Dtype* buffer = t->mutable_cpu_data();
+
+    for (int j = 0; j < num; ++j) {
+      index_type index = b->data_at(j, 0, 0, 0);
+      Blob<Dtype>* t = top[i];
+      CHECK_EQ(data_source_->retrieve(index,
+                                      buffer,
+                                      data_length_),
+               data_length_);
+      buffer += data_length_;
+    }
+  }
+}
+
+template <typename Dtype>
+void DataMappingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+                                   const vector<Blob<Dtype>*>& top) {
+  CHECK_EQ(bottom.size(), top.size());
+  const DataMappingParameter& param = this->layer_param().data_mapping_param();
+  for (int i = 0; i < top.size(); ++i) {
+    top[i]->Reshape(bottom[i]->num(), param.channels(),
+                    param.height(), param.width());
+  }
+}
+
+INSTANTIATE_CLASS(DataMappingLayer);
+REGISTER_LAYER_CLASS(DATA_MAPPING, DataMappingLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/data_mapping_layer.cpp
+++ b/src/caffe/layers/data_mapping_layer.cpp
@@ -7,6 +7,13 @@
 namespace caffe {
 
 template <typename Dtype>
+DataMappingLayer<Dtype>::DataMappingLayer(const LayerParameter& param,
+                                          shared_ptr<DataSource<Dtype> > source)
+  : Layer<Dtype>(param) {
+  data_source_ = source;
+}
+
+template <typename Dtype>
 void DataMappingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
                                          const vector<Blob<Dtype>*>& top) {
   CHECK_EQ(bottom.size(), top.size());
@@ -17,6 +24,8 @@ void DataMappingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   }
   const DataMappingParameter& param = this->layer_param().data_mapping_param();
   this->data_length_ = param.channels() * param.height() * param.width();
+  if (!data_source_)
+    data_source_.reset(create_data_source<Dtype>(param.data_source()));
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/data_mapping_layer.cpp
+++ b/src/caffe/layers/data_mapping_layer.cpp
@@ -39,7 +39,6 @@ void DataMappingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 
     for (int j = 0; j < num; ++j) {
       index_type index = b->data_at(j, 0, 0, 0);
-      Blob<Dtype>* t = top[i];
       CHECK_EQ(data_source_->retrieve(index,
                                       buffer,
                                       data_length_),

--- a/src/caffe/layers/data_sequence_layer.cpp
+++ b/src/caffe/layers/data_sequence_layer.cpp
@@ -7,12 +7,21 @@
 namespace caffe {
 
 template <typename Dtype>
+DataSequenceLayer<Dtype>::DataSequenceLayer(const LayerParameter& param,
+                                          shared_ptr<DataSource<Dtype> > source)
+  : Layer<Dtype>(param) {
+  data_source_ = source;
+}
+
+template <typename Dtype>
 void DataSequenceLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
                                          const vector<Blob<Dtype>*>& top) {
   CHECK_EQ(bottom.size(), 0);
   CHECK_EQ(top.size(), 1);
   const DataSequenceParameter& param =
       this->layer_param().data_sequence_param();
+  if (!data_source_)
+    data_source_.reset(create_data_source<Dtype>(param.data_source()));
   this->data_length_ = param.channels() * param.height() * param.width();
   this->indices_ = data_source_->indices();
   std::sort(indices_.begin(), indices_.end());

--- a/src/caffe/layers/data_sequence_layer.cpp
+++ b/src/caffe/layers/data_sequence_layer.cpp
@@ -1,0 +1,48 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/data_layers.hpp"
+#include "caffe/data_sources.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void DataSequenceLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+                                         const vector<Blob<Dtype>*>& top) {
+  CHECK_EQ(bottom.size(), 0);
+  CHECK_EQ(top.size(), 1);
+  const DataSequenceParameter& param =
+      this->layer_param().data_sequence_param();
+  this->data_length_ = param.channels() * param.height() * param.width();
+  this->indices_ = data_source_->indices();
+  std::sort(indices_.begin(), indices_.end());
+  cursor_ = -1;
+  batch_size_ = param.batch_size();
+}
+
+template <typename Dtype>
+void DataSequenceLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+                                   const vector<Blob<Dtype>*>& top) {
+  Dtype* buffer = top[0]->mutable_cpu_data();
+  for (int i = 0; i < batch_size_; ++i) {
+    cursor_ = (cursor_ + 1) % indices_.size();
+    CHECK_EQ(data_source_->retrieve(indices_[cursor_], buffer, data_length_),
+             data_length_);
+    buffer += data_length_;
+  }
+}
+
+template <typename Dtype>
+void DataSequenceLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+                                   const vector<Blob<Dtype>*>& top) {
+  const DataSequenceParameter& param =
+      this->layer_param().data_sequence_param();
+  top[0]->Reshape(batch_size_, param.channels(),
+                  param.height(), param.width());
+}
+
+INSTANTIATE_CLASS(DataSequenceLayer);
+REGISTER_LAYER_CLASS(DATA_SEQUENCE, DataSequenceLayer);
+
+}  // namespace caffe
+

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -844,14 +844,7 @@ message DataSourceParameter {
   enum DataSourceType {
     NONE = 0;
     CONSTANT = 1;
-    RANGE = 2;
-    RANDOM = 3;
-    CSV = 4;
-    GRAY_IMAGE = 5;
-    COLOR_IMAGE = 6;
-    LMDB = 7;
-    LEVELDB = 8;
-    HDF5 = 9;
+    CSV = 2;
   }
   optional DataSourceType type = 1;
   optional int32 channels = 2 [default = 1];
@@ -860,21 +853,8 @@ message DataSourceParameter {
   optional string filename = 5;
 
   optional ConstantDataSourceParameter constant_param = 6;
-  optional RangeDataSourceParameter range_param = 7;
-  optional RandomDataSourceParameter random_param = 8;
 }
 
 message ConstantDataSourceParameter {
   optional float constant = 1 [default = 0.0];
-}
-
-message RangeDataSourceParameter {
-  optional int32 start = 1 [default = 0];
-  optional int32 stop = 2 [default = 2];
-  optional int32 step = 3 [default = 1];
-}
-
-message RandomDataSourceParameter {
-  optional int32 minimum = 1 [default = 0];
-  optional int32 maximum = 2 [default = 1];
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -847,6 +847,11 @@ message DataSourceParameter {
     RANGE = 2;
     RANDOM = 3;
     CSV = 4;
+    GRAY_IMAGE = 5;
+    COLOR_IMAGE = 6;
+    LMDB = 7;
+    LEVELDB = 8;
+    HDF5 = 9;
   }
   optional DataSourceType type = 1;
   optional int32 channels = 2 [default = 1];

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -227,7 +227,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 39 (last added: EXP)
+  // LayerType next available ID: 41 (last added: DATA_SEQUENCE)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if
@@ -241,6 +241,8 @@ message LayerParameter {
     CONTRASTIVE_LOSS = 37;
     CONVOLUTION = 4;
     DATA = 5;
+    DATA_MAPPING = 39;
+    DATA_SEQUENCE = 40;
     DROPOUT = 6;
     DUMMY_DATA = 32;
     EUCLIDEAN_LOSS = 7;
@@ -305,6 +307,8 @@ message LayerParameter {
   optional ContrastiveLossParameter contrastive_loss_param = 40;
   optional ConvolutionParameter convolution_param = 10;
   optional DataParameter data_param = 11;
+  optional DataMappingParameter data_mapping_param = 42;
+  optional DataSequenceParameter data_sequence_param = 43;
   optional DropoutParameter dropout_param = 12;
   optional DummyDataParameter dummy_data_param = 26;
   optional EltwiseParameter eltwise_param = 24;
@@ -443,6 +447,23 @@ message DataParameter {
   // DEPRECATED. See TransformationParameter. Specify if we want to randomly mirror
   // data.
   optional bool mirror = 6 [default = false];
+}
+
+// Message that stores parameter for DataMappingLayer
+message DataMappingParameter {
+  optional DataSourceParameter data_source = 1;
+  optional uint32 channels = 2 [default = 1];
+  optional uint32 height = 3 [default = 1];
+  optional uint32 width = 4 [default = 1];
+}
+
+// Message that stores parameter for DataSequenceLayer
+message DataSequenceParameter {
+  optional DataSourceParameter data_source = 1;
+  optional uint32 channels = 2 [default = 1];
+  optional uint32 height = 3 [default = 1];
+  optional uint32 width = 4 [default = 1];
+  optional uint32 batch_size = 5;
 }
 
 // Message that stores parameters used by DropoutLayer
@@ -816,4 +837,39 @@ message V0LayerParameter {
   optional uint32 concat_dim = 65 [default = 1];
 
   optional HDF5OutputParameter hdf5_output_param = 1001;
+}
+
+// Message for DataSource
+message DataSourceParameter {
+  enum DataSourceType {
+    NONE = 0;
+    CONSTANT = 1;
+    RANGE = 2;
+    RANDOM = 3;
+    CSV = 4;
+  }
+  optional DataSourceType type = 1;
+  optional int32 channels = 2 [default = 1];
+  optional int32 height = 3 [default = 1];
+  optional int32 width = 4 [default = 1];
+  optional string filename = 5;
+
+  optional ConstantDataSourceParameter constant_param = 6;
+  optional RangeDataSourceParameter range_param = 7;
+  optional RandomDataSourceParameter random_param = 8;
+}
+
+message ConstantDataSourceParameter {
+  optional float constant = 1 [default = 0.0];
+}
+
+message RangeDataSourceParameter {
+  optional int32 start = 1 [default = 0];
+  optional int32 stop = 2 [default = 2];
+  optional int32 step = 3 [default = 1];
+}
+
+message RandomDataSourceParameter {
+  optional int32 minimum = 1 [default = 0];
+  optional int32 maximum = 2 [default = 1];
 }

--- a/src/caffe/test/test_csv_data_source.cpp
+++ b/src/caffe/test/test_csv_data_source.cpp
@@ -1,0 +1,98 @@
+#include <stdlib.h>
+
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
+
+#include <algorithm>
+#include <fstream>  // NOLINT(readability/streams)
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/data_sources.hpp"
+#include "caffe/util/rng.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+class CSVDataSourceTest : public ::testing::Test {
+ protected:
+  std::map<index_type, std::vector<Dtype> > data_;
+
+ protected:
+  void FillRandom(int rows, int columns) {
+    data_.clear();
+
+    rng_t& engine = *caffe_rng();
+
+    boost::uniform_int<index_type> index_dist(rows / 2, 2 * rows + 2);
+    boost::uniform_real<Dtype> value_dist;
+
+    while (data_.size() < rows) {
+      index_type index = index_dist(engine);
+      std::vector<Dtype>* buffer = &data_[index];
+      if (!buffer->empty())
+        continue;
+      for (int j = 0; j < columns; ++j)
+        buffer->push_back(value_dist(engine));
+    }
+  }
+
+  void ToCSV(const char* filename) {
+    std::ofstream output(filename);
+    CHECK(output) << "Failed to open " << filename << " for writing";
+
+    typedef typename std::map<index_type, std::vector<Dtype> >::const_iterator
+        iterator_type;
+
+    for (iterator_type it = data_.begin(); it != data_.end(); ++it) {
+      output << it->first << ", ";
+      const std::vector<Dtype>& values = it->second;
+      CHECK_GT(values.size(), 0);
+      for (int j = 0; j + 1 < values.size(); ++j) {
+        output << values[j] << ", ";
+      }
+      output << values.back() << '\n';
+    }
+  }
+};
+
+TYPED_TEST_CASE(CSVDataSourceTest, TestDtypes);
+
+TYPED_TEST(CSVDataSourceTest, TestReading) {
+  typedef TypeParam Dtype;
+
+  char temp_file_name[] = "/tmp/caffe_CSVDataSourceTest.XXXXXX";
+  int fd = mkstemp(temp_file_name);
+  CHECK_GT(fd, 0) << "Failed to create temporary file";
+  close(fd);
+
+  const int rows = 100, columns = 20;
+  this->FillRandom(rows, columns);
+  this->ToCSV(temp_file_name);
+
+  DataSourceParameter param;
+  param.set_type(caffe::DataSourceParameter_DataSourceType_CSV);
+  param.set_filename(temp_file_name);
+
+  DataSource<Dtype>* source = new CSVDataSource<Dtype>(param);
+
+  std::vector<Dtype> buffer(columns);
+  typedef typename std::map<index_type, std::vector<Dtype> >::const_iterator
+                                                    iterator_type;
+
+  for (iterator_type it = this->data_.begin(); it != this->data_.end(); ++it) {
+    CHECK_EQ(source->retrieve(it->first, &buffer[0], columns),
+             columns);
+    for (int j = 0; j < columns; ++j) {
+      CHECK_NEAR(it->second[j], buffer[j], 0.001);
+    }
+  }
+}
+}  // namespace caffe

--- a/src/caffe/test/test_data_mapping_layer.cpp
+++ b/src/caffe/test/test_data_mapping_layer.cpp
@@ -1,0 +1,155 @@
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/data_layers.hpp"
+#include "caffe/data_sources.hpp"
+#include "caffe/util/rng.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+template <typename TypeParam>
+class DataMappingLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ private:
+  class DummyDataSource: public DataSource<Dtype> {
+   public:
+    explicit DummyDataSource(const DataSourceParameter& param)
+      : DataSource<Dtype>(param) {}
+
+    virtual length_type retrieve(index_type index, Dtype* buffer,
+                                 length_type buffer_length) {
+      Dtype data[] = {index, index + 1, index + 2,
+                      index + 3, index + 4, index + 5};
+      length_type copy_length =
+          std::min<length_type>(buffer_length, sizeof(data) / sizeof(*data));
+      std::copy(data, data + copy_length, buffer);
+      return sizeof(data) / sizeof(*data);
+    }
+  };
+
+ protected:
+  shared_ptr<DataSource<Dtype> > data_source_;
+  std::vector<Blob<Dtype>*> top_, bottom_;
+
+ protected:
+  DataMappingLayerTest()
+    : data_source_(new DummyDataSource(DataSourceParameter())) {
+    for (int i = 0; i < 4; ++i) {
+      bottom_.push_back(new Blob<Dtype>(i * 4 + 1, 1, 1, 1));
+      top_.push_back(new Blob<Dtype>());
+    }
+  }
+
+  ~DataMappingLayerTest() {
+    for (int i = 0; i < bottom_.size(); ++i) {
+      delete bottom_[i];
+    }
+
+    for (int i = 0; i < bottom_.size(); ++i) {
+      delete top_[i];
+    }
+  }
+
+  void FillBottomRandomly(int maximum) {
+    rng_t& rng = *caffe_rng();
+    for (int i = 0; i < bottom_.size(); ++i) {
+      Blob<Dtype>* b = bottom_[i];
+      Dtype* out = b->mutable_cpu_data();
+      for (int j = 0; j < b->num(); ++j) {
+        out[j] = rng() % maximum;
+      }
+    }
+  }
+
+  void CheckTopAgainstBottom(const DataMappingParameter& param) {
+    CHECK_EQ(bottom_.size(), top_.size());
+    for (int i = 0; i < bottom_.size(); ++i) {
+      const Blob<Dtype>& b = *bottom_[i];
+      const Blob<Dtype>& t = *top_[i];
+
+      CHECK_EQ(t.num(), b.num());
+      CHECK_EQ(t.channels(), param.channels());
+      CHECK_EQ(t.height(), param.height());
+      CHECK_EQ(t.width(), param.width());
+    }
+  }
+};
+
+TYPED_TEST_CASE(DataMappingLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(DataMappingLayerTest, TestForward) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  this->FillBottomRandomly(65535);
+
+  LayerParameter param;
+  param.set_type(caffe::LayerParameter_LayerType_DATA_MAPPING);
+  DataMappingParameter* dm_param = param.mutable_data_mapping_param();
+  dm_param->set_channels(3);
+  dm_param->set_height(2);
+
+  DataMappingLayer<Dtype> layer(param, this->data_source_);
+
+  layer.SetUp(this->bottom_, this->top_);
+  this->CheckTopAgainstBottom(param.data_mapping_param());
+  layer.Forward(this->bottom_, this->top_);
+
+  for (int i = 0; i < this->bottom_.size(); ++i) {
+    const Blob<Dtype>& b = *this->bottom_[i];
+    const Blob<Dtype>& t = *this->top_[i];
+
+    int num = b.num();
+
+    for (int j = 0; j < num; ++j) {
+      CHECK_EQ(b.data_at(j, 0, 0, 0), t.data_at(j, 0, 0, 0));
+      CHECK_EQ(b.data_at(j, 0, 0, 0) + 5, t.data_at(j, 2, 1, 0));
+    }
+  }
+}
+
+template <typename Iterator>
+static bool all_zero(Iterator begin, Iterator end) {
+  while (begin != end) {
+    if (*begin != 0)
+      return false;
+    ++begin;
+  }
+  return true;
+}
+
+TYPED_TEST(DataMappingLayerTest, TestForwardZero) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  this->FillBottomRandomly(65535);
+
+  LayerParameter param;
+  param.set_type(caffe::LayerParameter_LayerType_DATA_MAPPING);
+  DataMappingParameter* dm_param = param.mutable_data_mapping_param();
+  dm_param->mutable_data_source()
+      ->set_type(caffe::DataSourceParameter_DataSourceType_CONSTANT);
+  dm_param->set_channels(3);
+  dm_param->set_height(2);
+  dm_param->set_width(9);
+
+  DataMappingLayer<Dtype> layer(param);
+
+  layer.SetUp(this->bottom_, this->top_);
+  this->CheckTopAgainstBottom(param.data_mapping_param());
+  layer.Forward(this->bottom_, this->top_);
+
+  for (int i = 0; i < this->bottom_.size(); ++i) {
+    const Blob<Dtype>& t = *this->top_[i];
+    const Dtype* buffer = t.cpu_data();
+    const int length = t.num() * t.channels() * t.height() * t.width();
+    CHECK(all_zero(buffer, buffer + length));
+  }
+}
+}  //  namespace caffe


### PR DESCRIPTION
This is a generalization of `IndirectionLayer` in #1414 as discussed with @sguada 

## Motivation

There are two problems with the current way of data input into the network:

1. The rigidity imposed by `Datum`. It unnecessarily couples "data" (which are usually images) with a single integer "label". The inflexibility of `Datum` makes it difficult and unnatural to model multi-label classification, attribute classification, face verification and many more cases where "data" and "label" does not have one-to-one correspondence.
2. The code duplication and multiple responsibilities of all kinds of `DataLayer`s. There are `DataLayer`, `ImageDataLayer`, `HDF5DataLayer`, `DummyDataLayer` and many other ones. Each data layer has to handle both the task of reading the data as well as propagating them in the network. They also repeatedly handle the error prone task of multithreaded prefetching despite sharing a common base class.

## Core idea

The first idea is unify data and label under `Blob`. All "data" and "label" are just regular blobs, where the latter is just a special case (1x1x1 integer). So the new layers will just output blob. Whether they should be interpreted as data or label or something else is not these layers' concern.

The second idea is to separate the data access from the act of propagating them. 

The data access is abstracted by `DataSource` class. The data source is modeled as a mapping between integer and floating point array (`int32 -> float[]`). The implementation may be 

* backed by files, like CSV, JSON, LMDB, HDF5, images
* dynamically generated, such as a counter, a  constant stream of zero (analogous to `/dev/zero`) and random numbers (analogous to `/dev/random`)
* modulation of other data sources, such as caching and transformation.

The propagation is handled by two layers, `DataSequenceLayer` and `DataMappingLayer` (the naming is not fixed yet).

* `DataSequenceLayer` outputs data in sequence. It reads from the lowest index to the highest and then cycles back. Because it knows in advance what data to retrieve, it may prefetch in a different thread. The threading code only needs to be implemented once for all sources.
* `DataMappingLayer` outputs data with the indices specified by the bottom blob. This allows filtering, reordering, shuffling and slicing of the data source.

## Example definition

Here is a definition file for `DataMappingLayer`

```protobuf
layer {
  type: DATA_MAPPING
  bottom: "index"
  top: "data"
  name: "mapping"
  data_mapping_param {
    channels: 3
    height: 12
    width: 12
    data_source_param {
      type: CSV
      filename: "mapping.csv"
    }
  }
}
```

`DataSequenceLayer` can be similarly declared, except that it does not have bottom input but a `batch_size` parameter.

## Example network

### Original case (image + label)

![](https://netheril96.github.io/images/abstraction_and_unification_of_data_input/img_label.svg)

### Multiple label

![](https://netheril96.github.io/images/abstraction_and_unification_of_data_input/img_label_label.svg)

### Verification

![](https://netheril96.github.io/images/abstraction_and_unification_of_data_input/img_img_label.svg)

### Shuffling

`ImageDataLayer` has a special option to constantly shuffle input. With the new architecture, the similar can be achieved on any data source, by piping random indices into `DataMappingLayer`. The result is not the same, though, because this allows duplication.

![](https://netheril96.github.io/images/abstraction_and_unification_of_data_input/shuffle.svg)

### Selection

If there are many data input, splitting them into training and testing set and maintaining synchronization is tedious and error-prone. Instead, we can group them in the same data source. A single layer that outputs indices will be able to select different part of them in different scenarios. The synchronization is ensured by the fact that each `DataMappingLayer` receives the same index.

![](https://netheril96.github.io/images/abstraction_and_unification_of_data_input/select.svg)

## To do

This PR is a *minimal* functional implementation of the above idea. It only has two data sources: one "pseudo device" that outputs constant, another backed by CSV files. It also lacks prefetching, which could be added later.

The following data sources may be implemented after and if this PR is accepted:

* LMDB
* LevelDB
* HDF5
* protobuf
* JSON
* Gray/color images
* Random integers
* Normal distributed float
* Range slice
* Window
