### PR TITLE
f29b8e5 Revert "[build] fix rpath for examples" as it breaks libcaffe.so...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -540,7 +540,7 @@ $(TOOL_BUILD_DIR)/%: $(TOOL_BUILD_DIR)/%.bin | $(TOOL_BUILD_DIR)
 $(TOOL_BINS) $(EXAMPLE_BINS): %.bin : %.o | $(DYNAMIC_NAME)
 	@ echo CXX/LD -o $@
 	$(Q)$(CXX) $< -o $@ $(LINKFLAGS) -l$(PROJECT) $(LDFLAGS) \
-		-Wl,-rpath,$(ORIGIN)/../../lib
+		-Wl,-rpath,$(ORIGIN)/../lib
 
 proto: $(PROTO_GEN_CC) $(PROTO_GEN_HEADER)
 


### PR DESCRIPTION
fixes issue #1919

This reverts commit 5c81243ad72234d8de6c347ec704653afc963bca.