### PR TITLE
Check caffe tool runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,6 +450,7 @@ $(MAT$(PROJECT)_SO): $(MAT$(PROJECT)_SRC) $(STATIC_NAME)
 			CXXLIBS="\$$CXXLIBS $(STATIC_LINK_COMMAND) $(LDFLAGS)" -output $@
 
 runtest: $(TEST_ALL_BIN)
+	$(TOOL_BUILD_DIR)/caffe
 	$(TEST_ALL_BIN) $(TEST_GPUID) --gtest_shuffle $(TEST_FILTER)
 
 pytest: py


### PR DESCRIPTION
Simply run the caffe tool in `runtest` to catch obvious issues like the linking
problem fixed in #1921.