### PR TITLE
Improvements to network drawing via draw_net.py

### DIFF
--- a/python/caffe/draw.py
+++ b/python/caffe/draw.py
@@ -11,11 +11,11 @@ from google.protobuf import text_format
 import pydot
 
 # Internal layer and blob styles.
-LAYER_STYLE = {'shape': 'record', 'fillcolor': '#6495ED',
+LAYER_STYLE_DEFAULT = {'shape': 'record', 'fillcolor': '#6495ED',
          'style': 'filled'}
 NEURON_LAYER_STYLE = {'shape': 'record', 'fillcolor': '#90EE90',
          'style': 'filled'}
-BLOB_STYLE = {'shape': 'octagon', 'fillcolor': '#F0E68C',
+BLOB_STYLE = {'shape': 'octagon', 'fillcolor': '#E0E0E0',
         'style': 'filled'}
 def get_enum_name_by_value():
   desc = caffe_pb2.LayerParameter.LayerType.DESCRIPTOR
@@ -24,39 +24,136 @@ def get_enum_name_by_value():
     d[v.number] = k
   return d
 
-def get_pydot_graph(caffe_net):
-  pydot_graph = pydot.Dot(caffe_net.name, graph_type='digraph', rankdir="BT")
+
+def get_pooling_types_dict():
+    """Get dictionary mapping pooling type number to type name
+    """
+    desc = caffe_pb2.PoolingParameter.PoolMethod.DESCRIPTOR
+    d = {}
+    for k,v in desc.values_by_name.items():
+        d[v.number] = k
+    return d
+
+
+def determine_edge_label_by_layertype(layer, layertype):
+    """Define edge label based on layer type
+    """
+
+    if layertype == 'DATA':
+        edge_label = 'Batch ' + str(layer.data_param.batch_size)
+    elif layertype == 'CONVOLUTION':
+        edge_label = str(layer.convolution_param.num_output)
+    elif layertype == 'INNER_PRODUCT':
+        edge_label = str(layer.inner_product_param.num_output)
+    else:
+        edge_label = '""'
+
+    return edge_label
+
+
+def determine_node_label_by_layertype(layer, layertype, rankdir):
+    """Define node label based on layer type
+    """
+
+    if rankdir in ('TB', 'BT'):
+        # If graph orientation is vertical, horizontal space is free and
+        # vertical space is not; separate words with spaces
+        separator = ' '
+    else:
+        # If graph orientation is horizontal, vertical space is free and
+        # horizontal space is not; separate words with newlines
+        separator = '\n'
+
+    if layertype == 'CONVOLUTION':
+        # Outer double quotes needed or else colon characters don't parse
+        # properly
+        node_label = '"%s%s(%s)%skernel size: %d%sstride: %d%spad: %d"' %\
+                     (layer.name,
+                      separator,
+                      layertype,
+                      separator,
+                      layer.convolution_param.kernel_size,
+                      separator,
+                      layer.convolution_param.stride,
+                      separator,
+                      layer.convolution_param.pad)
+    elif layertype == 'POOLING':
+        pooling_types_dict = get_pooling_types_dict()
+        node_label = '"%s%s(%s %s)%skernel size: %d%sstride: %d%spad: %d"' %\
+                     (layer.name,
+                      separator,
+                      pooling_types_dict[layer.pooling_param.pool],
+                      layertype,
+                      separator,
+                      layer.pooling_param.kernel_size,
+                      separator,
+                      layer.pooling_param.stride,
+                      separator,
+                      layer.pooling_param.pad)
+    else:
+        node_label = '"%s%s(%s)"' % (layer.name, separator, layertype)
+    return node_label
+
+
+def choose_color_by_layertype(layertype):
+    """Define colors for nodes based on the layer type
+    """
+    color = '#6495ED'  # Default
+    if layertype == 'CONVOLUTION':
+        color = '#FF5050'
+    elif layertype == 'POOLING':
+        color = '#FF9900'
+    elif layertype == 'INNER_PRODUCT':
+        color = '#CC33FF'
+    return color
+
+
+def get_pydot_graph(caffe_net, rankdir, label_edges=True):
+  pydot_graph = pydot.Dot(caffe_net.name, graph_type='digraph', rankdir=rankdir)
   pydot_nodes = {}
   pydot_edges = []
   d = get_enum_name_by_value()
   for layer in caffe_net.layers:
     name = layer.name
     layertype = d[layer.type]
+    node_label = determine_node_label_by_layertype(layer, layertype, rankdir)
     if (len(layer.bottom) == 1 and len(layer.top) == 1 and
         layer.bottom[0] == layer.top[0]):
       # We have an in-place neuron layer.
       pydot_nodes[name + '_' + layertype] = pydot.Node(
-          '%s (%s)' % (name, layertype), **NEURON_LAYER_STYLE)
+          node_label, **NEURON_LAYER_STYLE)
     else:
+      layer_style = LAYER_STYLE_DEFAULT
+      layer_style['fillcolor'] = choose_color_by_layertype(layertype)
       pydot_nodes[name + '_' + layertype] = pydot.Node(
-          '%s (%s)' % (name, layertype), **LAYER_STYLE)
+          node_label, **layer_style)
     for bottom_blob in layer.bottom:
       pydot_nodes[bottom_blob + '_blob'] = pydot.Node(
         '%s' % (bottom_blob), **BLOB_STYLE)
