### PR TITLE
leveldb iterator should be deleted before the db is deleted

### DIFF
--- a/tools/compute_image_mean.cpp
+++ b/tools/compute_image_mean.cpp
@@ -157,6 +157,7 @@ int main(int argc, char** argv) {
 
   // Clean up
   if (db_backend == "leveldb") {
+    delete it;
     delete db;
   } else if (db_backend == "lmdb") {
     mdb_cursor_close(mdb_cursor);


### PR DESCRIPTION
In some old version of leveldb, the iterator must be deleted before the db. Otherwise, it will cause a failure like:

**compute_image_mean: version_set.cc:715: leveldb::VersionSet::~VersionSet(): Assertion `dummy_versions_.next_ == &dummy_versions_' failed.**
./compute-mean.sh: line 2: 26811 Aborted                 ./build/tools/compute_image_mean train_leveldb mean.binaryproto leveldb

This is what I got on centos-6.5, rhel-6.5, with epel6 - leveldb-1.7.0-2.el6
Someone else had encountered the same problem, see https://groups.google.com/forum/#!topic/leveldb/I0_gN82a3vI