### PR TITLE
Update mean file help

### DIFF
--- a/python/classify.py
+++ b/python/classify.py
@@ -60,8 +60,8 @@ def main(argv):
         "--mean_file",
         default=os.path.join(pycaffe_dir,
                              'caffe/imagenet/ilsvrc_2012_mean.npy'),
-        help="Data set image mean of H x W x K dimensions (numpy array). " +
-             "Set to '' for no mean subtraction."
+        help="Data set image mean of [Channels x Height x Width] dimensions " +
+             "(numpy array). Set to '' for no mean subtraction."
     )
     parser.add_argument(
         "--input_scale",


### PR DESCRIPTION
Numpy array dimensions should be [Channels x Height x Width], NOT [Height x Width x Channels]

If an image mean file is supplied with channels as the last dimension, `classify.py` throws errors like:

```
ValueError: operands could not be broadcast together with shapes (3,227,227) (256,0,225) (3,227,227)
```
