### PR TITLE
provide a solver option to limit runtime (max_seconds)

### DIFF
--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -6,6 +6,8 @@
 
 #include "caffe/net.hpp"
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 namespace caffe {
 
 /**
@@ -26,7 +28,8 @@ class Solver {
   // in a non-zero iter number to resume training for a pre-trained net.
   virtual void Solve(const char* resume_file = NULL);
   inline void Solve(const string resume_file) { Solve(resume_file.c_str()); }
-  void Step(int iters);
+  void Step(int iters,
+	    boost::posix_time::ptime stop_time = boost::posix_time::pos_infin);
   virtual ~Solver() {}
   inline shared_ptr<Net<Dtype> > net() { return net_; }
   inline const vector<shared_ptr<Net<Dtype> > >& test_nets() {

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -75,7 +75,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 36 (last added: clip_gradients)
+// SolverParameter next available ID: 37 (last added: max_seconds)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -128,6 +128,8 @@ message SolverParameter {
   // Display the loss averaged over the last average_loss iterations
   optional int32 average_loss = 33 [default = 1];
   optional int32 max_iter = 7; // the maximum number of iterations
+  // the maximum number of seconds to train. Zero means do not limit run-time.
+  optional int32 max_seconds = 36 [default = 0];
   optional string lr_policy = 8; // The learning rate decay policy.
   optional float gamma = 9; // The parameter to compute the learning rate.
   optional float power = 10; // The parameter to compute the learning rate.

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -159,7 +159,7 @@ void Solver<Dtype>::InitTestNets() {
 }
 
 template <typename Dtype>
-void Solver<Dtype>::Step(int iters) {
+void Solver<Dtype>::Step(int iters,boost::posix_time::ptime stop_time) {
   vector<Blob<Dtype>*> bottom_vec;
   const int start_iter = iter_;
   const int stop_iter = iter_ + iters;
@@ -167,7 +167,9 @@ void Solver<Dtype>::Step(int iters) {
   vector<Dtype> losses;
   Dtype smoothed_loss = 0;
 
-  for (; iter_ < stop_iter; ++iter_) {
+  for (;iter_ < stop_iter &&
+	 boost::posix_time::second_clock::local_time() < stop_time;
+       ++iter_) {
     if (param_.test_interval() && iter_ % param_.test_interval() == 0
         && (iter_ > 0 || param_.test_initialization())) {
       TestAll();
@@ -227,9 +229,18 @@ void Solver<Dtype>::Solve(const char* resume_file) {
     Restore(resume_file);
   }
 
+  // by default the stop time is never...
+  boost::posix_time::ptime stop_time(boost::posix_time::pos_infin);
+  // if max_seconds is provided, compute the stop time
+  if(param_.max_seconds() > 0)
+  {
+    stop_time = boost::posix_time::second_clock::local_time() +
+      boost::posix_time::seconds(param_.max_seconds());
+  }
+  
   // For a network that is trained by the solver, no bottom or top vecs
   // should be given, and we will just provide dummy vecs.
-  Step(param_.max_iter() - iter_);
+  Step(param_.max_iter() - iter_, stop_time);
   // If we haven't already, save a snapshot after optimization, unless
   // overridden by setting snapshot_after_train := false
   if (param_.snapshot_after_train()


### PR DESCRIPTION
This patch lets you say "run for 12 hours = 43200 seconds". 
It's useful when you need exact limits with shared computing resources. 
The runtime limit is enabled by setting  max_seconds to a value > 0.
Maybe it helps? 

Best,
James