### PR TITLE
[fix] align pytest for solver with #1728

### DIFF
--- a/python/caffe/test/test_solver.py
+++ b/python/caffe/test/test_solver.py
@@ -17,7 +17,7 @@ class TestSolver(unittest.TestCase):
         display: 100 max_iter: 100 snapshot_after_train: false""")
         f.close()
         self.solver = caffe.SGDSolver(f.name)
-        self.solver.net.set_mode_cpu()
+        caffe.set_mode_cpu()
         # fill in valid labels
         self.solver.net.blobs['label'].data[...] = \
                 np.random.randint(self.num_output,


### PR DESCRIPTION
The test sets the mode by `caffe.set_mode_cpu()` as defined the interface change
in #1728.