### PR TITLE
Making python3 work with cmake and the new python wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ caffe_option(CPU_ONLY  "Build Caffe wihtout CUDA support" OFF) # TODO: rename to
 caffe_option(USE_CUDNN "Build Caffe with cuDNN libary support" ON IF NOT CPU_ONLY)
 caffe_option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 caffe_option(BUILD_python "Build Python wrapper" ON)
+set(python_version "2" CACHE STRING "Specify which python version to use")
 caffe_option(BUILD_matlab "Build Matlab wrapper" OFF IF UNIX OR APPLE)
 caffe_option(BUILD_docs   "Build documentation" ON IF UNIX OR APPLE)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -92,12 +92,39 @@ endif()
 
 # ---[ Python
 if(BUILD_python)
-  # disable Python 3 search
-  find_package(PythonInterp 2.7)
-  find_package(PythonLibs 2.7)
-  find_package(NumPy 1.7.1)
-  find_package(Boost 1.46 COMPONENTS python)
-
+  if("${python_version}" VERSION_GREATER "2.99")
+    # use python3
+    find_package(PythonInterp 3.0)
+    find_package(PythonLibs 3.0)
+    find_package(NumPy 1.7.1)
+    # Find the matching boost python implementation
+    set(version ${PYTHONLIBS_VERSION_STRING})
+    
+    STRING( REPLACE "." "" boost_py_version ${version} )
+    find_package(Boost 1.46 COMPONENTS "python-py${boost_py_version}")
+    set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
+    
+    while(NOT "${version}" STREQUAL "" AND NOT Boost_PYTHON_FOUND)
+      STRING( REGEX REPLACE "([0-9.]+).[0-9]+" "\\1" version ${version} )
+      STRING( REGEX MATCHALL "([0-9.]+).[0-9]+" has_more_version ${version} )
+      if("${has_more_version}" STREQUAL "")
+        break()
+      endif()
+      
+      STRING( REPLACE "." "" boost_py_version ${version} )
+      find_package(Boost 1.46 COMPONENTS "python-py${boost_py_version}")
+      set(Boost_PYTHON_FOUND ${Boost_PYTHON-PY${boost_py_version}_FOUND})
+    endwhile()
+    if(NOT Boost_PYTHON_FOUND)
+      find_package(Boost 1.46 COMPONENTS python)
+    endif()
+  else()
+    # disable Python 3 search
+    find_package(PythonInterp 2.7)
+    find_package(PythonLibs 2.7)
+    find_package(NumPy 1.7.1)
+    find_package(Boost 1.46 COMPONENTS python)
+  endif()
   if(PYTHONLIBS_FOUND AND NUMPY_FOUND AND Boost_PYTHON_FOUND)
     set(HAVE_PYTHON TRUE)
   endif()

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,7 +30,7 @@ Caffe has several dependencies.
 
 Pycaffe and Matcaffe interfaces have their own natural needs.
 
-* For Python Caffe:  `Python 2.7`, `numpy (>= 1.7)`, boost-provided `boost.python`
+* For Python Caffe:  `Python 2.7` or `Python 3.3+`, `numpy (>= 1.7)`, boost-provided `boost.python`
 * For MATLAB Caffe: MATLAB with the `mex` compiler.
 
 **cuDNN Caffe**: for fastest operation Caffe is accelerated by drop-in integration of [NVIDIA cuDNN](https://developer.nvidia.com/cudnn). To speed up your Caffe models, install cuDNN then uncomment the `USE_CUDNN := 1` flag in `Makefile.config` when installing Caffe. Acceleration is automatic. For now cuDNN v1 is integrated but see [PR #1731](https://github.com/BVLC/caffe/pull/1731) for v2.
@@ -69,7 +69,7 @@ but we suggest first installing the [Anaconda](https://store.continuum.io/cshop/
 
 To import the `caffe` Python module after completing the installation, add the module directory to your `$PYTHONPATH` by `export PYTHONPATH=/path/to/caffe/python:$PYTHONPATH` or the like. You should not import the module in the `caffe/python/caffe` directory!
 
-*Caffe's Python interface works with Python 2.7. Python 3 or earlier Pythons are your own adventure.*
+*Caffe's Python interface works with Python 2.7. Python 3.3+ should work out of the box without protobuf support. For protobuf support please install protobuf 3.0 alpha (https://developers.google.com/protocol-buffers/). Earlier Pythons are your own adventure.*
 
 #### MATLAB
 

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -266,7 +266,7 @@ BOOST_PYTHON_MODULE(_caffe) {
   bp::class_<vector<bool> >("BoolVec")
     .def(bp::vector_indexing_suite<vector<bool> >());
 
-  import_array();
+  import_array1();
 }
 
 }  // namespace caffe

--- a/python/caffe/detector.py
+++ b/python/caffe/detector.py
@@ -118,7 +118,7 @@ class Detector(caffe.Net):
             cmd='selective_search_rcnn'
         )
         # Run windowed detection on the selective search list.
