### PR TITLE
Python classifier: multi-label prediction support

### DIFF
--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -89,6 +89,7 @@ class Classifier(caffe.Net):
         multipreds = {}
         for bname in self.outputs:
             multipreds[bname] = out[bname]
+            # For oversampling, average predictions across crops.
             if oversample:
                 tmparray = multipreds[bname]
                 tmparray = tmparray.reshape((len(tmparray) / 10, 10, -1))

--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -90,8 +90,8 @@ class Classifier(caffe.Net):
         for bname in self.outputs:
             multipreds[bname] = out[bname]
             if oversample:
-                tmparray = multipreds[bname].reshape(
-                    (len(predictions) / 10, 10, -1))
+                tmparray = multipreds[bname]
+                tmparray = tmparray.reshape((len(tmparray) / 10, 10, -1))
                 multipreds[bname] = tmparray.mean(1)
         return multipreds
 

--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -111,7 +111,7 @@ class Classifier(caffe.Net):
         # Classify
         out = self.forward_all(**{self.inputs[0]: caffe_in})
         multipreds = {}
-        for bname in self.ouputs:
+        for bname in self.outputs:
             multipreds[bname] = out[bname].squeeze(axis=(2,3))
             if oversample:
                 tmparray = multipreds[bname].reshape(


### PR DESCRIPTION
- The preprocessing procedures of the inputs were moved to a separated function. Its code is just the same.
- The new prediction function, `predict_multi`, does almost the same thing `predict` does, but it returns a dictionary of probabilities where the keys are the names of the top blobs of the last network's layer.
- The function `predict` has the same behavior of its original code; now it is just a special case of `predict_multi`, taking only the first output label's probabilities.

## Related References

> Goodfellow, I., Bulatov, Y., & Ibarz, J. (2013). Multi-digit Number Recognition from Street View Imagery using Deep Convolutional Neural Networks. Retrieved from http://arxiv.org/abs/1312.6082

> Jaderberg, M., Simonyan, K., Vedaldi, A., & Zisserman, A. (2014). Synthetic Data and Artificial Neural Networks for Natural Scene Text Recognition, 1–10. Retrieved from http://arxiv.org/abs/1406.2227v4