### PR TITLE
Change Python interface for mode, phase, and device

### DIFF
--- a/examples/classification.ipynb
+++ b/examples/classification.ipynb
@@ -3,7 +3,8 @@
   "description": "Use the pre-trained ImageNet model to classify images with the Python interface.",
   "example_name": "ImageNet classification",
   "include_in_docs": true,
-  "priority": 1
+  "priority": 1,
+  "signature": "sha256:2caae2c1fe3e282b8f836d380a45622351c91db18a1591e4f2fa67faba9ab72c"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -54,13 +55,17 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Loading a network is easy. `caffe.Classifier` takes care of everything. Note the arguments for configuring input preprocessing: mean subtraction switched on by giving a mean array, input channel swapping takes care of mapping RGB into the reference ImageNet model's BGR order, and raw scaling multiplies the feature scale from the input [0,1] to the ImageNet model's [0,255]."
+      "Loading a network is easy. `caffe.Classifier` takes care of everything. Note the arguments for configuring input preprocessing: mean subtraction switched on by giving a mean array, input channel swapping takes care of mapping RGB into the reference ImageNet model's BGR order, and raw scaling multiplies the feature scale from the input [0,1] to the ImageNet model's [0,255].\n",
+      "\n",
+      "We will set the phase to test since we are doing testing, and will first use CPU for the computation."
      ]
     },
     {
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "caffe.set_phase_test()\n",
+      "caffe.set_mode_cpu()\n",
       "net = caffe.Classifier(MODEL_FILE, PRETRAINED,\n",
       "                       mean=np.load(caffe_root + 'python/caffe/imagenet/ilsvrc_2012_mean.npy'),\n",
       "                       channel_swap=(2,1,0),\n",
@@ -71,25 +76,6 @@
      "metadata": {},
      "outputs": [],
      "prompt_number": 2
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We will set the phase to test since we are doing testing, and will first use CPU for the computation."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "net.set_phase_test()\n",
-      "net.set_mode_cpu()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
     },
     {
      "cell_type": "markdown",
@@ -111,7 +97,7 @@
       {
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 4,
+       "prompt_number": 3,
        "text": [
         "<matplotlib.image.AxesImage at 0x7fda204c0e10>"
        ]
@@ -125,7 +111,7 @@
        ]
       }
      ],
-     "prompt_number": 4
+     "prompt_number": 3
     },
     {
      "cell_type": "markdown",
@@ -163,7 +149,7 @@
        ]
       }
      ],
-     "prompt_number": 5
+     "prompt_number": 4
     },
     {
      "cell_type": "markdown",
@@ -205,7 +191,7 @@
        ]
       }
      ],
-     "prompt_number": 6
+     "prompt_number": 5
     },
     {
      "cell_type": "markdown",
@@ -233,7 +219,7 @@
        ]
       }
      ],
-     "prompt_number": 7
+     "prompt_number": 6
     },
     {
      "cell_type": "markdown",
@@ -266,7 +252,7 @@
        ]
       }
      ],
-     "prompt_number": 8
+     "prompt_number": 7
     },
     {
      "cell_type": "markdown",
@@ -279,12 +265,12 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "net.set_mode_gpu()"
+      "caffe.set_mode_gpu()"
      ],
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 9
+     "prompt_number": 8
     },
     {
      "cell_type": "markdown",
@@ -314,7 +300,7 @@
       {
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 10,
+       "prompt_number": 9,
        "text": [
         "[<matplotlib.lines.Line2D at 0x7fda1ac309d0>]"
        ]
@@ -328,7 +314,7 @@
        ]
       }
      ],
-     "prompt_number": 10
+     "prompt_number": 9
     },
     {
      "cell_type": "markdown",
@@ -355,7 +341,7 @@
        ]
       }
      ],
-     "prompt_number": 11
+     "prompt_number": 10
     },
     {
      "cell_type": "code",
@@ -375,7 +361,7 @@
        ]
       }
      ],
