### PR TITLE
Added Pillow to requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,3 +14,4 @@ python-dateutil>=1.4,<2
 protobuf>=2.5.0
 python-gflags>=2.0
 pyyaml>=3.10
+Pillow>=2.7.0


### PR DESCRIPTION
This change will prevent the caffe python package break due to lack of supported image formats. I don't know which image formats would be supported without Pillow (or PIL) but now at least JPEG and PNG are supported.

See https://github.com/BVLC/caffe/issues/1997

Most people in this field probably already have Pillow or PIL and wouldn't notice about this, but it'll make installing pycaffe a little bit easier on a fresh OS install.



