### PR TITLE
switch cifar10 example to lmdb

### DIFF
--- a/examples/cifar10/cifar10_full_train_test.prototxt
+++ b/examples/cifar10/cifar10_full_train_test.prototxt
@@ -5,8 +5,9 @@ layers {
   top: "data"
   top: "label"
   data_param {
-    source: "examples/cifar10/cifar10_train_leveldb"
+    source: "examples/cifar10/cifar10_train_lmdb"
     batch_size: 100
+    backend: LMDB
   }
   transform_param {
     mean_file: "examples/cifar10/mean.binaryproto"
@@ -19,8 +20,9 @@ layers {
   top: "data"
   top: "label"
   data_param {
-    source: "examples/cifar10/cifar10_test_leveldb"
+    source: "examples/cifar10/cifar10_test_lmdb"
     batch_size: 100
+    backend: LMDB
   }
   transform_param {
     mean_file: "examples/cifar10/mean.binaryproto"

--- a/examples/cifar10/cifar10_quick_train_test.prototxt
+++ b/examples/cifar10/cifar10_quick_train_test.prototxt
@@ -5,8 +5,9 @@ layers {
   top: "data"
   top: "label"
   data_param {
-    source: "examples/cifar10/cifar10_train_leveldb"
+    source: "examples/cifar10/cifar10_train_lmdb"
     batch_size: 100
+    backend: LMDB
   }
   transform_param {
     mean_file: "examples/cifar10/mean.binaryproto"
@@ -19,8 +20,9 @@ layers {
   top: "data"
   top: "label"
   data_param {
-    source: "examples/cifar10/cifar10_test_leveldb"
+    source: "examples/cifar10/cifar10_test_lmdb"
     batch_size: 100
+    backend: LMDB
   }
   transform_param {
     mean_file: "examples/cifar10/mean.binaryproto"


### PR DESCRIPTION
I found the cifar10 example created lmdb dataset by default (see examples/cifar10/create_cifar10.sh) but the network prototxt didn't update accordingly. 
This PR switches dataset from leveldb to lmdb in prototxt in the cifar10 example.