### PR TITLE
Simplify the Solver class

### DIFF
--- a/include/caffe/caffe.hpp
+++ b/include/caffe/caffe.hpp
@@ -12,6 +12,7 @@
 #include "caffe/net.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/solver.hpp"
+#include "caffe/solving_driver.hpp"
 #include "caffe/util/benchmark.hpp"
 #include "caffe/util/io.hpp"
 #include "caffe/vision_layers.hpp"

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -1,6 +1,7 @@
 #ifndef CAFFE_COMMON_HPP_
 #define CAFFE_COMMON_HPP_
 
+#include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include <gflags/gflags.h>
 #include <glog/logging.h>

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -1,10 +1,10 @@
 #ifndef CAFFE_OPTIMIZATION_SOLVER_HPP_
 #define CAFFE_OPTIMIZATION_SOLVER_HPP_
 
+#include <boost/circular_buffer.hpp>
+
 #include <string>
 #include <vector>
-
-#include <boost/circular_buffer.hpp>
 
 #include "caffe/net.hpp"
 
@@ -32,13 +32,19 @@ class Solver {
   explicit Solver(const SolverParameter& param);
   explicit Solver(const string& param_file);
 
-  // The main entry of the solver function.
-  void Next(vector<shared_ptr<SolverResult<Dtype> > >* output = 0);
+  /**
+   * @brief Next
+   * @param output The output blobs before the network is updated
+   * @return The total loss of this round of forwarding
+   */
+  Dtype Next(vector<shared_ptr<SolverResult<Dtype> > >* output = 0);
   virtual ~Solver() {}
   inline shared_ptr<Net<Dtype> > net() { return net_; }
   inline shared_ptr<const Net<Dtype> > net() const { return net_; }
 
   int iter() const { return iter_; }
+  int current_step() const { return current_step_; }
+  const SolverParameter& param() const { return param_; }
   virtual void SnapshotSolverState(SolverState* state) const = 0;
   virtual void RestoreSolverState(const SolverState& state) = 0;
 

--- a/include/caffe/solving_driver.hpp
+++ b/include/caffe/solving_driver.hpp
@@ -1,0 +1,44 @@
+#ifndef CAFFE_OPTIMIZATION_SOLVING_DRIVER_HPP_
+#define CAFFE_OPTIMIZATION_SOLVING_DRIVER_HPP_
+
+#include <string>
+#include <vector>
+
+#include "caffe/solver.hpp"
+
+namespace caffe {
+template <typename Dtype>
+class SolvingDriver {
+ private:
+  shared_ptr<Solver<Dtype> > solver_;
+  vector<shared_ptr<Net<Dtype> > > test_nets_;
+
+  void TestAll();
+  void Test(int test_net_id);
+  void Snapshot() { solver_->Snapshot(); }
+
+ public:
+  explicit SolvingDriver(const SolverParameter& param);
+  explicit SolvingDriver(const string& param_file);
+  explicit SolvingDriver(shared_ptr<Solver<Dtype> > solver);
+  void Init(const SolverParameter& param);
+  void InitTrainNet();
+  void InitTestNets();
+  // The main entry of the driver function. In default, iter will be zero. Pass
+  // in a non-zero iter number to resume training for a pre-trained net.
+  virtual void Solve(const char* resume_file = NULL);
+  inline void Solve(const string resume_file) { Solve(resume_file.c_str()); }
+  void Step(int iters);
+  inline shared_ptr<Net<Dtype> > net() { return solver_->net(); }
+  inline const vector<shared_ptr<Net<Dtype> > >& test_nets() {
+    return test_nets_;
+  }
+  int iter() const { return solver_->iter(); }
+
+  const SolverParameter& param() const { return solver_->param(); }
+
+  DISABLE_COPY_AND_ASSIGN(SolvingDriver);
+};
+}  // namespace caffe
+
+#endif  // CAFFE_OPTIMIZATION_SOLVING_DRIVER_HPP_

--- a/include/caffe/solving_driver.hpp
+++ b/include/caffe/solving_driver.hpp
@@ -36,6 +36,7 @@ class SolvingDriver {
   int iter() const { return solver_->iter(); }
 
   const SolverParameter& param() const { return solver_->param(); }
+  inline shared_ptr<Solver<Dtype> > internal_solver() { return solver_; }
 
   DISABLE_COPY_AND_ASSIGN(SolvingDriver);
 };

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -133,7 +133,7 @@ PySGDSolver::PySGDSolver(const string& param_file) {
   // as in PyNet, (as a convenience, not a guarantee), create a Python
   // exception if param_file can't be opened
   CheckFile(param_file);
-  solver_.reset(new SGDSolver<float>(param_file));
+  solver_ = boost::make_shared<SolvingDriver<float> >(param_file);
   // we need to explicitly store the net wrapper, rather than constructing
   // it on the fly, so that it can hold references to Python objects
   net_.reset(new PyNet(solver_->net()));

--- a/python/caffe/_caffe.hpp
+++ b/python/caffe/_caffe.hpp
@@ -187,7 +187,7 @@ class PySGDSolver {
  protected:
   shared_ptr<PyNet> net_;
   vector<shared_ptr<PyNet> > test_nets_;
-  shared_ptr<SGDSolver<float> > solver_;
+  shared_ptr<SolvingDriver<float> > solver_;
 };
 
 // Declare the module init function created by boost::python, so that we can

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -4,8 +4,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/make_shared.hpp>
-
 #include "caffe/net.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/solver.hpp"
@@ -86,15 +84,16 @@ void Solver<Dtype>::InitTrainNet() {
 }
 
 template <typename Dtype>
-void Solver<Dtype>::Next(
+Dtype Solver<Dtype>::Next(
     vector<shared_ptr<SolverResult<Dtype> > >* output) {
+  Caffe::set_phase(Caffe::TRAIN);
   vector<Blob<Dtype>*> bottom_vec;
   Dtype loss = net_->ForwardBackward(bottom_vec);
   last_losses_.push_back(loss);
   Dtype size = Dtype(last_losses_.size());
   smoothed_loss_ = (smoothed_loss_ * (size - 1) + loss) / size;
 
-  if (output){
+  if (output) {
     const vector<Blob<Dtype>*>& result = net_->output_blobs();
     for (int j = 0; j < result.size(); ++j) {
       const Dtype* result_vec = result[j]->cpu_data();
@@ -113,6 +112,7 @@ void Solver<Dtype>::Next(
   ComputeUpdateValue();
   net_->Update();
   ++iter_;
+  return loss;
 }
 
 template <typename Dtype>

--- a/src/caffe/solving_driver.cpp
+++ b/src/caffe/solving_driver.cpp
@@ -43,7 +43,7 @@ void SolvingDriver<Dtype>::InitTrainNet() {
 
 template <typename Dtype>
 void SolvingDriver<Dtype>::InitTestNets() {
-  const SolverParameter& param_ = solver_->param();
+  const SolverParameter& param_ = param();
   const bool has_net_param = param_.has_net_param();
   const bool has_net_file = param_.has_net();
   const int num_generic_nets = has_net_param + has_net_file;
@@ -53,11 +53,11 @@ void SolvingDriver<Dtype>::InitTestNets() {
   const int num_test_net_files = param_.test_net_size();
   const int num_test_nets = num_test_net_params + num_test_net_files;
   if (num_generic_nets) {
-    CHECK_GE(param_.test_iter_size(), num_test_nets)
-        << "test_iter must be specified for each test network.";
+      CHECK_GE(param_.test_iter_size(), num_test_nets)
+          << "test_iter must be specified for each test network.";
   } else {
-    CHECK_EQ(param_.test_iter_size(), num_test_nets)
-        << "test_iter must be specified for each test network.";
+      CHECK_EQ(param_.test_iter_size(), num_test_nets)
+          << "test_iter must be specified for each test network.";
   }
   // If we have a generic net (specified by net or net_param, rather than
   // test_net or test_net_param), we may have an unlimited number of actual
@@ -77,50 +77,43 @@ void SolvingDriver<Dtype>::InitTestNets() {
   vector<string> sources(num_test_net_instances);
   vector<NetParameter> net_params(num_test_net_instances);
   for (int i = 0; i < num_test_net_params; ++i, ++test_net_id) {
-    sources[test_net_id] = "test_net_param";
-    net_params[test_net_id].CopyFrom(param_.test_net_param(i));
+      sources[test_net_id] = "test_net_param";
+      net_params[test_net_id].CopyFrom(param_.test_net_param(i));
   }
   for (int i = 0; i < num_test_net_files; ++i, ++test_net_id) {
-    sources[test_net_id] = "test_net file: " + param_.test_net(i);
-    ReadNetParamsFromTextFileOrDie(param_.test_net(i),
-                                   &net_params[test_net_id]);
+      sources[test_net_id] = "test_net file: " + param_.test_net(i);
+      ReadNetParamsFromTextFileOrDie(param_.test_net(i),
+          &net_params[test_net_id]);
   }
   const int remaining_test_nets = param_.test_iter_size() - test_net_id;
   if (has_net_param) {
     for (int i = 0; i < remaining_test_nets; ++i, ++test_net_id) {
       sources[test_net_id] = "net_param";
       net_params[test_net_id].CopyFrom(param_.net_param());
-      if (has_net_param) {
-        for (int i = 0; i < remaining_test_nets; ++i, ++test_net_id) {
-          sources[test_net_id] = "net_param";
-          net_params[test_net_id].CopyFrom(param_.net_param());
-        }
-      }
-      if (has_net_file) {
-        for (int i = 0; i < remaining_test_nets; ++i, ++test_net_id) {
-          sources[test_net_id] = "net file: " + param_.net();
-          ReadNetParamsFromTextFileOrDie(param_.net(),
-                                         &net_params[test_net_id]);
-        }
-      }
-      test_nets_.resize(num_test_net_instances);
-      for (int i = 0; i < num_test_net_instances; ++i) {
-        // Set the correct NetState.  We start with the solver defaults (lowest
-        // precedence); then, merge in any NetState specified by the net_param
-        // itself; finally, merge in any NetState specified by the test_state
-        // (highest precedence).
-        NetState net_state;
-        net_state.set_phase(TEST);
-        net_state.MergeFrom(net_params[i].state());
-        if (param_.test_state_size()) {
-          net_state.MergeFrom(param_.test_state(i));
-        }
-        net_params[i].mutable_state()->CopyFrom(net_state);
-        LOG(INFO)
-            << "Creating test net (#" << i << ") specified by " << sources[i];
-        test_nets_[i].reset(new Net<Dtype>(net_params[i]));
-      }
     }
+  }
+  if (has_net_file) {
+    for (int i = 0; i < remaining_test_nets; ++i, ++test_net_id) {
+      sources[test_net_id] = "net file: " + param_.net();
+      ReadNetParamsFromTextFileOrDie(param_.net(), &net_params[test_net_id]);
+    }
+  }
+  test_nets_.resize(num_test_net_instances);
+  for (int i = 0; i < num_test_net_instances; ++i) {
+    // Set the correct NetState.  We start with the solver defaults (lowest
+    // precedence); then, merge in any NetState specified by the net_param
+    // itself; finally, merge in any NetState specified by the test_state
+    // (highest precedence).
+    NetState net_state;
+    net_state.set_phase(TEST);
+    net_state.MergeFrom(net_params[i].state());
+    if (param_.test_state_size()) {
+      net_state.MergeFrom(param_.test_state(i));
+    }
+    net_params[i].mutable_state()->CopyFrom(net_state);
+    LOG(INFO)
+        << "Creating test net (#" << i << ") specified by " << sources[i];
+    test_nets_[i].reset(new Net<Dtype>(net_params[i]));
   }
 }
 

--- a/src/caffe/solving_driver.cpp
+++ b/src/caffe/solving_driver.cpp
@@ -1,0 +1,274 @@
+#include <cstdio>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "caffe/net.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/solver.hpp"
+#include "caffe/solving_driver.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/util/upgrade_proto.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+SolvingDriver<Dtype>::SolvingDriver(const SolverParameter& param) {
+  Init(param);
+}
+
+template <typename Dtype>
+SolvingDriver<Dtype>::SolvingDriver(const string& param_file) {
+  SolverParameter param;
+  ReadProtoFromTextFileOrDie(param_file, &param);
+  Init(param);
+}
+
+template <typename Dtype>
+SolvingDriver<Dtype>::SolvingDriver(shared_ptr<Solver<Dtype> > solver)
+  : solver_(solver) {}
+
+template <typename Dtype>
+void SolvingDriver<Dtype>::Init(const SolverParameter& param) {
+  solver_.reset(GetSolver<Dtype>(param));
+  InitTestNets();
+}
+
+template <typename Dtype>
+void SolvingDriver<Dtype>::InitTrainNet() {
+  // placeholder to match past interface
+}
+
+template <typename Dtype>
+void SolvingDriver<Dtype>::InitTestNets() {
+  const SolverParameter& param_ = solver_->param();
+  const bool has_net_param = param_.has_net_param();
+  const bool has_net_file = param_.has_net();
+  const int num_generic_nets = has_net_param + has_net_file;
+  CHECK_LE(num_generic_nets, 1)
+      << "Both net_param and net_file may not be specified.";
+  const int num_test_net_params = param_.test_net_param_size();
+  const int num_test_net_files = param_.test_net_size();
+  const int num_test_nets = num_test_net_params + num_test_net_files;
+  if (num_generic_nets) {
+    CHECK_GE(param_.test_iter_size(), num_test_nets)
+        << "test_iter must be specified for each test network.";
+  } else {
+    CHECK_EQ(param_.test_iter_size(), num_test_nets)
+        << "test_iter must be specified for each test network.";
+  }
+  // If we have a generic net (specified by net or net_param, rather than
+  // test_net or test_net_param), we may have an unlimited number of actual
+  // test networks -- the actual number is given by the number of remaining
+  // test_iters after any test nets specified by test_net_param and/or test_net
+  // are evaluated.
+  const int num_generic_net_instances = param_.test_iter_size() - num_test_nets;
+  const int num_test_net_instances = num_test_nets + num_generic_net_instances;
+  if (param_.test_state_size()) {
+    CHECK_EQ(param_.test_state_size(), num_test_net_instances)
+        << "test_state must be unspecified or specified once per test net.";
+  }
+  if (num_test_net_instances) {
+    CHECK_GT(param_.test_interval(), 0);
+  }
+  int test_net_id = 0;
+  vector<string> sources(num_test_net_instances);
+  vector<NetParameter> net_params(num_test_net_instances);
+  for (int i = 0; i < num_test_net_params; ++i, ++test_net_id) {
+    sources[test_net_id] = "test_net_param";
+    net_params[test_net_id].CopyFrom(param_.test_net_param(i));
+  }
+  for (int i = 0; i < num_test_net_files; ++i, ++test_net_id) {
+    sources[test_net_id] = "test_net file: " + param_.test_net(i);
+    ReadNetParamsFromTextFileOrDie(param_.test_net(i),
+                                   &net_params[test_net_id]);
+  }
+  const int remaining_test_nets = param_.test_iter_size() - test_net_id;
+  if (has_net_param) {
+    for (int i = 0; i < remaining_test_nets; ++i, ++test_net_id) {
+      sources[test_net_id] = "net_param";
+      net_params[test_net_id].CopyFrom(param_.net_param());
+      if (has_net_param) {
+        for (int i = 0; i < remaining_test_nets; ++i, ++test_net_id) {
+          sources[test_net_id] = "net_param";
+          net_params[test_net_id].CopyFrom(param_.net_param());
+        }
+      }
+      if (has_net_file) {
+        for (int i = 0; i < remaining_test_nets; ++i, ++test_net_id) {
+          sources[test_net_id] = "net file: " + param_.net();
+          ReadNetParamsFromTextFileOrDie(param_.net(),
+                                         &net_params[test_net_id]);
+        }
+      }
+      test_nets_.resize(num_test_net_instances);
+      for (int i = 0; i < num_test_net_instances; ++i) {
+        // Set the correct NetState.  We start with the solver defaults (lowest
+        // precedence); then, merge in any NetState specified by the net_param
+        // itself; finally, merge in any NetState specified by the test_state
+        // (highest precedence).
+        NetState net_state;
+        net_state.set_phase(TEST);
+        net_state.MergeFrom(net_params[i].state());
+        if (param_.test_state_size()) {
+          net_state.MergeFrom(param_.test_state(i));
+        }
+        net_params[i].mutable_state()->CopyFrom(net_state);
+        LOG(INFO)
+            << "Creating test net (#" << i << ") specified by " << sources[i];
+        test_nets_[i].reset(new Net<Dtype>(net_params[i]));
+      }
+    }
+  }
+}
+
+template <typename Dtype>
+void SolvingDriver<Dtype>::Step(int iters) {
+  const int start_iter = solver_->iter();
+  const int stop_iter = start_iter + iters;
+  const SolverParameter& param_ = solver_->param();
+  Net<Dtype>* net_ = solver_->net().get();
+  for (int iter_ = start_iter; iter_ < stop_iter; ++iter_) {
+    if (param_.test_interval() && iter_ % param_.test_interval() == 0
+        && (iter_ > 0 || param_.test_initialization())) {
+      TestAll();
+    }
+    const bool display = param_.display() && iter_ % param_.display() == 0;
+    net_->set_debug_info(display && param_.debug_info());
+
+    vector<shared_ptr<SolverResult<Dtype> > > output_info;
+    solver_->Next(display ? &output_info : NULL);
+    if (display) {
+      int score_index = 0;
+      LOG(INFO) << "Iteration " << solver_->iter()
+                << ", loss = " << solver_->smoothed_loss();
+      for (int i = 0; i < output_info.size(); ++i) {
+        const SolverResult<Dtype>& sr = *(output_info[i]);
+        for (int j = 0; j < sr.blob_data.size(); ++j) {
+          ostringstream loss_msg_stream;
+          if (sr.loss_weight) {
+            loss_msg_stream << " (* " << sr.loss_weight
+                            << " = " << sr.loss_weight * sr.blob_data[j]
+                            << " loss)";
+          }
+          LOG(INFO) << "    Train net output #"
+                    << score_index++ << ": " << sr.blob_name << " = "
+                    << sr.blob_data[j] << loss_msg_stream.str();}
+      }
+    }
+    if (param_.snapshot() && (iter_ + 1) % param_.snapshot() == 0) {
+      solver_->Snapshot();
+    }
+  }
+}
+
+template <typename Dtype>
+void SolvingDriver<Dtype>::Solve(const char* resume_file) {
+  Caffe::set_phase(Caffe::TRAIN);
+  LOG(INFO) << "Solving " << solver_->net()->name();
+  LOG(INFO) << "Learning Rate Policy: " << solver_->param().lr_policy();
+
+  const SolverParameter& param_ = solver_->param();
+  if (resume_file) {
+    LOG(INFO) << "Restoring previous solver status from " << resume_file;
+    solver_->Restore(resume_file);
+  }
+
+  // For a network that is trained by the solver, no bottom or top vecs
+  // should be given, and we will just provide dummy vecs.
+  Step(param_.max_iter() - solver_->iter());
+  // If we haven't already, save a snapshot after optimization, unless
+  // overridden by setting snapshot_after_train := false
+  if (param_.snapshot_after_train()
+      && (!param_.snapshot() || solver_->iter() % param_.snapshot() != 0)) {
+    Snapshot();
+  }
+  // After the optimization is done, run an additional train and test pass to
+  // display the train and test loss/outputs if appropriate (based on the
+  // display and test_interval settings, respectively).  Unlike in the rest of
+  // training, for the train net we only run a forward pass as we've already
+  // updated the parameters "max_iter" times -- this final pass is only done to
+  // display the loss, which is computed in the forward pass.
+  if (param_.display() && solver_->iter() % param_.display() == 0) {
+    Dtype loss;
+    solver_->net()->ForwardPrefilled(&loss);
+    LOG(INFO) << "Iteration " << solver_->iter() << ", loss = " << loss;
+  }
+  if (param_.test_interval() && solver_->iter() % param_.test_interval() == 0) {
+    TestAll();
+  }
+  LOG(INFO) << "Optimization Done.";
+}
+
+template <typename Dtype>
+void SolvingDriver<Dtype>::TestAll() {
+  for (int test_net_id = 0; test_net_id < test_nets_.size(); ++test_net_id) {
+    Test(test_net_id);
+  }
+}
+
+template <typename Dtype>
+void SolvingDriver<Dtype>::Test(const int test_net_id) {
+  LOG(INFO) << "Iteration " << solver_->iter()
+            << ", Testing net (#" << test_net_id << ")";
+  // We need to set phase to test before running.
+  Caffe::set_phase(Caffe::TEST);
+  const SolverParameter& param_ = param();
+  CHECK_NOTNULL(test_nets_[test_net_id].get())->
+      ShareTrainedLayersWith(solver_->net().get());
+  vector<Dtype> test_score;
+  vector<int> test_score_output_id;
+  vector<Blob<Dtype>*> bottom_vec;
+  const shared_ptr<Net<Dtype> >& test_net = test_nets_[test_net_id];
+  Dtype loss = 0;
+  for (int i = 0; i < param_.test_iter(test_net_id); ++i) {
+    Dtype iter_loss;
+    const vector<Blob<Dtype>*>& result =
+        test_net->Forward(bottom_vec, &iter_loss);
+    if (param_.test_compute_loss()) {
+      loss += iter_loss;
+    }
+    if (i == 0) {
+      for (int j = 0; j < result.size(); ++j) {
+        const Dtype* result_vec = result[j]->cpu_data();
+        for (int k = 0; k < result[j]->count(); ++k) {
+          test_score.push_back(result_vec[k]);
+          test_score_output_id.push_back(j);
+        }
+      }
+    } else {
+      int idx = 0;
+      for (int j = 0; j < result.size(); ++j) {
+        const Dtype* result_vec = result[j]->cpu_data();
+        for (int k = 0; k < result[j]->count(); ++k) {
+          test_score[idx++] += result_vec[k];
+        }
+      }
+    }
+  }
+  if (param_.test_compute_loss()) {
+    loss /= param_.test_iter(test_net_id);
+    LOG(INFO) << "Test loss: " << loss;
+  }
+  for (int i = 0; i < test_score.size(); ++i) {
+    const int output_blob_index =
+        test_net->output_blob_indices()[test_score_output_id[i]];
+    const string& output_name = test_net->blob_names()[output_blob_index];
+    const Dtype loss_weight = test_net->blob_loss_weights()[output_blob_index];
+    ostringstream loss_msg_stream;
+    const Dtype mean_score = test_score[i] / param_.test_iter(test_net_id);
+    if (loss_weight) {
+      loss_msg_stream << " (* " << loss_weight
+                      << " = " << loss_weight * mean_score << " loss)";
+    }
+    LOG(INFO) << "    Test net output #" << i << ": " << output_name << " = "
+        << mean_score << loss_msg_stream.str();
+  }
+  Caffe::set_phase(Caffe::TRAIN);
+}
+
+INSTANTIATE_CLASS(SolvingDriver);
+
+}  // namespace caffe

--- a/src/caffe/test/test_solving_driver.cpp
+++ b/src/caffe/test/test_solving_driver.cpp
@@ -7,7 +7,7 @@
 
 #include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"
-#include "caffe/solver.hpp"
+#include "caffe/solving_driver.hpp"
 
 #include "caffe/test/test_caffe_main.hpp"
 
@@ -16,7 +16,7 @@ using std::ostringstream;
 namespace caffe {
 
 template <typename TypeParam>
-class SolverTest : public MultiDeviceTest<TypeParam> {
+class SolvingDriverTest : public MultiDeviceTest<TypeParam> {
   typedef typename TypeParam::Dtype Dtype;
 
  protected:
@@ -34,15 +34,15 @@ class SolverTest : public MultiDeviceTest<TypeParam> {
       default:
         LOG(FATAL) << "Unknown Caffe mode: " << Caffe::mode();
     }
-    solver_.reset(new SGDSolver<Dtype>(param));
+    solver_.reset(new SolvingDriver<Dtype>(param));
   }
 
-  shared_ptr<Solver<Dtype> > solver_;
+  shared_ptr<SolvingDriver<Dtype> > solver_;
 };
 
-TYPED_TEST_CASE(SolverTest, TestDtypesAndDevices);
+TYPED_TEST_CASE(SolvingDriverTest, TestDtypesAndDevices);
 
-TYPED_TEST(SolverTest, TestInitTrainTestNets) {
+TYPED_TEST(SolvingDriverTest, TestInitTrainTestNets) {
   const string& proto =
      "test_interval: 10 "
      "test_iter: 10 "

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -105,8 +105,8 @@ int train() {
   }
 
   LOG(INFO) << "Starting Optimization";
-  shared_ptr<caffe::Solver<float> >
-    solver(caffe::GetSolver<float>(solver_param));
+  shared_ptr<caffe::SolvingDriver<float> > solver
+    = boost::make_shared<caffe::SolvingDriver<float> >(solver_param);
 
   if (FLAGS_snapshot.size()) {
     LOG(INFO) << "Resuming from " << FLAGS_snapshot;


### PR DESCRIPTION
The current `caffe::Solver` class is a giant behemoth that handles too many things at once. Not only does it compute and update the network, it also does I/O on its own, automatically determines snapshot filenames and time point, evaluates test networks at regular intervals, automatically determines learning rate and stop criteria, and formats the output of all the networks it handles. 

This PR attempts to reduce the `Solver` class to its core, that is, only for computation. A separate `SolvingDriver` class, which can be seen as an adaptor, conforms to the past interface and allows minimal changes to existing code. Users of `caffe.bin` won't find anything different, but those who link to `libcaffe` are now free to do the following things, which are impossible before:

* Control the pace of learning. For example, better stop criteria than the arbitrarily predetermined maximum number of iterations can be devised. One may stop the training process once the loss is below certain threshold, when the test accuracy no longer improves, or continue indefinitely until interrupted.

* Retrieve the intermediate outputs of networks by programming API. Before this PR the only way to get such information is by parsing the unstructured log file, which is error-prone and unnecessarily involves I/O for something as pure as computation.

* Serialize and deserialize at will. One can save the intermediate result wherever and whenever he/she likes. No more waste of cycles when you want to interrupt the training process but it has not proceeded to the next checkpoint.

* Implement your own learning rate policy. Instead of decaying the learning rate through predetermined function, it can now be dynamically adjusted in any ways the library users want.