### PR TITLE
Fix find warnings in upload_model_to_gist.sh

### DIFF
--- a/scripts/upload_model_to_gist.sh
+++ b/scripts/upload_model_to_gist.sh
@@ -7,7 +7,7 @@ if [ ! -f $DIRNAME/readme.md ]; then
     echo "  <dirname>/readme.md must exist"
 fi
 cd $DIRNAME
-FILES=`find . -type f -maxdepth 1 ! -name "*.caffemodel*" | xargs echo`
+FILES=`find . -maxdepth 1 -type f ! -name "*.caffemodel*" | xargs echo`
 
 # Check for gist tool.
 gist -v >/dev/null 2>&1 || { echo >&2 "I require 'gist' but it's not installed. Do 'gem install gist'."; exit 1; }


### PR DESCRIPTION
On my system, `find` warns that `-maxdepth` is not a positional argument, so it should come first. Putting it first fixes the warning.
