### PR TITLE
ImageNet example: lmdb filename not consistent

### DIFF
--- a/examples/imagenet/make_imagenet_mean.sh
+++ b/examples/imagenet/make_imagenet_mean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Compute the mean image from the imagenet training leveldb
+# Compute the mean image from the imagenet training lmdb
 # N.B. this is available in data/ilsvrc12
 
 ./build/tools/compute_image_mean examples/imagenet/ilsvrc12_train_lmdb \

--- a/examples/imagenet/make_imagenet_mean.sh
+++ b/examples/imagenet/make_imagenet_mean.sh
@@ -2,7 +2,7 @@
 # Compute the mean image from the imagenet training leveldb
 # N.B. this is available in data/ilsvrc12
 
-./build/tools/compute_image_mean examples/imagenet/ilsvrc12_train_leveldb \
+./build/tools/compute_image_mean examples/imagenet/ilsvrc12_train_lmdb \
   data/ilsvrc12/imagenet_mean.binaryproto
 
 echo "Done."


### PR DESCRIPTION
The create_imagenet_mean.sh file creates 2 db files: ilsvrc12_train_lmdb and ilsvrc12_val_lmdb
But the make_imagenet_mean.sh is currently using ilsvrc12_train_leveldb. The names are not consistent. 
Have changed ilsvrc12_train_leveldb to ilsvrc12_train_lmdb
The names in the documentation example have to be also changed accordingly.

Doing a change for the first time. Plz let me know if I miss any protocol.
Thanks