-        return self.detect_windows(zip(image_fnames, windows_list))
+        return self.detect_windows(list(zip(image_fnames, windows_list)))
 
 
     def crop(self, im, window):

--- a/python/caffe/draw.py
+++ b/python/caffe/draw.py
@@ -23,7 +23,7 @@ def get_pooling_types_dict():
     """
     desc = caffe_pb2.PoolingParameter.PoolMethod.DESCRIPTOR
     d = {}
-    for k,v in desc.values_by_name.items():
+    for k,v in list(desc.values_by_name.items()):
         d[v.number] = k
     return d
 
@@ -137,7 +137,7 @@ def get_pydot_graph(caffe_net, rankdir, label_edges=True):
                           'dst': top_blob + '_blob',
                           'label': edge_label})
   # Now, add the nodes and edges to the graph.
-  for node in pydot_nodes.values():
+  for node in list(pydot_nodes.values()):
     pydot_graph.add_node(node)
   for edge in pydot_edges:
     pydot_graph.add_edge(

--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -3,7 +3,11 @@ import skimage.io
 from scipy.ndimage import zoom
 from skimage.transform import resize
 
-from caffe.proto import caffe_pb2
+try:
+	# Python3 will most likely not be able to load protobuf
+	from caffe.proto import caffe_pb2
+except:
+	pass
 
 
 def load_image(filename, color=True):

--- a/python/caffe/pycaffe.py
+++ b/python/caffe/pycaffe.py
@@ -4,7 +4,10 @@ interface.
 """
 
 from collections import OrderedDict
-from itertools import izip_longest
+try:
+	from itertools import izip_longest
+except:
+	from itertools import zip_longest as izip_longest
 import numpy as np
 
 from ._caffe import Net, SGDSolver

--- a/python/classify.py
+++ b/python/classify.py
@@ -103,7 +103,7 @@ def main(argv):
             channel_swap=channel_swap)
 
     if args.gpu:
-        print 'GPU mode'
+        print('GPU mode')
 
     # Load numpy array (.npy), directory glob (*.jpg), or image file.
     args.input_file = os.path.expanduser(args.input_file)
@@ -115,12 +115,12 @@ def main(argv):
     else:
         inputs = [caffe.io.load_image(args.input_file)]
 
-    print "Classifying %d inputs." % len(inputs)
+    print("Classifying %d inputs." % len(inputs))
 
     # Classify.
     start = time.time()
     predictions = classifier.predict(inputs, not args.center_only)
-    print "Done in %.2f s." % (time.time() - start)
+    print("Done in %.2f s." % (time.time() - start))
 
     # Save
     np.save(args.output_file, predictions)

--- a/python/detect.py
+++ b/python/detect.py
@@ -113,7 +113,7 @@ def main(argv):
             context_pad=args.context_pad)
 
     if args.gpu:
-        print 'GPU mode'
+        print('GPU mode')
 
     # Load input.
     t = time.time()
@@ -137,8 +137,8 @@ def main(argv):
         detections = detector.detect_windows(images_windows)
     else:
         detections = detector.detect_selective_search(inputs)
-    print("Processed {} windows in {:.3f} s.".format(len(detections),
-                                                     time.time() - t))
+    print(("Processed {} windows in {:.3f} s.".format(len(detections),
+                                                     time.time() - t)))
 
     # Collect into dataframe with labeled fields.
     df = pd.DataFrame(detections)
@@ -159,8 +159,8 @@ def main(argv):
     else:
         # h5
         df.to_hdf(args.output_file, 'df', mode='w')
-    print("Saved to {} in {:.3f} s.".format(args.output_file,
-                                            time.time() - t))
+    print(("Saved to {} in {:.3f} s.".format(args.output_file,
+                                            time.time() - t)))
 
 
 if __name__ == "__main__":

--- a/python/draw_net.py
+++ b/python/draw_net.py
@@ -36,7 +36,7 @@ def main():
     args = parse_args()
     net = caffe_pb2.NetParameter()
     text_format.Merge(open(args.input_net_proto_file).read(), net)
-    print 'Drawing net to %s' % args.output_image_file
+    print('Drawing net to %s' % args.output_image_file)
     caffe.draw.draw_net_to_file(net, args.output_image_file, args.rankdir)
 
 


### PR DESCRIPTION
A small change than allows the cmake based build to use python3.
Simply specify the "python_version" in the cmake configuration (either 2 or 3).

Also replaced "import_array" with "import_array1" which works for both python 2.7 and 3.? .

Protobuf and pycaffe should now work with python3. Updated the docs to reflect the fact that protobuf 3.0 alpha is required for python3 (not for python2).