### PR TITLE
Encoded cleanup

### DIFF
--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -92,7 +92,14 @@ inline bool ReadFileToDatum(const string& filename, Datum* datum) {
 }
 
 bool ReadImageToDatum(const string& filename, const int label,
-    const int height, const int width, const bool is_color, Datum* datum);
+    const int height, const int width, const bool is_color,
+    const std::string & encoding, Datum* datum);
+
+inline bool ReadImageToDatum(const string& filename, const int label,
+    const int height, const int width, const bool is_color, Datum* datum) {
+  return ReadImageToDatum(filename, label, height, width, is_color,
+                          "", datum);
+}
 
 inline bool ReadImageToDatum(const string& filename, const int label,
     const int height, const int width, Datum* datum) {
@@ -109,20 +116,12 @@ inline bool ReadImageToDatum(const string& filename, const int label,
   return ReadImageToDatum(filename, label, 0, 0, true, datum);
 }
 
-bool DecodeDatum(const int height, const int width, const bool is_color,
-  Datum* datum);
-
-inline bool DecodeDatum(const int height, const int width, Datum* datum) {
-  return DecodeDatum(height, width, true, datum);
+inline bool ReadImageToDatum(const string& filename, const int label,
+    const std::string & encoding, Datum* datum) {
+  return ReadImageToDatum(filename, label, 0, 0, true, encoding, datum);
 }
 
-inline bool DecodeDatum(const bool is_color, Datum* datum) {
-  return DecodeDatum(0, 0, is_color, datum);
-}
-
-inline bool DecodeDatum(Datum* datum) {
-  return DecodeDatum(0, 0, true, datum);
-}
+bool DecodeDatumNative(Datum* datum);
 
 cv::Mat ReadImageToCVMat(const string& filename,
     const int height, const int width, const bool is_color);
@@ -135,16 +134,7 @@ cv::Mat ReadImageToCVMat(const string& filename,
 
 cv::Mat ReadImageToCVMat(const string& filename);
 
-cv::Mat DecodeDatumToCVMat(const Datum& datum,
-    const int height, const int width, const bool is_color);
-
-cv::Mat DecodeDatumToCVMat(const Datum& datum,
-    const int height, const int width);
-
-cv::Mat DecodeDatumToCVMat(const Datum& datum,
-    const bool is_color);
-
-cv::Mat DecodeDatumToCVMat(const Datum& datum);
+cv::Mat DecodeDatumToCVMatNative(const Datum& datum);
 
 void CVMatToDatum(const cv::Mat& cv_img, Datum* datum);
 

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -42,7 +42,7 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   Datum datum;
   datum.ParseFromString(cursor_->value());
 
-  if (DecodeDatum(&datum)) {
+  if (DecodeDatumNative(&datum)) {
     LOG(INFO) << "Decoding Datum";
   }
   // image
@@ -98,7 +98,7 @@ void DataLayer<Dtype>::InternalThreadEntry() {
 
     cv::Mat cv_img;
     if (datum.encoded()) {
-       cv_img = DecodeDatumToCVMat(datum);
+       cv_img = DecodeDatumToCVMatNative(datum);
     }
     read_time += timer.MicroSeconds();
     timer.Start();

--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -281,7 +281,7 @@ void WindowDataLayer<Dtype>::InternalThreadEntry() {
       if (this->cache_images_) {
         pair<std::string, Datum> image_cached =
           image_database_cache_[window[WindowDataLayer<Dtype>::IMAGE_INDEX]];
-        cv_img = DecodeDatumToCVMat(image_cached.second);
+        cv_img = DecodeDatumToCVMatNative(image_cached.second);
       } else {
         cv_img = cv::imread(image.first, CV_LOAD_IMAGE_COLOR);
         if (!cv_img.data) {

--- a/src/caffe/test/test_io.cpp
+++ b/src/caffe/test/test_io.cpp
@@ -289,8 +289,8 @@ TEST_F(IOTest, TestDecodeDatum) {
   string filename = EXAMPLES_SOURCE_DIR "images/cat.jpg";
   Datum datum;
   EXPECT_TRUE(ReadFileToDatum(filename, &datum));
-  EXPECT_TRUE(DecodeDatum(&datum));
-  EXPECT_FALSE(DecodeDatum(&datum));
+  EXPECT_TRUE(DecodeDatumNative(&datum));
+  EXPECT_FALSE(DecodeDatumNative(&datum));
   Datum datum_ref;
   ReadImageToDatumReference(filename, 0, 0, 0, true, &datum_ref);
   EXPECT_EQ(datum.channels(), datum_ref.channels());
@@ -309,38 +309,17 @@ TEST_F(IOTest, TestDecodeDatumToCVMat) {
   string filename = EXAMPLES_SOURCE_DIR "images/cat.jpg";
   Datum datum;
   EXPECT_TRUE(ReadFileToDatum(filename, &datum));
-  cv::Mat cv_img = DecodeDatumToCVMat(datum);
+  cv::Mat cv_img = DecodeDatumToCVMatNative(datum);
   EXPECT_EQ(cv_img.channels(), 3);
   EXPECT_EQ(cv_img.rows, 360);
   EXPECT_EQ(cv_img.cols, 480);
 }
 
-TEST_F(IOTest, TestDecodeDatumToCVMatResized) {
-  string filename = EXAMPLES_SOURCE_DIR "images/cat.jpg";
-  Datum datum;
-  EXPECT_TRUE(ReadFileToDatum(filename, &datum));
-  cv::Mat cv_img = DecodeDatumToCVMat(datum, 100, 200);
-  EXPECT_EQ(cv_img.channels(), 3);
-  EXPECT_EQ(cv_img.rows, 100);
-  EXPECT_EQ(cv_img.cols, 200);
-}
-
-TEST_F(IOTest, TestDecodeDatumToCVMatResizedGray) {
-  string filename = EXAMPLES_SOURCE_DIR "images/cat.jpg";
-  Datum datum;
-  EXPECT_TRUE(ReadFileToDatum(filename, &datum));
-  const bool is_color = false;
-  cv::Mat cv_img = DecodeDatumToCVMat(datum, 200, 100, is_color);
-  EXPECT_EQ(cv_img.channels(), 1);
-  EXPECT_EQ(cv_img.rows, 200);
-  EXPECT_EQ(cv_img.cols, 100);
-}
-
 TEST_F(IOTest, TestDecodeDatumToCVMatContent) {
   string filename = EXAMPLES_SOURCE_DIR "images/cat.jpg";
   Datum datum;
-  EXPECT_TRUE(ReadFileToDatum(filename, &datum));
-  cv::Mat cv_img = DecodeDatumToCVMat(datum);
+  EXPECT_TRUE(ReadImageToDatum(filename, 0, std::string("jpg"), &datum));
+  cv::Mat cv_img = DecodeDatumToCVMatNative(datum);
   cv::Mat cv_img_ref = ReadImageToCVMat(filename);
   EXPECT_EQ(cv_img_ref.channels(), cv_img.channels());
   EXPECT_EQ(cv_img_ref.rows, cv_img.rows);

--- a/tools/compute_image_mean.cpp
+++ b/tools/compute_image_mean.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv) {
   Datum datum;
   datum.ParseFromString(cursor->value());
 
-  if (DecodeDatum(&datum)) {
+  if (DecodeDatumNative(&datum)) {
     LOG(INFO) << "Decoding Datum";
   }
 
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
   while (cursor->valid()) {
     Datum datum;
     datum.ParseFromString(cursor->value());
-    DecodeDatum(&datum);
+    DecodeDatumNative(&datum);
 
     const std::string& data = datum.data();
     size_in_datum = std::max<int>(datum.data().size(),


### PR DESCRIPTION
I decided to clean the encoded flag up a bit and add some more options.
convert_imageset can now store images encoded with resize and gray options on. Internally io.cpp will use opencv to re-encode a resized image if needed. It is also possible to change the encoding, using the encode_type flag.

The DecodeDatumToCVMat and DecodeDatum functions were renamed to DecodeDatumToCVMatNative and DecodeDatumNative . The ...Native functions will load images with their native color channels (grey or BGR) instead of always converting encoded images to BGR. This allows the encoding of 1d label masks (such as image class labels).