### PR TITLE
Makefile: friendlier messages for link commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,11 +465,11 @@ $(ALL_BUILD_DIRS): | $(BUILD_DIR_LINK)
 	@ mkdir -p $@
 
 $(DYNAMIC_NAME): $(OBJS) | $(LIB_BUILD_DIR)
-	@ echo LD $<
+	@ echo LD -o $@
 	$(Q)$(CXX) -shared -o $@ $(OBJS) $(LINKFLAGS) $(LDFLAGS)
 
 $(STATIC_NAME): $(OBJS) | $(LIB_BUILD_DIR)
-	@ echo AR $<
+	@ echo AR -o $@
 	$(Q)ar rcs $@ $(OBJS)
 
 $(BUILD_DIR)/%.o: %.cpp | $(ALL_BUILD_DIRS)


### PR DESCRIPTION
This is a minor upgrade to #1561. The current pretty messages for linking libcaffe display the first required object file, which is rather obtuse; this commit switches to displaying the output file, which clears up exactly what these commands are doing.