### PR TITLE
Enabled the choice between OpenCV 2.4.x or OpenCV 3.x

### DIFF
--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -43,8 +43,8 @@ if(OpenCV_FOUND)
 add_definitions(-DOPENCV_3)
 message( STATUS "OpenCV: Found (3.x)")
 else()
-#find minimum the 2.4.6 version
-FIND_PACKAGE(OpenCV 2.4.6 COMPONENTS core highgui imgproc REQUIRED)
+#find minimum the 2.3 version
+FIND_PACKAGE(OpenCV 2.3.0 COMPONENTS core highgui imgproc REQUIRED)
 add_definitions( -DOPENCV_2)
 endif(OpenCV_FOUND)
 include_directories(${OpenCV_INCLUDE_DIRS})

--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories(${HDF5_INCLUDE_DIRS})
 
 #    OpenCV
 #OPENCV - Git version (>=3.0 has different namespaces for variables)
-FIND_PACKAGE(OpenCV 3.0.0 EXACT COMPONENTS core highgui imgproc)
+FIND_PACKAGE(OpenCV 3.0.0 EXACT COMPONENTS core highgui imgproc imgcodecs)
 if(OpenCV_FOUND)
 add_definitions(-DOPENCV_3)
 message( STATUS "OpenCV: Found (3.x)")

--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -37,7 +37,16 @@ find_package(HDF5 COMPONENTS HL REQUIRED)
 include_directories(${HDF5_INCLUDE_DIRS})
 
 #    OpenCV
-find_package(OpenCV REQUIRED core highgui imgproc)
+#OPENCV - Git version (>=3.0 has different namespaces for variables)
+FIND_PACKAGE(OpenCV 3.0.0 EXACT COMPONENTS core highgui imgproc)
+if(OpenCV_FOUND)
+add_definitions(-DOPENCV_3)
+message( STATUS "OpenCV: Found (3.x)")
+else()
+#find minimum the 2.4.6 version
+FIND_PACKAGE(OpenCV 2.4.6 COMPONENTS core highgui imgproc REQUIRED)
+add_definitions( -DOPENCV_2)
+endif(OpenCV_FOUND)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 #    LevelDB

--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -227,7 +227,11 @@ void WindowDataLayer<Dtype>::InternalThreadEntry() {
       pair<std::string, vector<int> > image =
           image_database_[window[WindowDataLayer<Dtype>::IMAGE_INDEX]];
 
+      #ifdef OPENCV_3
+      cv::Mat cv_img = cv::imread(image.first, cv::IMREAD_COLOR);
+      #else
       cv::Mat cv_img = cv::imread(image.first, CV_LOAD_IMAGE_COLOR);
+      #endif
       if (!cv_img.data) {
         LOG(ERROR) << "Could not open or find file " << image.first;
         return;

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -69,9 +69,12 @@ void WriteProtoToBinaryFile(const Message& proto, const char* filename) {
 bool ReadImageToDatum(const string& filename, const int label,
     const int height, const int width, const bool is_color, Datum* datum) {
   cv::Mat cv_img;
+  #ifdef OPENCV_3
+  int cv_read_flag = (is_color ? cv::IMREAD_COLOR : cv::IMREAD_GRAYSCALE);
+  #else
   int cv_read_flag = (is_color ? CV_LOAD_IMAGE_COLOR :
     CV_LOAD_IMAGE_GRAYSCALE);
-
+  #endif
   cv::Mat cv_img_origin = cv::imread(filename, cv_read_flag);
   if (!cv_img_origin.data) {
     LOG(ERROR) << "Could not open or find file " << filename;


### PR DESCRIPTION
Selecting OpenCV version during CMake configuration, defining variable OPENCV_3 for newer OpenCV 3.x and OPENCV_2 for older API (2.4.6+).
Added the fix for imread to solve the compiling error