### PR TITLE
Add error checking for image mean

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -238,11 +238,16 @@ class Transformer:
         """
         self.__check_input(in_)
         if mean.ndim == 1:
+            # broadcast pixel
             mean = mean[:, np.newaxis, np.newaxis]
-        mk, mh, mw = mean.shape
-        in_k, in_h, in_w = self.inputs[in_][1:]
-        #if mk != in_k or (mh, mw) != (in_h, in_w) and (mh, mw) != (1, 1):
-        #    raise Exception('Mean shape incompatible with input shape.')
+        else:
+            ms = mean.shape
+            if len(ms) == 2:
+                ms = (1,) + ms
+            if len(ms) != 3:
+                raise ValueError('Mean shape invalid')
+            if ms != self.inputs[in_][1:]:
+                raise ValueError('Mean shape incompatible with input shape.')
         self.mean[in_] = mean
 
 


### PR DESCRIPTION
When setting the mean, assert that it is either one pixel or an array with shape equal to the input data size.

Helps others who run into #1928 by giving them a meaningful error message.