### PR TITLE
Adding configuration option to enable USE_CUDNN declaration for cmake bu...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,11 @@ project( Caffe )
 ###    Build Options     ##########################################################################
 
 option(CPU_ONLY "Build Caffe without GPU support" OFF)
+option(CUDNN "Build with cuDNN support" ON)
 option(BUILD_PYTHON "Build Python wrapper" OFF)
 option(BUILD_MATLAB "Build Matlab wrapper" OFF)
 option(BUILD_EXAMPLES "Build examples" ON)
-option(BUILD_SHARED_LIBS "Build SHARED libs if ON and STATIC otherwise" OFF)
+option(BUILD_SHARED_LIBS "Build SHARED libs if ON and STATIC otherwise" ON)
 
 if(NOT BLAS)
     set(BLAS atlas)
@@ -32,6 +33,8 @@ set(CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE}) # set release flags
 #    Global Definitions
 if(CPU_ONLY)
     add_definitions(-DCPU_ONLY)
+elseif (CUDNN)
+    add_definitions(-DUSE_CUDNN)
 endif()
 
 #    Include Directories

--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -85,6 +85,10 @@ if(NOT CPU_ONLY)
             -gencode arch=compute_30,code=sm_30
             -gencode arch=compute_35,code=sm_35
     )
+
+    if(CUDNN)
+        set(CUDA_CUBLAS_LIBRARIES ${CUDA_CUBLAS_LIBRARIES} /usr/local/cuda/lib/libcudnn.so)
+    endif()
     
 # https://github.com/ComputationalRadiationPhysics/picongpu/blob/master/src/picongpu/CMakeLists.txt
     # work-arounds


### PR DESCRIPTION
Changes to support building on Jetson TK1 with cmake and with cuDNN library support.  Added additional option 'CUDNN' to enable support.  Used the following procedure to build

mkdir build
cd build
cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang ..
make VERBOSE=1