### PR TITLE
Check host malloc result

### DIFF
--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -24,6 +24,7 @@ namespace caffe {
 
 inline void CaffeMallocHost(void** ptr, size_t size) {
   *ptr = malloc(size);
+  CHECK(*ptr) << "host allocation of size " << size << " failed";
 }
 
 inline void CaffeFreeHost(void* ptr) {


### PR DESCRIPTION
I assume the lack of this check is simply an error of omission?

(It actually seems pretty difficult to get malloc to fail on a modern linux, but if it does it's better to find out here than to get a "check failed: data_" later on.)
