### PR TITLE
Fix incorrectly storing empty param_name to param_names_index_

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -402,7 +402,7 @@ void Net<Dtype>::AppendParam(const NetParameter& param, const int layer_id,
     // (i.e., not given a param_name) or explicitly given a name that we
     // haven't already seen.
     param_owners_.push_back(-1);
-    if (param_size) {
+    if (param_name.size()) {
       param_names_index_[param_name] = net_param_id;
     }
   } else {


### PR DESCRIPTION
Shouldn't it be `param_name.size()` if you intend to check if `param.name()` is specified for this parameter blob? It does not work if `ParamSpec` is given only for one of parameter blobs in a layer while the layer has multiple parameter blobs, e.g. Convolution, InnerProduct etc..