### PR TITLE
solver.cpp: call UpgradeNetAsNeeded() on learned_net in Solver::Restore()

### DIFF
--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -350,6 +350,7 @@ void Solver<Dtype>::Restore(const char* state_file) {
   ReadProtoFromBinaryFile(state_file, &state);
   if (state.has_learned_net()) {
     ReadProtoFromBinaryFile(state.learned_net().c_str(), &net_param);
+    UpgradeNetAsNeeded(state.learned_net().c_str(), &net_param);
     net_->CopyTrainedLayersFrom(net_param);
   }
   iter_ = state.iter();


### PR DESCRIPTION
when resuming training using the --snapshot option, and thus loading .solverstate files, it seems caffe will load the linked-to .caffemodel file without calling UpgradeNetAsNeeded() on the loaded net as it does elsewhere. this seems to cause the resultant loaded net to be (silently) garbage in the case where the linked-to prototxt needed an upgrade. perhaps we want to do something like this? i guess this is only an issue for resuming 'old' training runs, which might not in general be supported. but if it's not to be supported, perhaps it should be error-checked somehow? and perhaps even if it's generally unsupported this feature/fix might be wanted.