### PR TITLE
Use regular expressions to parse image data text files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ ifneq ($(CPU_ONLY), 1)
 	LIBRARIES := cudart cublas curand
 endif
 LIBRARIES += glog gflags protobuf leveldb snappy \
-	lmdb boost_system hdf5_hl hdf5 m \
+	lmdb boost_regex boost_system hdf5_hl hdf5 m \
 	opencv_core opencv_highgui opencv_imgproc
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -3,6 +3,8 @@
 
 #include <unistd.h>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "google/protobuf/message.h"
 #include "hdf5.h"
@@ -153,6 +155,10 @@ void hdf5_load_nd_dataset(
 template <typename Dtype>
 void hdf5_save_nd_dataset(
     const hid_t file_id, const string& dataset_name, const Blob<Dtype>& blob);
+
+void read_image_data_file(
+    const std::string& source,
+    std::vector<std::pair<std::string, int> >* lines);
 
 }  // namespace caffe
 

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -34,12 +34,7 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   // Read the file with filenames and labels
   const string& source = this->layer_param_.image_data_param().source();
   LOG(INFO) << "Opening file " << source;
-  std::ifstream infile(source.c_str());
-  string filename;
-  int label;
-  while (infile >> filename >> label) {
-    lines_.push_back(std::make_pair(filename, label));
-  }
+  read_image_data_file(source, &lines_);
 
   if (this->layer_param_.image_data_param().shuffle()) {
     // randomly shuffle data

--- a/tools/convert_imageset.cpp
+++ b/tools/convert_imageset.cpp
@@ -67,13 +67,9 @@ int main(int argc, char** argv) {
   const bool encoded = FLAGS_encoded;
   const string encode_type = FLAGS_encode_type;
 
-  std::ifstream infile(argv[2]);
   std::vector<std::pair<std::string, int> > lines;
-  std::string filename;
-  int label;
-  while (infile >> filename >> label) {
-    lines.push_back(std::make_pair(filename, label));
-  }
+  read_image_data_file(argv[2], &lines);
+
   if (FLAGS_shuffle) {
     // randomly shuffle data
     LOG(INFO) << "Shuffling data";


### PR DESCRIPTION
Fixes #1951.

This pull request consists of two changes:

1. Rather than the brittle `ifstream` method of parsing image data files, this pull request uses regular expressions for more robust matching.
2. Previously, the parsing code was duplicated across two files, `tools/convert_imageset.cpp` and `src/caffe/layers/image_data_layer.cpp`. This pull request pulls that common code out into a new function in `src/caffe/util/io.cpp` for ease of maintenance.

More details follow.

Each line of the input text file is matched against the following regular expression:

````
\h*("?)(.+?)\1\h+(\d+)\h*
````

Feel free to play around with [an interactive version](https://regex101.com/r/xK3hN7/3) so you can test it out and see what it matches. This regular expression handles a lot of cases that would've been difficult to handle using the previous naive approach. It captures whitespace within a filename, and enables quoting of filenames in case for some insane reason you have a space at the beginning of a file name.

Some concrete examples of really degenerate cases that will parse correctly:

````
file name with spaces.jpg 1
" file_name_with_leading_space.jpg" 2
file_name_with_"_symbol.jpg 3
" really disgusting " file  ""name  .jpg" 4
```

One drawback is that this introduces `boost_regex` as an additional dependency. However, since we already require Boost, this seems like an acceptable tradeoff.

Implementation-wise, this pull request should be complete, though it's lacking tests, which I will get around to writing at some point in the near future.