### PR TITLE
fix for layer-type-str: loss_param in V1LayerParameter

### DIFF
--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -719,6 +719,7 @@ message V1LayerParameter {
     CONTRASTIVE_LOSS = 37;
     CONVOLUTION = 4;
     DATA = 5;
+    DECONVOLUTION = 39;
     DROPOUT = 6;
     DUMMY_DATA = 32;
     EUCLIDEAN_LOSS = 7;
@@ -790,6 +791,7 @@ message V1LayerParameter {
   optional ThresholdParameter threshold_param = 25;
   optional WindowDataParameter window_data_param = 20;
   optional TransformationParameter transform_param = 36;
+  optional LossParameter loss_param = 42;
   optional V0LayerParameter layer = 1;
 }
 

--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -824,6 +824,10 @@ bool UpgradeV1LayerParameter(const V1LayerParameter& v1_layer_param,
     layer_param->mutable_transform_param()->CopyFrom(
         v1_layer_param.transform_param());
   }
+  if (v1_layer_param.has_loss_param()) {
+    layer_param->mutable_loss_param()->CopyFrom(
+        v1_layer_param.loss_param());
+  }
   if (v1_layer_param.has_layer()) {
     LOG(ERROR) << "Input NetParameter has V0 layer -- ignoring.";
     is_fully_compatible = false;
@@ -849,6 +853,8 @@ const char* UpgradeV1LayerType(const V1LayerParameter_LayerType type) {
     return "ContrastiveLoss";
   case V1LayerParameter_LayerType_CONVOLUTION:
     return "Convolution";
+  case V1LayerParameter_LayerType_DECONVOLUTION:
+    return "Deconvolution";
   case V1LayerParameter_LayerType_DATA:
     return "Data";
   case V1LayerParameter_LayerType_DROPOUT:


### PR DESCRIPTION
Fixes upgrade bug I introduced in #1694: I forgot to add `loss_param` to `V1LayerParameter` after it was added by @longjon and I rebased on his work.  Will merge this once Travis passes (and I go check caffe.proto again to make sure nothing else is missing..)