### PR TITLE
Saving memory by reusing col_buffer_.

### DIFF
--- a/include/caffe/tempmem.hpp
+++ b/include/caffe/tempmem.hpp
@@ -23,8 +23,10 @@ class TemporaryMemory {
   explicit TemporaryMemory(size_t size);
   ~TemporaryMemory();
 
-  void acquire();
-  void release();
+  void acquire_gpu();
+  void release_gpu();
+  void acquire_cpu();
+  void release_cpu();
   const Dtype* cpu_data() const;
   const Dtype* gpu_data() const;
   Dtype* mutable_cpu_data();

--- a/include/caffe/tempmem.hpp
+++ b/include/caffe/tempmem.hpp
@@ -1,0 +1,44 @@
+#ifndef CAFFE_TEMPMEM_HPP_
+#define CAFFE_TEMPMEM_HPP_
+
+#include <cstdlib>
+
+#include "caffe/common.hpp"
+#include "caffe/syncedmem.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Holds a block of temporary memory that can be shared between
+ *        different parts of caffe. The CPU and GPU memory is *not*
+ *        synchronized.
+ *
+ * TODO(dox): more thorough description.
+ */
+template<typename Dtype>
+class TemporaryMemory {
+ public:
+  TemporaryMemory():cpu_ptr_(NULL), gpu_ptr_(NULL), size_(0) {}
+  explicit TemporaryMemory(size_t size);
+  ~TemporaryMemory();
+
+  void acquire();
+  void release();
+  const Dtype* cpu_data() const;
+  const Dtype* gpu_data() const;
+  Dtype* mutable_cpu_data();
+  Dtype* mutable_gpu_data();
+  size_t size() { return size_; }
+  void resize(size_t size);
+ private:
+  Dtype* cpu_ptr_;
+  Dtype* gpu_ptr_;
+  size_t size_;
+
+  DISABLE_COPY_AND_ASSIGN(TemporaryMemory);
+};  // class TemporaryMemory
+
+}  // namespace caffe
+
+#endif  // CAFFE_TEMPMEM_HPP_

--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -13,6 +13,7 @@
 #include "caffe/loss_layers.hpp"
 #include "caffe/neuron_layers.hpp"
 #include "caffe/proto/caffe.pb.h"
