### PR TITLE
Check for overflow in Blob::Reshape

### DIFF
--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -17,6 +17,9 @@ void Blob<Dtype>::Reshape(const int num, const int channels, const int height,
   height_ = height;
   width_ = width;
   count_ = num_ * channels_ * height_ * width_;
+  // Check for overflow.
+  CHECK_GE(count_, 0) << "num: " << num_ << ", channels: " << channels_
+      << ", height: " << height_ << ", width: " << width_;
   if (count_ > capacity_) {
     capacity_ = count_;
     data_.reset(new SyncedMemory(capacity_ * sizeof(Dtype)));


### PR DESCRIPTION
~~The check on `count_` is more succinct than checking the individual dimensions, and~~ more importantly includes the previously ignored case where bad values for the dimensions cause an overflow for `count_`, resulting in a silent failure to allocate. Printing the dimension values ensures that no useful debugging information is lost ~~in the change.~~