### PR TITLE
Augment layers with their induced coordinate maps

### DIFF
--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -91,6 +91,9 @@ class ConcatLayer : public Layer<Dtype> {
   }
   virtual inline int MinBottomBlobs() const { return 2; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   /**
@@ -171,6 +174,9 @@ class EltwiseLayer : public Layer<Dtype> {
   }
   virtual inline int MinBottomBlobs() const { return 2; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -301,6 +307,9 @@ class MVNLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -367,6 +376,9 @@ class SoftmaxLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -431,6 +443,9 @@ class SplitLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int MinTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -466,6 +481,9 @@ class SliceLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int MinTopBlobs() const { return 2; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -3,12 +3,14 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
 #include "caffe/layer_factory.hpp"
 #include "caffe/proto/caffe.pb.h"
+#include "caffe/util/coords.hpp"
 #include "caffe/util/device_alternate.hpp"
 
 namespace caffe {
@@ -291,6 +293,12 @@ class Layer {
       param_propagate_down_.resize(param_id + 1, true);
     }
     param_propagate_down_[param_id] = value;
+  }
+
+  virtual DiagonalAffineMap<Dtype> coord_map() {
+    NOT_IMPLEMENTED;
+    // suppress warnings
+    return DiagonalAffineMap<Dtype>(vector<pair<Dtype, Dtype> >());
   }
 
 

--- a/include/caffe/neuron_layers.hpp
+++ b/include/caffe/neuron_layers.hpp
@@ -34,6 +34,9 @@ class NeuronLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 };
 
 /**

--- a/include/caffe/util/coords.hpp
+++ b/include/caffe/util/coords.hpp
@@ -45,6 +45,17 @@ class DiagonalAffineMap {
   vector<pair<Dtype, Dtype> > coefs_;
 };
 
+template <typename Dtype>
+DiagonalAffineMap<Dtype> FilterMap(const int kernel_h, const int kernel_w,
+    const int stride_h, const int stride_w, const int pad_h, const int pad_w) {
+  vector<pair<Dtype, Dtype> > coefs;
+  coefs.push_back(make_pair(stride_h,
+        static_cast<Dtype>(kernel_h - 1) / 2 - pad_h));
+  coefs.push_back(make_pair(stride_w,
+        static_cast<Dtype>(kernel_w - 1) / 2 - pad_w));
+  return DiagonalAffineMap<Dtype>(coefs);
+}
+
 }  // namespace caffe
 
 #endif  // CAFFE_UTIL_COORDS_H_

--- a/include/caffe/util/coords.hpp
+++ b/include/caffe/util/coords.hpp
@@ -1,0 +1,50 @@
+#ifndef CAFFE_UTIL_COORDS_H_
+#define CAFFE_UTIL_COORDS_H_
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+namespace caffe {
+
+template <typename Dtype>
+class DiagonalAffineMap {
+ public:
+  explicit DiagonalAffineMap(const vector<pair<Dtype, Dtype> > coefs)
+    : coefs_(coefs) { }
+  static DiagonalAffineMap identity(const int nd) {
+    return DiagonalAffineMap(vector<pair<Dtype, Dtype> >(nd, make_pair(1, 0)));
+  }
+
+  inline DiagonalAffineMap compose(const DiagonalAffineMap& other) const {
+    CHECK_EQ(coefs_.size(), other.coefs_.size())
+        << "Attempt to compose DiagonalAffineMaps of different dimensions";
+    DiagonalAffineMap<Dtype> out;
+    transform(coefs_.begin(), coefs_.end(), other.coefs_.begin(),
+        std::back_inserter(out.coefs_), &compose_coefs);
+    return out;
+  }
+  inline DiagonalAffineMap inv() const {
+    DiagonalAffineMap<Dtype> out;
+    transform(coefs_.begin(), coefs_.end(), std::back_inserter(out.coefs_),
+        &inv_coefs);
+    return out;
+  }
+  inline vector<pair<Dtype, Dtype> > coefs() { return coefs_; }
+
+ private:
+  DiagonalAffineMap() { }
+  static inline pair<Dtype, Dtype> compose_coefs(pair<Dtype, Dtype> left,
+      pair<Dtype, Dtype> right) {
+    return make_pair(left.first * right.first,
+                     left.first * right.second + left.second);
+  }
+  static inline pair<Dtype, Dtype> inv_coefs(pair<Dtype, Dtype> coefs) {
+    return make_pair(1 / coefs.first, - coefs.second / coefs.first);
+  }
+  vector<pair<Dtype, Dtype> > coefs_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_UTIL_COORDS_H_

--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -159,6 +159,10 @@ class ConvolutionLayer : public BaseConvolutionLayer<Dtype> {
   virtual inline LayerParameter_LayerType type() const {
     return LayerParameter_LayerType_CONVOLUTION;
   }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return FilterMap<Dtype>(this->kernel_h_, this->kernel_w_, this->stride_h_,
+        this->stride_w_, this->pad_h_, this->pad_w_).inv();
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -181,7 +185,10 @@ class DeconvolutionLayer : public BaseConvolutionLayer<Dtype> {
   virtual inline LayerParameter_LayerType type() const {
     return LayerParameter_LayerType_DECONVOLUTION;
   }
-
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return FilterMap<Dtype>(this->kernel_h_, this->kernel_w_, this->stride_h_,
+        this->stride_w_, this->pad_h_, this->pad_w_);
+  }
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
@@ -301,6 +308,9 @@ class LRNLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -384,6 +394,10 @@ class PoolingLayer : public Layer<Dtype> {
   virtual inline int MaxTopBlobs() const {
     return (this->layer_param_.pooling_param().pool() ==
             PoolingParameter_PoolMethod_MAX) ? 2 : 1;
+  }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return FilterMap<Dtype>(kernel_h_, kernel_w_, stride_h_, stride_w_,
+        pad_h_, pad_w_).inv();
   }
 
  protected:


### PR DESCRIPTION
~~After #1615, not because that PR is necessary for this one, but so that `DeconvolutionLayer` is already supported.~~

All layers map values from some array to another, often of a different size. For most basic convnet layers, this forward mapping naturally induces a mapping on the _coordinates_ that index the values of the input and output arrays. Computing this map is often useful for constructing and analyzing nets. Doing so by hand is laborious and error-prone; this PR provides an automated mechanism.

There are a few basic ways this could be done:

1. Provide an external utility (perhaps implemented in Python).
2. Provide a mechanism within Caffe proper, but keep all information about the coordinate maps separate from the layer implementations.
3. Augment each layer with its induced coordinate map.

Options 1 and 2 avoid touching the layer class definition, but require separated pieces of code to be kept in sync. Option 1 makes it impossible to use these coordinate maps within Caffe proper, e.g., by a future layer. Option 3 is the one implemented here.

This PR augments layers with a member function, `coord_map`, that keeps track of the coordinate mapping. A new type, `DiagonalAffineMap`, is introduced to store these mappings. (Note that they all that they all take the form `Ax + b`, where `A` is diagonal. This could be generalized to a class hierarchy in the future.) Note that the coordinate maps depend only on the layer (specification) parameters, not on bottom data (though the latter is not strictly prohibited).

For all existing layers, the induced coordinate map is one of the following:
* not meaningful
* the identity
* the mapping induced by deconvolution, implemented by `FilterMap`
* the mapping induced by convolution, i.e. the inverse of the above, implemented via `FilterMap(...).inv()`.

Certain conventions need to be chosen to define the induced coordinate map. The conventions used here:
* The coordinate map does not make sense for all dimensions; for convolution, for example, while the `num` dimension induces the identity map, the `channel` dimension does not induce a meaningful coordinate transformation. The mapping returned by `coord_map` therefore applies only to the coordinates for which such a mapping makes sense and is useful (i.e., the spatial dimensions). Thus all implemented maps are 2-dimensional (but the code should be easily extendable to #1486).
* The induced mapping goes from bottom coordinates to top coordinates, in the direction of `Forward`. (Often one wants the reverse, easily accessible with `DiagonalAffineMap::inv`.)
* When an output value depends on input values within a rectangular region (as in convolution or pooling), the corresponding input coordinates are given by the center of that rectangle. (By symmetry, this is the only sensible choice.)

Questions
* Neither existing code nor the Google style guide give firm rules about which methods should be CamelCase and which should be underscore_case. I made some fairly arbitrary choices here; do you like them?
* I implemented `DiagonalAffineMap::identity` as a static method, but `FilterMap` as a separate function. Should they both be separate functions?
* What if a layer has more than one bottom, or more than one top, and the mappings between bottoms and tops are not all compatible? Currently this issue does not come up.