### PR TITLE
Fix an error made in removing the SoftmaxLossLayer GPU stubs

### DIFF
--- a/src/caffe/layers/softmax_loss_layer.cpp
+++ b/src/caffe/layers/softmax_loss_layer.cpp
@@ -85,11 +85,7 @@ void SoftmaxWithLossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
   }
 }
 
-
-#ifdef CPU_ONLY
-STUB_GPU(SoftmaxWithLossLayer);
-#endif
-
 INSTANTIATE_CLASS(SoftmaxWithLossLayer);
 REGISTER_LAYER_CLASS(SOFTMAX_LOSS, SoftmaxWithLossLayer);
+
 }  // namespace caffe


### PR DESCRIPTION
#1655 was accidentally merged breaking the `CPU_ONLY` build, since the GPU stubs were still being generated in that case. This PR should fix that.
