### PR TITLE
Check input line count in HDF5 data layer

### DIFF
--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -75,6 +75,8 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   num_files_ = hdf_filenames_.size();
   current_file_ = 0;
   LOG(INFO) << "Number of HDF5 files: " << num_files_;
+  CHECK_GE(num_files_, 1) << "Must have at least 1 HDF5 filename listed in "
+    << source;
 
   // Load the first HDF5 file and initialize the line counter.
   LoadHDF5FileData(hdf_filenames_[current_file_].c_str());


### PR DESCRIPTION
The HDF5 data layer tries to read input files even if there are none, causing a segmentation fault. This check makes sure that doesn't happen.
