### PR TITLE
turned fatal errors into exceptions, allowing error handling outside of ...

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -9,6 +9,8 @@
 // avoid fatal checks from glog
 //#define CAFFE_THROW_ON_ERROR
 #ifdef CAFFE_THROW_ON_ERROR
+#undef CHECK
+#undef CHECK_OP_LOG
 #include <sstream>
 #define SSTR( x ) dynamic_cast< std::ostringstream & >( \
 		 ( std::ostringstream() << std::dec << x ) ).str()

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -1,9 +1,34 @@
 #ifndef CAFFE_COMMON_HPP_
 #define CAFFE_COMMON_HPP_
 
+#include <exception>
 #include <boost/shared_ptr.hpp>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+
+// avoid fatal checks from glog
+//#define CAFFE_THROW_ON_ERROR
+#ifdef CAFFE_THROW_ON_ERROR
+#include <sstream>
+#define SSTR( x ) dynamic_cast< std::ostringstream & >( \
+		 ( std::ostringstream() << std::dec << x ) ).str()
+class CaffeErrorException : public std::exception
+{
+public:
+  CaffeErrorException(const std::string &s):_s(s) {}
+  ~CaffeErrorException() throw() {}
+  const char* what() const throw() { return _s.c_str(); }
+  std::string _s;
+};
+
+#define CHECK(condition)						\
+  if (GOOGLE_PREDICT_BRANCH_NOT_TAKEN(!(condition)))			\
+    throw CaffeErrorException(std::string(__FILE__) + ":" + SSTR(__LINE__) + " / Check failed (custom): " #condition ""); \
+  LOG_IF(ERROR, false) \
+  << "Check failed (custom): " #condition " "
+
+#define CHECK_OP_LOG(name, op, val1, val2, log) CHECK((val1) op (val2))
+#endif
 
 #include <cmath>
 #include <fstream>  // NOLINT(readability/streams)

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -35,7 +35,6 @@ public:
 #include <iostream>  // NOLINT(readability/streams)
 #include <map>
 #include <set>
-#include <sstream>
 #include <string>
 #include <utility>  // pair
 #include <vector>

--- a/include/caffe/util/math_functions.hpp
+++ b/include/caffe/util/math_functions.hpp
@@ -4,8 +4,6 @@
 #include <stdint.h>
 #include <cmath>  // for std::fabs and std::signbit
 
-#include "glog/logging.h"
-
 #include "caffe/common.hpp"
 #include "caffe/util/device_alternate.hpp"
 #include "caffe/util/mkl_alternate.hpp"

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -1,4 +1,3 @@
-#include <glog/logging.h>
 #include <cstdio>
 #include <ctime>
 


### PR DESCRIPTION
Hi brewers! 

This PR allows to transform all fatal glog's fatal CHECK from Caffe code into exceptions. In general, my understanding is that it is regarded as bad behavior for a library to trigger fatal errors. For my own purpose (code to be released soon), I needed to handle Caffe errors outside of the libcaffe.

This PR has two drawbacks that I know of:
- triggers a lot of warning at compile time since it does redefine a couple of macros from libglog
- the LOG_IF(ERROR,false) part of the code is useless and in-code custom error messages are not passed to the exception.

However, the exception captures the file and line of the error, which in practice allows to trace back the problem to the check without difficulty.

I could not find how to do simpler and better, but in case the problem of fatal errors within libcaffe should be handled differently, please let me know as I might well (re)take the token.