### PR TITLE
'make everything' tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ PYTHON_LDFLAGS := $(LDFLAGS) $(foreach library,$(PYTHON_LIBRARIES),-l$(library))
 SUPERCLEAN_EXTS := .so .a .o .bin .testbin .pb.cc .pb.h _pb2.py .cuo
 
 # Set the sub-targets of the 'everything' target.
-EVERYTHING_TARGETS := all py$(PROJECT) test warn lint runtest
+EVERYTHING_TARGETS := all py$(PROJECT) test warn lint
 # Only build matcaffe as part of "everything" if MATLAB_DIR is specified.
 ifneq ($(MATLAB_DIR),)
 	EVERYTHING_TARGETS += mat$(PROJECT)


### PR DESCRIPTION
First commit: only build `matcaffe` if `MATLAB_DIR` is set.

Second commit ("optional"): don't do `runtest` as part of everything.  This is totally subjective, but it's more useful to me to have a target that just "builds" everything (and/or reassure myself that I have built everything with a poetic `Nothing to be done for everything`).  Running the whole test suite takes a while, so for the few times I want to do that I'd rather just spend 8 extra keystrokes to do `make everything runtest`.  @longjon (who wrote the `everything` build target), what do you think? If you like the `runtest` I can just add a new target to only do the build.
