### PR TITLE
fixes: cpp_lint.py fails silently with Python3 

### DIFF
--- a/scripts/cpp_lint.py
+++ b/scripts/cpp_lint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # Copyright (c) 2009 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
cpp_lint.py fails silently with Python3 (which is the default on some systems).
This commit specifies Python2 with which cpp_lint.py works :-)

Best,
James