### PR TITLE
Fix matcaffe printout to specify correct # of arguments

### DIFF
--- a/matlab/caffe/matcaffe.cpp
+++ b/matlab/caffe/matcaffe.cpp
@@ -272,7 +272,7 @@ static void get_init_key(MEX_ARGS) {
 static void init(MEX_ARGS) {
   if (nrhs != 3) {
     ostringstream error_msg;
-    error_msg << "Expected 2 arguments, got " << nrhs;
+    error_msg << "Expected 3 arguments, got " << nrhs;
     mex_error(error_msg.str());
   }
 


### PR DESCRIPTION
In a recent revision to Matcaffe, phase (train or test) was added to the of caffe('init', ...) arguments. Fixed the error printout to reflect this.