### PR TITLE
cmake: CMAKE_SOURCE/BINARY_DIR to PROJECT_SOURCE/BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.8.7)
 project(Caffe C CXX)
 
 # ---[ Using cmake scripts and modules
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
 include(cmake/Utils.cmake)
 include(cmake/Targets.cmake)
@@ -39,11 +39,11 @@ add_definitions(-DGTEST_USE_OWN_TR1_TUPLE)
 caffe_warnings_disable(CMAKE_CXX_FLAGS -Wno-sign-compare -Wno-uninitialized)
 
 # ---[ Config generation
-configure_file(cmake/Templates/caffe_config.h.in "${CMAKE_BINARY_DIR}/caffe_config.h")
+configure_file(cmake/Templates/caffe_config.h.in "${PROJECT_BINARY_DIR}/caffe_config.h")
 
 # ---[ Includes
-set(Caffe_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
-include_directories(${Caffe_INCLUDE_DIR} ${CMAKE_BINARY_DIR})
+set(Caffe_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
+include_directories(${Caffe_INCLUDE_DIR} ${PROJECT_BINARY_DIR})
 include_directories(BEFORE src) # This is needed for gtest.
 
 # ---[ Subdirectories
@@ -56,7 +56,7 @@ add_subdirectory(matlab)
 add_subdirectory(docs)
 
 # ---[ Linter target
-add_custom_target(lint COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/lint.cmake)
+add_custom_target(lint COMMAND ${CMAKE_COMMAND} -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
 # ---[ Configuration summary
 caffe_print_configuration_summary()

--- a/cmake/ConfigGen.cmake
+++ b/cmake/ConfigGen.cmake
@@ -7,8 +7,8 @@ function(caffe_get_current_includes includes_variable)
   get_property(current_includes DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
   caffe_convert_absolute_paths(current_includes)
 
-  # remove at most one ${CMAKE_BINARY_DIR} include added for caffe_config.h
-  list(FIND current_includes ${CMAKE_BINARY_DIR} __index)
+  # remove at most one ${PROJECT_BINARY_DIR} include added for caffe_config.h
+  list(FIND current_includes ${PROJECT_BINARY_DIR} __index)
   list(REMOVE_AT current_includes ${__index})
 
   caffe_list_unique(current_includes)
@@ -55,17 +55,17 @@ function(caffe_generate_export_configs)
     list(APPEND Caffe_DEFINITIONS -DUSE_MKL)
   endif()
 
-  configure_file("cmake/Templates/CaffeConfig.cmake.in" "${CMAKE_BINARY_DIR}/CaffeConfig.cmake" @ONLY)
+  configure_file("cmake/Templates/CaffeConfig.cmake.in" "${PROJECT_BINARY_DIR}/CaffeConfig.cmake" @ONLY)
 
   # Add targets to the build-tree export set
-  export(TARGETS caffe proto FILE "${CMAKE_BINARY_DIR}/CaffeTargets.cmake")
+  export(TARGETS caffe proto FILE "${PROJECT_BINARY_DIR}/CaffeTargets.cmake")
   export(PACKAGE Caffe)
 
   # ---[ Configure install-tree CaffeConfig.cmake file ]---
 
   # remove source and build dir includes
-  caffe_get_items_with_prefix(${CMAKE_SOURCE_DIR} Caffe_INCLUDE_DIRS __insource)
-  caffe_get_items_with_prefix(${CMAKE_BINARY_DIR} Caffe_INCLUDE_DIRS __inbinary)
+  caffe_get_items_with_prefix(${PROJECT_SOURCE_DIR} Caffe_INCLUDE_DIRS __insource)
+  caffe_get_items_with_prefix(${PROJECT_BINARY_DIR} Caffe_INCLUDE_DIRS __inbinary)
   list(REMOVE_ITEM Caffe_INCLUDE_DIRS ${__insource} ${__inbinary})
 
   # add `install` include folder
@@ -75,10 +75,10 @@ function(caffe_generate_export_configs)
      "unset(__caffe_include)\n")
   string(REPLACE ";" "" Caffe_INSTALL_INCLUDE_DIR_APPEND_COMMAND ${lines})
 
-  configure_file("cmake/Templates/CaffeConfig.cmake.in" "${CMAKE_BINARY_DIR}/cmake/CaffeConfig.cmake" @ONLY)
+  configure_file("cmake/Templates/CaffeConfig.cmake.in" "${PROJECT_BINARY_DIR}/cmake/CaffeConfig.cmake" @ONLY)
 
   # Install the CaffeConfig.cmake and export set to use wuth install-tree
-  install(FILES "${CMAKE_BINARY_DIR}/cmake/CaffeConfig.cmake" DESTINATION ${install_cmake_suffix})
+  install(FILES "${PROJECT_BINARY_DIR}/cmake/CaffeConfig.cmake" DESTINATION ${install_cmake_suffix})
   install(EXPORT CaffeTargets DESTINATION ${install_cmake_suffix})
 
   # ---[ Configure and install version file ]---
@@ -86,8 +86,8 @@ function(caffe_generate_export_configs)
   # TODO: Lines below are commented because Caffe does't declare its version in headers.
   # When the declarations are added, modify `caffe_extract_caffe_version()` macro and uncomment
 
-  # configure_file(cmake/Templates/CaffeConfigVersion.cmake.in "${CMAKE_BINARY_DIR}/CaffeConfigVersion.cmake" @ONLY)
-  # install(FILES "${CMAKE_BINARY_DIR}/CaffeConfigVersion.cmake" DESTINATION ${install_cmake_suffix})
+  # configure_file(cmake/Templates/CaffeConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/CaffeConfigVersion.cmake" @ONLY)
+  # install(FILES "${PROJECT_BINARY_DIR}/CaffeConfigVersion.cmake" DESTINATION ${install_cmake_suffix})
 endfunction()
 
 

--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -12,7 +12,7 @@ set(Caffe_known_gpu_archs "20 21(20) 30 35 50")
 #   caffe_detect_installed_gpus(out_variable)
 function(caffe_detect_installed_gpus out_variable)
   if(NOT CUDA_gpu_detect_output)
-    set(__cufile ${CMAKE_BINARY_DIR}/detect_cuda_archs.cu)
+    set(__cufile ${PROJECT_BINARY_DIR}/detect_cuda_archs.cu)
 
     file(WRITE ${__cufile} ""
       "#include <cstdio>\n"
@@ -31,7 +31,7 @@ function(caffe_detect_installed_gpus out_variable)
       "}\n")
 
     execute_process(COMMAND "${CUDA_NVCC_EXECUTABLE}" "--run" "${__cufile}"
-                    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/CMakeFiles/"
+                    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/CMakeFiles/"
                     RESULT_VARIABLE __nvcc_res OUTPUT_VARIABLE __nvcc_out
                     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/cmake/Misc.cmake
+++ b/cmake/Misc.cmake
@@ -25,7 +25,7 @@ endif()
 
 # ---[ Install options
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Default install path" FORCE)
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/install" CACHE PATH "Default install path" FORCE)
 endif()
 
 # ---[ RPATH settings
@@ -34,8 +34,8 @@ set(CMAKE_MACOSX_RPATH TRUE)
 
 # ---[ Funny target
 if(UNIX OR APPLE)
-  add_custom_target(symlink_to_build COMMAND "ln" "-sf" "${CMAKE_BINARY_DIR}" "${CMAKE_SOURCE_DIR}/build"
-                                     COMMENT "Adding symlink: <caffe_root>/build -> ${CMAKE_BINARY_DIR}" )
+  add_custom_target(symlink_to_build COMMAND "ln" "-sf" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}/build"
+                                     COMMENT "Adding symlink: <caffe_root>/build -> ${PROJECT_BINARY_DIR}" )
 endif()
 
 # ---[ Set debug postfix

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -22,8 +22,8 @@ if(PROTOBUF_FOUND)
 endif()
 
 # place where to generate protobuf sources
-set(proto_gen_folder "${CMAKE_BINARY_DIR}/include/caffe/proto")
-include_directories(SYSTEM "${CMAKE_BINARY_DIR}/include")
+set(proto_gen_folder "${PROJECT_BINARY_DIR}/include/caffe/proto")
+include_directories(SYSTEM "${PROJECT_BINARY_DIR}/include")
 
 set(PROTOBUF_GENERATE_CPP_APPEND_PATH TRUE)
 

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -65,7 +65,7 @@ function(caffe_extract_caffe_version)
   if(GIT_FOUND)
     execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
                     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
-                    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
                     OUTPUT_VARIABLE Caffe_GIT_VERSION
                     RESULT_VARIABLE __git_result)
     if(NOT ${__git_result} EQUAL 0)

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -53,7 +53,7 @@ function(caffe_pickup_caffe_sources root)
   # put all files in source groups (visible as subfolder in many IDEs)
   caffe_source_group("Include"        GLOB "${root}/include/caffe/*.h*")
   caffe_source_group("Include\\Util"  GLOB "${root}/include/caffe/util/*.h*")
-  caffe_source_group("Include"        GLOB "${CMAKE_BINARY_DIR}/caffe_config.h*")
+  caffe_source_group("Include"        GLOB "${PROJECT_BINARY_DIR}/caffe_config.h*")
   caffe_source_group("Source"         GLOB "${root}/src/caffe/*.cpp")
   caffe_source_group("Source\\Util"   GLOB "${root}/src/caffe/util/*.cpp")
   caffe_source_group("Source\\Layers" GLOB "${root}/src/caffe/layers/*.cpp")
@@ -75,7 +75,7 @@ function(caffe_pickup_caffe_sources root)
   list(REMOVE_ITEM  srcs ${test_srcs})
 
   # adding headers to make the visible in some IDEs (Qt, VS, Xcode)
-  list(APPEND srcs ${hdrs} ${CMAKE_BINARY_DIR}/caffe_config.h)
+  list(APPEND srcs ${hdrs} ${PROJECT_BINARY_DIR}/caffe_config.h)
   list(APPEND test_srcs ${test_hdrs})
 
   # collect cuda files
@@ -107,9 +107,9 @@ endfunction()
 function(caffe_default_properties target)
   set_target_properties(${target} PROPERTIES
     DEBUG_POSTFIX ${Caffe_DEBUG_POSTFIX}
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+    ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 endfunction()
 
 ################################################################################################
@@ -139,7 +139,7 @@ function(caffe_configure_testdatafile file)
   file(STRINGS ${file} __lines)
   set(result "")
   foreach(line ${__lines})
-    set(result "${result}${CMAKE_SOURCE_DIR}/${line}\n")
+    set(result "${result}${PROJECT_SOURCE_DIR}/${line}\n")
   endforeach()  
   file(WRITE ${file}.gen.cmake ${result})
 endfunction()

--- a/cmake/Templates/caffe_config.h.in
+++ b/cmake/Templates/caffe_config.h.in
@@ -1,8 +1,8 @@
 /* Sources directory */
-#define SOURCE_FOLDER "${CMAKE_SOURCE_DIR}"
+#define SOURCE_FOLDER "${PROJECT_SOURCE_DIR}"
 
 /* Binaries directory */
-#define BINARY_FOLDER "${CMAKE_BINARY_DIR}"
+#define BINARY_FOLDER "${PROJECT_BINARY_DIR}"
 
 /* NVIDA Cuda */
 #cmakedefine HAVE_CUDA

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -64,19 +64,19 @@ endfunction()
 ########################## [ Non macro part ] ##################################################
 
 # Gathering is done at each 'make doc'
-file(REMOVE_RECURSE ${CMAKE_SOURCE_DIR}/docs/gathered)
+file(REMOVE_RECURSE ${PROJECT_SOURCE_DIR}/docs/gathered)
 
 # Doxygen config file path
-set(DOXYGEN_config_file ${CMAKE_SOURCE_DIR}/.Doxyfile CACHE FILEPATH "Doxygen config file")
+set(DOXYGEN_config_file ${PROJECT_SOURCE_DIR}/.Doxyfile CACHE FILEPATH "Doxygen config file")
 
 # Adding docs target
 add_custom_target(docs COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_config_file}
-                       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                        COMMENT "Launching doxygen..." VERBATIM)
 
 # Gathering examples into docs subfolder
-gather_notebooks_as_prebuild_cmd(docs docs/gathered ${CMAKE_SOURCE_DIR})
-gather_readmes_as_prebuild_cmd(docs docs/gathered  ${CMAKE_SOURCE_DIR})
+gather_notebooks_as_prebuild_cmd(docs docs/gathered ${PROJECT_SOURCE_DIR})
+gather_readmes_as_prebuild_cmd(docs docs/gathered  ${PROJECT_SOURCE_DIR})
 
 # Auto detect output directory
 file(STRINGS ${DOXYGEN_config_file} config_line REGEX "OUTPUT_DIRECTORY[ \t]+=[^=].*")
@@ -90,17 +90,17 @@ else()
 endif()
 
 if(NOT IS_ABSOLUTE ${output_dir})
-  set(output_dir ${CMAKE_SOURCE_DIR}/${output_dir})
+  set(output_dir ${PROJECT_SOURCE_DIR}/${output_dir})
   get_filename_component(output_dir ${output_dir} ABSOLUTE)
 endif()
 
 # creates symlink in docs subfolder to code documentation built by doxygen
 add_custom_command(TARGET docs POST_BUILD VERBATIM
                    COMMAND ln -sfn "${output_dir}/html" doxygen
-                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs
-                   COMMENT "Creating symlink ${CMAKE_SOURCE_DIR}/docs/doxygen -> ${output_dir}/html")
+                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
+                   COMMENT "Creating symlink ${PROJECT_SOURCE_DIR}/docs/doxygen -> ${output_dir}/html")
 
 # for quick launch of jekyll
 add_custom_target(jekyll COMMAND jekyll serve -w -s . -d _site --port=4000
-                         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/docs
+                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/docs
                          COMMENT "Launching jekyll..." VERBATIM)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB_RECURSE examples_srcs "${CMAKE_SOURCE_DIR}/examples/*.cpp")
