### PR TITLE
relax MemoryData transform check to warning

### DIFF
--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -81,9 +81,11 @@ void MemoryDataLayer<Dtype>::Reset(Dtype* data, Dtype* labels, int n) {
   CHECK(data);
   CHECK(labels);
   CHECK_EQ(n % batch_size_, 0) << "n must be a multiple of batch size";
-  // Refuse transformation parameters since a memory array is totally generic.
-  CHECK(!this->layer_param_.has_transform_param()) <<
-      this->type() << " does not transform data.";
+  // Warn with transformation parameters since a memory array is meant to
+  // be generic and no transformations are done with Reset().
+  if (this->layer_param_.has_transform_param()) {
+    LOG(WARNING) << this->type() << " does not transform array data on Reset()";
+  }
   data_ = data;
   labels_ = labels;
   n_ = n;


### PR DESCRIPTION
warning is still useful to keep from accidentally running data without
pre-processing.