### PR TITLE
Added bvlc_googlenet prototxt and weights

### DIFF
--- a/models/bvlc_googlenet/deploy.prototxt
+++ b/models/bvlc_googlenet/deploy.prototxt
@@ -1,0 +1,1924 @@
+name: "GoogleNet"
+input: "data"
+input_dim: 10
+input_dim: 3
+input_dim: 224
+input_dim: 224
+layers {
+  bottom: "data"
+  top: "conv1/7x7_s2"
+  name: "conv1/7x7_s2"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    pad: 3
+    kernel_size: 7
+    stride: 2
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv1/7x7_s2"
+  top: "conv1/7x7_s2"
+  name: "conv1/relu_7x7"
+  type: RELU
+}
+layers {
+  bottom: "conv1/7x7_s2"
+  top: "pool1/3x3_s2"
+  name: "pool1/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool1/3x3_s2"
+  top: "pool1/norm1"
+  name: "pool1/norm1"
+  type: LRN
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+layers {
+  bottom: "pool1/norm1"
+  top: "conv2/3x3_reduce"
+  name: "conv2/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv2/3x3_reduce"
+  top: "conv2/3x3_reduce"
+  name: "conv2/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "conv2/3x3_reduce"
+  top: "conv2/3x3"
+  name: "conv2/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 192
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv2/3x3"
+  top: "conv2/3x3"
+  name: "conv2/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "conv2/3x3"
+  top: "conv2/norm2"
+  name: "conv2/norm2"
+  type: LRN
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+layers {
+  bottom: "conv2/norm2"
+  top: "pool2/3x3_s2"
+  name: "pool2/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/1x1"
+  name: "inception_3a/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/1x1"
+  top: "inception_3a/1x1"
+  name: "inception_3a/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/3x3_reduce"
+  name: "inception_3a/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 96
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/3x3_reduce"
+  top: "inception_3a/3x3_reduce"
+  name: "inception_3a/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/3x3_reduce"
+  top: "inception_3a/3x3"
+  name: "inception_3a/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/3x3"
+  top: "inception_3a/3x3"
+  name: "inception_3a/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/5x5_reduce"
+  name: "inception_3a/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 16
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/5x5_reduce"
+  top: "inception_3a/5x5_reduce"
+  name: "inception_3a/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/5x5_reduce"
+  top: "inception_3a/5x5"
+  name: "inception_3a/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/5x5"
+  top: "inception_3a/5x5"
+  name: "inception_3a/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/pool"
+  name: "inception_3a/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_3a/pool"
+  top: "inception_3a/pool_proj"
+  name: "inception_3a/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/pool_proj"
+  top: "inception_3a/pool_proj"
+  name: "inception_3a/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/1x1"
+  bottom: "inception_3a/3x3"
+  bottom: "inception_3a/5x5"
+  bottom: "inception_3a/pool_proj"
+  top: "inception_3a/output"
+  name: "inception_3a/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_3a/output"
+  top: "inception_3b/1x1"
+  name: "inception_3b/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/1x1"
+  top: "inception_3b/1x1"
+  name: "inception_3b/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/output"
+  top: "inception_3b/3x3_reduce"
+  name: "inception_3b/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/3x3_reduce"
+  top: "inception_3b/3x3_reduce"
+  name: "inception_3b/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_3b/3x3_reduce"
+  top: "inception_3b/3x3"
+  name: "inception_3b/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 192
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/3x3"
+  top: "inception_3b/3x3"
+  name: "inception_3b/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/output"
+  top: "inception_3b/5x5_reduce"
+  name: "inception_3b/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/5x5_reduce"
+  top: "inception_3b/5x5_reduce"
+  name: "inception_3b/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_3b/5x5_reduce"
+  top: "inception_3b/5x5"
+  name: "inception_3b/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 96
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/5x5"
+  top: "inception_3b/5x5"
+  name: "inception_3b/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/output"
+  top: "inception_3b/pool"
+  name: "inception_3b/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_3b/pool"
+  top: "inception_3b/pool_proj"
+  name: "inception_3b/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/pool_proj"
+  top: "inception_3b/pool_proj"
+  name: "inception_3b/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_3b/1x1"
+  bottom: "inception_3b/3x3"
+  bottom: "inception_3b/5x5"
+  bottom: "inception_3b/pool_proj"
+  top: "inception_3b/output"
+  name: "inception_3b/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_3b/output"
+  top: "pool3/3x3_s2"
+  name: "pool3/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/1x1"
+  name: "inception_4a/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 192
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/1x1"
+  top: "inception_4a/1x1"
+  name: "inception_4a/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/3x3_reduce"
+  name: "inception_4a/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 96
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/3x3_reduce"
+  top: "inception_4a/3x3_reduce"
+  name: "inception_4a/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/3x3_reduce"
+  top: "inception_4a/3x3"
+  name: "inception_4a/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 208
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/3x3"
+  top: "inception_4a/3x3"
+  name: "inception_4a/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/5x5_reduce"
+  name: "inception_4a/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 16
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/5x5_reduce"
+  top: "inception_4a/5x5_reduce"
+  name: "inception_4a/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/5x5_reduce"
+  top: "inception_4a/5x5"
+  name: "inception_4a/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 48
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/5x5"
+  top: "inception_4a/5x5"
+  name: "inception_4a/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/pool"
+  name: "inception_4a/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4a/pool"
+  top: "inception_4a/pool_proj"
+  name: "inception_4a/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/pool_proj"
+  top: "inception_4a/pool_proj"
+  name: "inception_4a/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/1x1"
+  bottom: "inception_4a/3x3"
+  bottom: "inception_4a/5x5"
+  bottom: "inception_4a/pool_proj"
+  top: "inception_4a/output"
+  name: "inception_4a/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4a/output"
+  top: "inception_4b/1x1"
+  name: "inception_4b/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 160
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/1x1"
+  top: "inception_4b/1x1"
+  name: "inception_4b/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/output"
+  top: "inception_4b/3x3_reduce"
+  name: "inception_4b/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 112
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/3x3_reduce"
+  top: "inception_4b/3x3_reduce"
+  name: "inception_4b/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/3x3_reduce"
+  top: "inception_4b/3x3"
+  name: "inception_4b/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 224
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/3x3"
+  top: "inception_4b/3x3"
+  name: "inception_4b/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/output"
+  top: "inception_4b/5x5_reduce"
+  name: "inception_4b/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 24
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/5x5_reduce"
+  top: "inception_4b/5x5_reduce"
+  name: "inception_4b/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/5x5_reduce"
+  top: "inception_4b/5x5"
+  name: "inception_4b/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/5x5"
+  top: "inception_4b/5x5"
+  name: "inception_4b/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/output"
+  top: "inception_4b/pool"
+  name: "inception_4b/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4b/pool"
+  top: "inception_4b/pool_proj"
+  name: "inception_4b/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/pool_proj"
+  top: "inception_4b/pool_proj"
+  name: "inception_4b/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/1x1"
+  bottom: "inception_4b/3x3"
+  bottom: "inception_4b/5x5"
+  bottom: "inception_4b/pool_proj"
+  top: "inception_4b/output"
+  name: "inception_4b/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4b/output"
+  top: "inception_4c/1x1"
+  name: "inception_4c/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/1x1"
+  top: "inception_4c/1x1"
+  name: "inception_4c/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/output"
+  top: "inception_4c/3x3_reduce"
+  name: "inception_4c/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/3x3_reduce"
+  top: "inception_4c/3x3_reduce"
+  name: "inception_4c/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/3x3_reduce"
+  top: "inception_4c/3x3"
+  name: "inception_4c/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/3x3"
+  top: "inception_4c/3x3"
+  name: "inception_4c/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/output"
+  top: "inception_4c/5x5_reduce"
+  name: "inception_4c/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 24
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/5x5_reduce"
+  top: "inception_4c/5x5_reduce"
+  name: "inception_4c/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/5x5_reduce"
+  top: "inception_4c/5x5"
+  name: "inception_4c/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/5x5"
+  top: "inception_4c/5x5"
+  name: "inception_4c/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/output"
+  top: "inception_4c/pool"
+  name: "inception_4c/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4c/pool"
+  top: "inception_4c/pool_proj"
+  name: "inception_4c/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/pool_proj"
+  top: "inception_4c/pool_proj"
+  name: "inception_4c/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/1x1"
+  bottom: "inception_4c/3x3"
+  bottom: "inception_4c/5x5"
+  bottom: "inception_4c/pool_proj"
+  top: "inception_4c/output"
+  name: "inception_4c/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4c/output"
+  top: "inception_4d/1x1"
+  name: "inception_4d/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 112
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/1x1"
+  top: "inception_4d/1x1"
+  name: "inception_4d/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/output"
+  top: "inception_4d/3x3_reduce"
+  name: "inception_4d/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 144
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/3x3_reduce"
+  top: "inception_4d/3x3_reduce"
+  name: "inception_4d/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/3x3_reduce"
+  top: "inception_4d/3x3"
+  name: "inception_4d/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 288
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/3x3"
+  top: "inception_4d/3x3"
+  name: "inception_4d/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/output"
+  top: "inception_4d/5x5_reduce"
+  name: "inception_4d/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/5x5_reduce"
+  top: "inception_4d/5x5_reduce"
+  name: "inception_4d/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/5x5_reduce"
+  top: "inception_4d/5x5"
+  name: "inception_4d/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/5x5"
+  top: "inception_4d/5x5"
+  name: "inception_4d/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/output"
+  top: "inception_4d/pool"
+  name: "inception_4d/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4d/pool"
+  top: "inception_4d/pool_proj"
+  name: "inception_4d/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/pool_proj"
+  top: "inception_4d/pool_proj"
+  name: "inception_4d/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/1x1"
+  bottom: "inception_4d/3x3"
+  bottom: "inception_4d/5x5"
+  bottom: "inception_4d/pool_proj"
+  top: "inception_4d/output"
+  name: "inception_4d/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4d/output"
+  top: "inception_4e/1x1"
+  name: "inception_4e/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 256
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/1x1"
+  top: "inception_4e/1x1"
+  name: "inception_4e/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/output"
+  top: "inception_4e/3x3_reduce"
+  name: "inception_4e/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 160
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/3x3_reduce"
+  top: "inception_4e/3x3_reduce"
+  name: "inception_4e/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4e/3x3_reduce"
+  top: "inception_4e/3x3"
+  name: "inception_4e/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 320
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/3x3"
+  top: "inception_4e/3x3"
+  name: "inception_4e/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/output"
+  top: "inception_4e/5x5_reduce"
+  name: "inception_4e/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/5x5_reduce"
+  top: "inception_4e/5x5_reduce"
+  name: "inception_4e/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4e/5x5_reduce"
+  top: "inception_4e/5x5"
+  name: "inception_4e/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/5x5"
+  top: "inception_4e/5x5"
+  name: "inception_4e/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/output"
+  top: "inception_4e/pool"
+  name: "inception_4e/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4e/pool"
+  top: "inception_4e/pool_proj"
+  name: "inception_4e/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/pool_proj"
+  top: "inception_4e/pool_proj"
+  name: "inception_4e/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4e/1x1"
+  bottom: "inception_4e/3x3"
+  bottom: "inception_4e/5x5"
+  bottom: "inception_4e/pool_proj"
+  top: "inception_4e/output"
+  name: "inception_4e/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4e/output"
+  top: "pool4/3x3_s2"
+  name: "pool4/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool4/3x3_s2"
+  top: "inception_5a/1x1"
+  name: "inception_5a/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 256
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/1x1"
+  top: "inception_5a/1x1"
+  name: "inception_5a/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "pool4/3x3_s2"
+  top: "inception_5a/3x3_reduce"
+  name: "inception_5a/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 160
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/3x3_reduce"
+  top: "inception_5a/3x3_reduce"
+  name: "inception_5a/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/3x3_reduce"
+  top: "inception_5a/3x3"
+  name: "inception_5a/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 320
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/3x3"
+  top: "inception_5a/3x3"
+  name: "inception_5a/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "pool4/3x3_s2"
+  top: "inception_5a/5x5_reduce"
+  name: "inception_5a/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/5x5_reduce"
+  top: "inception_5a/5x5_reduce"
+  name: "inception_5a/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/5x5_reduce"
+  top: "inception_5a/5x5"
+  name: "inception_5a/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/5x5"
+  top: "inception_5a/5x5"
+  name: "inception_5a/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "pool4/3x3_s2"
+  top: "inception_5a/pool"
+  name: "inception_5a/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_5a/pool"
+  top: "inception_5a/pool_proj"
+  name: "inception_5a/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/pool_proj"
+  top: "inception_5a/pool_proj"
+  name: "inception_5a/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/1x1"
+  bottom: "inception_5a/3x3"
+  bottom: "inception_5a/5x5"
+  bottom: "inception_5a/pool_proj"
+  top: "inception_5a/output"
+  name: "inception_5a/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_5a/output"
+  top: "inception_5b/1x1"
+  name: "inception_5b/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 384
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/1x1"
+  top: "inception_5b/1x1"
+  name: "inception_5b/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/output"
+  top: "inception_5b/3x3_reduce"
+  name: "inception_5b/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 192
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/3x3_reduce"
+  top: "inception_5b/3x3_reduce"
+  name: "inception_5b/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_5b/3x3_reduce"
+  top: "inception_5b/3x3"
+  name: "inception_5b/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 384
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/3x3"
+  top: "inception_5b/3x3"
+  name: "inception_5b/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/output"
+  top: "inception_5b/5x5_reduce"
+  name: "inception_5b/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 48
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/5x5_reduce"
+  top: "inception_5b/5x5_reduce"
+  name: "inception_5b/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_5b/5x5_reduce"
+  top: "inception_5b/5x5"
+  name: "inception_5b/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/5x5"
+  top: "inception_5b/5x5"
+  name: "inception_5b/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/output"
+  top: "inception_5b/pool"
+  name: "inception_5b/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_5b/pool"
+  top: "inception_5b/pool_proj"
+  name: "inception_5b/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/pool_proj"
+  top: "inception_5b/pool_proj"
+  name: "inception_5b/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_5b/1x1"
+  bottom: "inception_5b/3x3"
+  bottom: "inception_5b/5x5"
+  bottom: "inception_5b/pool_proj"
+  top: "inception_5b/output"
+  name: "inception_5b/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_5b/output"
+  top: "pool5/7x7_s1"
+  name: "pool5/7x7_s1"
+  type: POOLING
+  pooling_param {
+    pool: AVE
+    kernel_size: 7
+    stride: 1
+  }
+}
+layers {
+  bottom: "pool5/7x7_s1"
+  top: "pool5/7x7_s1"
+  name: "pool5/drop_7x7_s1"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.4
+  }
+}
+layers {
+  bottom: "pool5/7x7_s1"
+  top: "loss3/classifier"
+  name: "loss3/classifier"
+  type: INNER_PRODUCT
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 1000
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers {
+  name: "prob"
+  type: SOFTMAX
+  bottom: "loss3/classifier"
+  top: "prob"
+}

--- a/models/bvlc_googlenet/quick_solver.prototxt
+++ b/models/bvlc_googlenet/quick_solver.prototxt
@@ -1,0 +1,15 @@
+net: "models/bvlc_googlenet/train_val.prototxt"
+test_iter: 1000
+test_interval: 4000
+test_initialization: false
+display: 40
+average_loss: 40
+base_lr: 0.01
+lr_policy: "poly"
+power: 0.5
+max_iter: 2400000
+momentum: 0.9
+weight_decay: 0.0002
+snapshot: 40000
+snapshot_prefix: "models/bvlc_googlenet/bvlc_googlenet_quick"
+solver_mode: GPU

--- a/models/bvlc_googlenet/readme.md
+++ b/models/bvlc_googlenet/readme.md
@@ -1,0 +1,33 @@
+---
+name: BVLC GoogleNet Model
+caffemodel: bvlc_googlenet.caffemodel
+caffemodel_url: http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel
+license: non-commercial
+sha1: 405fc5acd08a3bb12de8ee5e23a96bec22f08204
+caffe_commit: bc614d1bd91896e3faceaf40b23b72dab47d44f5
+---
+
+This model is a replication of the model described in the [GoogleNet](http://arxiv.org/abs/1409.4842) publication. We would like to thank Christian Szegedy for all his help in the replication of GoogleNet model.
+
+Differences:
+- not training with the relighting data-augmentation;
+- not training with the scale or aspect-ratio data-augmentation;
+- uses "xavier" to initialize the weights instead of "gaussian";
+- quick_solver.prototxt uses a different learning rate decay policy than the original solver.prototxt, that allows a much faster training (60 epochs vs 250 epochs);
+
+The bundled model is the iteration 2,400,000 snapshot (60 epochs) using quick_solver.prototxt
+
+This bundled model obtains a top-1 accuracy 68.7% (31.3% error) and a top-5 accuracy 88.9% (11.1% error) on the validation set, using just the center crop.
+(Using the average of 10 crops, (4 + 1 center) * 2 mirror, should obtain a bit higher accuracy.)
+
+Timings for bvlc_googlenet with cuDNN using batch_size:128 on a K40c:
+ - Average Forward pass: 562.841 ms.
+ - Average Backward pass: 1123.84 ms.
+ - Average Forward-Backward: 1688.8 ms.
+
+
+## License
+
+The data used to train this model comes from the ImageNet project, which distributes its database to researchers who agree to a following term of access:
+"Researcher shall use the Database only for non-commercial research and educational purposes."
+Accordingly, this model is distributed under a non-commercial license.

--- a/models/bvlc_googlenet/solver.prototxt
+++ b/models/bvlc_googlenet/solver.prototxt
@@ -1,0 +1,16 @@
+net: "models/bvlc_googlenet/train_val.prototxt"
+test_iter: 1000
+test_interval: 4000
+test_initialization: false
+display: 40
+average_loss: 40
+base_lr: 0.01
+lr_policy: "step"
+stepsize: 320000
+gamma: 0.96
+max_iter: 10000000
+momentum: 0.9
+weight_decay: 0.0002
+snapshot: 40000
+snapshot_prefix: "models/bvlc_googlenet/bvlc_googlenet"
+solver_mode: GPU

--- a/models/bvlc_googlenet/train_val.prototxt
+++ b/models/bvlc_googlenet/train_val.prototxt
@@ -1,0 +1,2240 @@
+name: "GoogleNet"
+layers {
+  top: "data"
+  top: "label"
+  name: "data"
+  type: DATA
+  data_param {
+    source: "examples/imagenet/ilsvrc12_train_lmdb"
+    batch_size: 32
+    backend: LMDB
+  }
+  include {
+    phase: TRAIN
+  }
+  transform_param {
+    mirror: true
+    crop_size: 224
+    mean_value: 104
+    mean_value: 117
+    mean_value: 123
+  }
+}
+layers {
+  top: "data"
+  top: "label"
+  name: "data"
+  type: DATA
+  data_param {
+    source: "examples/imagenet/ilsvrc12_val_lmdb"
+    batch_size: 50
+    backend: LMDB
+  }
+  include {
+    phase: TEST
+  }
+  transform_param {
+    mirror: false
+    crop_size: 224
+    mean_value: 104
+    mean_value: 117
+    mean_value: 123
+  }
+}
+layers {
+  bottom: "data"
+  top: "conv1/7x7_s2"
+  name: "conv1/7x7_s2"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    pad: 3
+    kernel_size: 7
+    stride: 2
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv1/7x7_s2"
+  top: "conv1/7x7_s2"
+  name: "conv1/relu_7x7"
+  type: RELU
+}
+layers {
+  bottom: "conv1/7x7_s2"
+  top: "pool1/3x3_s2"
+  name: "pool1/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool1/3x3_s2"
+  top: "pool1/norm1"
+  name: "pool1/norm1"
+  type: LRN
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+layers {
+  bottom: "pool1/norm1"
+  top: "conv2/3x3_reduce"
+  name: "conv2/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv2/3x3_reduce"
+  top: "conv2/3x3_reduce"
+  name: "conv2/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "conv2/3x3_reduce"
+  top: "conv2/3x3"
+  name: "conv2/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 192
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "conv2/3x3"
+  top: "conv2/3x3"
+  name: "conv2/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "conv2/3x3"
+  top: "conv2/norm2"
+  name: "conv2/norm2"
+  type: LRN
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+layers {
+  bottom: "conv2/norm2"
+  top: "pool2/3x3_s2"
+  name: "pool2/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/1x1"
+  name: "inception_3a/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/1x1"
+  top: "inception_3a/1x1"
+  name: "inception_3a/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/3x3_reduce"
+  name: "inception_3a/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 96
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/3x3_reduce"
+  top: "inception_3a/3x3_reduce"
+  name: "inception_3a/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/3x3_reduce"
+  top: "inception_3a/3x3"
+  name: "inception_3a/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/3x3"
+  top: "inception_3a/3x3"
+  name: "inception_3a/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/5x5_reduce"
+  name: "inception_3a/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 16
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/5x5_reduce"
+  top: "inception_3a/5x5_reduce"
+  name: "inception_3a/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/5x5_reduce"
+  top: "inception_3a/5x5"
+  name: "inception_3a/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/5x5"
+  top: "inception_3a/5x5"
+  name: "inception_3a/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "pool2/3x3_s2"
+  top: "inception_3a/pool"
+  name: "inception_3a/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_3a/pool"
+  top: "inception_3a/pool_proj"
+  name: "inception_3a/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3a/pool_proj"
+  top: "inception_3a/pool_proj"
+  name: "inception_3a/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/1x1"
+  bottom: "inception_3a/3x3"
+  bottom: "inception_3a/5x5"
+  bottom: "inception_3a/pool_proj"
+  top: "inception_3a/output"
+  name: "inception_3a/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_3a/output"
+  top: "inception_3b/1x1"
+  name: "inception_3b/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/1x1"
+  top: "inception_3b/1x1"
+  name: "inception_3b/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/output"
+  top: "inception_3b/3x3_reduce"
+  name: "inception_3b/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/3x3_reduce"
+  top: "inception_3b/3x3_reduce"
+  name: "inception_3b/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_3b/3x3_reduce"
+  top: "inception_3b/3x3"
+  name: "inception_3b/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 192
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/3x3"
+  top: "inception_3b/3x3"
+  name: "inception_3b/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/output"
+  top: "inception_3b/5x5_reduce"
+  name: "inception_3b/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/5x5_reduce"
+  top: "inception_3b/5x5_reduce"
+  name: "inception_3b/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_3b/5x5_reduce"
+  top: "inception_3b/5x5"
+  name: "inception_3b/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 96
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/5x5"
+  top: "inception_3b/5x5"
+  name: "inception_3b/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_3a/output"
+  top: "inception_3b/pool"
+  name: "inception_3b/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_3b/pool"
+  top: "inception_3b/pool_proj"
+  name: "inception_3b/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_3b/pool_proj"
+  top: "inception_3b/pool_proj"
+  name: "inception_3b/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_3b/1x1"
+  bottom: "inception_3b/3x3"
+  bottom: "inception_3b/5x5"
+  bottom: "inception_3b/pool_proj"
+  top: "inception_3b/output"
+  name: "inception_3b/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_3b/output"
+  top: "pool3/3x3_s2"
+  name: "pool3/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/1x1"
+  name: "inception_4a/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 192
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/1x1"
+  top: "inception_4a/1x1"
+  name: "inception_4a/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/3x3_reduce"
+  name: "inception_4a/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 96
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/3x3_reduce"
+  top: "inception_4a/3x3_reduce"
+  name: "inception_4a/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/3x3_reduce"
+  top: "inception_4a/3x3"
+  name: "inception_4a/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 208
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/3x3"
+  top: "inception_4a/3x3"
+  name: "inception_4a/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/5x5_reduce"
+  name: "inception_4a/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 16
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/5x5_reduce"
+  top: "inception_4a/5x5_reduce"
+  name: "inception_4a/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/5x5_reduce"
+  top: "inception_4a/5x5"
+  name: "inception_4a/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 48
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/5x5"
+  top: "inception_4a/5x5"
+  name: "inception_4a/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "pool3/3x3_s2"
+  top: "inception_4a/pool"
+  name: "inception_4a/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4a/pool"
+  top: "inception_4a/pool_proj"
+  name: "inception_4a/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4a/pool_proj"
+  top: "inception_4a/pool_proj"
+  name: "inception_4a/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/1x1"
+  bottom: "inception_4a/3x3"
+  bottom: "inception_4a/5x5"
+  bottom: "inception_4a/pool_proj"
+  top: "inception_4a/output"
+  name: "inception_4a/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4a/output"
+  top: "loss1/ave_pool"
+  name: "loss1/ave_pool"
+  type: POOLING
+  pooling_param {
+    pool: AVE
+    kernel_size: 5
+    stride: 3
+  }
+}
+layers {
+  bottom: "loss1/ave_pool"
+  top: "loss1/conv"
+  name: "loss1/conv"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.08
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "loss1/conv"
+  top: "loss1/conv"
+  name: "loss1/relu_conv"
+  type: RELU
+}
+layers {
+  bottom: "loss1/conv"
+  top: "loss1/fc"
+  name: "loss1/fc"
+  type: INNER_PRODUCT
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 1024
+    weight_filler {
+      type: "xavier"
+      std: 0.02
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "loss1/fc"
+  top: "loss1/fc"
+  name: "loss1/relu_fc"
+  type: RELU
+}
+layers {
+  bottom: "loss1/fc"
+  top: "loss1/fc"
+  name: "loss1/drop_fc"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.7
+  }
+}
+layers {
+  bottom: "loss1/fc"
+  top: "loss1/classifier"
+  name: "loss1/classifier"
+  type: INNER_PRODUCT
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 1000
+    weight_filler {
+      type: "xavier"
+      std: 0.0009765625
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers {
+  bottom: "loss1/classifier"
+  bottom: "label"
+  top: "loss1/loss1"
+  name: "loss1/loss"
+  type: SOFTMAX_LOSS
+  loss_weight: 0.3
+}
+layers {
+  bottom: "loss1/classifier"
+  bottom: "label"
+  top: "loss1/top-1"
+  name: "loss1/top-1"
+  type: ACCURACY
+  include {
+    phase: TEST
+  }
+}
+layers {
+  bottom: "loss1/classifier"
+  bottom: "label"
+  top: "loss1/top-5"
+  name: "loss1/top-5"
+  type: ACCURACY
+  accuracy_param {
+    top_k: 5
+  }
+  include {
+    phase: TEST
+  }
+}
+layers {
+  bottom: "inception_4a/output"
+  top: "inception_4b/1x1"
+  name: "inception_4b/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 160
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/1x1"
+  top: "inception_4b/1x1"
+  name: "inception_4b/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/output"
+  top: "inception_4b/3x3_reduce"
+  name: "inception_4b/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 112
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/3x3_reduce"
+  top: "inception_4b/3x3_reduce"
+  name: "inception_4b/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/3x3_reduce"
+  top: "inception_4b/3x3"
+  name: "inception_4b/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 224
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/3x3"
+  top: "inception_4b/3x3"
+  name: "inception_4b/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/output"
+  top: "inception_4b/5x5_reduce"
+  name: "inception_4b/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 24
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/5x5_reduce"
+  top: "inception_4b/5x5_reduce"
+  name: "inception_4b/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/5x5_reduce"
+  top: "inception_4b/5x5"
+  name: "inception_4b/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/5x5"
+  top: "inception_4b/5x5"
+  name: "inception_4b/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_4a/output"
+  top: "inception_4b/pool"
+  name: "inception_4b/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4b/pool"
+  top: "inception_4b/pool_proj"
+  name: "inception_4b/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4b/pool_proj"
+  top: "inception_4b/pool_proj"
+  name: "inception_4b/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/1x1"
+  bottom: "inception_4b/3x3"
+  bottom: "inception_4b/5x5"
+  bottom: "inception_4b/pool_proj"
+  top: "inception_4b/output"
+  name: "inception_4b/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4b/output"
+  top: "inception_4c/1x1"
+  name: "inception_4c/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/1x1"
+  top: "inception_4c/1x1"
+  name: "inception_4c/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/output"
+  top: "inception_4c/3x3_reduce"
+  name: "inception_4c/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/3x3_reduce"
+  top: "inception_4c/3x3_reduce"
+  name: "inception_4c/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/3x3_reduce"
+  top: "inception_4c/3x3"
+  name: "inception_4c/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/3x3"
+  top: "inception_4c/3x3"
+  name: "inception_4c/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/output"
+  top: "inception_4c/5x5_reduce"
+  name: "inception_4c/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 24
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/5x5_reduce"
+  top: "inception_4c/5x5_reduce"
+  name: "inception_4c/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/5x5_reduce"
+  top: "inception_4c/5x5"
+  name: "inception_4c/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/5x5"
+  top: "inception_4c/5x5"
+  name: "inception_4c/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_4b/output"
+  top: "inception_4c/pool"
+  name: "inception_4c/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4c/pool"
+  top: "inception_4c/pool_proj"
+  name: "inception_4c/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4c/pool_proj"
+  top: "inception_4c/pool_proj"
+  name: "inception_4c/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/1x1"
+  bottom: "inception_4c/3x3"
+  bottom: "inception_4c/5x5"
+  bottom: "inception_4c/pool_proj"
+  top: "inception_4c/output"
+  name: "inception_4c/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4c/output"
+  top: "inception_4d/1x1"
+  name: "inception_4d/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 112
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/1x1"
+  top: "inception_4d/1x1"
+  name: "inception_4d/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/output"
+  top: "inception_4d/3x3_reduce"
+  name: "inception_4d/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 144
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/3x3_reduce"
+  top: "inception_4d/3x3_reduce"
+  name: "inception_4d/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/3x3_reduce"
+  top: "inception_4d/3x3"
+  name: "inception_4d/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 288
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/3x3"
+  top: "inception_4d/3x3"
+  name: "inception_4d/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/output"
+  top: "inception_4d/5x5_reduce"
+  name: "inception_4d/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/5x5_reduce"
+  top: "inception_4d/5x5_reduce"
+  name: "inception_4d/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/5x5_reduce"
+  top: "inception_4d/5x5"
+  name: "inception_4d/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/5x5"
+  top: "inception_4d/5x5"
+  name: "inception_4d/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_4c/output"
+  top: "inception_4d/pool"
+  name: "inception_4d/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4d/pool"
+  top: "inception_4d/pool_proj"
+  name: "inception_4d/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 64
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4d/pool_proj"
+  top: "inception_4d/pool_proj"
+  name: "inception_4d/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/1x1"
+  bottom: "inception_4d/3x3"
+  bottom: "inception_4d/5x5"
+  bottom: "inception_4d/pool_proj"
+  top: "inception_4d/output"
+  name: "inception_4d/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4d/output"
+  top: "loss2/ave_pool"
+  name: "loss2/ave_pool"
+  type: POOLING
+  pooling_param {
+    pool: AVE
+    kernel_size: 5
+    stride: 3
+  }
+}
+layers {
+  bottom: "loss2/ave_pool"
+  top: "loss2/conv"
+  name: "loss2/conv"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.08
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "loss2/conv"
+  top: "loss2/conv"
+  name: "loss2/relu_conv"
+  type: RELU
+}
+layers {
+  bottom: "loss2/conv"
+  top: "loss2/fc"
+  name: "loss2/fc"
+  type: INNER_PRODUCT
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 1024
+    weight_filler {
+      type: "xavier"
+      std: 0.02
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "loss2/fc"
+  top: "loss2/fc"
+  name: "loss2/relu_fc"
+  type: RELU
+}
+layers {
+  bottom: "loss2/fc"
+  top: "loss2/fc"
+  name: "loss2/drop_fc"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.7
+  }
+}
+layers {
+  bottom: "loss2/fc"
+  top: "loss2/classifier"
+  name: "loss2/classifier"
+  type: INNER_PRODUCT
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 1000
+    weight_filler {
+      type: "xavier"
+      std: 0.0009765625
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers {
+  bottom: "loss2/classifier"
+  bottom: "label"
+  top: "loss2/loss1"
+  name: "loss2/loss"
+  type: SOFTMAX_LOSS
+  loss_weight: 0.3
+}
+layers {
+  bottom: "loss2/classifier"
+  bottom: "label"
+  top: "loss2/top-1"
+  name: "loss2/top-1"
+  type: ACCURACY
+  include {
+    phase: TEST
+  }
+}
+layers {
+  bottom: "loss2/classifier"
+  bottom: "label"
+  top: "loss2/top-5"
+  name: "loss2/top-5"
+  type: ACCURACY
+  accuracy_param {
+    top_k: 5
+  }
+  include {
+    phase: TEST
+  }
+}
+layers {
+  bottom: "inception_4d/output"
+  top: "inception_4e/1x1"
+  name: "inception_4e/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 256
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/1x1"
+  top: "inception_4e/1x1"
+  name: "inception_4e/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/output"
+  top: "inception_4e/3x3_reduce"
+  name: "inception_4e/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 160
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/3x3_reduce"
+  top: "inception_4e/3x3_reduce"
+  name: "inception_4e/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4e/3x3_reduce"
+  top: "inception_4e/3x3"
+  name: "inception_4e/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 320
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/3x3"
+  top: "inception_4e/3x3"
+  name: "inception_4e/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/output"
+  top: "inception_4e/5x5_reduce"
+  name: "inception_4e/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/5x5_reduce"
+  top: "inception_4e/5x5_reduce"
+  name: "inception_4e/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_4e/5x5_reduce"
+  top: "inception_4e/5x5"
+  name: "inception_4e/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/5x5"
+  top: "inception_4e/5x5"
+  name: "inception_4e/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_4d/output"
+  top: "inception_4e/pool"
+  name: "inception_4e/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_4e/pool"
+  top: "inception_4e/pool_proj"
+  name: "inception_4e/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_4e/pool_proj"
+  top: "inception_4e/pool_proj"
+  name: "inception_4e/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_4e/1x1"
+  bottom: "inception_4e/3x3"
+  bottom: "inception_4e/5x5"
+  bottom: "inception_4e/pool_proj"
+  top: "inception_4e/output"
+  name: "inception_4e/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_4e/output"
+  top: "pool4/3x3_s2"
+  name: "pool4/3x3_s2"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layers {
+  bottom: "pool4/3x3_s2"
+  top: "inception_5a/1x1"
+  name: "inception_5a/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 256
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/1x1"
+  top: "inception_5a/1x1"
+  name: "inception_5a/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "pool4/3x3_s2"
+  top: "inception_5a/3x3_reduce"
+  name: "inception_5a/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 160
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/3x3_reduce"
+  top: "inception_5a/3x3_reduce"
+  name: "inception_5a/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/3x3_reduce"
+  top: "inception_5a/3x3"
+  name: "inception_5a/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 320
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/3x3"
+  top: "inception_5a/3x3"
+  name: "inception_5a/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "pool4/3x3_s2"
+  top: "inception_5a/5x5_reduce"
+  name: "inception_5a/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 32
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/5x5_reduce"
+  top: "inception_5a/5x5_reduce"
+  name: "inception_5a/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/5x5_reduce"
+  top: "inception_5a/5x5"
+  name: "inception_5a/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/5x5"
+  top: "inception_5a/5x5"
+  name: "inception_5a/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "pool4/3x3_s2"
+  top: "inception_5a/pool"
+  name: "inception_5a/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_5a/pool"
+  top: "inception_5a/pool_proj"
+  name: "inception_5a/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5a/pool_proj"
+  top: "inception_5a/pool_proj"
+  name: "inception_5a/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/1x1"
+  bottom: "inception_5a/3x3"
+  bottom: "inception_5a/5x5"
+  bottom: "inception_5a/pool_proj"
+  top: "inception_5a/output"
+  name: "inception_5a/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_5a/output"
+  top: "inception_5b/1x1"
+  name: "inception_5b/1x1"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 384
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/1x1"
+  top: "inception_5b/1x1"
+  name: "inception_5b/relu_1x1"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/output"
+  top: "inception_5b/3x3_reduce"
+  name: "inception_5b/3x3_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 192
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.09
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/3x3_reduce"
+  top: "inception_5b/3x3_reduce"
+  name: "inception_5b/relu_3x3_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_5b/3x3_reduce"
+  top: "inception_5b/3x3"
+  name: "inception_5b/3x3"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 384
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/3x3"
+  top: "inception_5b/3x3"
+  name: "inception_5b/relu_3x3"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/output"
+  top: "inception_5b/5x5_reduce"
+  name: "inception_5b/5x5_reduce"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 48
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.2
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/5x5_reduce"
+  top: "inception_5b/5x5_reduce"
+  name: "inception_5b/relu_5x5_reduce"
+  type: RELU
+}
+layers {
+  bottom: "inception_5b/5x5_reduce"
+  top: "inception_5b/5x5"
+  name: "inception_5b/5x5"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    pad: 2
+    kernel_size: 5
+    weight_filler {
+      type: "xavier"
+      std: 0.03
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/5x5"
+  top: "inception_5b/5x5"
+  name: "inception_5b/relu_5x5"
+  type: RELU
+}
+layers {
+  bottom: "inception_5a/output"
+  top: "inception_5b/pool"
+  name: "inception_5b/pool"
+  type: POOLING
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layers {
+  bottom: "inception_5b/pool"
+  top: "inception_5b/pool_proj"
+  name: "inception_5b/pool_proj"
+  type: CONVOLUTION
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  convolution_param {
+    num_output: 128
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.2
+    }
+  }
+}
+layers {
+  bottom: "inception_5b/pool_proj"
+  top: "inception_5b/pool_proj"
+  name: "inception_5b/relu_pool_proj"
+  type: RELU
+}
+layers {
+  bottom: "inception_5b/1x1"
+  bottom: "inception_5b/3x3"
+  bottom: "inception_5b/5x5"
+  bottom: "inception_5b/pool_proj"
+  top: "inception_5b/output"
+  name: "inception_5b/output"
+  type: CONCAT
+}
+layers {
+  bottom: "inception_5b/output"
+  top: "pool5/7x7_s1"
+  name: "pool5/7x7_s1"
+  type: POOLING
+  pooling_param {
+    pool: AVE
+    kernel_size: 7
+    stride: 1
+  }
+}
+layers {
+  bottom: "pool5/7x7_s1"
+  top: "pool5/7x7_s1"
+  name: "pool5/drop_7x7_s1"
+  type: DROPOUT
+  dropout_param {
+    dropout_ratio: 0.4
+  }
+}
+layers {
+  bottom: "pool5/7x7_s1"
+  top: "loss3/classifier"
+  name: "loss3/classifier"
+  type: INNER_PRODUCT
+  blobs_lr: 1
+  blobs_lr: 2
+  weight_decay: 1
+  weight_decay: 0
+  inner_product_param {
+    num_output: 1000
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layers {
+  bottom: "loss3/classifier"
+  bottom: "label"
+  top: "loss3/loss3"
+  name: "loss3/loss3"
+  type: SOFTMAX_LOSS
+  loss_weight: 1
+}
+layers {
+  bottom: "loss3/classifier"
+  bottom: "label"
+  top: "loss3/top-1"
+  name: "loss3/top-1"
+  type: ACCURACY
+  include {
+    phase: TEST
+  }
+}
+layers {
+  bottom: "loss3/classifier"
+  bottom: "label"
+  top: "loss3/top-5"
+  name: "loss3/top-5"
+  type: ACCURACY
+  accuracy_param {
+    top_k: 5
+  }
+  include {
+    phase: TEST
+  }
+}


### PR DESCRIPTION
This PR add GoogleNet to the set of models provided by BVLC, it includes the the prototxt needed for training and deploying.

This model is a replication of the model described in the [GoogleNet](http://arxiv.org/abs/1409.4842) publication. We would like to thank Christian Szegedy for all his help in the replication of GoogleNet model.

Differences:
- not training with the relighting data-augmentation;
- not training with the scale or aspect-ratio data-augmentation;
- uses "xavier" to initialize the weights instead of "gaussian";
- quick_solver.prototxt uses a different learning rate decay policy than the original solver.prototxt, that allows a much faster training (60 epochs vs 250 epochs);

The bundled model is the iteration 2,400,000 snapshot (60 epochs) using quick_solver.prototxt

This bundled model obtains a top-1 accuracy 68.7% (31.3% error) and a top-5 accuracy 88.9% (11.1% error) on the validation set, using just the center crop.
(Using the average of 10 crops, (4 + 1 center) \* 2 mirror, should obtain a bit higher accuracy.)

Timings for bvlc_googlenet with cuDNN using batch_size:128 on a K40c:
- Average Forward pass: 562.841 ms.
- Average Backward pass: 1123.84 ms.
- Average Forward-Backward: 1688.8 ms.

P.S: For timing look at #1317
