### PR TITLE
Fixing cmake scripts to make it compile

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,7 @@
 project( Examples )
 
+include_directories(${PROTOBUF_INCLUDE_DIR})
+
 file(GLOB_RECURSE EXAMPLES_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 foreach(source ${EXAMPLES_SOURCES})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(Boost 1.46 COMPONENTS python REQUIRED)
 
 
 include_directories(${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS})
+    ${Boost_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIR})
 
 file(GLOB_RECURSE Python_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 

--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -1,7 +1,7 @@
 project( CaffeSrc )
 
-
 add_subdirectory(proto)
+include_directories(${PROTOBUF_INCLUDE_DIR})
 
 #    Recursively find source files
 ##    test sources

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,7 @@
 project( Tools )
 
+include_directories(${PROTOBUF_INCLUDE_DIR})
+
 #    Find all source files
 file(GLOB_RECURSE TOOLS_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 


### PR DESCRIPTION
This code patch fixes forgotten `include_directories(${PROTOBUF_INCLUDE_DIR})` 