### PR TITLE
Crop layer for automatically aligning computations

### DIFF
--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -91,6 +91,9 @@ class ConcatLayer : public Layer<Dtype> {
   }
   virtual inline int MinBottomBlobs() const { return 2; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   /**
@@ -171,6 +174,9 @@ class EltwiseLayer : public Layer<Dtype> {
   }
   virtual inline int MinBottomBlobs() const { return 2; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -301,6 +307,9 @@ class MVNLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -367,6 +376,9 @@ class SoftmaxLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -431,6 +443,9 @@ class SplitLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int MinTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -466,6 +481,9 @@ class SliceLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int MinTopBlobs() const { return 2; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -15,6 +15,8 @@
 
 namespace caffe {
 
+template <typename Dtype> class Net;
+
 /**
  * @brief An interface for the units of computation which can be composed into a
  *        Net.
@@ -301,6 +303,10 @@ class Layer {
     return DiagonalAffineMap<Dtype>(vector<pair<Dtype, Dtype> >());
   }
 
+  /**
+   * @brief Used by Net to give layers a pointer to their owning net.
+   */
+  void set_net(Net<Dtype>* net) { net_ = net; }
 
  protected:
   /** The protobuf that stores the layer parameters */
@@ -313,6 +319,9 @@ class Layer {
   /** The vector that indicates whether each top blob has a non-zero weight in
    *  the objective function. */
   vector<Dtype> loss_;
+
+  /** The net to which this layer belongs. */
+  Net<Dtype>* net_;
 
   /** @brief Using the CPU device, compute the layer output. */
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -3,12 +3,14 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
 #include "caffe/layer_factory.hpp"
 #include "caffe/proto/caffe.pb.h"
+#include "caffe/util/coords.hpp"
 #include "caffe/util/device_alternate.hpp"
 
 namespace caffe {
@@ -291,6 +293,12 @@ class Layer {
       param_propagate_down_.resize(param_id + 1, true);
     }
     param_propagate_down_[param_id] = value;
+  }
+
+  virtual DiagonalAffineMap<Dtype> coord_map() {
+    NOT_IMPLEMENTED;
+    // suppress warnings
+    return DiagonalAffineMap<Dtype>(vector<pair<Dtype, Dtype> >());
   }
 
 

--- a/include/caffe/neuron_layers.hpp
+++ b/include/caffe/neuron_layers.hpp
@@ -34,6 +34,9 @@ class NeuronLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 };
 
 /**

--- a/include/caffe/util/coords.hpp
+++ b/include/caffe/util/coords.hpp
@@ -45,6 +45,17 @@ class DiagonalAffineMap {
   vector<pair<Dtype, Dtype> > coefs_;
 };
 
+template <typename Dtype>
+DiagonalAffineMap<Dtype> FilterMap(const int kernel_h, const int kernel_w,
+    const int stride_h, const int stride_w, const int pad_h, const int pad_w) {
+  vector<pair<Dtype, Dtype> > coefs;
+  coefs.push_back(make_pair(stride_h,
+        static_cast<Dtype>(kernel_h - 1) / 2 - pad_h));
+  coefs.push_back(make_pair(stride_w,
+        static_cast<Dtype>(kernel_w - 1) / 2 - pad_w));
+  return DiagonalAffineMap<Dtype>(coefs);
+}
+
 }  // namespace caffe
 
 #endif  // CAFFE_UTIL_COORDS_H_

--- a/include/caffe/util/coords.hpp
+++ b/include/caffe/util/coords.hpp
@@ -1,0 +1,50 @@
+#ifndef CAFFE_UTIL_COORDS_H_
+#define CAFFE_UTIL_COORDS_H_
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+namespace caffe {
+
+template <typename Dtype>
+class DiagonalAffineMap {
+ public:
+  explicit DiagonalAffineMap(const vector<pair<Dtype, Dtype> > coefs)
+    : coefs_(coefs) { }
+  static DiagonalAffineMap identity(const int nd) {
+    return DiagonalAffineMap(vector<pair<Dtype, Dtype> >(nd, make_pair(1, 0)));
+  }
+
+  inline DiagonalAffineMap compose(const DiagonalAffineMap& other) const {
+    CHECK_EQ(coefs_.size(), other.coefs_.size())
+        << "Attempt to compose DiagonalAffineMaps of different dimensions";
+    DiagonalAffineMap<Dtype> out;
+    transform(coefs_.begin(), coefs_.end(), other.coefs_.begin(),
+        std::back_inserter(out.coefs_), &compose_coefs);
+    return out;
+  }
+  inline DiagonalAffineMap inv() const {
+    DiagonalAffineMap<Dtype> out;
+    transform(coefs_.begin(), coefs_.end(), std::back_inserter(out.coefs_),
+        &inv_coefs);
+    return out;
+  }
+  inline vector<pair<Dtype, Dtype> > coefs() { return coefs_; }
+
+ private:
+  DiagonalAffineMap() { }
+  static inline pair<Dtype, Dtype> compose_coefs(pair<Dtype, Dtype> left,
+      pair<Dtype, Dtype> right) {
+    return make_pair(left.first * right.first,
+                     left.first * right.second + left.second);
+  }
+  static inline pair<Dtype, Dtype> inv_coefs(pair<Dtype, Dtype> coefs) {
+    return make_pair(1 / coefs.first, - coefs.second / coefs.first);
+  }
+  vector<pair<Dtype, Dtype> > coefs_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_UTIL_COORDS_H_

--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -159,6 +159,10 @@ class ConvolutionLayer : public BaseConvolutionLayer<Dtype> {
   virtual inline LayerParameter_LayerType type() const {
     return LayerParameter_LayerType_CONVOLUTION;
   }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return FilterMap<Dtype>(this->kernel_h_, this->kernel_w_, this->stride_h_,
+        this->stride_w_, this->pad_h_, this->pad_w_).inv();
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -181,7 +185,10 @@ class DeconvolutionLayer : public BaseConvolutionLayer<Dtype> {
   virtual inline LayerParameter_LayerType type() const {
     return LayerParameter_LayerType_DECONVOLUTION;
   }
-
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return FilterMap<Dtype>(this->kernel_h_, this->kernel_w_, this->stride_h_,
+        this->stride_w_, this->pad_h_, this->pad_w_);
+  }
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
@@ -301,6 +308,9 @@ class LRNLayer : public Layer<Dtype> {
   }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return DiagonalAffineMap<Dtype>::identity(2);
+  }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -384,6 +394,10 @@ class PoolingLayer : public Layer<Dtype> {
   virtual inline int MaxTopBlobs() const {
     return (this->layer_param_.pooling_param().pool() ==
             PoolingParameter_PoolMethod_MAX) ? 2 : 1;
+  }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    return FilterMap<Dtype>(kernel_h_, kernel_w_, stride_h_, stride_w_,
+        pad_h_, pad_w_).inv();
   }
 
  protected:

--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -453,6 +453,41 @@ class CuDNNPoolingLayer : public PoolingLayer<Dtype> {
 };
 #endif
 
+template <typename Dtype>
+class CropLayer : public Layer<Dtype> {
+ public:
+  explicit CropLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline LayerParameter_LayerType type() const {
+    return LayerParameter_LayerType_CROP;
+  }
+  virtual inline int ExactNumBottomBlobs() const { return 2; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline DiagonalAffineMap<Dtype> coord_map() {
+    vector<pair<Dtype, Dtype> > coefs;
+    coefs.push_back(make_pair(1, - crop_h_));
+    coefs.push_back(make_pair(1, - crop_w_));
+    return DiagonalAffineMap<Dtype>(coefs);
+  }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  int crop_h_, crop_w_;
+};
+
 }  // namespace caffe
 
 #endif  // CAFFE_VISION_LAYERS_HPP_

--- a/src/caffe/layers/crop_layer.cpp
+++ b/src/caffe/layers/crop_layer.cpp
@@ -1,0 +1,126 @@
+#include <algorithm>
+#include <map>
+#include <set>
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/net.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void CropLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  // Construct a map from top blobs to layer inds, skipping over in-place
+  // connections.
+  map<Blob<Dtype>*, int> down_map;
+  for (int layer_ind = 0; layer_ind < this->net_->top_vecs().size();
+       ++layer_ind) {
+    vector<Blob<Dtype>*> tops = this->net_->top_vecs()[layer_ind];
+    for (int top_ind = 0; top_ind < tops.size(); ++top_ind) {
+      if (down_map.find(tops[top_ind]) == down_map.end()) {
+        down_map[tops[top_ind]] = layer_ind;
+      }
+    }
+  }
+  // Walk back from the first bottom, keeping track of all the blobs we pass.
+  set<Blob<Dtype>*> path_blobs;
+  Blob<Dtype>* blob = bottom[0];
+  int layer_ind;
+  // TODO this logic can be simplified if all blobs are tops
+  path_blobs.insert(blob);
+  while (down_map.find(blob) != down_map.end()) {
+    layer_ind = down_map[blob];
+    if (this->net_->bottom_vecs()[layer_ind].size() == 0) {
+      break;
+    }
+    blob = this->net_->bottom_vecs()[layer_ind][0];
+    path_blobs.insert(blob);
+  }
+  // Now walk back from the second bottom, until we find a blob of intersection.
+  Blob<Dtype>* inter_blob = bottom[1];
+  while (path_blobs.find(inter_blob) == path_blobs.end()) {
+    CHECK(down_map.find(inter_blob) != down_map.end())
+        << "Cannot align apparently disconnected blobs.";
+    layer_ind = down_map[inter_blob];
+    CHECK_GT(this->net_->bottom_vecs()[layer_ind].size(), 0)
+        << "Cannot align apparently disconnected blobs.";
+    inter_blob = this->net_->bottom_vecs()[layer_ind][0];
+  }
+  // Compute the coord map from the blob of intersection to each bottom.
+  vector<DiagonalAffineMap<Dtype> > coord_maps(2,
+      DiagonalAffineMap<Dtype>::identity(2));
+  for (int i = 0; i < 2; ++i) {
+    for (Blob<Dtype>* blob = bottom[i]; blob != inter_blob;
+         blob = this->net_->bottom_vecs()[down_map[blob]][0]) {
+      shared_ptr<Layer<Dtype> > layer = this->net_->layers()[down_map[blob]];
+      coord_maps[i] = coord_maps[i].compose(layer->coord_map());
+    }
+  }
+  // Compute the mapping from first bottom coordinates to second.
+  DiagonalAffineMap<Dtype> crop_map =
+      coord_maps[1].compose(coord_maps[0].inv());
+  for (int i = 0; i < 2; ++i) {
+    // Check for scale mismatch (unfortunately, CHECK_DOUBLE_EQ does not
+    // support a message like the other CHECKs).
+    CHECK_DOUBLE_EQ(crop_map.coefs()[i].first, 1);
+    CHECK_LE(crop_map.coefs()[i].second, 0) << "Negative crop width.";
+    // Check that the crop width is an integer.
+    CHECK_DOUBLE_EQ(crop_map.coefs()[i].second,
+        round(crop_map.coefs()[i].second));
+  }
+  crop_h_ = - round(crop_map.coefs()[0].second);
+  crop_w_ = - round(crop_map.coefs()[1].second);
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  top[0]->Reshape(bottom[0]->num(), bottom[0]->channels(), bottom[1]->height(),
+      bottom[1]->width());
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  for (int n = 0; n < top[0]->num(); ++n) {
+    for (int c = 0; c < top[0]->channels(); ++c) {
+      for (int h = 0; h < top[0]->height(); ++h) {
+        caffe_copy(top[0]->width(),
+            bottom_data + bottom[0]->offset(n, c, crop_h_ + h, crop_w_),
+            top_data + top[0]->offset(n, c, h));
+      }
+    }
+  }
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  const Dtype* top_diff = top[0]->cpu_diff();
+  Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+  if (propagate_down[0]) {
+    caffe_set(bottom[0]->count(), static_cast<Dtype>(0), bottom_diff);
+    for (int n = 0; n < top[0]->num(); ++n) {
+      for (int c = 0; c < top[0]->channels(); ++c) {
+        for (int h = 0; h < top[0]->height(); ++h) {
+          caffe_copy(top[0]->width(),
+              top_diff + top[0]->offset(n, c, h),
+              bottom_diff + bottom[0]->offset(n, c, crop_h_ + h, crop_w_));
+        }
+      }
+    }
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(CropLayer);
+#endif
+
+INSTANTIATE_CLASS(CropLayer);
+REGISTER_LAYER_CLASS(CROP, CropLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/crop_layer.cu
+++ b/src/caffe/layers/crop_layer.cu
@@ -1,0 +1,60 @@
+#include <vector>
+
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+// Copy (one line per thread) from one array to another, with arbitrary
+// strides in the last two dimensions.
+template <typename Dtype>
+__global__ void copy_kernel(const int n, const int height, const int width,
+    const int src_outer_stride, const int src_inner_stride,
+    const int dest_outer_stride, const int dest_inner_stride,
+    const Dtype* src, Dtype* dest) {
+  CUDA_KERNEL_LOOP(index, n) {
+    int src_start = index / height * src_outer_stride
+                  + index % height * src_inner_stride;
+    int dest_start = index / height * dest_outer_stride
+                   + index % height * dest_inner_stride;
+    for (int i = 0; i < width; ++i) {
+      dest[dest_start + i] = src[src_start + i];
+    }
+  }
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  Dtype* top_data = top[0]->mutable_gpu_data();
+  const int lines = top[0]->count() / top[0]->width();
+
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  copy_kernel<<<CAFFE_GET_BLOCKS(lines), CAFFE_CUDA_NUM_THREADS>>>(
+      lines, top[0]->height(), top[0]->width(),
+      bottom[0]->height() * bottom[0]->width(), bottom[0]->width(),
+      top[0]->height() * top[0]->width(), top[0]->width(),
+      bottom_data + bottom[0]->offset(0, 0, crop_h_, crop_w_), top_data);
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  const Dtype* top_diff = top[0]->gpu_diff();
+  Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
+  const int lines = top[0]->count() / top[0]->width();
+
+  if (propagate_down[0]) {
+    caffe_gpu_set(bottom[0]->count(), static_cast<Dtype>(0), bottom_diff);
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    copy_kernel<<<CAFFE_GET_BLOCKS(lines), CAFFE_CUDA_NUM_THREADS>>>(
+        lines, top[0]->height(), top[0]->width(),
+        top[0]->height() * top[0]->width(), top[0]->width(),
+        bottom[0]->height() * bottom[0]->width(), bottom[0]->width(),
+        top_diff, bottom_diff + bottom[0]->offset(0, 0, crop_h_, crop_w_));
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(CropLayer);
+
+}  // namespace caffe

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -64,6 +64,7 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
     const LayerParameter& layer_param = param.layers(layer_id);
     layers_.push_back(shared_ptr<Layer<Dtype> >(
           LayerRegistry<Dtype>::CreateLayer(layer_param)));
+    layers_[layer_id]->set_net(this);
     layer_names_.push_back(layer_param.name());
     LOG(INFO) << "Creating Layer " << layer_param.name();
     bool need_backward = false;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -227,7 +227,7 @@ message LayerParameter {
   // line above the enum. Update the next available ID when you add a new
   // LayerType.
   //
-  // LayerType next available ID: 40 (last added: DECONVOLUTION)
+  // LayerType next available ID: 41 (last added: CROP)
   enum LayerType {
     // "NONE" layer type is 0th enum element so that we don't cause confusion
     // by defaulting to an existent LayerType (instead, should usually error if
@@ -240,6 +240,7 @@ message LayerParameter {
     CONCAT = 3;
     CONTRASTIVE_LOSS = 37;
     CONVOLUTION = 4;
+    CROP = 40;
     DATA = 5;
     DECONVOLUTION = 39;
     DROPOUT = 6;


### PR DESCRIPTION
After #1637 and #1638 (new content is just the commit https://github.com/longjon/caffe/commit/4e38c93d3f9e05aabb2e3fdb74bd79872dd2b008).

Existing layers shift and warp coordinate space: translation by padding (or lack thereof), contraction by strided convolution or pooling, and expansion by strided deconvolution (#1615). Often one wants to align two blobs, e.g., to establish a correspondence between input and output, or to fuse two different paths of computation. Counting conv/deconv strides to ensure that blob coordinates have the same scale is generally straightforward. Computing the offset between two blobs that results from intermediate padding and kernel sizes is trickier.

This layer takes two bottom blobs and produces one top, which is a copy of the first bottom cropped to the size of the second so that coordinates exactly correspond, i.e., it makes sense to fuse or compare the top blob with the second bottom, regardless of whatever padding or other shenanigans took place between their computation.

This is done by computing the coordinate mapping between the two bottom blobs, as provided by #1637 and made accessible by #1638. If that mapping is a simple translation, and has the right sign to allow the first blob to be "cropped to" the second, the layer simply performs the copy. If the mapping is not an integer translation, or the translation has the wrong sign, an error is thrown, and the net may be rearranged to allow sensible fusion.

The implementation of `LayerSetUp` amounts to some simple graph traversal to find the path connecting the two bottoms. Currently `Net` does not provide great facilities for traversing the layer graph, so it's a bit cumbersome; maybe this can be improved in the future.

There is a bit of engineering involved in these three PRs, but the result is pretty convenient: what was before a tricky offline calculation becomes a trivial layer specification.

Another way to implement this, without #1638, would be to remove the graph traversal from `CropLayer`, giving it a simple parameter instead, and provide some other mechanism for automatically filling in that parameter.

Currently CPU and GPU (trivially) are provided, but tests and documentation are not.