### PR TITLE
Bug in MemoryData that does not allow using arrays with n_ * size_ > 2^31

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -281,7 +281,7 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   Dtype* data_;
   Dtype* labels_;
   int n_;
-  int pos_;
+  size_t pos_;
   Blob<Dtype> added_data_;
   Blob<Dtype> added_label_;
   bool has_new_data_;


### PR DESCRIPTION
So the problem is in here: 
```
top[0]->set_cpu_data(data_ + pos_ * size_);
```
`pos_` and `size_` are `int`, so I had segmentation fault due to overflow in there, I think, when using huge array.  To overcome this we need to change some variables types, so please comment how you think to do it better since I did the first thing that came to my mind that would fix the crashes I had. 