### PR TITLE
Enhance debug info

### DIFF
--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -106,6 +106,10 @@ class Blob {
   Dtype asum_data() const;
   /// @brief Compute the sum of absolute values (L1 norm) of the diff.
   Dtype asum_diff() const;
+  /// @brief Compute the sum of squares (L2 norm squared) of the data.
+  Dtype sumsq_data() const;
+  /// @brief Compute the sum of squares (L2 norm squared) of the diff.
+  Dtype sumsq_diff() const;
 
   /**
    * @brief Set the data_ shared_ptr to point to the SyncedMemory holding the

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -194,6 +194,8 @@ class Net {
   void AppendParam(const NetParameter& param, const int layer_id,
                    const int param_id);
 
+  /// @brief Helper for displaying debug info in Forward about input Blobs.
+  void InputDebugInfo(const int layer_id);
   /// @brief Helper for displaying debug info in Forward.
   void ForwardDebugInfo(const int layer_id);
   /// @brief Helper for displaying debug info in Backward.
@@ -226,6 +228,7 @@ class Net {
   /// Vector of weight in the loss (or objective) function of each net blob,
   /// indexed by blob_id.
   vector<Dtype> blob_loss_weights_;
+  vector<vector<int> > param_id_vecs_;
   vector<int> param_owners_;
   vector<string> param_display_names_;
   vector<pair<int, int> > param_layer_indices_;

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -205,6 +205,80 @@ Dtype Blob<Dtype>::asum_diff() const {
   return 0;
 }
 
+template <> unsigned int Blob<unsigned int>::sumsq_data() const {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template <> int Blob<int>::sumsq_data() const {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template <typename Dtype>
+Dtype Blob<Dtype>::sumsq_data() const {
+  Dtype sumsq;
+  const Dtype* data;
+  if (!data_) { return 0; }
+  switch (data_->head()) {
+  case SyncedMemory::HEAD_AT_CPU:
+    data = cpu_data();
+    sumsq = caffe_cpu_dot(count_, data, data);
+    break;
+  case SyncedMemory::HEAD_AT_GPU:
+  case SyncedMemory::SYNCED:
+#ifndef CPU_ONLY
+    data = gpu_data();
+    caffe_gpu_dot(count_, data, data, &sumsq);
+#else
+    NO_GPU;
+#endif
+    break;
+  case SyncedMemory::UNINITIALIZED:
+    return 0;
+  default:
+    LOG(FATAL) << "Unknown SyncedMemory head state: " << data_->head();
+  }
+  return sumsq;
+}
+
+template <> unsigned int Blob<unsigned int>::sumsq_diff() const {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template <> int Blob<int>::sumsq_diff() const {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template <typename Dtype>
+Dtype Blob<Dtype>::sumsq_diff() const {
+  Dtype sumsq;
+  const Dtype* diff;
+  if (!diff_) { return 0; }
+  switch (diff_->head()) {
+  case SyncedMemory::HEAD_AT_CPU:
+    diff = cpu_diff();
+    sumsq = caffe_cpu_dot(count_, diff, diff);
+    break;
+  case SyncedMemory::HEAD_AT_GPU:
+  case SyncedMemory::SYNCED:
+#ifndef CPU_ONLY
+    diff = gpu_diff();
+    caffe_gpu_dot(count_, diff, diff, &sumsq);
+    break;
+#else
+    NO_GPU;
+#endif
+  case SyncedMemory::UNINITIALIZED:
+    return 0;
+  default:
+    LOG(FATAL) << "Unknown SyncedMemory head state: " << data_->head();
+  }
+  return sumsq;
+}
+
 template <typename Dtype>
 void Blob<Dtype>::CopyFrom(const Blob& source, bool copy_diff, bool reshape) {
   if (num_ != source.num() || channels_ != source.channels() ||

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -218,10 +218,9 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
     layer_names_index_[layer_names_[layer_id]] = layer_id;
   }
   GetLearningRateAndWeightDecay();
+  debug_info_ = param.debug_info();
   LOG(INFO) << "Network initialization done.";
   LOG(INFO) << "Memory required for data: " << memory_used_ * sizeof(Dtype);
-  // Don't display debug info by default.
-  debug_info_ = false;
 }
 
 template <typename Dtype>

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -705,6 +705,21 @@ void Net<Dtype>::BackwardTo(int end) {
 template <typename Dtype>
 void Net<Dtype>::Backward() {
   BackwardFromTo(layers_.size() - 1, 0);
+  if (debug_info_) {
+    Dtype asum_data = 0, asum_diff = 0, sumsq_data = 0, sumsq_diff = 0;
+    for (int i = 0; i < params_.size(); ++i) {
+      if (param_owners_[i] >= 0) { continue; }
+      asum_data += params_[i]->asum_data();
+      asum_diff += params_[i]->asum_diff();
+      sumsq_data += params_[i]->sumsq_data();
+      sumsq_diff += params_[i]->sumsq_diff();
+    }
+    const Dtype l2norm_data = std::sqrt(sumsq_data);
+    const Dtype l2norm_diff = std::sqrt(sumsq_diff);
+    LOG(ERROR) << "    [Backward] All net params (data, diff): "
+        << "L1 norm = (" << asum_data << ", " << asum_diff << "); "
+        << "L2 norm = (" << l2norm_data << ", " << l2norm_diff << ")";
+  }
 }
 
 template <typename Dtype>

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -60,6 +60,10 @@ message NetParameter {
   // Some layers may be included/excluded depending on this state and the states
   // specified in the layers' include and exclude fields.
   optional NetState state = 6;
+
+  // Print debugging information about results while running Net::Forward,
+  // Net::Backward, and Net::Update.
+  optional bool debug_info = 7 [default = false];
 }
 
 // NOTE

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -154,6 +154,7 @@ void Solver<Dtype>::InitTestNets() {
     LOG(INFO)
         << "Creating test net (#" << i << ") specified by " << sources[i];
     test_nets_[i].reset(new Net<Dtype>(net_params[i]));
+    test_nets_[i]->set_debug_info(param_.debug_info());
   }
 }
 

--- a/src/caffe/test/test_blob.cpp
+++ b/src/caffe/test/test_blob.cpp
@@ -54,4 +54,117 @@ TYPED_TEST(BlobSimpleTest, TestReshape) {
   EXPECT_EQ(this->blob_->count(), 120);
 }
 
+template <typename TypeParam>
+class BlobMathTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+ protected:
+  BlobMathTest()
+      : blob_(new Blob<Dtype>(2, 3, 4, 5)) {}
+  virtual ~BlobMathTest() { delete blob_; }
+  Blob<Dtype>* const blob_;
+};
+
+TYPED_TEST_CASE(BlobMathTest, TestDtypesAndDevices);
+
+TYPED_TEST(BlobMathTest, TestSumOfSquares) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Blob should have sum of squares == 0.
+  EXPECT_EQ(0, this->blob_->sumsq_data());
+  EXPECT_EQ(0, this->blob_->sumsq_diff());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(this->blob_);
+  Dtype expected_sumsq = 0;
+  const Dtype* data = this->blob_->cpu_data();
+  for (int i = 0; i < this->blob_->count(); ++i) {
+    expected_sumsq += data[i] * data[i];
+  }
+  // Do a mutable access on the current device,
+  // so that the sumsq computation is done on that device.
+  // (Otherwise, this would only check the CPU sumsq implementation.)
+  switch (TypeParam::device) {
+  case Caffe::CPU:
+    this->blob_->mutable_cpu_data();
+    break;
+  case Caffe::GPU:
+    this->blob_->mutable_gpu_data();
+    break;
+  default:
+    LOG(FATAL) << "Unknown device: " << TypeParam::device;
+  }
+  EXPECT_FLOAT_EQ(expected_sumsq, this->blob_->sumsq_data());
+  EXPECT_EQ(0, this->blob_->sumsq_diff());
+
+  // Check sumsq_diff too.
+  const Dtype kDiffScaleFactor = 7;
+  caffe_cpu_scale(this->blob_->count(), kDiffScaleFactor, data,
+                  this->blob_->mutable_cpu_diff());
+  switch (TypeParam::device) {
+  case Caffe::CPU:
+    this->blob_->mutable_cpu_diff();
+    break;
+  case Caffe::GPU:
+    this->blob_->mutable_gpu_diff();
+    break;
+  default:
+    LOG(FATAL) << "Unknown device: " << TypeParam::device;
+  }
+  EXPECT_FLOAT_EQ(expected_sumsq, this->blob_->sumsq_data());
+  EXPECT_FLOAT_EQ(expected_sumsq * kDiffScaleFactor * kDiffScaleFactor,
+                  this->blob_->sumsq_diff());
+}
+
+TYPED_TEST(BlobMathTest, TestAsum) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Blob should have sum of squares == 0.
+  EXPECT_EQ(0, this->blob_->asum_data());
+  EXPECT_EQ(0, this->blob_->asum_diff());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(this->blob_);
+  Dtype expected_asum = 0;
+  const Dtype* data = this->blob_->cpu_data();
+  for (int i = 0; i < this->blob_->count(); ++i) {
+    expected_asum += std::fabs(data[i]);
+  }
+  // Do a mutable access on the current device,
+  // so that the asum computation is done on that device.
+  // (Otherwise, this would only check the CPU asum implementation.)
+  switch (TypeParam::device) {
+  case Caffe::CPU:
+    this->blob_->mutable_cpu_data();
+    break;
+  case Caffe::GPU:
+    this->blob_->mutable_gpu_data();
+    break;
+  default:
+    LOG(FATAL) << "Unknown device: " << TypeParam::device;
+  }
+  EXPECT_FLOAT_EQ(expected_asum, this->blob_->asum_data());
+  EXPECT_EQ(0, this->blob_->asum_diff());
+
+  // Check asum_diff too.
+  const Dtype kDiffScaleFactor = 7;
+  caffe_cpu_scale(this->blob_->count(), kDiffScaleFactor, data,
+                  this->blob_->mutable_cpu_diff());
+  switch (TypeParam::device) {
+  case Caffe::CPU:
+    this->blob_->mutable_cpu_diff();
+    break;
+  case Caffe::GPU:
+    this->blob_->mutable_gpu_diff();
+    break;
+  default:
+    LOG(FATAL) << "Unknown device: " << TypeParam::device;
+  }
+  EXPECT_FLOAT_EQ(expected_asum, this->blob_->asum_data());
+  EXPECT_FLOAT_EQ(expected_asum * kDiffScaleFactor, this->blob_->asum_diff());
+}
+
 }  // namespace caffe


### PR DESCRIPTION
- a882248 adds debug info about inputs and parameters in forward, and for test nets
- 9f94917 adds `sumsq_{data,diff}` methods to `Blob` compute a sum of squares of all data
- 2fcab20 uses the `sumsq_*` methods to compute net-wide parameter stats (L1 and L2 norm)
- 4280ac8 adds `debug_info` to `NetParameter` so it can be enabled outside of training