### PR TITLE
fixed missing climits header in build

### DIFF
--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <climits>
 
 #include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"


### PR DESCRIPTION
Missing climits header was killing my builds with brand new commits.