### PR TITLE
provide a solver option to limit runtime (max_seconds)

### DIFF
--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -1,6 +1,8 @@
 #ifndef CAFFE_OPTIMIZATION_SOLVER_HPP_
 #define CAFFE_OPTIMIZATION_SOLVER_HPP_
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 #include <string>
 #include <vector>
 
@@ -26,7 +28,8 @@ class Solver {
   // in a non-zero iter number to resume training for a pre-trained net.
   virtual void Solve(const char* resume_file = NULL);
   inline void Solve(const string resume_file) { Solve(resume_file.c_str()); }
-  void Step(int iters);
+  void Step(int iters,
+            boost::posix_time::ptime stop_time = boost::posix_time::pos_infin);
   virtual ~Solver() {}
   inline shared_ptr<Net<Dtype> > net() { return net_; }
   inline const vector<shared_ptr<Net<Dtype> > >& test_nets() {

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -75,7 +75,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 36 (last added: clip_gradients)
+// SolverParameter next available ID: 37 (last added: max_seconds)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -128,6 +128,8 @@ message SolverParameter {
   // Display the loss averaged over the last average_loss iterations
   optional int32 average_loss = 33 [default = 1];
   optional int32 max_iter = 7; // the maximum number of iterations
+  // the maximum number of seconds to train. Zero means do not limit run-time.
+  optional int32 max_seconds = 36 [default = 0];
   optional string lr_policy = 8; // The learning rate decay policy.
   optional float gamma = 9; // The parameter to compute the learning rate.
   optional float power = 10; // The parameter to compute the learning rate.


### PR DESCRIPTION
This is an updated version of PR #1925 which should pass the lint checks . For some reason I cannot reopen a PR after force pushing, but can force push to an open PR? Strange behavior to keep in mind. Ref. https://github.com/isaacs/github/issues/361

This patch lets you say "run for 12 hours = 43200 seconds".
It's useful when you need exact limits with shared computing resources.
The runtime limit is enabled by setting max_seconds to a value > 0.
Maybe it helps?

Best,
James
