### PR TITLE
Share convolution buffers to reduce memory usage

### DIFF
--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -107,7 +107,7 @@ class BaseConvolutionLayer : public Layer<Dtype> {
   int col_offset_;
   int output_offset_;
 
-  Blob<Dtype> col_buffer_;
+  static Blob<Dtype> col_buffer_;
   Blob<Dtype> bias_multiplier_;
 };
 

--- a/src/caffe/layers/base_conv_layer.cpp
+++ b/src/caffe/layers/base_conv_layer.cpp
@@ -9,6 +9,9 @@
 namespace caffe {
 
 template <typename Dtype>
+Blob<Dtype> BaseConvolutionLayer<Dtype>::col_buffer_;
+
+template <typename Dtype>
 void BaseConvolutionLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   // Configure the kernel size, padding, stride, and inputs.


### PR DESCRIPTION
Share the columnation buffer for im2col / col2im transformations across all Caffe convolution layers. The memory usage is now equal to the maximum buffer size instead of the sum over all layers. In particular this is useful for many-layered architectures like the VGG ILSVRC14 19 layer model.

Advice and Cautions:

- This is worth it for fully-convolutional models where Caffe convolution is faster than cuDNN.
- No parallelism. Only a single net can do forward / backward at a time. As the buffer is shared by all layers within and across nets, no convolution can be done in parallel. (A fix for parallel nets is to make the buffer a member of net. DAG parallelism is still out in that case, but isn't currently parallelized anyway.)
- This has no effect on cuDNN convolution, but that consumes less memory anyway.

All credit to @longjon who reshaped our world in #594 and suggested this patch in https://github.com/BVLC/caffe/pull/520#issuecomment-59000788.

`master` edition of #1291.

**Do not merge.**