### PR TITLE
Use valid MathJax delimiters.

### DIFF
--- a/tutorial/forward_backward.html
+++ b/tutorial/forward_backward.html
@@ -58,7 +58,7 @@ This pass goes from bottom to top.</p>
 
 <p><img src="fig/forward.jpg" alt="Forward pass" width="320" /></p>
 
-<p>The data $x$ is passed through an inner product layer for $g(x)$ then through a softmax for $h(g(x))$ and softmax loss to give $f_W(x)$.</p>
+<p>The data <script type="math/tex">x</script> is passed through an inner product layer for <script type="math/tex">g(x)</script> then through a softmax for <script type="math/tex">h(g(x))</script> and softmax loss to give <script type="math/tex">f_W(x)</script>.</p>
 
 <p>The <strong>backward</strong> pass computes the gradient given the loss for learning.
 In backward Caffe reverse-composes the gradient of each layer to compute the gradient of the whole model by automatic differentiation.
@@ -67,7 +67,7 @@ This pass goes from top to bottom.</p>
 
 <p><img src="fig/backward.jpg" alt="Backward pass" width="320" /></p>
 
-<p>The backward pass begins with the loss and computes the gradient with respect to the output $\frac{\partial f_W}{\partial h}$. The gradient with respect to the rest of the model is computed layer-by-layer through the chain rule. Layers with parameters, like the <code>INNER_PRODUCT</code> layer, compute the gradient with respect to their parameters $\frac{\partial f_W}{\partial W_{\text{ip}}}$ during the backward step.</p>
+<p>The backward pass begins with the loss and computes the gradient with respect to the output <script type="math/tex">\frac{\partial f_W}{\partial h}</script>. The gradient with respect to the rest of the model is computed layer-by-layer through the chain rule. Layers with parameters, like the <code>INNER_PRODUCT</code> layer, compute the gradient with respect to their parameters <script type="math/tex">\frac{\partial f_W}{\partial W_{\text{ip}}}</script> during the backward step.</p>
 
 <p>These computations follow immediately from defining the model: Caffe plans and carries out the forward and backward passes for you.</p>
 


### PR DESCRIPTION
MathJax does not support $ as a delimiter by default, so math was not
displayed properly on the “Forward and Backward” page.
