### PR TITLE
Makefile fix for OS X 10.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ else
 		# 10.10 has accelerate while 10.9 has veclib
 		XCODE_CLT_VER := $(shell pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | grep -o 'version: 6')
 		ifneq (,$(findstring version: 6,$(XCODE_CLT_VER)))
-			BLAS_INCLUDE ?= /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
+			BLAS_INCLUDE ?= /System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
 			LDFLAGS += -framework Accelerate
 		else
 			BLAS_INCLUDE ?= /System/Library/Frameworks/vecLib.framework/Versions/Current/Headers/


### PR DESCRIPTION
Fixes the following make error on OS X:

```
In file included from ./include/caffe/util/math_functions.hpp:11:
./include/caffe/util/mkl_alternate.hpp:11:10: fatal error: 'cblas.h' file not found
#include <cblas.h>
```