### PR TITLE
Fix PowerLayer gradient check failures by reducing step size

### DIFF
--- a/src/caffe/test/test_power_layer.cpp
+++ b/src/caffe/test/test_power_layer.cpp
@@ -74,7 +74,7 @@ class PowerLayerTest : public MultiDeviceTest<TypeParam> {
         }
       }
     }
-    GradientChecker<Dtype> checker(1e-2, 1e-2, 1701, 0., 0.01);
+    GradientChecker<Dtype> checker(1e-3, 1e-2, 1701, 0., 0.01);
     checker.CheckGradientEltwise(&layer, this->blob_bottom_vec_,
         this->blob_top_vec_);
   }


### PR DESCRIPTION
See #1252. This reduces the step size of the gradient checker so that the finite-difference approximation holds better. Tests now pass with boost 1.56+, which rewrote the normal distribution RNG -- although the switch to Ziggurat from Box-Muller was supposed to be transparent, it seems it wasn't.

Thanks to @jeffdonahue for the inference to boost RNG since it is always by the fillers regardless of CPU / GPU mode!