-      pydot_edges.append((bottom_blob + '_blob', name + '_' + layertype))
+      edge_label = '""'
+      pydot_edges.append({'src': bottom_blob + '_blob',
+                          'dst': name + '_' + layertype,
+                          'label': edge_label})
     for top_blob in layer.top:
       pydot_nodes[top_blob + '_blob'] = pydot.Node(
         '%s' % (top_blob))
-      pydot_edges.append((name + '_' + layertype, top_blob + '_blob'))
+      if label_edges:
+        edge_label = determine_edge_label_by_layertype(layer, layertype)
+      else:
+        edge_label = '""'
+      pydot_edges.append({'src': name + '_' + layertype,
+                          'dst': top_blob + '_blob',
+                          'label': edge_label})
   # Now, add the nodes and edges to the graph.
   for node in pydot_nodes.values():
     pydot_graph.add_node(node)
   for edge in pydot_edges:
     pydot_graph.add_edge(
-        pydot.Edge(pydot_nodes[edge[0]], pydot_nodes[edge[1]]))
+        pydot.Edge(pydot_nodes[edge['src']], pydot_nodes[edge['dst']],
+                   label=edge['label']))
   return pydot_graph
 
-def draw_net(caffe_net, ext='png'):
+def draw_net(caffe_net, rankdir, ext='png'):
   """Draws a caffe net and returns the image string encoded using the given
   extension.
 
@@ -64,13 +161,13 @@ def draw_net(caffe_net, ext='png'):
     caffe_net: a caffe.proto.caffe_pb2.NetParameter protocol buffer.
     ext: the image extension. Default 'png'.
   """
-  return get_pydot_graph(caffe_net).create(format=ext)
+  return get_pydot_graph(caffe_net, rankdir).create(format=ext)
 
-def draw_net_to_file(caffe_net, filename):
+def draw_net_to_file(caffe_net, filename, rankdir='LR'):
   """Draws a caffe net, and saves it to file using the format given as the
   file extension. Use '.raw' to output raw text that you can manually feed
   to graphviz to draw graphs.
   """
   ext = filename[filename.rfind('.')+1:]
   with open(filename, 'wb') as fid:
-    fid.write(draw_net(caffe_net, ext))
+    fid.write(draw_net(caffe_net, rankdir, ext))

--- a/python/draw_net.py
+++ b/python/draw_net.py
@@ -2,24 +2,43 @@
 """
 Draw a graph of the net architecture.
 """
-import os
+import argparse
 from google.protobuf import text_format
 
-import caffe, caffe.draw
+import caffe
+import caffe.draw
 from caffe.proto import caffe_pb2
 
 
-def main(argv):
-    if len(argv) != 3:
-        print 'Usage: %s input_net_proto_file output_image_file' % \
-                os.path.basename(sys.argv[0])
-    else:
-        net = caffe_pb2.NetParameter()
-        text_format.Merge(open(sys.argv[1]).read(), net)
-        print 'Drawing net to %s' % sys.argv[2]
-        caffe.draw.draw_net_to_file(net, sys.argv[2])
+def parse_args():
+    """Parse input arguments
+    """
+
+    parser = argparse.ArgumentParser(description='Draw a network graph')
+
+    parser.add_argument('input_net_proto_file',
+                        help='Input network prototxt file')
+    parser.add_argument('output_image_file',
+                        help='Output image file')
+    parser.add_argument('--rankdir',
+                        help=('One of TB (top-bottom, i.e., vertical), '
+                              'RL (right-left, i.e., horizontal), or another'
+                              'valid dot option; see'
+                              'http://www.graphviz.org/doc/info/attrs.html#k:rankdir'
+                              '(default: LR)'),
+                        default='LR')
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    net = caffe_pb2.NetParameter()
+    text_format.Merge(open(args.input_net_proto_file).read(), net)
+    print 'Drawing net to %s' % args.output_image_file
+    caffe.draw.draw_net_to_file(net, args.output_image_file, args.rankdir)
 
 
 if __name__ == '__main__':
-    import sys
-    main(sys.argv)
+    main()


### PR DESCRIPTION
A few improvements to the aesthetics and information content of graphs created using `draw_net.py`.

Highlights:
* Use `ArgumentParser` in `draw_net.py` to parse input arguments
* Plot network horizontally (left-right) by default; yes, this confuses the standard "top" and "bottom" names, but since everyone's monitor is wider than it is tall, the advantage is that you'll be able to see over 50% more of the network on your screen at once. Then you don't have to tilt the network graph on its side and make it completely unreadable during presentations. The top-bottom functionality is available via the `--rankdir BT` command line argument to `draw_net.py`
* Display number of outputs on edge for data, convolution and inner product layers
* In node names, add newline between layer name and layer type, to save horizontal space (only if graph rank direction is left-right or right-left)
* Include convolution and pooling parameters within node names
* Distinct colors for convolution, pooling and inner product nodes

If any of these changes are particularly offensive, I'm amenable to restoring the default behavior and exposing the changes via optional command line parameters.

# Change this drab, ho-hum-looking network graph:
![old](https://cloud.githubusercontent.com/assets/1332812/5381868/2a5606e0-805a-11e4-895e-08f63b2d62c3.png)

# To this amazing one!
![new_bt](https://cloud.githubusercontent.com/assets/1332812/5381879/4083d49c-805a-11e4-9576-f37105c71a5c.png)

# Plotted horizontally by default:
![new_lr](https://cloud.githubusercontent.com/assets/1332812/5381893/5c582470-805a-11e4-89d3-67f19582f4c4.png)

 