+#include "caffe/tempmem.hpp"
 
 namespace caffe {
 
@@ -107,7 +108,7 @@ class BaseConvolutionLayer : public Layer<Dtype> {
   int col_offset_;
   int output_offset_;
 
-  Blob<Dtype> col_buffer_;
+  TemporaryMemory<Dtype> col_buffer_;
   Blob<Dtype> bias_multiplier_;
 };
 

--- a/src/caffe/layers/base_conv_layer.cpp
+++ b/src/caffe/layers/base_conv_layer.cpp
@@ -159,7 +159,7 @@ template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::forward_cpu_gemm(const Dtype* input,
     const Dtype* weights, Dtype* output, bool skip_im2col) {
   const Dtype* col_buff = input;
-  col_buffer_.acquire();
+  col_buffer_.acquire_cpu();
   if (!is_1x1_) {
     if (!skip_im2col) {
       conv_im2col_cpu(input, col_buffer_.mutable_cpu_data());
@@ -172,7 +172,7 @@ void BaseConvolutionLayer<Dtype>::forward_cpu_gemm(const Dtype* input,
         (Dtype)1., weights + weight_offset_ * g, col_buff + col_offset_ * g,
         (Dtype)0., output + output_offset_ * g);
   }
-  col_buffer_.release();
+  col_buffer_.release_cpu();
 }
 
 template <typename Dtype>
@@ -186,7 +186,7 @@ void BaseConvolutionLayer<Dtype>::forward_cpu_bias(Dtype* output,
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::backward_cpu_gemm(const Dtype* output,
     const Dtype* weights, Dtype* input) {
-  col_buffer_.acquire();
+  col_buffer_.acquire_cpu();
   Dtype* col_buff = col_buffer_.mutable_cpu_data();
   if (is_1x1_) {
     col_buff = input;
@@ -200,13 +200,13 @@ void BaseConvolutionLayer<Dtype>::backward_cpu_gemm(const Dtype* output,
   if (!is_1x1_) {
     conv_col2im_cpu(col_buff, input);
   }
-  col_buffer_.release();
+  col_buffer_.release_cpu();
 }
 
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::weight_cpu_gemm(const Dtype* input,
     const Dtype* output, Dtype* weights) {
-  col_buffer_.acquire();
+  col_buffer_.acquire_cpu();
   const Dtype* col_buff = input;
   if (!is_1x1_) {
     conv_im2col_cpu(input, col_buffer_.mutable_cpu_data());
@@ -218,7 +218,7 @@ void BaseConvolutionLayer<Dtype>::weight_cpu_gemm(const Dtype* input,
         (Dtype)1., output + output_offset_ * g, col_buff + col_offset_ * g,
         (Dtype)1., weights + weight_offset_ * g);
   }
-  col_buffer_.release();
+  col_buffer_.release_cpu();
 }
 
 template <typename Dtype>
@@ -233,7 +233,7 @@ void BaseConvolutionLayer<Dtype>::backward_cpu_bias(Dtype* bias,
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::forward_gpu_gemm(const Dtype* input,
     const Dtype* weights, Dtype* output, bool skip_im2col) {
-  col_buffer_.acquire();
+  col_buffer_.acquire_gpu();
   const Dtype* col_buff = input;
   if (!is_1x1_) {
     if (!skip_im2col) {
@@ -247,7 +247,7 @@ void BaseConvolutionLayer<Dtype>::forward_gpu_gemm(const Dtype* input,
         (Dtype)1., weights + weight_offset_ * g, col_buff + col_offset_ * g,
         (Dtype)0., output + output_offset_ * g);
   }
-  col_buffer_.release();
+  col_buffer_.release_gpu();
 }
 
 template <typename Dtype>
@@ -261,7 +261,7 @@ void BaseConvolutionLayer<Dtype>::forward_gpu_bias(Dtype* output,
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::backward_gpu_gemm(const Dtype* output,
     const Dtype* weights, Dtype* input) {
-  col_buffer_.acquire();
+  col_buffer_.acquire_gpu();
   Dtype* col_buff = col_buffer_.mutable_gpu_data();
   if (is_1x1_) {
     col_buff = input;
@@ -275,13 +275,13 @@ void BaseConvolutionLayer<Dtype>::backward_gpu_gemm(const Dtype* output,
   if (!is_1x1_) {
     conv_col2im_gpu(col_buff, input);
   }
-  col_buffer_.release();
+  col_buffer_.release_gpu();
 }
 
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::weight_gpu_gemm(const Dtype* input,
     const Dtype* output, Dtype* weights) {
-  col_buffer_.acquire();
+  col_buffer_.acquire_gpu();
   const Dtype* col_buff = input;
   if (!is_1x1_) {
     conv_im2col_gpu(input, col_buffer_.mutable_gpu_data());
@@ -293,7 +293,7 @@ void BaseConvolutionLayer<Dtype>::weight_gpu_gemm(const Dtype* input,
         (Dtype)1., output + output_offset_ * g, col_buff + col_offset_ * g,
         (Dtype)1., weights + weight_offset_ * g);
   }
-  col_buffer_.release();
+  col_buffer_.release_gpu();
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/base_conv_layer.cpp
+++ b/src/caffe/layers/base_conv_layer.cpp
@@ -142,9 +142,9 @@ void BaseConvolutionLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   // overly large memory usage. In the special case of 1x1 convolution
   // it goes lazily unused to save memory.
   if (reverse_dimensions()) {
-    col_buffer_.Reshape(1, kernel_dim_, height_, width_);
+    col_buffer_.resize(kernel_dim_*height_*width_);
   } else {
-    col_buffer_.Reshape(1, kernel_dim_, height_out_, width_out_);
+    col_buffer_.resize(kernel_dim_*height_out_*width_out_);
   }
   // Set up the all ones "bias multiplier" for adding biases by BLAS
   if (bias_term_) {
@@ -159,6 +159,7 @@ template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::forward_cpu_gemm(const Dtype* input,
     const Dtype* weights, Dtype* output, bool skip_im2col) {
   const Dtype* col_buff = input;
+  col_buffer_.acquire();
   if (!is_1x1_) {
     if (!skip_im2col) {
       conv_im2col_cpu(input, col_buffer_.mutable_cpu_data());
@@ -171,6 +172,7 @@ void BaseConvolutionLayer<Dtype>::forward_cpu_gemm(const Dtype* input,
         (Dtype)1., weights + weight_offset_ * g, col_buff + col_offset_ * g,
         (Dtype)0., output + output_offset_ * g);
   }
+  col_buffer_.release();
 }
 
 template <typename Dtype>
@@ -184,6 +186,7 @@ void BaseConvolutionLayer<Dtype>::forward_cpu_bias(Dtype* output,
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::backward_cpu_gemm(const Dtype* output,
     const Dtype* weights, Dtype* input) {
+  col_buffer_.acquire();
   Dtype* col_buff = col_buffer_.mutable_cpu_data();
   if (is_1x1_) {
     col_buff = input;
@@ -197,11 +200,13 @@ void BaseConvolutionLayer<Dtype>::backward_cpu_gemm(const Dtype* output,
   if (!is_1x1_) {
     conv_col2im_cpu(col_buff, input);
   }
+  col_buffer_.release();
 }
 
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::weight_cpu_gemm(const Dtype* input,
     const Dtype* output, Dtype* weights) {
+  col_buffer_.acquire();
   const Dtype* col_buff = input;
   if (!is_1x1_) {
     conv_im2col_cpu(input, col_buffer_.mutable_cpu_data());
@@ -213,6 +218,7 @@ void BaseConvolutionLayer<Dtype>::weight_cpu_gemm(const Dtype* input,
         (Dtype)1., output + output_offset_ * g, col_buff + col_offset_ * g,
         (Dtype)1., weights + weight_offset_ * g);
   }
+  col_buffer_.release();
 }
 
 template <typename Dtype>
@@ -227,6 +233,7 @@ void BaseConvolutionLayer<Dtype>::backward_cpu_bias(Dtype* bias,
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::forward_gpu_gemm(const Dtype* input,
     const Dtype* weights, Dtype* output, bool skip_im2col) {
+  col_buffer_.acquire();
   const Dtype* col_buff = input;
   if (!is_1x1_) {
     if (!skip_im2col) {
@@ -240,6 +247,7 @@ void BaseConvolutionLayer<Dtype>::forward_gpu_gemm(const Dtype* input,
         (Dtype)1., weights + weight_offset_ * g, col_buff + col_offset_ * g,
         (Dtype)0., output + output_offset_ * g);
   }
+  col_buffer_.release();
 }
 
 template <typename Dtype>
@@ -253,6 +261,7 @@ void BaseConvolutionLayer<Dtype>::forward_gpu_bias(Dtype* output,
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::backward_gpu_gemm(const Dtype* output,
     const Dtype* weights, Dtype* input) {
+  col_buffer_.acquire();
   Dtype* col_buff = col_buffer_.mutable_gpu_data();
   if (is_1x1_) {
     col_buff = input;
@@ -266,11 +275,13 @@ void BaseConvolutionLayer<Dtype>::backward_gpu_gemm(const Dtype* output,
   if (!is_1x1_) {
     conv_col2im_gpu(col_buff, input);
   }
+  col_buffer_.release();
 }
 
 template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::weight_gpu_gemm(const Dtype* input,
     const Dtype* output, Dtype* weights) {
+  col_buffer_.acquire();
   const Dtype* col_buff = input;
   if (!is_1x1_) {
     conv_im2col_gpu(input, col_buffer_.mutable_gpu_data());
@@ -282,6 +293,7 @@ void BaseConvolutionLayer<Dtype>::weight_gpu_gemm(const Dtype* input,
         (Dtype)1., output + output_offset_ * g, col_buff + col_offset_ * g,
         (Dtype)1., weights + weight_offset_ * g);
   }
+  col_buffer_.release();
 }
 
 template <typename Dtype>

--- a/src/caffe/tempmem.cpp
+++ b/src/caffe/tempmem.cpp
@@ -1,0 +1,141 @@
+#include <cstring>
+
+#include "caffe/common.hpp"
+#include "caffe/tempmem.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template<bool gpu>
+struct TemporaryMemoryAllocator {
+};
+#ifndef CPU_ONLY
+// GPU allocator
+template<>
+struct TemporaryMemoryAllocator<true> {
+  static void * calloc(size_t size) {
+    void * p;
+    CUDA_CHECK(cudaMalloc(&p, size));
+    caffe_gpu_memset(size, 0, p);
+    return p;
+  }
+  static void free(void * p) {
+      cudaFree(p);
+  }
+};
+#endif
+// CPU allocator
+template<>
+struct TemporaryMemoryAllocator<false> {
+  static void * calloc(size_t size) {
+    void * p;
+    CaffeMallocHost(&p, size);
+    caffe_memset(size, 0, p);
+    return p;
+  }
+  static void free(void * p) {
+      CaffeFreeHost(p);
+  }
+};
+
+template<bool gpu>
+class GlobalTemporaryMemory {
+ private:
+  size_t size_;
+  void * data_;
+  bool is_locked_;
+
+ public:
+  GlobalTemporaryMemory():size_(0), data_(NULL), is_locked_(false) {}
+  ~GlobalTemporaryMemory() {
+    if (data_)
+      TemporaryMemoryAllocator<gpu>::free(data_);
+  }
+  void * lock() {
+    CHECK(!is_locked_) << "Temporary memory is already locked!";
+    is_locked_ = true;
+    return data_;
+  }
+  template<typename Dtype>
+  Dtype * lock() {
+    CHECK(!is_locked_) << "Temporary memory is already locked!";
+    is_locked_ = true;
+    return static_cast<Dtype*>(data_);
+  }
+  void unlock() {
+    is_locked_ = false;
+  }
+  void allocate(size_t size) {
+    if (size_ < size) {
+      CHECK(!is_locked_) << "Cannot allocate memory while locked!";
+      if (data_)
+        TemporaryMemoryAllocator<gpu>::free(data_);
+      size_ = size;
+      data_ = TemporaryMemoryAllocator<gpu>::calloc(size_);
+    }
+  }
+};
+#ifndef CPU_ONLY
+static GlobalTemporaryMemory<true> gpu_memory_;
+#endif
+static GlobalTemporaryMemory<false> cpu_memory_;
+
+#ifdef CPU_ONLY
+#define GMEM(x) cpu_memory_.x
+#else
+#define GMEM(x) gpu_memory_.x; cpu_memory_.x
+#endif
+
+template<typename Dtype>
+TemporaryMemory<Dtype>::TemporaryMemory(size_t size):cpu_ptr_(NULL),
+  gpu_ptr_(NULL), size_(0) {
+  resize(size_);
+}
+template<typename Dtype>
+TemporaryMemory<Dtype>::~TemporaryMemory() {
+}
+
+template<typename Dtype>
+void TemporaryMemory<Dtype>::acquire() {
+#ifndef CPU_ONLY
+  gpu_ptr_ = gpu_memory_.lock<Dtype>();
+#endif
+  cpu_ptr_ = cpu_memory_.lock<Dtype>();
+}
+template<typename Dtype>
+void TemporaryMemory<Dtype>::release() {
+  GMEM(unlock());
+  gpu_ptr_ = cpu_ptr_ = NULL;
+}
+template<typename Dtype>
+const Dtype* TemporaryMemory<Dtype>::cpu_data() const {
+  CHECK(cpu_ptr_ != NULL) << "Need to allocate and acquire the data first";
+  return cpu_ptr_;
+}
+template<typename Dtype>
+const Dtype* TemporaryMemory<Dtype>::gpu_data() const {
+  CHECK(gpu_ptr_ != NULL) << "Need to allocate and acquire the data first";
+  return gpu_ptr_;
+}
+template<typename Dtype>
+Dtype* TemporaryMemory<Dtype>::mutable_cpu_data() {
+  CHECK(cpu_ptr_ != NULL) << "Need to allocate and acquire the data first";
+  return cpu_ptr_;
+}
+template<typename Dtype>
+Dtype* TemporaryMemory<Dtype>::mutable_gpu_data() {
+  CHECK(gpu_ptr_ != NULL) << "Need to allocate and acquire the data first";
+  return gpu_ptr_;
+}
+template<typename Dtype>
+void TemporaryMemory<Dtype>::resize(size_t size) {
+  size_ = size;
+  GMEM(allocate(size_*sizeof(Dtype)));
+}
+
+INSTANTIATE_CLASS(TemporaryMemory);
+template class TemporaryMemory<int>;
+template class TemporaryMemory<unsigned int>;
+
+}  // namespace caffe
+

--- a/src/caffe/tempmem.cpp
+++ b/src/caffe/tempmem.cpp
@@ -1,6 +1,6 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/make_shared.hpp>
-#include <boost/thread/lock_guard.hpp>
+#include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <cstring>
 #include <vector>


### PR DESCRIPTION
For fully convolutional nets the `col_buffer_` in the `BaseColvolutionLayer` can get quite large (1GB or more in total). Currently this temporary buffer is allocated for each convolution separately. This PR introduces a `TemporaryMemory` class which allows all temporary memory to be shared between convolutional layers. This could be used for other layers that use temporary memory, but I couldn't find any other memory hungry ones...
This saves up to 1GB of memory for fully convolutional VGG models.
