### PR TITLE
Update use of GetLayer to new registry function

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -62,7 +62,8 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
   bottom_need_backward_.resize(param.layers_size());
   for (int layer_id = 0; layer_id < param.layers_size(); ++layer_id) {
     const LayerParameter& layer_param = param.layers(layer_id);
-    layers_.push_back(shared_ptr<Layer<Dtype> >(GetLayer<Dtype>(layer_param)));
+    layers_.push_back(shared_ptr<Layer<Dtype> >(
+          LayerRegistry<Dtype>::CreateLayer(layer_param)));
     layer_names_.push_back(layer_param.name());
     LOG(INFO) << "Creating Layer " << layer_param.name();
     bool need_backward = false;


### PR DESCRIPTION
According to @Yangqing's note of September 26 at https://github.com/BVLC/caffe/blob/dev/include/caffe/layer_factory.hpp#L119, `GetLayer` is obsolete; however we still use it during net construction.

This patch replaces `GetLayer` with the newer `LayerRegistry::CreateLayer`. It seems to me this is the only place we are still using `GetLayer`, so maybe it should be removed altogether as well?
