### PR TITLE
Die on inputs that fail to load

### DIFF
--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -118,10 +118,8 @@ void ImageDataLayer<Dtype>::InternalThreadEntry() {
     timer.Start();
     CHECK_GT(lines_size, lines_id_);
     cv::Mat cv_img = ReadImageToCVMat(root_folder + lines_[lines_id_].first,
-                                    new_height, new_width, is_color);
-    if (!cv_img.data) {
-      continue;
-    }
+        new_height, new_width, is_color);
+    CHECK(cv_img.data) << "Could not load " << lines_[lines_id_].first;
     read_time += timer.MicroSeconds();
     timer.Start();
     // Apply transformations (mirror, crop...) to the image


### PR DESCRIPTION
It's better to know than march silently on. Further cleanup of IMAGE_DATA might
follow in this PR, but this single change should be made to avoid accidentally
missing data.