### PR TITLE
Replaced illegal tab in Makefile with spaces.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,8 @@ ifneq (,$(findstring clang++,$(CXX)))
 else ifneq (,$(findstring g++,$(CXX)))
 	STATIC_LINK_COMMAND := -Wl,--whole-archive $(STATIC_NAME) -Wl,--no-whole-archive
 else
-	$(error Cannot static link with the $(CXX) compiler.)
+  # The following line must not be indented with a tab, since we are not inside a target
+  $(error Cannot static link with the $(CXX) compiler)
 endif
 
 # Debugging


### PR DESCRIPTION
Commands, such as `$(error ...)`, are not allowed to be indented with tabs
outside of targets, throwing an error instead of outputting the actual
error. The solution is to use innocuous spaces instead. Ideally, spaces
should be used everywhere outside targets, but since make does not mind
it if variable assignments are tab-indented outside targets, a complete
overhaul is not necessary. However, if more errors are added, it might
make more sense to be consistent.

You can easily see what happens by creating a simple Makefile:

    ifeq (,)
        $(error test)
    endif

Try tab-indenting the error, and you will see the error (at least for GNU make 3.81):

    Makefile:2: *** commands commence before first target.  Stop.

The problem is resolved if you switch to spaces.