### PR TITLE
Refactored solvers with fluent pattern

### DIFF
--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -90,6 +90,9 @@ class SGDSolver : public Solver<Dtype> {
   //   of gradients/updates and is not needed in snapshots
   vector<shared_ptr<Blob<Dtype> > > history_, update_, temp_;
 
+  template <typename BlobAccessor, typename Fluent>
+  void Compute();
+
   DISABLE_COPY_AND_ASSIGN(SGDSolver);
 };
 
@@ -103,6 +106,9 @@ class NesterovSolver : public SGDSolver<Dtype> {
 
  protected:
   virtual void ComputeUpdateValue();
+
+  template <typename BlobAccessor, typename Fluent>
+  void Compute();
 
   DISABLE_COPY_AND_ASSIGN(NesterovSolver);
 };
@@ -121,6 +127,9 @@ class AdaGradSolver : public SGDSolver<Dtype> {
     CHECK_EQ(0, this->param_.momentum())
         << "Momentum cannot be used with AdaGrad.";
   }
+
+  template <typename BlobAccessor, typename Fluent>
+  void Compute();
 
   DISABLE_COPY_AND_ASSIGN(AdaGradSolver);
 };

--- a/include/caffe/util/fluent.hpp
+++ b/include/caffe/util/fluent.hpp
@@ -1,0 +1,236 @@
+#ifndef CAFFE_UTIL_FLUENT_H // CAFFE_UTIL_FLUENT_H
+#define CAFFE_UTIL_FLUENT_H
+
+#include "caffe/net.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+namespace cpu {
+
+template <typename Dtype>
+struct BlobAccessor
+{
+  Blob<Dtype>* blob;
+  bool diff;
+  BlobAccessor(shared_ptr<Blob<Dtype> >& blob, bool diff = false)
+  :blob(blob.get()), diff(diff)
+  {}
+
+  Dtype* write() { return diff ? blob->mutable_cpu_diff() : blob->mutable_cpu_data(); }
+  const Dtype* read() const { return diff ? blob->cpu_diff() : blob->cpu_data(); }
+};
+
+template <typename Dtype>
+struct Fluent
+{
+  typedef BlobAccessor<Dtype> Accessor;
+
+  int N;
+  Fluent(int N)
+  : N(N) 
+  {}
+
+  inline Fluent& axpy(Dtype a, const Accessor& x, Accessor& y)
+  {
+    caffe_axpy(N,a,x.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& axpby(Dtype a, const Accessor& x, Dtype b, Accessor& y)
+  {
+    caffe_cpu_axpby(N,a,x.read(),b,y.write());
+    return *this;
+  }
+
+  inline Fluent& sign(const Accessor& x, Accessor& y)
+  {
+    caffe_cpu_sign(N,x.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& powx(const Accessor& x, Dtype pow, Accessor& y)
+  {
+    caffe_powx(N,x.read(),pow,y.write());
+    return *this;
+  }
+
+  inline Fluent& mul(const Accessor& a, const Accessor& b, Accessor& y)
+  {
+    caffe_mul(N,a.read(),b.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& div(const Accessor& a, const Accessor& b, Accessor& y)
+  {
+    caffe_div(N,a.read(),b.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& clamp(Dtype a, Dtype b, Accessor& y)
+  {
+    caffe_clamp(N,a,b,y.write());
+    return *this;
+  }
+
+  inline Fluent& add(const Accessor& a, const Accessor& b, Accessor& y)
+  {
+    caffe_add(N,a.read(),b.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& add_scalar(Dtype a, Accessor& y)
+  {
+    caffe_add_scalar(N,a,y.write());
+    return *this;
+  }
+
+  inline Fluent& copy(const Accessor& a, Accessor& y)
+  {
+    caffe_copy(N,a.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& sqrt(const Accessor& a, Accessor& y)
+  {
+    caffe_sqrt(N,a.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& sqr(const Accessor& a, Accessor& y)
+  {
+    caffe_sqr(N,a.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& set(Dtype a, Accessor& y)
+  {
+    caffe_set(N, a, y.write()); 
+    return *this;
+  }
+
+  inline Fluent& scal(Dtype a, Accessor& y)
+  {
+    caffe_scal(N, a, y.write()); 
+    return *this;
+  }  
+};
+
+}  // namespace cpu
+
+namespace gpu {
+
+template <typename Dtype>
+struct BlobAccessor
+{
+  Blob<Dtype>* blob;
+  bool diff;
+  BlobAccessor(shared_ptr<Blob<Dtype> >& blob, bool diff = false)
+  :blob(blob.get()), diff(diff)
+  {}
+
+  Dtype* write() { return diff ? blob->mutable_gpu_diff() : blob->mutable_gpu_data(); }
+  const Dtype* read() const { return diff ? blob->gpu_diff() : blob->gpu_data(); }
+};
+
+template <typename Dtype>
+struct Fluent
+{
+  typedef BlobAccessor<Dtype> Accessor;
+
+  int N;
+  Fluent(int N)
+  : N(N) 
+  {}
+
+  inline Fluent& axpy(Dtype a, const Accessor& x, Accessor& y)
+  {
+    caffe_gpu_axpy(N,a,x.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& axpby(Dtype a, const Accessor& x, Dtype b, Accessor& y)
+  {
+    caffe_gpu_axpby(N,a,x.read(),b,y.write());
+    return *this;
+  }
+
+  inline Fluent& sign(const Accessor& x, Accessor& y)
+  {
+    caffe_gpu_sign(N,x.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& powx(const Accessor& x, Dtype pow, Accessor& y)
+  {
+    caffe_gpu_powx(N,x.read(),pow,y.write());
+    return *this;
+  }
+
+  inline Fluent& mul(const Accessor& a, const Accessor& b, Accessor& y)
+  {
+    caffe_gpu_mul(N,a.read(),b.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& div(const Accessor& a, const Accessor& b, Accessor& y)
+  {
+    caffe_gpu_div(N,a.read(),b.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& clamp(Dtype a, Dtype b, Accessor& y)
+  {
+    caffe_gpu_clamp(N,a,b,y.write());
+    return *this;
+  }
+
+  inline Fluent& add(const Accessor& a, const Accessor& b, Accessor& y)
+  {
+    caffe_gpu_add(N,a.read(),b.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& add_scalar(Dtype a, Accessor& y)
+  {
+    caffe_gpu_add_scalar(N,a,y.write());
+    return *this;
+  }
+
+  inline Fluent& copy(const Accessor& a, Accessor& y)
+  {
+    caffe_copy(N,a.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& sqrt(const Accessor& a, Accessor& y)
+  {
+    caffe_gpu_sqrt(N,a.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& sqr(const Accessor& a, Accessor& y)
+  {
+    caffe_gpu_mul(N,a.read(),a.read(),y.write());
+    return *this;
+  }
+
+  inline Fluent& set(Dtype a, Accessor& y)
+  {
+    caffe_gpu_set(N, a, y.write()); 
+    return *this;
+  }
+
+  inline Fluent& scal(Dtype a, Accessor& y)
+  {
+    caffe_gpu_scal(N, a, y.write()); 
+    return *this;
+  }  
+};
+
+}  // namespace gpu
+
+}  // namespace caffe
+
+#endif  // CAFFE_UTIL_FLUENT_H

--- a/include/caffe/util/fluent.hpp
+++ b/include/caffe/util/fluent.hpp
@@ -1,4 +1,4 @@
-#ifndef CAFFE_UTIL_FLUENT_H // CAFFE_UTIL_FLUENT_H
+#ifndef CAFFE_UTIL_FLUENT_H  // CAFFE_UTIL_FLUENT_H
 #define CAFFE_UTIL_FLUENT_H
 
 #include "caffe/net.hpp"
@@ -10,111 +10,99 @@ namespace caffe {
 namespace cpu {
 
 template <typename Dtype>
-struct BlobAccessor
-{
+struct BlobAccessor {
   Blob<Dtype>* blob;
   bool diff;
   BlobAccessor(shared_ptr<Blob<Dtype> >& blob, bool diff = false)
-  :blob(blob.get()), diff(diff)
-  {}
+  :blob(blob.get()), diff(diff) {}
 
-  Dtype* write() { return diff ? blob->mutable_cpu_diff() : blob->mutable_cpu_data(); }
-  const Dtype* read() const { return diff ? blob->cpu_diff() : blob->cpu_data(); }
+  Dtype* write() {
+    return diff ? blob->mutable_cpu_diff() : blob->mutable_cpu_data();
+  }
+
+  const Dtype* read() const {
+    return diff ? blob->cpu_diff() : blob->cpu_data();
+  }
 };
 
 template <typename Dtype>
-struct Fluent
-{
+struct Fluent {
   typedef BlobAccessor<Dtype> Accessor;
 
   int N;
-  Fluent(int N)
-  : N(N) 
-  {}
+  explicit Fluent(int N)
+  : N(N) {}
 
-  inline Fluent& axpy(Dtype a, const Accessor& x, Accessor& y)
-  {
-    caffe_axpy(N,a,x.read(),y.write());
+  inline Fluent& axpy(Dtype a, const Accessor& x, Accessor& y) {
+    caffe_axpy(N, a, x.read(), y.write());
     return *this;
   }
 
-  inline Fluent& axpby(Dtype a, const Accessor& x, Dtype b, Accessor& y)
-  {
-    caffe_cpu_axpby(N,a,x.read(),b,y.write());
+  inline Fluent& axpby(Dtype a, const Accessor& x, Dtype b, Accessor& y) {
+    caffe_cpu_axpby(N, a, x.read(), b, y.write());
     return *this;
   }
 
-  inline Fluent& sign(const Accessor& x, Accessor& y)
-  {
-    caffe_cpu_sign(N,x.read(),y.write());
+  inline Fluent& sign(const Accessor& x, Accessor& y) {
+    caffe_cpu_sign(N, x.read(), y.write());
     return *this;
   }
 
-  inline Fluent& powx(const Accessor& x, Dtype pow, Accessor& y)
-  {
-    caffe_powx(N,x.read(),pow,y.write());
+  inline Fluent& powx(const Accessor& x, Dtype pow, Accessor& y) {
+    caffe_powx(N, x.read(), pow, y.write());
     return *this;
   }
 
-  inline Fluent& mul(const Accessor& a, const Accessor& b, Accessor& y)
-  {
-    caffe_mul(N,a.read(),b.read(),y.write());
+  inline Fluent& mul(const Accessor& a, const Accessor& b, Accessor& y) {
+    caffe_mul(N, a.read(), b.read(), y.write());
     return *this;
   }
 
-  inline Fluent& div(const Accessor& a, const Accessor& b, Accessor& y)
-  {
-    caffe_div(N,a.read(),b.read(),y.write());
+  inline Fluent& div(const Accessor& a, const Accessor& b, Accessor& y) {
+    caffe_div(N, a.read(), b.read(), y.write());
     return *this;
   }
 
-  inline Fluent& clamp(Dtype a, Dtype b, Accessor& y)
-  {
-    caffe_clamp(N,a,b,y.write());
+  inline Fluent& clamp(Dtype a, Dtype b, Accessor& y) {
+    caffe_clamp(N, a, b, y.write());
     return *this;
   }
 
-  inline Fluent& add(const Accessor& a, const Accessor& b, Accessor& y)
-  {
-    caffe_add(N,a.read(),b.read(),y.write());
+  inline Fluent& add(const Accessor& a, const Accessor& b, Accessor& y) {
+    caffe_add(N, a.read(), b.read(), y.write());
     return *this;
   }
 
-  inline Fluent& add_scalar(Dtype a, Accessor& y)
-  {
-    caffe_add_scalar(N,a,y.write());
+  inline Fluent& add_scalar(Dtype a, Accessor& y) {
+    caffe_add_scalar(N, a, y.write());
     return *this;
   }
 
-  inline Fluent& copy(const Accessor& a, Accessor& y)
-  {
-    caffe_copy(N,a.read(),y.write());
+  // NOLINT_NEXT_LINE(build/include_what_you_use)
+  inline Fluent& copy(const Accessor& a, Accessor& y) {
+    caffe_copy(N, a.read(), y.write());
     return *this;
   }
 
-  inline Fluent& sqrt(const Accessor& a, Accessor& y)
-  {
-    caffe_sqrt(N,a.read(),y.write());
+  inline Fluent& sqrt(const Accessor& a, Accessor& y) {
+    caffe_sqrt(N, a.read(), y.write());
     return *this;
   }
 
-  inline Fluent& sqr(const Accessor& a, Accessor& y)
-  {
-    caffe_sqr(N,a.read(),y.write());
+  inline Fluent& sqr(const Accessor& a, Accessor& y) {
+    caffe_sqr(N, a.read(), y.write());
     return *this;
   }
 
-  inline Fluent& set(Dtype a, Accessor& y)
-  {
-    caffe_set(N, a, y.write()); 
+  inline Fluent& set(Dtype a, Accessor& y) {
+    caffe_set(N, a, y.write());
     return *this;
   }
 
-  inline Fluent& scal(Dtype a, Accessor& y)
-  {
-    caffe_scal(N, a, y.write()); 
+  inline Fluent& scal(Dtype a, Accessor& y) {
+    caffe_scal(N, a, y.write());
     return *this;
-  }  
+  }
 };
 
 }  // namespace cpu
@@ -122,111 +110,99 @@ struct Fluent
 namespace gpu {
 
 template <typename Dtype>
-struct BlobAccessor
-{
+struct BlobAccessor {
   Blob<Dtype>* blob;
   bool diff;
   BlobAccessor(shared_ptr<Blob<Dtype> >& blob, bool diff = false)
-  :blob(blob.get()), diff(diff)
-  {}
+  :blob(blob.get()), diff(diff) {}
 
-  Dtype* write() { return diff ? blob->mutable_gpu_diff() : blob->mutable_gpu_data(); }
-  const Dtype* read() const { return diff ? blob->gpu_diff() : blob->gpu_data(); }
+  Dtype* write() {
+    return diff ? blob->mutable_gpu_diff() : blob->mutable_gpu_data();
+  }
+
+  const Dtype* read() const {
+    return diff ? blob->gpu_diff() : blob->gpu_data();
+  }
 };
 
 template <typename Dtype>
-struct Fluent
-{
+struct Fluent {
   typedef BlobAccessor<Dtype> Accessor;
 
   int N;
-  Fluent(int N)
-  : N(N) 
-  {}
+  explicit Fluent(int N)
+  : N(N) {}
 
-  inline Fluent& axpy(Dtype a, const Accessor& x, Accessor& y)
-  {
-    caffe_gpu_axpy(N,a,x.read(),y.write());
+  inline Fluent& axpy(Dtype a, const Accessor& x, Accessor& y) {
+    caffe_gpu_axpy(N, a, x.read(), y.write());
     return *this;
   }
 
-  inline Fluent& axpby(Dtype a, const Accessor& x, Dtype b, Accessor& y)
-  {
-    caffe_gpu_axpby(N,a,x.read(),b,y.write());
+  inline Fluent& axpby(Dtype a, const Accessor& x, Dtype b, Accessor& y) {
+    caffe_gpu_axpby(N, a, x.read(), b, y.write());
     return *this;
   }
 
-  inline Fluent& sign(const Accessor& x, Accessor& y)
-  {
-    caffe_gpu_sign(N,x.read(),y.write());
+  inline Fluent& sign(const Accessor& x, Accessor& y) {
+    caffe_gpu_sign(N, x.read(), y.write());
     return *this;
   }
 
-  inline Fluent& powx(const Accessor& x, Dtype pow, Accessor& y)
-  {
-    caffe_gpu_powx(N,x.read(),pow,y.write());
+  inline Fluent& powx(const Accessor& x, Dtype pow, Accessor& y) {
+    caffe_gpu_powx(N, x.read(), pow, y.write());
     return *this;
   }
 
-  inline Fluent& mul(const Accessor& a, const Accessor& b, Accessor& y)
-  {
-    caffe_gpu_mul(N,a.read(),b.read(),y.write());
+  inline Fluent& mul(const Accessor& a, const Accessor& b, Accessor& y) {
+    caffe_gpu_mul(N, a.read(), b.read(), y.write());
     return *this;
   }
 
-  inline Fluent& div(const Accessor& a, const Accessor& b, Accessor& y)
-  {
-    caffe_gpu_div(N,a.read(),b.read(),y.write());
+  inline Fluent& div(const Accessor& a, const Accessor& b, Accessor& y) {
+    caffe_gpu_div(N, a.read(), b.read(), y.write());
     return *this;
   }
 
-  inline Fluent& clamp(Dtype a, Dtype b, Accessor& y)
-  {
-    caffe_gpu_clamp(N,a,b,y.write());
+  inline Fluent& clamp(Dtype a, Dtype b, Accessor& y) {
+    caffe_gpu_clamp(N, a, b, y.write());
     return *this;
   }
 
-  inline Fluent& add(const Accessor& a, const Accessor& b, Accessor& y)
-  {
-    caffe_gpu_add(N,a.read(),b.read(),y.write());
+  inline Fluent& add(const Accessor& a, const Accessor& b, Accessor& y) {
+    caffe_gpu_add(N, a.read(), b.read(), y.write());
     return *this;
   }
 
-  inline Fluent& add_scalar(Dtype a, Accessor& y)
-  {
-    caffe_gpu_add_scalar(N,a,y.write());
+  inline Fluent& add_scalar(Dtype a, Accessor& y) {
+    caffe_gpu_add_scalar(N, a, y.write());
     return *this;
   }
 
-  inline Fluent& copy(const Accessor& a, Accessor& y)
-  {
-    caffe_copy(N,a.read(),y.write());
+  // NOLINT_NEXT_LINE(build/include_what_you_use
+  inline Fluent& copy(const Accessor& a, Accessor& y) {
+    caffe_copy(N, a.read(), y.write());
     return *this;
   }
 
-  inline Fluent& sqrt(const Accessor& a, Accessor& y)
-  {
-    caffe_gpu_sqrt(N,a.read(),y.write());
+  inline Fluent& sqrt(const Accessor& a, Accessor& y) {
+    caffe_gpu_sqrt(N, a.read(), y.write());
     return *this;
   }
 
-  inline Fluent& sqr(const Accessor& a, Accessor& y)
-  {
-    caffe_gpu_mul(N,a.read(),a.read(),y.write());
+  inline Fluent& sqr(const Accessor& a, Accessor& y) {
+    caffe_gpu_mul(N, a.read(), a.read(), y.write());
     return *this;
   }
 
-  inline Fluent& set(Dtype a, Accessor& y)
-  {
-    caffe_gpu_set(N, a, y.write()); 
+  inline Fluent& set(Dtype a, Accessor& y) {
+    caffe_gpu_set(N, a, y.write());
     return *this;
   }
 
-  inline Fluent& scal(Dtype a, Accessor& y)
-  {
-    caffe_gpu_scal(N, a, y.write()); 
+  inline Fluent& scal(Dtype a, Accessor& y) {
+    caffe_gpu_scal(N, a, y.write());
     return *this;
-  }  
+  }
 };
 
 }  // namespace gpu

--- a/include/caffe/util/math_functions.hpp
+++ b/include/caffe/util/math_functions.hpp
@@ -53,6 +53,9 @@ template <typename Dtype>
 void caffe_sqr(const int N, const Dtype* a, Dtype* y);
 
 template <typename Dtype>
+void caffe_sqrt(const int N, const Dtype* a, Dtype* y);
+
+template <typename Dtype>
 void caffe_add(const int N, const Dtype* a, const Dtype* b, Dtype* y);
 
 template <typename Dtype>
@@ -146,6 +149,9 @@ DEFINE_CAFFE_CPU_UNARY_FUNC(fabs, y[i] = std::fabs(x[i]));
 
 template <typename Dtype>
 void caffe_cpu_scale(const int n, const Dtype alpha, const Dtype *x, Dtype* y);
+
+template <typename Dtype>
+void caffe_clamp(const int n, Dtype m, Dtype M, Dtype* y);
 
 #ifndef CPU_ONLY  // GPU
 
@@ -248,6 +254,12 @@ void caffe_gpu_fabs(const int n, const Dtype* x, Dtype* y);
 
 template <typename Dtype>
 void caffe_gpu_scale(const int n, const Dtype alpha, const Dtype *x, Dtype* y);
+
+template <typename Dtype>
+void caffe_gpu_clamp(const int N, const Dtype m, const Dtype M, Dtype* X);
+
+template <typename Dtype>
+void caffe_gpu_sqrt(const int N, const Dtype* x, Dtype* y);
 
 #define DEFINE_AND_INSTANTIATE_GPU_UNARY_FUNC(name, operation) \
 template<typename Dtype> \

--- a/include/caffe/util/mkl_alternate.hpp
+++ b/include/caffe/util/mkl_alternate.hpp
@@ -34,6 +34,7 @@ extern "C" {
 DEFINE_VSL_UNARY_FUNC(Sqr, y[i] = a[i] * a[i]);
 DEFINE_VSL_UNARY_FUNC(Exp, y[i] = exp(a[i]));
 DEFINE_VSL_UNARY_FUNC(Abs, y[i] = fabs(a[i]));
+DEFINE_VSL_UNARY_FUNC(Sqrt, y[i] = sqrt(a[i]));
 
 // A simple way to define the vsl unary functions with singular parameter b.
 // The operation should be in the form e.g. y[i] = pow(a[i], b)

--- a/scripts/cpp_lint.py
+++ b/scripts/cpp_lint.py
@@ -4222,7 +4222,10 @@ def CheckForNonConstReference(filename, clean_lines, linenum,
                            r'operator\s*[<>][<>]|'
                            r'static_assert|COMPILE_ASSERT'
                            r')\s*\(')
-  if Search(whitelisted_functions, line):
+  fluent_patterns = (r'(Fluent|Accessor)')
+  if Search(fluent_patterns, line):
+    check_params = False
+  elif Search(whitelisted_functions, line):
     check_params = False
   elif not Search(r'\S+\([^)]*$', line):
     # Don't see a whitelisted function on this line.  Actually we

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -593,15 +593,16 @@ void AdaGradSolver<Dtype>::Compute() {
   }
 }
 
-#if CPU_ONLY
+#ifndef CPU_ONLY
 #define IMPLEMENT_CLASS(Name)\
 template <typename Dtype>\
 void Name<Dtype>::ComputeUpdateValue() {\
   switch (Caffe::mode()) {\
   case Caffe::CPU:\
-  this->Compute<cpu::BlobAccessor<Dtype>, cpu::Fluent<Dtype> >();\
+    this->Compute<cpu::BlobAccessor<Dtype>, cpu::Fluent<Dtype> >();\
+    break;\
   case Caffe::GPU:\
-  NO_GPU;\
+    this->Compute<gpu::BlobAccessor<Dtype>, gpu::Fluent<Dtype> >();\
     break;\
   default:\
     LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();\
@@ -613,9 +614,10 @@ template <typename Dtype>\
 void Name<Dtype>::ComputeUpdateValue() {\
   switch (Caffe::mode()) {\
   case Caffe::CPU:\
-  this->Compute<cpu::BlobAccessor<Dtype>, cpu::Fluent<Dtype> >();\
+    this->Compute<cpu::BlobAccessor<Dtype>, cpu::Fluent<Dtype> >();\
+    break;\
   case Caffe::GPU:\
-  this->Compute<gpu::BlobAccessor<Dtype>, gpu::Fluent<Dtype> >();\
+    NO_GPU;\
     break;\
   default:\
     LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();\

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -563,8 +563,7 @@ void AdaGradSolver<Dtype>::Compute() {
     weight_decay = this->param_.weight_decay();
 
   string regularization_type = this->param_.regularization_type();
-  size_t update_history_offset = net_params.size();
-
+  
   for (int param_id = 0; param_id < net_params.size(); ++param_id) {
     Dtype local_rate = rate * net_params_lr[param_id];
     Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
@@ -573,8 +572,7 @@ void AdaGradSolver<Dtype>::Compute() {
       param(net_params[param_id],true),
       temp(this->temp_[param_id]),
       update(this->update_[param_id]),
-      history(this->history_[param_id]),
-      delta_history(this->history_[param_id + update_history_offset]);
+      history(this->history_[param_id]);
 
     Fluent op(net_params[param_id]->count());
     

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -584,7 +584,7 @@ void AdaGradSolver<Dtype>::Compute() {
       // update history
       .add(update,history,history)
       // prepare update
-      .powx(history,Dtype(0.5),update)
+      .sqrt(history,update)
       .add_scalar(delta,update)
       .div(param,update,update)      
       // scale and copy

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -10,6 +10,7 @@
 #include "caffe/util/io.hpp"
 #include "caffe/util/math_functions.hpp"
 #include "caffe/util/upgrade_proto.hpp"
+#include "caffe/util/fluent.hpp"
 
 namespace caffe {
 
@@ -433,100 +434,6 @@ void SGDSolver<Dtype>::PreSolve() {
   }
 }
 
-
-template <typename Dtype>
-void SGDSolver<Dtype>::ComputeUpdateValue() {
-  vector<shared_ptr<Blob<Dtype> > >& net_params = this->net_->params();
-  vector<float>& net_params_lr = this->net_->params_lr();
-  vector<float>& net_params_weight_decay = this->net_->params_weight_decay();
-  // get the learning rate
-  Dtype rate = GetLearningRate();
-  if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
-    LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate;
-  }
-  Dtype momentum = this->param_.momentum();
-  Dtype weight_decay = this->param_.weight_decay();
-  string regularization_type = this->param_.regularization_type();
-  switch (Caffe::mode()) {
-  case Caffe::CPU:
-    for (int param_id = 0; param_id < net_params.size(); ++param_id) {
-      // Compute the value to history, and then copy them to the blob's diff.
-      Dtype local_rate = rate * net_params_lr[param_id];
-      Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
-
-      if (local_decay) {
-        if (regularization_type == "L2") {
-          // add weight decay
-          caffe_axpy(net_params[param_id]->count(),
-              local_decay,
-              net_params[param_id]->cpu_data(),
-              net_params[param_id]->mutable_cpu_diff());
-        } else if (regularization_type == "L1") {
-          caffe_cpu_sign(net_params[param_id]->count(),
-              net_params[param_id]->cpu_data(),
-              temp_[param_id]->mutable_cpu_data());
-          caffe_axpy(net_params[param_id]->count(),
-              local_decay,
-              temp_[param_id]->cpu_data(),
-              net_params[param_id]->mutable_cpu_diff());
-        } else {
-          LOG(FATAL) << "Unknown regularization type: " << regularization_type;
-        }
-      }
-
-      caffe_cpu_axpby(net_params[param_id]->count(), local_rate,
-                net_params[param_id]->cpu_diff(), momentum,
-                history_[param_id]->mutable_cpu_data());
-      // copy
-      caffe_copy(net_params[param_id]->count(),
-          history_[param_id]->cpu_data(),
-          net_params[param_id]->mutable_cpu_diff());
-    }
-    break;
-  case Caffe::GPU:
-#ifndef CPU_ONLY
-    for (int param_id = 0; param_id < net_params.size(); ++param_id) {
-      // Compute the value to history, and then copy them to the blob's diff.
-      Dtype local_rate = rate * net_params_lr[param_id];
-      Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
-
-      if (local_decay) {
-        if (regularization_type == "L2") {
-          // add weight decay
-          caffe_gpu_axpy(net_params[param_id]->count(),
-              local_decay,
-              net_params[param_id]->gpu_data(),
-              net_params[param_id]->mutable_gpu_diff());
-        } else if (regularization_type == "L1") {
-          caffe_gpu_sign(net_params[param_id]->count(),
-              net_params[param_id]->gpu_data(),
-              temp_[param_id]->mutable_gpu_data());
-          caffe_gpu_axpy(net_params[param_id]->count(),
-              local_decay,
-              temp_[param_id]->gpu_data(),
-              net_params[param_id]->mutable_gpu_diff());
-        } else {
-          LOG(FATAL) << "Unknown regularization type: " << regularization_type;
-        }
-      }
-
-      caffe_gpu_axpby(net_params[param_id]->count(), local_rate,
-                net_params[param_id]->gpu_diff(), momentum,
-                history_[param_id]->mutable_gpu_data());
-      // copy
-      caffe_copy(net_params[param_id]->count(),
-          history_[param_id]->gpu_data(),
-          net_params[param_id]->mutable_gpu_diff());
-    }
-#else
-    NO_GPU;
-#endif
-    break;
-  default:
-    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
-  }
-}
-
 template <typename Dtype>
 void SGDSolver<Dtype>::SnapshotSolverState(SolverState* state) {
   state->clear_history();
@@ -547,8 +454,26 @@ void SGDSolver<Dtype>::RestoreSolverState(const SolverState& state) {
   }
 }
 
+template <typename Dtype, typename BlobAccessor, typename Fluent>
+void apply_regulator(Fluent& op, BlobAccessor& param, BlobAccessor& temp, Dtype local_decay, const string& regularization_type) {
+  if (local_decay) {
+      if (regularization_type == "L2") {
+        op
+          // add weight decay
+          .axpy(local_decay,param,param);          
+      } else if (regularization_type == "L1") {
+        op
+          .sign(param,temp)
+          .axpy(local_decay,temp,param);
+      } else {
+        LOG(FATAL) << "Unknown regularization type: " << regularization_type;
+      }
+    }  
+}
+
 template <typename Dtype>
-void NesterovSolver<Dtype>::ComputeUpdateValue() {
+template <typename BlobAccessor, typename Fluent>
+void SGDSolver<Dtype>::Compute() {
   vector<shared_ptr<Blob<Dtype> > >& net_params = this->net_->params();
   vector<float>& net_params_lr = this->net_->params_lr();
   vector<float>& net_params_weight_decay = this->net_->params_weight_decay();
@@ -560,240 +485,149 @@ void NesterovSolver<Dtype>::ComputeUpdateValue() {
   Dtype momentum = this->param_.momentum();
   Dtype weight_decay = this->param_.weight_decay();
   string regularization_type = this->param_.regularization_type();
-  switch (Caffe::mode()) {
-  case Caffe::CPU:
-    for (int param_id = 0; param_id < net_params.size(); ++param_id) {
-      // save history momentum for stepping back
-      caffe_copy(net_params[param_id]->count(),
-          this->history_[param_id]->cpu_data(),
-          this->update_[param_id]->mutable_cpu_data());
+  
+  for (int param_id = 0; param_id < net_params.size(); ++param_id) {
+    Dtype local_rate = rate * net_params_lr[param_id];
+    Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
 
-      Dtype local_rate = rate * net_params_lr[param_id];
-      Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
+    BlobAccessor
+      param(net_params[param_id],true), 
+      temp(this->temp_[param_id]),
+      history(this->history_[param_id]);      
 
-      if (local_decay) {
-        if (regularization_type == "L2") {
-          // add weight decay
-          caffe_axpy(net_params[param_id]->count(),
-              local_decay,
-              net_params[param_id]->cpu_data(),
-              net_params[param_id]->mutable_cpu_diff());
-        } else if (regularization_type == "L1") {
-          caffe_cpu_sign(net_params[param_id]->count(),
-              net_params[param_id]->cpu_data(),
-              this->temp_[param_id]->mutable_cpu_data());
-          caffe_axpy(net_params[param_id]->count(),
-              local_decay,
-              this->temp_[param_id]->cpu_data(),
-              net_params[param_id]->mutable_cpu_diff());
-        } else {
-          LOG(FATAL) << "Unknown regularization type: " << regularization_type;
-        }
-      }
-
-      // update history
-      caffe_cpu_axpby(net_params[param_id]->count(), local_rate,
-                net_params[param_id]->cpu_diff(), momentum,
-                this->history_[param_id]->mutable_cpu_data());
-
-      // compute udpate: step back then over step
-      caffe_cpu_axpby(net_params[param_id]->count(), Dtype(1) + momentum,
-          this->history_[param_id]->cpu_data(), -momentum,
-          this->update_[param_id]->mutable_cpu_data());
-
-      // copy
-      caffe_copy(net_params[param_id]->count(),
-          this->update_[param_id]->cpu_data(),
-          net_params[param_id]->mutable_cpu_diff());
-    }
-    break;
-  case Caffe::GPU:
-#ifndef CPU_ONLY
-    for (int param_id = 0; param_id < net_params.size(); ++param_id) {
-      // save history momentum for stepping back
-      caffe_copy(net_params[param_id]->count(),
-          this->history_[param_id]->gpu_data(),
-          this->update_[param_id]->mutable_gpu_data());
-
-      Dtype local_rate = rate * net_params_lr[param_id];
-      Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
-
-      if (local_decay) {
-        if (regularization_type == "L2") {
-          // add weight decay
-          caffe_gpu_axpy(net_params[param_id]->count(),
-              local_decay,
-              net_params[param_id]->gpu_data(),
-              net_params[param_id]->mutable_gpu_diff());
-        } else if (regularization_type == "L1") {
-          caffe_gpu_sign(net_params[param_id]->count(),
-              net_params[param_id]->gpu_data(),
-              this->temp_[param_id]->mutable_gpu_data());
-          caffe_gpu_axpy(net_params[param_id]->count(),
-              local_decay,
-              this->temp_[param_id]->gpu_data(),
-              net_params[param_id]->mutable_gpu_diff());
-        } else {
-          LOG(FATAL) << "Unknown regularization type: " << regularization_type;
-        }
-      }
-
-      // update history
-      caffe_gpu_axpby(net_params[param_id]->count(), local_rate,
-                net_params[param_id]->gpu_diff(), momentum,
-                this->history_[param_id]->mutable_gpu_data());
-
-      // compute udpate: step back then over step
-      caffe_gpu_axpby(net_params[param_id]->count(), Dtype(1) + momentum,
-          this->history_[param_id]->gpu_data(), -momentum,
-          this->update_[param_id]->mutable_gpu_data());
-
-      // copy
-      caffe_copy(net_params[param_id]->count(),
-          this->update_[param_id]->gpu_data(),
-          net_params[param_id]->mutable_gpu_diff());
-    }
-#else
-    NO_GPU;
-#endif
-    break;
-  default:
-    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
-  }
+    Fluent op(net_params[param_id]->count());
+    
+    apply_regulator(op,param,temp,local_decay,regularization_type);    
+      
+    op
+      // update history of gradient
+      .axpby(local_rate, temp, momentum, history)      
+       // copy
+      .copy(history, param);
+  }  
 }
 
 template <typename Dtype>
-void AdaGradSolver<Dtype>::ComputeUpdateValue() {
+template <typename BlobAccessor, typename Fluent>
+void NesterovSolver<Dtype>::Compute() {
   vector<shared_ptr<Blob<Dtype> > >& net_params = this->net_->params();
   vector<float>& net_params_lr = this->net_->params_lr();
   vector<float>& net_params_weight_decay = this->net_->params_weight_decay();
   // get the learning rate
   Dtype rate = this->GetLearningRate();
-  Dtype delta = this->param_.delta();
   if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
     LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate;
   }
+  Dtype momentum = this->param_.momentum();
   Dtype weight_decay = this->param_.weight_decay();
   string regularization_type = this->param_.regularization_type();
-  switch (Caffe::mode()) {
-  case Caffe::CPU:
-    for (int param_id = 0; param_id < net_params.size(); ++param_id) {
-      Dtype local_rate = rate * net_params_lr[param_id];
-      Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
+  
+  for (int param_id = 0; param_id < net_params.size(); ++param_id) {
+    Dtype local_rate = rate * net_params_lr[param_id];
+    Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
 
-      if (local_decay) {
-        if (regularization_type == "L2") {
-          // add weight decay
-          caffe_axpy(net_params[param_id]->count(),
-              local_decay,
-              net_params[param_id]->cpu_data(),
-              net_params[param_id]->mutable_cpu_diff());
-        } else if (regularization_type == "L1") {
-          caffe_cpu_sign(net_params[param_id]->count(),
-              net_params[param_id]->cpu_data(),
-              this->temp_[param_id]->mutable_cpu_data());
-          caffe_axpy(net_params[param_id]->count(),
-              local_decay,
-              this->temp_[param_id]->cpu_data(),
-              net_params[param_id]->mutable_cpu_diff());
-        } else {
-          LOG(FATAL) << "Unknown regularization type: " << regularization_type;
-        }
-      }
+    BlobAccessor
+      param(net_params[param_id],true), 
+      temp(this->temp_[param_id]),
+      update(this->update_[param_id]),
+      history(this->history_[param_id]);      
 
+    Fluent op(net_params[param_id]->count());
+
+    op.copy(history,update);
+
+    apply_regulator(op,param,temp,local_decay,regularization_type);    
+      
+    op
+      // update history of gradient
+      .axpby(local_rate, temp, momentum, history)
+      // compute update: step back then over step      
+      .axpby(Dtype(1) + momentum, history, -momentum, update)
+       // copy
+      .copy(update, param);                  
+  }  
+}
+
+
+template <typename Dtype>
+template <typename BlobAccessor, typename Fluent>
+void AdaGradSolver<Dtype>::Compute() {
+  vector<shared_ptr<Blob<Dtype> > >& net_params = this->net_->params();
+  vector<float>& net_params_lr = this->net_->params_lr();
+  vector<float>& net_params_weight_decay = this->net_->params_weight_decay();  
+
+  // get the learning rate
+  Dtype 
+    delta = this->param_.delta(),
+    rate = this->GetLearningRate(),
+    weight_decay = this->param_.weight_decay();
+
+  string regularization_type = this->param_.regularization_type();
+  size_t update_history_offset = net_params.size();
+
+  for (int param_id = 0; param_id < net_params.size(); ++param_id) {
+    Dtype local_rate = rate * net_params_lr[param_id];
+    Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
+
+    BlobAccessor
+      param(net_params[param_id],true),
+      temp(this->temp_[param_id]),
+      update(this->update_[param_id]),
+      history(this->history_[param_id]),
+      delta_history(this->history_[param_id + update_history_offset]);
+
+    Fluent op(net_params[param_id]->count());
+    
+    apply_regulator(op,param,temp,local_decay,regularization_type);      
+
+    op
       // compute square of gradient in update
-      caffe_powx(net_params[param_id]->count(),
-          net_params[param_id]->cpu_diff(), Dtype(2),
-          this->update_[param_id]->mutable_cpu_data());
-
+      .sqr(param, update)
       // update history
-      caffe_add(net_params[param_id]->count(),
-          this->update_[param_id]->cpu_data(),
-          this->history_[param_id]->cpu_data(),
-          this->history_[param_id]->mutable_cpu_data());
-
+      .add(update,history,history)
       // prepare update
-      caffe_powx(net_params[param_id]->count(),
-                this->history_[param_id]->cpu_data(), Dtype(0.5),
-                this->update_[param_id]->mutable_cpu_data());
-
-      caffe_add_scalar(net_params[param_id]->count(),
-                delta, this->update_[param_id]->mutable_cpu_data());
-
-      caffe_div(net_params[param_id]->count(),
-                net_params[param_id]->cpu_diff(),
-                this->update_[param_id]->cpu_data(),
-                this->update_[param_id]->mutable_cpu_data());
-
+      .powx(history,Dtype(0.5),update)
+      .add_scalar(delta,update)
+      .div(param,update,update)      
       // scale and copy
-      caffe_cpu_axpby(net_params[param_id]->count(), local_rate,
-          this->update_[param_id]->cpu_data(), Dtype(0),
-          net_params[param_id]->mutable_cpu_diff());
-    }
-    break;
-  case Caffe::GPU:
-#ifndef CPU_ONLY
-    for (int param_id = 0; param_id < net_params.size(); ++param_id) {
-      Dtype local_rate = rate * net_params_lr[param_id];
-      Dtype local_decay = weight_decay * net_params_weight_decay[param_id];
-
-      if (local_decay) {
-        if (regularization_type == "L2") {
-          // add weight decay
-          caffe_gpu_axpy(net_params[param_id]->count(),
-              local_decay,
-              net_params[param_id]->gpu_data(),
-              net_params[param_id]->mutable_gpu_diff());
-        } else if (regularization_type == "L1") {
-          caffe_gpu_sign(net_params[param_id]->count(),
-              net_params[param_id]->gpu_data(),
-              this->temp_[param_id]->mutable_gpu_data());
-          caffe_gpu_axpy(net_params[param_id]->count(),
-              local_decay,
-              this->temp_[param_id]->gpu_data(),
-              net_params[param_id]->mutable_gpu_diff());
-        } else {
-          LOG(FATAL) << "Unknown regularization type: " << regularization_type;
-        }
-      }
-
-      // compute square of gradient in update
-      caffe_gpu_powx(net_params[param_id]->count(),
-          net_params[param_id]->gpu_diff(), Dtype(2),
-          this->update_[param_id]->mutable_gpu_data());
-
-      // update history
-      caffe_gpu_add(net_params[param_id]->count(),
-          this->update_[param_id]->gpu_data(),
-          this->history_[param_id]->gpu_data(),
-          this->history_[param_id]->mutable_gpu_data());
-
-      // prepare update
-      caffe_gpu_powx(net_params[param_id]->count(),
-                this->history_[param_id]->gpu_data(), Dtype(0.5),
-                this->update_[param_id]->mutable_gpu_data());
-
-      caffe_gpu_add_scalar(net_params[param_id]->count(),
-                delta, this->update_[param_id]->mutable_gpu_data());
-
-      caffe_gpu_div(net_params[param_id]->count(),
-                net_params[param_id]->gpu_diff(),
-                this->update_[param_id]->gpu_data(),
-                this->update_[param_id]->mutable_gpu_data());
-
-      // scale and copy
-      caffe_gpu_axpby(net_params[param_id]->count(), local_rate,
-          this->update_[param_id]->gpu_data(), Dtype(0),
-          net_params[param_id]->mutable_gpu_diff());
-    }
-#else
-    NO_GPU;
-#endif
-    break;
-  default:
-    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
+      .axpby(local_rate,update,Dtype(0),param)
+    ;     
   }
 }
+
+#if CPU_ONLY
+#define IMPLEMENT_CLASS(Name)\
+template <typename Dtype>\
+void Name<Dtype>::ComputeUpdateValue() {\
+  switch (Caffe::mode()) {\
+  case Caffe::CPU:\
+  this->Compute<cpu::BlobAccessor<Dtype>,cpu::Fluent<Dtype> >();\
+  case Caffe::GPU:\
+  NO_GPU;\
+    break;\
+  default:\
+    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();\
+  }\
+}
+#else
+#define IMPLEMENT_CLASS(Name)\
+template <typename Dtype>\
+void Name<Dtype>::ComputeUpdateValue() {\
+  switch (Caffe::mode()) {\
+  case Caffe::CPU:\
+  this->Compute<cpu::BlobAccessor<Dtype>,cpu::Fluent<Dtype> >();\
+  case Caffe::GPU:\
+  this->Compute<gpu::BlobAccessor<Dtype>,gpu::Fluent<Dtype> >();\
+    break;\
+  default:\
+    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();\
+  }\
+}
+#endif // CPU_ONLY
+
+IMPLEMENT_CLASS(SGDSolver);
+IMPLEMENT_CLASS(NesterovSolver);
+IMPLEMENT_CLASS(AdaGradSolver);
 
 INSTANTIATE_CLASS(Solver);
 INSTANTIATE_CLASS(SGDSolver);

--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -197,6 +197,16 @@ void caffe_sqr<double>(const int n, const double* a, double* y) {
 }
 
 template <>
+void caffe_sqrt<float>(const int n, const float* a, float* y) {
+  vsSqrt(n, a, y);
+}
+
+template <>
+void caffe_sqrt<double>(const int n, const double* a, double* y) {
+  vdSqrt(n, a, y);
+}
+
+template <>
 void caffe_exp<float>(const int n, const float* a, float* y) {
   vsExp(n, a, y);
 }
@@ -385,6 +395,29 @@ void caffe_cpu_scale<double>(const int n, const double alpha, const double *x,
                              double* y) {
   cblas_dcopy(n, x, 1, y, 1);
   cblas_dscal(n, alpha, y, 1);
+}
+
+
+template <>
+void caffe_clamp<float>(const int n, float m, float M, float* y) {
+  for (int i = 0; i < n; ++i) {
+    float x = y[i];
+    if (x < m)
+      x = m;
+    else if (x > M)
+      x = M;
+  }
+}
+
+template <>
+void caffe_clamp<double>(const int n, double m, double M, double* y) {
+  for (int i = 0; i < n; ++i) {
+    double x = y[i];
+    if (x < m)
+      x = m;
+    else if (x > M)
+      x = M;
+  }
 }
 
 }  // namespace caffe

--- a/src/caffe/util/math_functions.cu
+++ b/src/caffe/util/math_functions.cu
@@ -420,4 +420,40 @@ void caffe_gpu_rng_gaussian(const int n, const double mu, const double sigma,
       curandGenerateNormalDouble(Caffe::curand_generator(), r, n, mu, sigma));
 }
 
+template <typename Dtype>
+__global__ void clamp_kernel(const int n, const Dtype m, const Dtype M, Dtype* X) {
+  CUDA_KERNEL_LOOP(index, n) {
+    X[index] = max(m, min(M, X[index]));
+  }
+}
+
+template <>
+void caffe_gpu_clamp<float>(const int N, const float m, const float M, float* X) {
+  clamp_kernel<float><<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(N, m, M, X);
+}
+
+template <>
+void caffe_gpu_clamp<double>(const int N, const double m, const double M, double* X) {
+  clamp_kernel<double><<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(N, m, M, X);
+}
+
+template <typename Dtype>
+__global__ void sqrt_kernel(const int n, const Dtype* a, Dtype* y) {
+  CUDA_KERNEL_LOOP(index, n) {
+    y[index] = sqrt(a[index]);
+  }
+}
+
+template <>
+void caffe_gpu_sqrt<float>(const int N, const float* a, float* y) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  sqrt_kernel<float><<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(N, a, y);
+}
+
+template <>
+void caffe_gpu_sqrt<double>(const int N, const double* a, double* y) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  sqrt_kernel<double><<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(N, a, y);
+}
+
 }  // namespace caffe

--- a/src/caffe/util/math_functions.cu
+++ b/src/caffe/util/math_functions.cu
@@ -421,20 +421,28 @@ void caffe_gpu_rng_gaussian(const int n, const double mu, const double sigma,
 }
 
 template <typename Dtype>
-__global__ void clamp_kernel(const int n, const Dtype m, const Dtype M, Dtype* X) {
+__global__ void clamp_kernel(const int n, const Dtype m, const Dtype M,
+  Dtype* X) {
   CUDA_KERNEL_LOOP(index, n) {
+    // NOLINT_NEXT_LINE(build/include_what_you_use
     X[index] = max(m, min(M, X[index]));
   }
 }
 
 template <>
-void caffe_gpu_clamp<float>(const int N, const float m, const float M, float* X) {
-  clamp_kernel<float><<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(N, m, M, X);
+void caffe_gpu_clamp<float>(const int N, const float m, const float M,
+  float* X) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  clamp_kernel<float><<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(
+    N, m, M, X);
 }
 
 template <>
-void caffe_gpu_clamp<double>(const int N, const double m, const double M, double* X) {
-  clamp_kernel<double><<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(N, m, M, X);
+void caffe_gpu_clamp<double>(const int N, const double m, const double M,
+  double* X) {
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  clamp_kernel<double><<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(
+    N, m, M, X);
 }
 
 template <typename Dtype>


### PR DESCRIPTION
I refactored solvers with fluent pattern to add a solver like rmsprop, which isn't included in this PR. After merging this PR, rmsprop will be proposed.

A cool thing introduced by this PR is keeping code DRY(Do not Repeat Yourself). You don't have to write similar code paths for cpu/gpu.

Modified ADAGRAD solver is like below:
```
op
      // compute square of gradient in update
      .sqr(param, update)
      // update history
      .add(update,history,history)
      // prepare update
      .sqrt(history,update)
      .add_scalar(delta,update)
      .div(param,update,update)      
      // scale and copy
      .axpby(local_rate,update,Dtype(0),param)
```