### PR TITLE
Transforms for memory data layer

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -277,14 +277,19 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
 
-  int batch_size_, channels_, height_, width_, size_;
+  int batch_size_, channels_, size_;
+  // This is input data shape
+  int height_, width_;
+  // This correspones to tops blob shape
+  int top_width_, top_height_;
+
   Dtype* data_;
   Dtype* labels_;
   int n_;
   size_t pos_;
   Blob<Dtype> added_data_;
   Blob<Dtype> added_label_;
-  bool has_new_data_;
+  bool has_new_data_, need_reshape;
 };
 
 /**

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -289,7 +289,7 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   size_t pos_;
   Blob<Dtype> added_data_;
   Blob<Dtype> added_label_;
-  bool has_new_data_, need_reshape;
+  bool has_new_data_, need_reshape_;
 };
 
 /**

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -40,7 +40,7 @@ void MemoryDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   added_data_.cpu_data();
   added_label_.cpu_data();
 
-  need_reshape = false;
+  need_reshape_ = false;
 }
 
 template <typename Dtype>
@@ -111,7 +111,7 @@ void MemoryDataLayer<Dtype>::set_batch_size(int new_size) {
   added_data_.Reshape(batch_size_, channels_, top_height_, top_width_);
   added_label_.Reshape(batch_size_, 1, 1, 1);
 
-  need_reshape = true;
+  need_reshape_ = true;
 }
 
 template <typename Dtype>
@@ -119,10 +119,10 @@ void MemoryDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   CHECK(data_) << "MemoryDataLayer needs to be initalized by calling Reset";
 
-  if (need_reshape) {
+  if (need_reshape_) {
     top[0]->Reshape(batch_size_, channels_, top_height_, top_width_);
     top[1]->Reshape(batch_size_, 1, 1, 1);
-    need_reshape = false;
+    need_reshape_ = false;
   }
 
   if (this->layer_param_.has_transform_param()) {

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -16,17 +16,31 @@ void MemoryDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   height_ = this->layer_param_.memory_data_param().height();
   width_ = this->layer_param_.memory_data_param().width();
   size_ = channels_ * height_ * width_;
+
   CHECK_GT(batch_size_ * size_, 0) <<
       "batch_size, channels, height, and width must be specified and"
       " positive in memory_data_param";
-  top[0]->Reshape(batch_size_, channels_, height_, width_);
+
+  int crop_size = this->layer_param_.transform_param().crop_size();
+
+  top_height_ = height_;
+  top_width_ = width_;
+  if (crop_size > 0) {
+    top_height_ = crop_size;
+    top_width_ = crop_size;
+  }
+
+  top[0]->Reshape(batch_size_, channels_, top_height_, top_width_);
   top[1]->Reshape(batch_size_, 1, 1, 1);
-  added_data_.Reshape(batch_size_, channels_, height_, width_);
+  added_data_.Reshape(batch_size_, channels_, top_height_, top_width_);
   added_label_.Reshape(batch_size_, 1, 1, 1);
+
   data_ = NULL;
   labels_ = NULL;
   added_data_.cpu_data();
   added_label_.cpu_data();
+
+  need_reshape = false;
 }
 
 template <typename Dtype>
@@ -37,7 +51,7 @@ void MemoryDataLayer<Dtype>::AddDatumVector(const vector<Datum>& datum_vector) {
   CHECK_GT(num, 0) << "There is no datum to add.";
   CHECK_EQ(num % batch_size_, 0) <<
       "The added data must be a multiple of the batch size.";
-  added_data_.Reshape(num, channels_, height_, width_);
+  added_data_.Reshape(num, channels_, top_height_, top_width_);
   added_label_.Reshape(num, 1, 1, 1);
   // Apply data transformations (mirror, scale, crop...)
   this->data_transformer_->Transform(datum_vector, &added_data_);
@@ -61,7 +75,7 @@ void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
   CHECK_GT(num, 0) << "There is no mat to add";
   CHECK_EQ(num % batch_size_, 0) <<
       "The added data must be a multiple of the batch size.";
-  added_data_.Reshape(num, channels_, height_, width_);
+  added_data_.Reshape(num, channels_, top_height_, top_width_);
   added_label_.Reshape(num, 1, 1, 1);
   // Apply data transformations (mirror, scale, crop...)
   this->data_transformer_->Transform(mat_vector, &added_data_);
@@ -81,11 +95,7 @@ void MemoryDataLayer<Dtype>::Reset(Dtype* data, Dtype* labels, int n) {
   CHECK(data);
   CHECK(labels);
   CHECK_EQ(n % batch_size_, 0) << "n must be a multiple of batch size";
-  // Warn with transformation parameters since a memory array is meant to
-  // be generic and no transformations are done with Reset().
-  if (this->layer_param_.has_transform_param()) {
-    LOG(WARNING) << this->type() << " does not transform array data on Reset()";
-  }
+
   data_ = data;
   labels_ = labels;
   n_ = n;
@@ -97,18 +107,41 @@ void MemoryDataLayer<Dtype>::set_batch_size(int new_size) {
   CHECK(!has_new_data_) <<
       "Can't change batch_size until current data has been consumed.";
   batch_size_ = new_size;
-  added_data_.Reshape(batch_size_, channels_, height_, width_);
+
+  added_data_.Reshape(batch_size_, channels_, top_height_, top_width_);
   added_label_.Reshape(batch_size_, 1, 1, 1);
+
+  need_reshape = true;
 }
 
 template <typename Dtype>
 void MemoryDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   CHECK(data_) << "MemoryDataLayer needs to be initalized by calling Reset";
-  top[0]->Reshape(batch_size_, channels_, height_, width_);
-  top[1]->Reshape(batch_size_, 1, 1, 1);
-  top[0]->set_cpu_data(data_ + pos_ * size_);
-  top[1]->set_cpu_data(labels_ + pos_);
+
+  if (need_reshape) {
+    top[0]->Reshape(batch_size_, channels_, top_height_, top_width_);
+    top[1]->Reshape(batch_size_, 1, 1, 1);
+    need_reshape = false;
+  }
+
+  if (this->layer_param_.has_transform_param()) {
+    // Copy to blob
+    Blob<Dtype> b;
+    b.Reshape(batch_size_, channels_, top_height_, top_width_);
+    b.set_cpu_data(data_ + pos_ * size_);
+
+    // transform
+    this->data_transformer_->Transform(&b, top[0]);
+
+    // Copy labels
+    top[1]->set_cpu_data(labels_ + pos_);
+
+  } else {
+    top[0]->set_cpu_data(data_ + pos_ * size_);
+    top[1]->set_cpu_data(labels_ + pos_);
+  }
+
   pos_ = (pos_ + batch_size_) % n_;
   if (pos_ == 0)
     has_new_data_ = false;


### PR DESCRIPTION
Confused a lot with the code inside, to be true,  let's make it clear and better.

```c++
size_t num = datum_vector.size();
```
There's no reason to make it size_t, anyway it goes right to the functions where it is casted to int.

And because you had no refs to top blob you reshaped it every time in Forward, not the best thing to do probably, are you ok with storing ref to `vector<Blob<Dtype>*>& top` in setup in order to reshape the blob immediately in `set_batch_size` ?

This comment is very confusing, at least because there is no variable num_images, I really could not get what it is about.
```c++
 // num_images == batch_size_
```

and I need to remove this lines somehow: 
```c++
// Apply data transformations (mirror, scale, crop...)
  this->data_transformer_->Transform(mat_vector, &added_data_);
```
```c++
  // Apply data transformations (mirror, scale, crop...)
  this->data_transformer_->Transform(datum_vector, &added_data_);
```
Please post a piece of code how to convert these `mat_vector` and  `datum_vector` to `added_data_` without transformations, didn't find a good looking way to do it. 

But it looks like it is transforming something :) Added setup test, don't know how to organize Forward test with all this random crops, how would you do it ? 
