### PR TITLE
MSR weight filler

### DIFF
--- a/include/caffe/filler.hpp
+++ b/include/caffe/filler.hpp
@@ -157,6 +157,27 @@ class XavierFiller : public Filler<Dtype> {
   }
 };
 
+/**
+ * @brief Fills a Blob with values @f$ x \sim N(-a, +a) @f$ where @f$ a @f$ is
+ *        set by the number of incoming nodes, based on the paper [He,
+ *        Zhang, Ren and Sun 2015]
+ */
+template <typename Dtype>
+class MSRFiller : public Filler<Dtype> {
+ public:
+  explicit MSRFiller(const FillerParameter& param)
+      : Filler<Dtype>(param) {}
+  virtual void Fill(Blob<Dtype>* blob) {
+    CHECK(blob->count());
+    int fan_in = blob->count() / blob->num();
+    Dtype std = sqrt(Dtype(2) / fan_in);
+    caffe_rng_gaussian<Dtype>(blob->count(), Dtype(0), std,
+        blob->mutable_cpu_data());
+    CHECK_EQ(this->filler_param_.sparse(), -1)
+         << "Sparsity not supported by this Filler.";
+  }
+};
+
 
 /**
  * @brief Get a specific filler from the specification given in FillerParameter.
@@ -177,6 +198,8 @@ Filler<Dtype>* GetFiller(const FillerParameter& param) {
     return new UniformFiller<Dtype>(param);
   } else if (type == "xavier") {
     return new XavierFiller<Dtype>(param);
+  } else if (type == "msr") {
+    return new MSRFiller<Dtype>(param);
   } else {
     CHECK(false) << "Unknown filler name: " << param.type();
   }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -41,6 +41,10 @@ message FillerParameter {
   // The expected number of non-zero output weights for a given input in
   // Gaussian filler -- the default -1 means don't perform sparsification.
   optional int32 sparse = 7 [default = -1];
+  // for the msr filler we can consider the fan_in size, the fan_out size, or
+  // both (by averaging)
+  optional bool fan_in = 8 [default = true];
+  optional bool fan_out = 9 [default = false];
 }
 
 message NetParameter {

--- a/src/caffe/test/test_filler.cpp
+++ b/src/caffe/test/test_filler.cpp
@@ -146,10 +146,29 @@ template <typename Dtype>
 class MSRFillerTest : public ::testing::Test {
  protected:
   MSRFillerTest()
-      : blob_(new Blob<Dtype>(1000, 3, 4, 5)),
+      : blob_(new Blob<Dtype>(1000, 2, 4, 5)),
         filler_param_() {
-    filler_.reset(new MSRFiller<Dtype>(filler_param_));
-    filler_->Fill(blob_);
+  }
+  virtual void test_params(bool fan_in, bool fan_out, Dtype n) {
+    this->filler_param_.set_fan_in(fan_in);
+    this->filler_param_.set_fan_out(fan_out);
+    this->filler_.reset(new MSRFiller<Dtype>(this->filler_param_));
+    this->filler_->Fill(blob_);
+    EXPECT_TRUE(this->blob_);
+    const int count = this->blob_->count();
+    const Dtype* data = this->blob_->cpu_data();
+    Dtype mean = 0.;
+    Dtype ex2 = 0.;
+    for (int i = 0; i < count; ++i) {
+      mean += data[i];
+      ex2 += data[i] * data[i];
+    }
+    mean /= count;
+    ex2 /= count;
+    Dtype std = sqrt(ex2 - mean*mean);
+    Dtype target_std = sqrt(2.0 / n);
+    EXPECT_NEAR(mean, 0.0, 0.1);
+    EXPECT_NEAR(std, target_std, 0.1);
   }
   virtual ~MSRFillerTest() { delete blob_; }
   Blob<Dtype>* const blob_;
@@ -159,23 +178,17 @@ class MSRFillerTest : public ::testing::Test {
 
 TYPED_TEST_CASE(MSRFillerTest, TestDtypes);
 
-TYPED_TEST(MSRFillerTest, TestFill) {
-  EXPECT_TRUE(this->blob_);
-  const int count = this->blob_->count();
-  const TypeParam* data = this->blob_->cpu_data();
-  TypeParam mean = 0.;
-  TypeParam ex2 = 0.;
-  for (int i = 0; i < count; ++i) {
-    mean += data[i];
-    ex2 += data[i] * data[i];
-  }
-  mean /= count;
-  ex2 /= count;
-  TypeParam std = sqrt(ex2 - mean*mean);
-  int fan_in = 3*4*5;
-  TypeParam target_std = sqrt(2.0 / fan_in);
-  EXPECT_NEAR(mean, 0.0, 0.1);
-  EXPECT_NEAR(std, target_std, 0.1);
+TYPED_TEST(MSRFillerTest, TestFillFanIn) {
+  TypeParam n = 2*4*5;
+  this->test_params(true, false, n);
+}
+TYPED_TEST(MSRFillerTest, TestFillFanOut) {
+  TypeParam n = 1000*4*5;
+  this->test_params(false, true, n);
+}
+TYPED_TEST(MSRFillerTest, TestFillFanInFanOut) {
+  TypeParam n = (2*4*5 + 1000*4*5) / 2.0;
+  this->test_params(true, true, n);
 }
 
 }  // namespace caffe


### PR DESCRIPTION
This PR implements the weight initialization strategy from http://arxiv.org/abs/1502.01852. It is very similar to the Xavier filler---except designed for RLU instead of tanh non-linearities. 

This would compliment #1880 which implements the PReLU layer also proposed in this paper.