### PR TITLE
fix random crop in DataTransformer

### DIFF
--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -31,8 +31,8 @@ void DataTransformer<Dtype>::Transform(const int batch_item_id,
     int h_off, w_off;
     // We only do random crop when we do training.
     if (phase_ == Caffe::TRAIN) {
-      h_off = Rand() % (height - crop_size);
-      w_off = Rand() % (width - crop_size);
+      h_off = Rand() % (height - crop_size + 1);
+      w_off = Rand() % (width - crop_size + 1);
     } else {
       h_off = (height - crop_size) / 2;
       w_off = (width - crop_size) / 2;


### PR DESCRIPTION
It's a really small fix. I found the random crop in DataTransformer doesn't work properly. It produces neither rightmost  nor bottom-most random crop. Let's see the extreme case, height=32 and crop_size=31. `Rand() % (height - crop_size)` --> `Rand() % 1` never generate other than 0. No test so far.