-     "prompt_number": 12
+     "prompt_number": 11
     },
     {
      "cell_type": "markdown",

--- a/examples/filter_visualization.ipynb
+++ b/examples/filter_visualization.ipynb
@@ -3,7 +3,8 @@
   "description": "Extracting features and visualizing trained filters with an example image, viewed layer-by-layer.",
   "example_name": "Filter visualization",
   "include_in_docs": true,
-  "priority": 2
+  "priority": 2,
+  "signature": "sha256:526501b358e0f60c489eaf5799e8603a75019cc65401533baa307b5603fdefa1"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -61,10 +62,10 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
+      "caffe.set_phase_test()\n",
+      "caffe.set_mode_cpu()\n",
       "net = caffe.Classifier(caffe_root + 'models/bvlc_reference_caffenet/deploy.prototxt',\n",
       "                       caffe_root + 'models/bvlc_reference_caffenet/bvlc_reference_caffenet.caffemodel')\n",
-      "net.set_phase_test()\n",
-      "net.set_mode_cpu()\n",
       "# input preprocessing: 'data' is the name of the input blob == net.inputs[0]\n",
       "net.set_mean('data', np.load(caffe_root + 'python/caffe/imagenet/ilsvrc_2012_mean.npy'))  # ImageNet mean\n",
       "net.set_raw_scale('data', 255)  # the reference model operates on images in [0,255] range instead of [0,1]\n",

--- a/examples/net_surgery.ipynb
+++ b/examples/net_surgery.ipynb
@@ -4,7 +4,7 @@
   "example_name": "Editing model parameters",
   "include_in_docs": true,
   "priority": 5,
-  "signature": "sha256:179fb20339497f5e64f6fbeb57987f27a962b7ae6d940c8fede2631aba9bffaf"
+  "signature": "sha256:bf84bcbd78fe007310f86d71c5969ba4205b6e06f408029860eec94821844bee"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -279,9 +279,10 @@
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",
+      "caffe.set_phase_test()\n",
+      "\n",
       "# load input and configure preprocessing\n",
       "im = caffe.io.load_image('images/cat.jpg')\n",
-      "net_full_conv.set_phase_test()\n",
       "net_full_conv.set_mean('data', np.load('../python/caffe/imagenet/ilsvrc_2012_mean.npy'))\n",
       "net_full_conv.set_channel_swap('data', (2,1,0))\n",
       "net_full_conv.set_raw_scale('data', 255.0)\n",

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,4 +1,6 @@
 from .pycaffe import Net, SGDSolver
+from .pycaffe import set_mode_cpu, set_mode_gpu, set_phase_train, set_phase_test
+from .pycaffe import set_device
 from .classifier import Classifier
 from .detector import Detector
 import io

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -142,6 +142,13 @@ void PySGDSolver::SolveResume(const string& resume_file) {
 }
 
 BOOST_PYTHON_MODULE(_caffe) {
+  // Caffe utility methods
+  bp::def("set_mode_cpu",          &set_mode_cpu);
+  bp::def("set_mode_gpu",          &set_mode_gpu);
+  bp::def("set_phase_train",       &set_phase_train);
+  bp::def("set_phase_test",        &set_phase_test);
+  bp::def("set_device",            &Caffe::SetDevice);
+
   // below, we prepend an underscore to methods that will be replaced
   // in Python
   bp::class_<PyNet, shared_ptr<PyNet> >(
@@ -150,11 +157,6 @@ BOOST_PYTHON_MODULE(_caffe) {
       .def("_forward",              &PyNet::Forward)
       .def("_backward",             &PyNet::Backward)
       .def("reshape",               &PyNet::Reshape)
-      .def("set_mode_cpu",          &PyNet::set_mode_cpu)
-      .def("set_mode_gpu",          &PyNet::set_mode_gpu)
-      .def("set_phase_train",       &PyNet::set_phase_train)
-      .def("set_phase_test",        &PyNet::set_phase_test)
-      .def("set_device",            &PyNet::set_device)
       .add_property("_blobs",       &PyNet::blobs)
       .add_property("layers",       &PyNet::layers)
       .add_property("_blob_names",  &PyNet::blob_names)

--- a/python/caffe/_caffe.hpp
+++ b/python/caffe/_caffe.hpp
@@ -18,6 +18,12 @@ using boost::shared_ptr;
 
 namespace caffe {
 
+// Selecting mode and phase.
+void set_mode_cpu() { Caffe::set_mode(Caffe::CPU); }
+void set_mode_gpu() { Caffe::set_mode(Caffe::GPU); }
+void set_phase_train() { Caffe::set_phase(Caffe::TRAIN); }
+void set_phase_test() { Caffe::set_phase(Caffe::TEST); }
+
 // wrap shared_ptr<Blob> in a class that we construct in C++ and pass
 // to Python
 template <typename Dtype>
@@ -108,13 +114,6 @@ class PyNet {
     net_->ToProto(&net_param, false);
     WriteProtoToBinaryFile(net_param, filename.c_str());
   }
-
-  // The caffe::Caffe utility functions.
-  void set_mode_cpu() { Caffe::set_mode(Caffe::CPU); }
-  void set_mode_gpu() { Caffe::set_mode(Caffe::GPU); }
-  void set_phase_train() { Caffe::set_phase(Caffe::TRAIN); }
-  void set_phase_test() { Caffe::set_phase(Caffe::TEST); }
-  void set_device(int device_id) { Caffe::SetDevice(device_id); }
 
   vector<PyBlob<float> > blobs() {
     return vector<PyBlob<float> >(net_->blobs().begin(), net_->blobs().end());

--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -24,12 +24,12 @@ class Classifier(caffe.Net):
             preprocessing options.
         """
         caffe.Net.__init__(self, model_file, pretrained_file)
-        self.set_phase_test()
+        caffe.set_phase_test()
 
         if gpu:
-            self.set_mode_gpu()
+            caffe.set_mode_gpu()
         else:
-            self.set_mode_cpu()
+            caffe.set_mode_cpu()
 
         if mean is not None:
             self.set_mean(self.inputs[0], mean)

--- a/python/caffe/detector.py
+++ b/python/caffe/detector.py
@@ -36,12 +36,12 @@ class Detector(caffe.Net):
             R-CNN feature extraction.
         """
         caffe.Net.__init__(self, model_file, pretrained_file)
-        self.set_phase_test()
+        caffe.set_phase_test()
 
         if gpu:
-            self.set_mode_gpu()
+            caffe.set_mode_gpu()
         else:
-            self.set_mode_cpu()
+            caffe.set_mode_cpu()
 
         if mean is not None:
             self.set_mean(self.inputs[0], mean)

--- a/python/caffe/pycaffe.py
+++ b/python/caffe/pycaffe.py
@@ -8,6 +8,8 @@ from itertools import izip_longest
 import numpy as np
 
 from ._caffe import Net, SGDSolver
+from ._caffe import set_mode_cpu, set_mode_gpu, set_phase_train, set_phase_test
+from ._caffe import set_device
 import caffe.io
 
 # We directly update methods from Net here (rather than using composition or


### PR DESCRIPTION
Attach mode, phase, and device setters to caffe module itself so that these can be set before making nets. This is needed to properly initialize layers with the right device and phase configuration.

Fix #1700.

**This breaks existing pycaffe code that makes `Net.set_{mode,phase,device}` calls.**

@longjon 