### PR TITLE
Max out the protobuf file read size limit

### DIFF
--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -17,6 +17,8 @@
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/io.hpp"
 
+const int kProtoReadBytesLimit = INT_MAX;  // Max size of 2 GB minus 1 byte.
+
 namespace caffe {
 
 using google::protobuf::io::FileInputStream;
@@ -50,7 +52,7 @@ bool ReadProtoFromBinaryFile(const char* filename, Message* proto) {
   CHECK_NE(fd, -1) << "File not found: " << filename;
   ZeroCopyInputStream* raw_input = new FileInputStream(fd);
   CodedInputStream* coded_input = new CodedInputStream(raw_input);
-  coded_input->SetTotalBytesLimit(1073741824, 536870912);
+  coded_input->SetTotalBytesLimit(kProtoReadBytesLimit, 536870912);
 
   bool success = proto->ParseFromCodedStream(coded_input);
 


### PR DESCRIPTION
This sets the max possible size of protobuf reads to 2 GB minus 1 byte (= 2^31 - 1), the largest `int` value.  (If we want to start supporting nets with total param size >= 2 GB this we'll have to come up with a new solution.  For example, we could store each parameter in a separate binary proto file, or switch to HDF5 for parameter serialization.)