### PR TITLE
Give layers a pointer to their owning Net

### DIFF
--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -13,6 +13,8 @@
 
 namespace caffe {
 
+template <typename Dtype> class Net;
+
 /**
  * @brief An interface for the units of computation which can be composed into a
  *        Net.
@@ -285,6 +287,10 @@ class Layer {
     param_propagate_down_[param_id] = value;
   }
 
+  /**
+   * @brief Used by Net to give layers a pointer to their owning net.
+   */
+  void set_net(Net<Dtype>* net) { net_ = net; }
 
  protected:
   /** The protobuf that stores the layer parameters */
@@ -299,6 +305,9 @@ class Layer {
   /** The vector that indicates whether each top blob has a non-zero weight in
    *  the objective function. */
   vector<Dtype> loss_;
+
+  /** The net to which this layer belongs. */
+  Net<Dtype>* net_;
 
   /** @brief Using the CPU device, compute the layer output. */
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -72,6 +72,7 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
     // Setup layer.
     const LayerParameter& layer_param = param.layer(layer_id);
     layers_.push_back(LayerRegistry<Dtype>::CreateLayer(layer_param));
+    layers_[layer_id]->set_net(this);
     layer_names_.push_back(layer_param.name());
     LOG(INFO) << "Creating Layer " << layer_param.name();
     bool need_backward = false;


### PR DESCRIPTION
`master` edition of @longjon's #1638:

> This allows layers to do essentially arbitrary things that depend on the structure of the net.

> This provides a lot of power, but breaks the nice abstraction of a layer as a function-with-gradient. A future PR will depend on this functionality. If it seems sufficiently useful, perhaps we should merge this, but be wary not to abuse it. Or perhaps we should find another way to compute on the structure of nets. Or perhaps we should do the former keeping the latter as a future possibility.