### PR TITLE
Give phase to Net

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -104,8 +104,6 @@ class Caffe {
     return *singleton_;
   }
   enum Brew { CPU, GPU };
-  enum Phase { TRAIN, TEST };
-
 
   // This random number generator facade hides boost and CUDA rng
   // implementation from one another (for cross-platform compatibility).
@@ -137,16 +135,12 @@ class Caffe {
 
   // Returns the mode: running on CPU or GPU.
   inline static Brew mode() { return Get().mode_; }
-  // Returns the phase: TRAIN or TEST.
-  inline static Phase phase() { return Get().phase_; }
   // The setters for the variables
   // Sets the mode. It is recommended that you don't change the mode halfway
   // into the program since that may cause allocation of pinned memory being
   // freed in a non-pinned way, which may cause problems - I haven't verified
   // it personally but better to note it here in the header file.
   inline static void set_mode(Brew mode) { Get().mode_ = mode; }
-  // Sets the phase.
-  inline static void set_phase(Phase phase) { Get().phase_ = phase; }
   // Sets the random seed of both boost and curand
   static void set_random_seed(const unsigned int seed);
   // Sets the device. Since we have cublas and curand stuff, set device also
@@ -163,7 +157,6 @@ class Caffe {
   shared_ptr<RNG> random_generator_;
 
   Brew mode_;
-  Phase phase_;
   static shared_ptr<Caffe> singleton_;
 
  private:

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -48,8 +48,7 @@ class BaseDataLayer : public Layer<Dtype> {
 
  protected:
   TransformationParameter transform_param_;
-  DataTransformer<Dtype> data_transformer_;
-  Caffe::Phase phase_;
+  shared_ptr<DataTransformer<Dtype> > data_transformer_;
   bool output_labels_;
 };
 

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -14,6 +14,7 @@
 #include "caffe/filler.hpp"
 #include "caffe/internal_thread.hpp"
 #include "caffe/layer.hpp"
+#include "caffe/net.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/db.hpp"
 

--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -16,7 +16,7 @@ namespace caffe {
 template <typename Dtype>
 class DataTransformer {
  public:
-  explicit DataTransformer(const TransformationParameter& param);
+  explicit DataTransformer(const TransformationParameter& param, Phase phase);
   virtual ~DataTransformer() {}
 
   /**
@@ -104,7 +104,7 @@ class DataTransformer {
 
 
   shared_ptr<Caffe::RNG> rng_;
-  Caffe::Phase phase_;
+  Phase phase_;
   Blob<Dtype> data_mean_;
   vector<Dtype> mean_values_;
 };

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -33,7 +33,8 @@ class Layer {
    */
   explicit Layer(const LayerParameter& param)
     : layer_param_(param) {
-      // The only thing we do is to copy blobs if there are any.
+      // Set phase and copy blobs (if there are any).
+      phase_ = param.phase();
       if (layer_param_.blobs_size() > 0) {
         blobs_.resize(layer_param_.blobs_size());
         for (int i = 0; i < layer_param_.blobs_size(); ++i) {
@@ -288,6 +289,8 @@ class Layer {
  protected:
   /** The protobuf that stores the layer parameters */
   LayerParameter layer_param_;
+  /** The phase: TRAIN or TEST */
+  Phase phase_;
   /** The vector that stores the learnable parameters as a set of blobs. */
   vector<shared_ptr<Blob<Dtype> > > blobs_;
   /** Vector indicating whether to compute the diff of each param blob. */

--- a/include/caffe/loss_layers.hpp
+++ b/include/caffe/loss_layers.hpp
@@ -169,8 +169,8 @@ class ContrastiveLossLayer : public LossLayer<Dtype> {
 
   /**
    * @brief Computes the Contrastive error gradient w.r.t. the inputs.
-   * 
-   * Computes the gradients with respect to the two input vectors (bottom[0] and 
+   *
+   * Computes the gradients with respect to the two input vectors (bottom[0] and
    * bottom[1]), but not the similarity label (bottom[2]).
    *
    * @param top output Blob vector (length 1), providing the error gradient with
@@ -189,7 +189,7 @@ class ContrastiveLossLayer : public LossLayer<Dtype> {
    *      the features @f$a@f$; Backward fills their diff with
    *      gradients if propagate_down[0]
    *   -# @f$ (N \times C \times 1 \times 1) @f$
-   *      the features @f$b@f$; Backward fills their diff with gradients if 
+   *      the features @f$b@f$; Backward fills their diff with gradients if
    *      propagate_down[1]
    */
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -115,6 +115,8 @@ class Net {
   inline const vector<shared_ptr<Layer<Dtype> > >& layers() const {
     return layers_;
   }
+  /// @brief returns the phase: TRAIN or TEST
+  inline Phase phase() const { return phase_; }
   /**
    * @brief returns the bottom vecs for each layer -- usually you won't
    *        need this unless you do per-layer checks such as gradients.
@@ -207,6 +209,10 @@ class Net {
   /// @brief Get misc parameters, e.g. the LR multiplier and weight decay.
   void GetLearningRateAndWeightDecay();
 
+  /// @brief The network name
+  string name_;
+  /// @brief The phase: TRAIN or TEST
+  Phase phase_;
   /// @brief Individual layers in the net
   vector<shared_ptr<Layer<Dtype> > > layers_;
   vector<string> layer_names_;
@@ -239,7 +245,6 @@ class Net {
   vector<int> net_output_blob_indices_;
   vector<Blob<Dtype>*> net_input_blobs_;
   vector<Blob<Dtype>*> net_output_blobs_;
-  string name_;
   /// The parameters in the network.
   vector<shared_ptr<Blob<Dtype> > > params_;
   /// the learning rate multipliers

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -24,7 +24,7 @@ template <typename Dtype>
 class Net {
  public:
   explicit Net(const NetParameter& param);
-  explicit Net(const string& param_file);
+  explicit Net(const string& param_file, Phase phase);
   virtual ~Net() {}
 
   /// @brief Initialize a network with a NetParameter.

--- a/include/caffe/neuron_layers.hpp
+++ b/include/caffe/neuron_layers.hpp
@@ -8,6 +8,7 @@
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
 #include "caffe/layer.hpp"
+#include "caffe/net.hpp"
 #include "caffe/proto/caffe.pb.h"
 
 #define HDF5_DATA_DATASET_NAME "data"

--- a/matlab/caffe/matcaffe_init.m
+++ b/matlab/caffe/matcaffe_init.m
@@ -25,7 +25,8 @@ if caffe('is_initialized') == 0
     % NOTE: you'll have to get network definition
     error('You need the network prototxt definition');
   end
-  caffe('init', model_def_file, model_file)
+  % load network in TEST phase
+  caffe('init', model_def_file, model_file, 'test')
 end
 fprintf('Done with init\n');
 
@@ -38,7 +39,3 @@ else
   caffe('set_mode_cpu');
 end
 fprintf('Done with set_mode\n');
-
-% put into test mode
-caffe('set_phase_test');
-fprintf('Done with set_phase_test\n');

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,6 +1,7 @@
 from .pycaffe import Net, SGDSolver
 from ._caffe import set_mode_cpu, set_mode_gpu, set_device, \
-    set_phase_train, set_phase_test, Layer, get_solver
+    Layer, get_solver
+from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector
 import io

--- a/python/caffe/test/test_net.py
+++ b/python/caffe/test/test_net.py
@@ -35,7 +35,7 @@ class TestNet(unittest.TestCase):
     def setUp(self):
         self.num_output = 13
         net_file = simple_net_file(self.num_output)
-        self.net = caffe.Net(net_file)
+        self.net = caffe.Net(net_file, caffe.TRAIN)
         # fill in valid labels
         self.net.blobs['label'].data[...] = \
                 np.random.randint(self.num_output,
@@ -69,7 +69,7 @@ class TestNet(unittest.TestCase):
         f.close()
         self.net.save(f.name)
         net_file = simple_net_file(self.num_output)
-        net2 = caffe.Net(net_file, f.name)
+        net2 = caffe.Net(net_file, f.name, caffe.TRAIN)
         os.remove(net_file)
         os.remove(f.name)
         for name in self.net.params:

--- a/python/caffe/test/test_python_layer.py
+++ b/python/caffe/test/test_python_layer.py
@@ -36,7 +36,7 @@ def python_net_file():
 class TestPythonLayer(unittest.TestCase):
     def setUp(self):
         net_file = python_net_file()
-        self.net = caffe.Net(net_file)
+        self.net = caffe.Net(net_file, caffe.TRAIN)
         os.remove(net_file)
 
     def test_forward(self):

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -42,7 +42,7 @@ void GlobalInit(int* pargc, char*** pargv) {
 #ifdef CPU_ONLY  // CPU-only Caffe.
 
 Caffe::Caffe()
-    : random_generator_(), mode_(Caffe::CPU), phase_(Caffe::TRAIN) { }
+    : random_generator_(), mode_(Caffe::CPU) { }
 
 Caffe::~Caffe() { }
 
@@ -86,7 +86,7 @@ void* Caffe::RNG::generator() {
 
 Caffe::Caffe()
     : cublas_handle_(NULL), curand_generator_(NULL), random_generator_(),
-    mode_(Caffe::CPU), phase_(Caffe::TRAIN) {
+    mode_(Caffe::CPU) {
   // Try to create a cublas handler, and report an error if failed (but we will
   // keep the program running as one might just want to run CPU code).
   if (cublasCreate(&cublas_handle_) != CUBLAS_STATUS_SUCCESS) {

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -11,9 +11,9 @@
 namespace caffe {
 
 template<typename Dtype>
-DataTransformer<Dtype>::DataTransformer(const TransformationParameter& param)
-    : param_(param) {
-  phase_ = Caffe::phase();
+DataTransformer<Dtype>::DataTransformer(const TransformationParameter& param,
+    Phase phase)
+    : param_(param), phase_(phase) {
   // check if we want to use mean_file
   if (param_.has_mean_file()) {
     CHECK_EQ(param_.mean_value_size(), 0) <<
@@ -80,7 +80,7 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
     height = crop_size;
     width = crop_size;
     // We only do random crop when we do training.
-    if (phase_ == Caffe::TRAIN) {
+    if (phase_ == TRAIN) {
       h_off = Rand(datum_height - crop_size + 1);
       w_off = Rand(datum_width - crop_size + 1);
     } else {
@@ -247,7 +247,7 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
     CHECK_EQ(crop_size, height);
     CHECK_EQ(crop_size, width);
     // We only do random crop when we do training.
-    if (phase_ == Caffe::TRAIN) {
+    if (phase_ == TRAIN) {
       h_off = Rand(img_height - crop_size + 1);
       w_off = Rand(img_width - crop_size + 1);
     } else {
@@ -325,7 +325,7 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
     CHECK_EQ(crop_size, height);
     CHECK_EQ(crop_size, width);
     // We only do random crop when we do training.
-    if (phase_ == Caffe::TRAIN) {
+    if (phase_ == TRAIN) {
       h_off = Rand(input_height - crop_size + 1);
       w_off = Rand(input_width - crop_size + 1);
     } else {
@@ -398,7 +398,7 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
 template <typename Dtype>
 void DataTransformer<Dtype>::InitRand() {
   const bool needs_rand = param_.mirror() ||
-      (phase_ == Caffe::TRAIN && param_.crop_size());
+      (phase_ == TRAIN && param_.crop_size());
   if (needs_rand) {
     const unsigned int rng_seed = caffe_rng_rand();
     rng_.reset(new Caffe::RNG(rng_seed));

--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -23,7 +23,7 @@ void BaseDataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   }
   // The subclasses should setup the size of bottom and top
   DataLayerSetUp(bottom, top);
-  data_transformer_.InitRand();
+  data_transformer_->InitRand();
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include "caffe/data_layers.hpp"
+#include "caffe/net.hpp"
 #include "caffe/util/io.hpp"
 
 namespace caffe {
@@ -9,8 +10,7 @@ namespace caffe {
 template <typename Dtype>
 BaseDataLayer<Dtype>::BaseDataLayer(const LayerParameter& param)
     : Layer<Dtype>(param),
-      transform_param_(param.transform_param()),
-      data_transformer_(transform_param_) {
+      transform_param_(param.transform_param()) {
 }
 
 template <typename Dtype>
@@ -23,6 +23,8 @@ void BaseDataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   }
   // The subclasses should setup the size of bottom and top
   DataLayerSetUp(bottom, top);
+  data_transformer_.reset(
+      new DataTransformer<Dtype>(transform_param_, this->phase_));
   data_transformer_->InitRand();
 }
 
@@ -45,8 +47,7 @@ void BasePrefetchingDataLayer<Dtype>::LayerSetUp(
 
 template <typename Dtype>
 void BasePrefetchingDataLayer<Dtype>::CreatePrefetchThread() {
-  this->phase_ = Caffe::phase();
-  this->data_transformer_.InitRand();
+  this->data_transformer_->InitRand();
   CHECK(StartInternalThread()) << "Thread execution failed";
 }
 

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -119,9 +119,9 @@ void DataLayer<Dtype>::InternalThreadEntry() {
     int offset = this->prefetch_data_.offset(item_id);
     this->transformed_data_.set_cpu_data(top_data + offset);
     if (datum.encoded()) {
-      this->data_transformer_.Transform(cv_img, &(this->transformed_data_));
+      this->data_transformer_->Transform(cv_img, &(this->transformed_data_));
     } else {
-      this->data_transformer_.Transform(datum, &(this->transformed_data_));
+      this->data_transformer_->Transform(datum, &(this->transformed_data_));
     }
     if (this->output_labels_) {
       top_label[item_id] = datum.label();

--- a/src/caffe/layers/dropout_layer.cpp
+++ b/src/caffe/layers/dropout_layer.cpp
@@ -37,7 +37,7 @@ void DropoutLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   Dtype* top_data = top[0]->mutable_cpu_data();
   unsigned int* mask = rand_vec_.mutable_cpu_data();
   const int count = bottom[0]->count();
-  if (Caffe::phase() == Caffe::TRAIN) {
+  if (this->phase_ == TRAIN) {
     // Create random numbers
     caffe_rng_bernoulli(count, 1. - threshold_, mask);
     for (int i = 0; i < count; ++i) {
@@ -55,7 +55,7 @@ void DropoutLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
   if (propagate_down[0]) {
     const Dtype* top_diff = top[0]->cpu_diff();
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
-    if (Caffe::phase() == Caffe::TRAIN) {
+    if (this->phase_ == TRAIN) {
       const unsigned int* mask = rand_vec_.cpu_data();
       const int count = bottom[0]->count();
       for (int i = 0; i < count; ++i) {

--- a/src/caffe/layers/dropout_layer.cu
+++ b/src/caffe/layers/dropout_layer.cu
@@ -26,7 +26,7 @@ void DropoutLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
   const int count = bottom[0]->count();
-  if (Caffe::phase() == Caffe::TRAIN) {
+  if (this->phase_ == TRAIN) {
     unsigned int* mask =
         static_cast<unsigned int*>(rand_vec_.mutable_gpu_data());
     caffe_gpu_rng_uniform(count, mask);
@@ -56,7 +56,7 @@ void DropoutLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   if (propagate_down[0]) {
     const Dtype* top_diff = top[0]->gpu_diff();
     Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
-    if (Caffe::phase() == Caffe::TRAIN) {
+    if (this->phase_ == TRAIN) {
       const unsigned int* mask =
           static_cast<const unsigned int*>(rand_vec_.gpu_data());
       const int count = bottom[0]->count();

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -137,7 +137,7 @@ void ImageDataLayer<Dtype>::InternalThreadEntry() {
     // Apply transformations (mirror, crop...) to the image
     int offset = this->prefetch_data_.offset(item_id);
     this->transformed_data_.set_cpu_data(prefetch_data + offset);
-    this->data_transformer_.Transform(cv_img, &(this->transformed_data_));
+    this->data_transformer_->Transform(cv_img, &(this->transformed_data_));
     trans_time += timer.MicroSeconds();
 
     prefetch_label[item_id] = lines_[lines_id_].second;

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -40,7 +40,7 @@ void MemoryDataLayer<Dtype>::AddDatumVector(const vector<Datum>& datum_vector) {
   added_data_.Reshape(num, channels_, height_, width_);
   added_label_.Reshape(num, 1, 1, 1);
   // Apply data transformations (mirror, scale, crop...)
-  this->data_transformer_.Transform(datum_vector, &added_data_);
+  this->data_transformer_->Transform(datum_vector, &added_data_);
   // Copy Labels
   Dtype* top_label = added_label_.mutable_cpu_data();
   for (int item_id = 0; item_id < num; ++item_id) {
@@ -64,7 +64,7 @@ void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
   added_data_.Reshape(num, channels_, height_, width_);
   added_label_.Reshape(num, 1, 1, 1);
   // Apply data transformations (mirror, scale, crop...)
-  this->data_transformer_.Transform(mat_vector, &added_data_);
+  this->data_transformer_->Transform(mat_vector, &added_data_);
   // Copy Labels
   Dtype* top_label = added_label_.mutable_cpu_data();
   for (int item_id = 0; item_id < num; ++item_id) {

--- a/src/caffe/layers/pooling_layer.cu
+++ b/src/caffe/layers/pooling_layer.cu
@@ -182,7 +182,7 @@ void PoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
         kernel_w_, stride_h_, stride_w_, pad_h_, pad_w_, top_data);
     break;
   case PoolingParameter_PoolMethod_STOCHASTIC:
-    if (Caffe::phase() == Caffe::TRAIN) {
+    if (this->phase_ == TRAIN) {
       // We need to create the random index as well.
       caffe_gpu_rng_uniform(count, Dtype(0), Dtype(1),
                             rand_idx_.mutable_gpu_data());

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -32,6 +32,8 @@ Net<Dtype>::Net(const string& param_file) {
 
 template <typename Dtype>
 void Net<Dtype>::Init(const NetParameter& in_param) {
+  // Set phase from the state.
+  phase_ = in_param.state().phase();
   // Filter layers based on their include/exclude rules and
   // the current NetState.
   NetParameter filtered_param;
@@ -62,6 +64,11 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
   top_id_vecs_.resize(param.layer_size());
   bottom_need_backward_.resize(param.layer_size());
   for (int layer_id = 0; layer_id < param.layer_size(); ++layer_id) {
+    // Inherit phase from net if unset.
+    if (!param.layer(layer_id).has_phase()) {
+      param.mutable_layer(layer_id)->set_phase(phase_);
+    }
+    // Setup layer.
     const LayerParameter& layer_param = param.layer(layer_id);
     layers_.push_back(LayerRegistry<Dtype>::CreateLayer(layer_param));
     layer_names_.push_back(layer_param.name());
@@ -210,20 +217,6 @@ template <typename Dtype>
 void Net<Dtype>::FilterNet(const NetParameter& param,
     NetParameter* param_filtered) {
   NetState net_state(param.state());
-  // Let the phase of the net be the current global phase provided in the Caffe
-  // singleton, unless explicitly provided by the state.
-  if (!net_state.has_phase()) {
-    switch (Caffe::phase()) {
-      case Caffe::TRAIN:
-        net_state.set_phase(TRAIN);
-        break;
-      case Caffe::TEST:
-        net_state.set_phase(TEST);
-        break;
-      default:
-        LOG(FATAL) << "Unknown phase: " << Caffe::phase();
-    }
-  }
   param_filtered->CopyFrom(param);
   param_filtered->clear_layer();
   for (int i = 0; i < param.layer_size(); ++i) {

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -24,9 +24,10 @@ Net<Dtype>::Net(const NetParameter& param) {
 }
 
 template <typename Dtype>
-Net<Dtype>::Net(const string& param_file) {
+Net<Dtype>::Net(const string& param_file, Phase phase) {
   NetParameter param;
   ReadNetParamsFromTextFileOrDie(param_file, &param);
+  param.mutable_state()->set_phase(phase);
   Init(param);
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -253,6 +253,9 @@ message LayerParameter {
   repeated string bottom = 3; // the name of each bottom blob
   repeated string top = 4; // the name of each top blob
 
+  // The train / test phase for computation.
+  optional Phase phase = 10;
+
   // The amount of weight to assign each top blob in the objective.
   // Each layer assigns a default value, usually of either 0 or 1,
   // to each top blob.

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -219,7 +219,6 @@ void Solver<Dtype>::Step(int iters) {
 
 template <typename Dtype>
 void Solver<Dtype>::Solve(const char* resume_file) {
-  Caffe::set_phase(Caffe::TRAIN);
   LOG(INFO) << "Solving " << net_->name();
   LOG(INFO) << "Learning Rate Policy: " << param_.lr_policy();
 
@@ -266,8 +265,6 @@ template <typename Dtype>
 void Solver<Dtype>::Test(const int test_net_id) {
   LOG(INFO) << "Iteration " << iter_
             << ", Testing net (#" << test_net_id << ")";
-  // We need to set phase to test before running.
-  Caffe::set_phase(Caffe::TEST);
   CHECK_NOTNULL(test_nets_[test_net_id].get())->
       ShareTrainedLayersWith(net_.get());
   vector<Dtype> test_score;
@@ -318,7 +315,6 @@ void Solver<Dtype>::Test(const int test_net_id) {
     LOG(INFO) << "    Test net output #" << i << ": " << output_name << " = "
         << mean_score << loss_msg_stream.str();
   }
-  Caffe::set_phase(Caffe::TRAIN);
 }
 
 

--- a/src/caffe/test/test_common.cpp
+++ b/src/caffe/test/test_common.cpp
@@ -29,13 +29,6 @@ TEST_F(CommonTest, TestBrewMode) {
   EXPECT_EQ(Caffe::mode(), Caffe::GPU);
 }
 
-TEST_F(CommonTest, TestPhase) {
-  Caffe::set_phase(Caffe::TRAIN);
-  EXPECT_EQ(Caffe::phase(), Caffe::TRAIN);
-  Caffe::set_phase(Caffe::TEST);
-  EXPECT_EQ(Caffe::phase(), Caffe::TEST);
-}
-
 TEST_F(CommonTest, TestRandSeedCPU) {
   SyncedMemory data_a(10 * sizeof(int));
   SyncedMemory data_b(10 * sizeof(int));

--- a/src/caffe/test/test_data_layer.cpp
+++ b/src/caffe/test/test_data_layer.cpp
@@ -69,6 +69,7 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
   void TestRead() {
     const Dtype scale = 3;
     LayerParameter param;
+    param.set_phase(TRAIN);
     DataParameter* data_param = param.mutable_data_param();
     data_param->set_batch_size(5);
     data_param->set_source(filename_->c_str());
@@ -132,6 +133,7 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
 
     // Load and check data of various shapes.
     LayerParameter param;
+    param.set_phase(TEST);
     DataParameter* data_param = param.mutable_data_param();
     data_param->set_batch_size(1);
     data_param->set_source(filename_->c_str());
@@ -167,9 +169,10 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
     }
   }
 
-  void TestReadCrop() {
+  void TestReadCrop(Phase phase) {
     const Dtype scale = 3;
     LayerParameter param;
+    param.set_phase(phase);
     Caffe::set_random_seed(1701);
 
     DataParameter* data_param = param.mutable_data_param();
@@ -205,7 +208,7 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
           num_with_center_value +=
               (center_value == blob_top_data_->cpu_data()[i * 2 + j]);
           // At TEST time, check that we always get center value.
-          if (Caffe::phase() == Caffe::TEST) {
+          if (phase == caffe::TEST) {
             EXPECT_EQ(center_value, this->blob_top_data_->cpu_data()[i * 2 + j])
                 << "debug: iter " << iter << " i " << i << " j " << j;
           }
@@ -214,7 +217,7 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
       // At TRAIN time, check that we did not get the center crop all 10 times.
       // (This check fails with probability 1-1/12^10 in a correct
       // implementation, so we call set_random_seed.)
-      if (Caffe::phase() == Caffe::TRAIN) {
+      if (phase == caffe::TRAIN) {
         EXPECT_LT(num_with_center_value, 10);
       }
     }
@@ -222,6 +225,7 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
 
   void TestReadCropTrainSequenceSeeded() {
     LayerParameter param;
+    param.set_phase(TRAIN);
     DataParameter* data_param = param.mutable_data_param();
     data_param->set_batch_size(5);
     data_param->set_source(filename_->c_str());
@@ -276,6 +280,7 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
 
   void TestReadCropTrainSequenceUnseeded() {
     LayerParameter param;
+    param.set_phase(TRAIN);
     DataParameter* data_param = param.mutable_data_param();
     data_param->set_batch_size(5);
     data_param->set_source(filename_->c_str());
@@ -354,16 +359,14 @@ TYPED_TEST(DataLayerTest, TestReshapeLevelDB) {
 }
 
 TYPED_TEST(DataLayerTest, TestReadCropTrainLevelDB) {
-  Caffe::set_phase(Caffe::TRAIN);
   const bool unique_pixels = true;  // all images the same; pixels different
   this->Fill(unique_pixels, DataParameter_DB_LEVELDB);
-  this->TestReadCrop();
+  this->TestReadCrop(TRAIN);
 }
 
 // Test that the sequence of random crops is consistent when using
 // Caffe::set_random_seed.
 TYPED_TEST(DataLayerTest, TestReadCropTrainSequenceSeededLevelDB) {
-  Caffe::set_phase(Caffe::TRAIN);
   const bool unique_pixels = true;  // all images the same; pixels different
   this->Fill(unique_pixels, DataParameter_DB_LEVELDB);
   this->TestReadCropTrainSequenceSeeded();
@@ -372,17 +375,15 @@ TYPED_TEST(DataLayerTest, TestReadCropTrainSequenceSeededLevelDB) {
 // Test that the sequence of random crops differs across iterations when
 // Caffe::set_random_seed isn't called (and seeds from srand are ignored).
 TYPED_TEST(DataLayerTest, TestReadCropTrainSequenceUnseededLevelDB) {
-  Caffe::set_phase(Caffe::TRAIN);
   const bool unique_pixels = true;  // all images the same; pixels different
   this->Fill(unique_pixels, DataParameter_DB_LEVELDB);
   this->TestReadCropTrainSequenceUnseeded();
 }
 
 TYPED_TEST(DataLayerTest, TestReadCropTestLevelDB) {
-  Caffe::set_phase(Caffe::TEST);
   const bool unique_pixels = true;  // all images the same; pixels different
   this->Fill(unique_pixels, DataParameter_DB_LEVELDB);
-  this->TestReadCrop();
+  this->TestReadCrop(TEST);
 }
 
 TYPED_TEST(DataLayerTest, TestReadLMDB) {
@@ -396,16 +397,14 @@ TYPED_TEST(DataLayerTest, TestReshapeLMDB) {
 }
 
 TYPED_TEST(DataLayerTest, TestReadCropTrainLMDB) {
-  Caffe::set_phase(Caffe::TRAIN);
   const bool unique_pixels = true;  // all images the same; pixels different
   this->Fill(unique_pixels, DataParameter_DB_LMDB);
-  this->TestReadCrop();
+  this->TestReadCrop(TRAIN);
 }
 
 // Test that the sequence of random crops is consistent when using
 // Caffe::set_random_seed.
 TYPED_TEST(DataLayerTest, TestReadCropTrainSequenceSeededLMDB) {
-  Caffe::set_phase(Caffe::TRAIN);
   const bool unique_pixels = true;  // all images the same; pixels different
   this->Fill(unique_pixels, DataParameter_DB_LMDB);
   this->TestReadCropTrainSequenceSeeded();
@@ -414,17 +413,15 @@ TYPED_TEST(DataLayerTest, TestReadCropTrainSequenceSeededLMDB) {
 // Test that the sequence of random crops differs across iterations when
 // Caffe::set_random_seed isn't called (and seeds from srand are ignored).
 TYPED_TEST(DataLayerTest, TestReadCropTrainSequenceUnseededLMDB) {
-  Caffe::set_phase(Caffe::TRAIN);
   const bool unique_pixels = true;  // all images the same; pixels different
   this->Fill(unique_pixels, DataParameter_DB_LMDB);
   this->TestReadCropTrainSequenceUnseeded();
 }
 
 TYPED_TEST(DataLayerTest, TestReadCropTestLMDB) {
-  Caffe::set_phase(Caffe::TEST);
   const bool unique_pixels = true;  // all images the same; pixels different
   this->Fill(unique_pixels, DataParameter_DB_LMDB);
-  this->TestReadCrop();
+  this->TestReadCrop(TEST);
 }
 
 }  // namespace caffe

--- a/src/caffe/test/test_maxpool_dropout_layers.cpp
+++ b/src/caffe/test/test_maxpool_dropout_layers.cpp
@@ -88,8 +88,8 @@ TYPED_TEST(MaxPoolingDropoutTest, TestForward) {
 
 TYPED_TEST(MaxPoolingDropoutTest, TestBackward) {
   typedef typename TypeParam::Dtype Dtype;
-  Caffe::set_phase(Caffe::TRAIN);
   LayerParameter layer_param;
+  layer_param.set_phase(TRAIN);
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
   pooling_param->set_kernel_size(3);
   pooling_param->set_stride(2);

--- a/src/caffe/test/test_net.cpp
+++ b/src/caffe/test/test_net.cpp
@@ -1534,20 +1534,6 @@ TEST_F(FilterNetTest, TestFilterLeNetTrainTest) {
       output_proto_test + " state: { phase: TEST } ";
   this->RunFilterNetTest(input_proto_train, output_proto_train_explicit);
   this->RunFilterNetTest(input_proto_test, output_proto_test_explicit);
-
-  // Also check that nets are filtered according to the Caffe singleton phase,
-  // if not explicitly specified in the input proto.
-  Caffe::set_phase(Caffe::TRAIN);
-  this->RunFilterNetTest(input_proto, output_proto_train);
-  Caffe::set_phase(Caffe::TEST);
-  this->RunFilterNetTest(input_proto, output_proto_test);
-
-  // Finally, check that the current Caffe singleton phase is ignored if the
-  // phase is explicitly specified in the input proto.
-  Caffe::set_phase(Caffe::TEST);
-  this->RunFilterNetTest(input_proto_train, output_proto_train_explicit);
-  Caffe::set_phase(Caffe::TRAIN);
-  this->RunFilterNetTest(input_proto_test, output_proto_test_explicit);
 }
 
 TEST_F(FilterNetTest, TestFilterOutByStage) {

--- a/src/caffe/test/test_neuron_layer.cpp
+++ b/src/caffe/test/test_neuron_layer.cpp
@@ -43,8 +43,8 @@ class NeuronLayerTest : public MultiDeviceTest<TypeParam> {
     if (dropout_ratio != 0.5) {
       layer_param.mutable_dropout_param()->set_dropout_ratio(dropout_ratio);
     }
-    Caffe::set_phase(Caffe::TRAIN);
     DropoutLayer<Dtype> layer(layer_param);
+    layer_param.set_phase(TRAIN);
     layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
     layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
     // Now, check values
@@ -334,7 +334,7 @@ TYPED_TEST(NeuronLayerTest, TestDropoutThreeQuarters) {
 TYPED_TEST(NeuronLayerTest, TestDropoutTestPhase) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  Caffe::set_phase(Caffe::TEST);
+  layer_param.set_phase(TEST);
   DropoutLayer<Dtype> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -351,7 +351,7 @@ TYPED_TEST(NeuronLayerTest, TestDropoutTestPhase) {
 TYPED_TEST(NeuronLayerTest, TestDropoutGradient) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  Caffe::set_phase(Caffe::TRAIN);
+  layer_param.set_phase(TRAIN);
   DropoutLayer<Dtype> layer(layer_param);
   GradientChecker<Dtype> checker(1e-2, 1e-3);
   checker.CheckGradientEltwise(&layer, this->blob_bottom_vec_,
@@ -361,7 +361,7 @@ TYPED_TEST(NeuronLayerTest, TestDropoutGradient) {
 TYPED_TEST(NeuronLayerTest, TestDropoutGradientTest) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  Caffe::set_phase(Caffe::TEST);
+  layer_param.set_phase(TEST);
   DropoutLayer<Dtype> layer(layer_param);
   GradientChecker<Dtype> checker(1e-2, 1e-3);
   checker.CheckGradientEltwise(&layer, this->blob_bottom_vec_,

--- a/src/caffe/test/test_stochastic_pooling.cpp
+++ b/src/caffe/test/test_stochastic_pooling.cpp
@@ -62,8 +62,8 @@ TYPED_TEST(StochasticPoolingLayerTest, TestSetup) {
 
 TYPED_TEST(StochasticPoolingLayerTest, TestStochasticGPU) {
   Caffe::set_mode(Caffe::GPU);
-  Caffe::set_phase(Caffe::TRAIN);
   LayerParameter layer_param;
+  layer_param.set_phase(TRAIN);
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
   pooling_param->set_kernel_size(3);
   pooling_param->set_stride(2);
@@ -106,8 +106,8 @@ TYPED_TEST(StochasticPoolingLayerTest, TestStochasticGPU) {
 
 TYPED_TEST(StochasticPoolingLayerTest, TestStochasticGPUTestPhase) {
   Caffe::set_mode(Caffe::GPU);
-  Caffe::set_phase(Caffe::TEST);
   LayerParameter layer_param;
+  layer_param.set_phase(TEST);
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
   pooling_param->set_kernel_size(3);
   pooling_param->set_stride(2);
@@ -144,8 +144,8 @@ TYPED_TEST(StochasticPoolingLayerTest, TestStochasticGPUTestPhase) {
 
 TYPED_TEST(StochasticPoolingLayerTest, TestGradientGPU) {
   Caffe::set_mode(Caffe::GPU);
-  Caffe::set_phase(Caffe::TRAIN);
   LayerParameter layer_param;
+  layer_param.set_phase(TRAIN);
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
   pooling_param->set_kernel_size(3);
   pooling_param->set_stride(2);

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -139,8 +139,7 @@ int test() {
     Caffe::set_mode(Caffe::CPU);
   }
   // Instantiate the caffe net.
-  Caffe::set_phase(Caffe::TEST);
-  Net<float> caffe_net(FLAGS_model);
+  Net<float> caffe_net(FLAGS_model, caffe::TEST);
   caffe_net.CopyTrainedLayersFrom(FLAGS_weights);
   LOG(INFO) << "Running for " << FLAGS_iterations << " iterations.";
 
@@ -205,8 +204,7 @@ int time() {
     Caffe::set_mode(Caffe::CPU);
   }
   // Instantiate the caffe net.
-  Caffe::set_phase(Caffe::TRAIN);
-  Net<float> caffe_net(FLAGS_model);
+  Net<float> caffe_net(FLAGS_model, caffe::TRAIN);
 
   // Do a clean forward and backward pass, so that memory allocation are done
   // and future iterations will be more stable.

--- a/tools/extract_features.cpp
+++ b/tools/extract_features.cpp
@@ -64,7 +64,6 @@ int feature_extraction_pipeline(int argc, char** argv) {
     LOG(ERROR) << "Using CPU";
     Caffe::set_mode(Caffe::CPU);
   }
-  Caffe::set_phase(Caffe::TEST);
 
   arg_pos = 0;  // the name of the executable
   std::string pretrained_binary_proto(argv[++arg_pos]);
@@ -98,7 +97,7 @@ int feature_extraction_pipeline(int argc, char** argv) {
    */
   std::string feature_extraction_proto(argv[++arg_pos]);
   shared_ptr<Net<Dtype> > feature_extraction_net(
-      new Net<Dtype>(feature_extraction_proto));
+      new Net<Dtype>(feature_extraction_proto, caffe::TEST));
   feature_extraction_net->CopyTrainedLayersFrom(pretrained_binary_proto);
 
   std::string extract_feature_blob_names(argv[++arg_pos]);


### PR DESCRIPTION
After #1794 since `dump_network` is dropped for incompatibility here.

Make Net master of phase as is its proper due and let layers inherit its phase. This fixes #1430 and satisfies the phase part of #1500. Here's to taking a small step toward abolishing the singleton.

- phase is set at instantiation and should never change. 
- phase defaults to TEST by the [caffe.proto default](https://github.com/BVLC/caffe/blob/dev/src/caffe/proto/caffe.proto#L183). This fits the wishes in #192, but should there be a default phase at all?

Misgivings:
-  the `explicit Net(const string& param_file, Phase phase)` constructor works, but what of `stage` and `level` and further extensions to net state? Should the parameter file constructor be done away with and all these set through `NetParameter`? The `caffe` tool and wrappers will need to learn about `NetState`.
- exposing the `Phase` enum seemed like a hassle, so 001f060 just exposes the proto values as `caffe.{TRAIN,TEST}` for instantiating `caffe.Net`. I suppose this could have a pytest.