+file(GLOB_RECURSE examples_srcs "${PROJECT_SOURCE_DIR}/examples/*.cpp")
 
 foreach(source_file ${examples_srcs})
   # get file name
@@ -14,7 +14,7 @@ foreach(source_file ${examples_srcs})
 
   # set back RUNTIME_OUTPUT_DIRECTORY
   set_target_properties(${name} PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/${folder}")
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/examples/${folder}")
 
   caffe_set_solution_folder(${name} examples)
 
@@ -24,7 +24,7 @@ foreach(source_file ${examples_srcs})
   if(UNIX OR APPLE)
     # Funny command to make tutorials work
     # TODO: remove in future as soon as naming is standartaized everywhere
-    set(__outname ${CMAKE_BINARY_DIR}/examples/${folder}/${name}${CAffe_POSTFIX})
+    set(__outname ${PROJECT_BINARY_DIR}/examples/${folder}/${name}${CAffe_POSTFIX})
     add_custom_command(TARGET ${name} POST_BUILD
                        COMMAND ln -sf "${__outname}" "${__outname}.bin")
   endif()

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -32,7 +32,7 @@ endfunction()
 
 # global settings
 file(GLOB Matlab_srcs caffe/matcaffe.cpp)
-set(Matlab_caffe_mex ${CMAKE_SOURCE_DIR}/matlab/caffe/caffe.mex)
+set(Matlab_caffe_mex ${PROJECT_SOURCE_DIR}/matlab/caffe/caffe.mex)
 
 caffe_get_current_cflags(cflags)
 caffe_parse_linker_libs(Caffe_LINKER_LIBS folders libflags macos_frameworks)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT HAVE_PYTHON)
 endif()
 
 include_directories(${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
-file(GLOB_RECURSE python_srcs ${CMAKE_SOURCE_DIR}/python/*.cpp)
+file(GLOB_RECURSE python_srcs ${PROJECT_SOURCE_DIR}/python/*.cpp)
 
 add_library(pycaffe SHARED ${python_srcs})
 target_link_libraries(pycaffe ${Caffe_LINK} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
@@ -12,13 +12,13 @@ set_target_properties(pycaffe PROPERTIES PREFIX "" OUTPUT_NAME "_caffe")
 caffe_default_properties(pycaffe)
 
 if(UNIX OR APPLE)
-    set(__linkname "${CMAKE_SOURCE_DIR}/python/caffe/_caffe.so")
+    set(__linkname "${PROJECT_SOURCE_DIR}/python/caffe/_caffe.so")
     add_custom_command(TARGET pycaffe POST_BUILD
                        COMMAND ln -sf $<TARGET_LINKER_FILE:pycaffe> "${__linkname}"
-                       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_SOURCE_DIR}/python/caffe/proto
-                       COMMAND touch ${CMAKE_SOURCE_DIR}/python/caffe/proto/__init__.py
-                       COMMAND cp ${proto_gen_folder}/*.py ${CMAKE_SOURCE_DIR}/python/caffe/proto/
-                       COMMENT "Creating symlink ${__linkname} -> ${CMAKE_BINARY_DIR}/lib/_caffe${CAffe_POSTFIX}.so")
+                       COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_SOURCE_DIR}/python/caffe/proto
+                       COMMAND touch ${PROJECT_SOURCE_DIR}/python/caffe/proto/__init__.py
+                       COMMAND cp ${proto_gen_folder}/*.py ${PROJECT_SOURCE_DIR}/python/caffe/proto/
+                       COMMENT "Creating symlink ${__linkname} -> ${PROJECT_BINARY_DIR}/lib/_caffe${CAffe_POSTFIX}.so")
 endif()
 
 # ---[ Install

--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -10,7 +10,7 @@ caffe_default_properties(proto)
 # --[ Caffe library
 
 # creates 'test_srcs', 'srcs', 'test_cuda', 'cuda' lists
-caffe_pickup_caffe_sources(${CMAKE_SOURCE_DIR})
+caffe_pickup_caffe_sources(${PROJECT_SOURCE_DIR})
 
 if(HAVE_CUDA)
   caffe_cuda_compile(cuda_objs ${cuda})
@@ -29,8 +29,8 @@ install(DIRECTORY ${Caffe_INCLUDE_DIR}/caffe DESTINATION include)
 install(FILES ${proto_hdrs} DESTINATION include/caffe/proto)
 install(TARGETS caffe proto EXPORT CaffeTargets DESTINATION lib)
 
-file(WRITE ${CMAKE_BINARY_DIR}/__init__.py)
-list(APPEND proto_python ${CMAKE_BINARY_DIR}/__init__.py)
+file(WRITE ${PROJECT_BINARY_DIR}/__init__.py)
+list(APPEND proto_python ${PROJECT_BINARY_DIR}/__init__.py)
 install(PROGRAMS ${proto_python} DESTINATION python/caffe/proto)
 
 

--- a/src/caffe/test/CMakeLists.txt
+++ b/src/caffe/test/CMakeLists.txt
@@ -29,8 +29,8 @@ endif()
 add_executable(${the_target} EXCLUDE_FROM_ALL ${test_srcs})
 target_link_libraries(${the_target} gtest ${Caffe_LINK})
 caffe_default_properties(${the_target})
-caffe_set_runtime_directory(${the_target} "${CMAKE_BINARY_DIR}/test")
+caffe_set_runtime_directory(${the_target} "${PROJECT_BINARY_DIR}/test")
 
 # ---[ Adding runtest
 add_custom_target(runtest COMMAND ${the_target} ${test_args}
-                          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+                          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -16,7 +16,7 @@ foreach(source ${srcs})
   caffe_default_properties(${name})
 
   # set back RUNTIME_OUTPUT_DIRECTORY
-  caffe_set_runtime_directory(${name} "${CMAKE_BINARY_DIR}/tools")
+  caffe_set_runtime_directory(${name} "${PROJECT_BINARY_DIR}/tools")
   caffe_set_solution_folder(${name} tools)
 
   # restore output name without suffix


### PR DESCRIPTION
This is a simple string replace from CMAKE_SOURCE_DIR/CMAKE_BINARY_DIR to PROJECT_SOURCE_DIR/PROJECT_BINARY_DIR.
If caffe is build directly using cmake, this has no effect.
However if caffe is included as a subproject (add_subdirectory) it now builds correctly, as all PROJECT_.._DIR point to the root of the caffe directory and not root of the parent project.