### PR TITLE
Full-sized image cropping and Scale Augmentation

### DIFF
--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -148,6 +148,12 @@ cv::Mat DecodeDatumToCVMat(const Datum& datum);
 
 void CVMatToDatum(const cv::Mat& cv_img, Datum* datum);
 
+template <typename Dtype, int channels>
+cv::Mat BlobToCVMat(Blob<Dtype> *blob, int num = 0);
+
+template <typename Dtype, int channels>
+void CVMatToBlob(cv::Mat img, Blob<Dtype> *blob);
+
 template <typename Dtype>
 void hdf5_load_nd_dataset_helper(
     hid_t file_id, const char* dataset_name_, int min_dim, int max_dim,

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -14,8 +15,15 @@
 #include "caffe/util/math_functions.hpp"
 #include "caffe/util/rng.hpp"
 
-namespace caffe {
+#include "google/protobuf/io/coded_stream.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "google/protobuf/text_format.h"
 
+using google::protobuf::io::ZeroCopyInputStream;
+using google::protobuf::io::ArrayInputStream;
+using google::protobuf::io::CodedInputStream;
+
+namespace caffe {
 template <typename Dtype>
 DataLayer<Dtype>::~DataLayer<Dtype>() {
   this->JoinPrefetchThread();
@@ -38,9 +46,17 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       cursor_->Next();
     }
   }
+
   // Read a data point, and use it to initialize the top blob.
+  string stringcoding = cursor_->value();
+  ZeroCopyInputStream* raw_input =
+      new ArrayInputStream(stringcoding.c_str(), stringcoding.length());
+  CodedInputStream* coded_input = new CodedInputStream(raw_input);
+  coded_input->SetTotalBytesLimit(std::numeric_limits<int>::max(),
+      std::numeric_limits<int>::max()*0.8);
+
   Datum datum;
-  datum.ParseFromString(cursor_->value());
+  datum.ParseFromCodedStream(coded_input);
 
   if (DecodeDatum(&datum)) {
     LOG(INFO) << "Decoding Datum";
@@ -71,6 +87,9 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
     this->prefetch_label_.Reshape(this->layer_param_.data_param().batch_size(),
         1, 1, 1);
   }
+
+  delete coded_input;
+  delete raw_input;
 }
 
 // This function is used to create a thread that prefetches the data.
@@ -105,8 +124,15 @@ void DataLayer<Dtype>::InternalThreadEntry() {
   for (int item_id = 0; item_id < batch_size; ++item_id) {
     timer.Start();
     // get a blob
+    string stringcoding = cursor_->value();
+    ZeroCopyInputStream* raw_input =
+        new ArrayInputStream(stringcoding.c_str(), stringcoding.length());
+    CodedInputStream* coded_input = new CodedInputStream(raw_input);
+    coded_input->SetTotalBytesLimit(std::numeric_limits<int>::max(),
+        std::numeric_limits<int>::max()*0.8);
+
     Datum datum;
-    datum.ParseFromString(cursor_->value());
+    datum.ParseFromCodedStream(coded_input);
 
     cv::Mat cv_img;
     if (datum.encoded()) {
@@ -133,6 +159,9 @@ void DataLayer<Dtype>::InternalThreadEntry() {
       DLOG(INFO) << "Restarting data prefetching from start.";
       cursor_->SeekToFirst();
     }
+
+    delete coded_input;
+    delete raw_input;
   }
   batch_timer.Stop();
   DLOG(INFO) << "Prefetch batch: " << batch_timer.MilliSeconds() << " ms.";

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -337,6 +337,10 @@ message TransformationParameter {
   // or can be repeated the same number of times as channels
   // (would subtract them from the corresponding channel)
   repeated float mean_value = 5;
+  // Specify minimum size of images before crop (used for scale augmentation). 
+  optional uint32 min_size = 6;
+  // Specify maximum size of images before crop (used for scale agumentation).
+  optional uint32 max_size = 7;
 }
 
 // Message that stores parameters shared by loss layers

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -205,6 +205,55 @@ void CVMatToDatum(const cv::Mat& cv_img, Datum* datum) {
   datum->set_data(buffer);
 }
 
+template <typename Dtype, int channels>
+cv::Mat BlobToCVMat(Blob<Dtype> *blob, int num) {
+  CHECK(blob->channels() == channels)
+      << "Blob does not have correct number of channels";
+  cv::Mat img = cv::Mat(blob->height(), blob->width(),
+      CV_MAKETYPE(cv::DataDepth<Dtype>::value, channels));
+  for (int y = 0; y < blob->height(); y++) {
+    for (int x = 0; x < blob->width(); x++) {
+      cv::Vec<Dtype, channels> val;
+      for (int c = 0; c < channels; c++) {
+        img.at<cv::Vec<Dtype, channels> >(y, x)[c] =
+          static_cast<Dtype>(*(blob->cpu_data()+blob->offset(num, c, y, x)));
+      }
+    }
+  }
+  return img;
+}
+
+template
+cv::Mat BlobToCVMat<float, 3>(Blob<float> *blob, int num);
+
+template
+cv::Mat BlobToCVMat<double, 3>(Blob<double> *blob, int num);
+
+template <typename Dtype, int channels>
+void CVMatToBlob(cv::Mat img, Blob<Dtype> *blob) {
+  CHECK(img.depth() == CV_MAKETYPE(cv::DataDepth<Dtype>::value, channels))
+    << "OpenCV matrix and Blob must have same type";
+  CHECK(img.channels() == channels)
+    << "OpenCV matrix does not have correct number of channels";
+  blob->Reshape(1, channels, img.rows, img.cols);
+
+  for (int y = 0; y < blob->height(); y++) {
+    for (int x = 0; x < blob->width(); x++) {
+      cv::Vec<Dtype, channels> val;
+      for (int c = 0; c < channels; c++) {
+        *(blob->mutable_cpu_data()+blob->offset(0, c, y, x)) =
+          img.at<cv::Vec<Dtype, channels> >(y, x)[c];
+      }
+    }
+  }
+}
+
+template
+void CVMatToBlob<float, 3>(cv::Mat img, Blob<float> *blob);
+
+template
+void CVMatToBlob<double, 3>(cv::Mat img, Blob<double> *blob);
+
 // Verifies format of data stored in HDF5 file and reshapes blob accordingly.
 template <typename Dtype>
 void hdf5_load_nd_dataset_helper(


### PR DESCRIPTION
At the moment Caffe is missing a range of training time augmentation tricks, which is one of the main reasons that networks such as AlexNet, VGG and GoogleNet in the model zoo do not realize their published accuracy. One such augmentation is image relighting, for which I have a separate pull request. This patch on the other hand adds full-size image based cropping and scale augmentation support to data_transformer which is a bit more involved.

State-of-the-art networks are trained on Imagenet using random crops from original images (not necessarily square or of minimum image size) resized up or down such that one side is of a minimum size (i.e. 256) - rather than from pre-cropped/an-istropically scaled square images (i.e. 256x256) as Caffe currently uses. Furthermore scale augmentation is usually used, in the form of varying the size of the minimum side an image is resized to (i.e. between 256 - 512 in VGG, or similar usage in GoogLeNet), or using a set of sizes. This patch allows for the former which is apparently more effective.

Luckily it turns out the current DB backend supports storing full-sized images already, with the exception that for some rare, very large images in Imagenet, the Google protobuf message `ParseFromString` will refuse to parse such a long string. A common work-around for using protobuf messages with large messages is to use a `ZeroCopyInputStream`/`CodedInputStream`  and `ParseFromCodedStream` for which maximum message sizes can be set. Google however says using protobuf messages for large objects should be avoided - so perhaps a transition away from this in future makes sense.

Two new parameters are added to `TranformationParameter`:

`min_size` - the minimum image size to scale the smallest image side to (i.e. 256 in the existing framework)
`min_size` - the maximum image size to scale the smallest image side to

Setting min_size will enable full-sized image cropping, while setting both min_size and max_size will enable scale-augmentation.

One observation is that to do image resizing on Blobs (rather than CvMat encoded images), I first copy the format into a CvMat, call cv::resize, and then copy back. It doesn't make sense to me to re-implement such functionality from scratch, and from a maintainability standpoint I lean towards using the OpenCV resize. 

In fact it might make sense to remove the current code duplication in data_transformer by merging the code for both CvMat encoded images and Blobs to both use CvMats, this allows the appropriate flexibility to easily add transformations in future (which seems likely) while keeping the code more maintainable. I recognize this might incur a slight performance penalty for the non-encoded DBs though.

Yani