### PR TITLE
add <climits> for INT_MAX

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -5,6 +5,7 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include <climits>
 #include <cmath>
 #include <fstream>  // NOLINT(readability/streams)
 #include <iostream>  // NOLINT(readability/streams)


### PR DESCRIPTION
Fixes #2027 as suggested by @albenoit.  I don't see any compilation errors without this extra include; hopefully this fixes it for people who do.