### PR TITLE
Pretty up the build

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -74,3 +74,6 @@ DISTRIBUTE_DIR := distribute
 
 # The ID of the GPU that 'make runtest' will use to run unit tests.
 TEST_GPUID := 0
+
+# enable pretty build (comment to see full commands)
+Q ?= @


### PR DESCRIPTION
After #1472.

The Makefile build currently produces a hard-to-follow terminal-scrolling mess of commands, parameters, shell hacks, etc. This PR makes some simple changes for a prettier build (in the style of, e.g., the linux kernel, last I checked).

Build commands are displayed as "CMD input_file". The full commands can be printed using `Q= make`, or by changing `Makefile.config` (currently, pretty is on by default with an up-to-date `Makefile.config`).

The method is described at http://stackoverflow.com/questions/2969912/pretty-print-makefiles.
