### PR TITLE
Use proto extensions with hashed field numbers for layer-specific parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,10 @@ EXAMPLE_SRCS := $(shell find examples -name "*.cpp")
 BUILD_INCLUDE_DIR := $(BUILD_DIR)/src
 # PROTO_SRCS are the protocol buffer definitions
 PROTO_SRC_DIR := src/$(PROJECT)/proto
-PROTO_SRCS := $(wildcard $(PROTO_SRC_DIR)/*.proto)
+PROTO_VAR_EXT_SRCS := $(wildcard $(PROTO_SRC_DIR)/*.proto.varextnum)
+PROTO_GEN_SRCS := $(PROTO_VAR_EXT_SRCS:.proto.varextnum=.proto)
+PROTO_SRCS := $(wildcard $(PROTO_SRC_DIR)/*.proto) $(PROTO_GEN_SRCS)
+PROTO_VAR_EXT_FILLER := ./scripts/fill_proto_ext_num.py
 # PROTO_BUILD_DIR will contain the .cc and obj files generated from
 # PROTO_SRCS; PROTO_BUILD_INCLUDE_DIR will contain the .h header files
 PROTO_BUILD_DIR := $(BUILD_DIR)/$(PROTO_SRC_DIR)
@@ -555,6 +558,9 @@ $(PROTO_BUILD_DIR)/%.pb.cc $(PROTO_BUILD_DIR)/%.pb.h : \
 		$(PROTO_SRC_DIR)/%.proto | $(PROTO_BUILD_DIR)
 	@ echo PROTOC $<
 	$(Q)protoc --proto_path=$(PROTO_SRC_DIR) --cpp_out=$(PROTO_BUILD_DIR) $<
+
+$(PROTO_SRC_DIR)/%.proto : $(PROTO_SRC_DIR)/%.proto.varextnum
+	$(PROTO_VAR_EXT_FILLER) $< $@
 
 $(PY_PROTO_BUILD_DIR)/%_pb2.py : $(PROTO_SRC_DIR)/%.proto \
 		$(PY_PROTO_INIT) | $(PY_PROTO_BUILD_DIR)

--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -298,6 +298,55 @@ class MVNLayer : public Layer<Dtype> {
 };
 
 /**
+ * @brief Reshapes an input Blob.
+ */
+template <typename Dtype>
+class ReshapeLayer : public Layer<Dtype> {
+ public:
+  explicit ReshapeLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "Reshape"; }
+  virtual inline int ExactNumBottomBlobs() const { return 1; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  /**
+   * @param bottom input Blob vector (length 1)
+   *   -# @f$ (D_1 \times D_2 \times ... \times D_m) @f$
+   *      the inputs
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (d_1 \times d_2 \times ... \times d_n) @f$,
+   *      the outputs -- i.e., the (virtually) copied inputs.
+   *      The shape is specified by <code>reshape_param.shape()</code>, and the
+   *      product of the dimensions in the new shape must match that of the
+   *      input shape; i.e., @f$ d_1 d_2 ... d_n = D_1 D_2 ... D_m @f$.
+   */
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {}
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {}
+
+  /**
+   * @brief Computes the error gradient w.r.t. the concatenate inputs.
+   *
+   * @param top output Blob vector (length 1), providing the error gradient with
+   *        respect to the outputs
+   * @param propagate_down see Layer::Backward.
+   * @param bottom input Blob vector (length K), into which the top error
+   *        gradient is (virtually) copied
+   */
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {}
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {}
+};
+
+/**
  * @brief Ignores bottom blobs while producing no top blobs. (This is useful
  *        to suppress outputs during testing.)
  */

--- a/scripts/fill_proto_ext_num.py
+++ b/scripts/fill_proto_ext_num.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import re
+import hashlib
+
+REPLACE_REGEXP = re.compile(r'\${FIELD_NUM:(?P<start>.*?),(?P<end>.*?),(?P<key>.*?)}')
+PROTOBUF_MAX_VALUE = 2 ** 29 - 1 # = 536,870,911
+
+# Returns an integer in the range [start, end] (inclusive) based on the sha1
+# hash of the input key.
+def compute_hash(key, start, end):
+    if start > end:
+        raise Exception('Invalid range: start = %d > end = %d' % (start, end))
+    output_range = end - start + 1
+    hashed_key = int(hashlib.sha1(key).hexdigest(), 16)
+    modded_key = hashed_key % output_range + start
+    return modded_key
+
+# Replaces wildcards of the form ${FIELD_NUM:start,end,key} with an integer
+# in [start, end] (inclusive) based on the hash of key.
+def replace_var_field_nums(text):
+    while True:
+        match = REPLACE_REGEXP.search(text)
+        if match is None: return text
+        start = int(match.group('start'))
+        end = match.group('end')
+        if end == 'max': end = PROTOBUF_MAX_VALUE
+        end = int(end)
+        key = match.group('key')
+        hashed_key = compute_hash(key, start, end)
+        text = text[:match.start()] + str(hashed_key) + text[match.end():]
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) != 3:
+        raise Exception('Usage: %s <input filename> <output filename>' % sys.argv[0])
+    _, input_filename, output_filename = sys.argv
+    with open(input_filename, 'r') as input_file:
+        text = input_file.read()
+    text = replace_var_field_nums(text)
+    with open(output_filename, 'w') as output_file:
+        output_file.write(text)

--- a/src/caffe/layers/reshape_layer.cpp
+++ b/src/caffe/layers/reshape_layer.cpp
@@ -1,0 +1,30 @@
+#include <vector>
+
+#include "caffe/common_layers.hpp"
+#include "caffe/layer.hpp"
+
+#include "caffe/proto/reshape_param.pb.h"
+
+namespace caffe {
+
+template <typename Dtype>
+void ReshapeLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  const ReshapeParameter& param =
+      this->layer_param_.GetExtension(reshape_param);
+  top[0]->Reshape(param.shape());
+}
+
+template <typename Dtype>
+void ReshapeLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  CHECK_EQ(top[0]->count(), bottom[0]->count())
+      << "New shape must have the same count as input shape.";
+  top[0]->ShareData(*bottom[0]);
+  top[0]->ShareDiff(*bottom[0]);
+}
+
+INSTANTIATE_CLASS(ReshapeLayer);
+REGISTER_LAYER_CLASS(Reshape);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -331,6 +331,9 @@ message LayerParameter {
   optional TanHParameter tanh_param = 127;
   optional ThresholdParameter threshold_param = 128;
   optional WindowDataParameter window_data_param = 129;
+
+  // Layer type-specific extensions.
+  extensions 20000 to max;
 }
 
 // Message that stores parameters used to apply transformation

--- a/src/caffe/proto/reshape_param.proto.varextnum
+++ b/src/caffe/proto/reshape_param.proto.varextnum
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package caffe;
+
+import "caffe.proto";
+
+extend LayerParameter {
+  optional ReshapeParameter reshape_param = ${FIELD_NUM:20000,max,reshape_param};
+}
+
+// Message that stores parameters used by ReshapeLayer
+message ReshapeParameter {
+  // The new shape of the Blob. Must have the same "count" (product of
+  // dimensions) as the input Blob.
+  optional BlobShape shape = 1;
+}

--- a/src/caffe/test/test_reshape_layer.cpp
+++ b/src/caffe/test/test_reshape_layer.cpp
@@ -1,0 +1,79 @@
+#include <algorithm>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/common_layers.hpp"
+#include "caffe/filler.hpp"
+
+#include "caffe/proto/reshape_param.pb.h"
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+namespace caffe {
+
+template <typename TypeParam>
+class ReshapeLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  ReshapeLayerTest()
+      : blob_bottom_(new Blob<Dtype>(2, 3, 4, 5)),
+        blob_top_(new Blob<Dtype>()) {
+    Caffe::set_random_seed(1701);
+    FillerParameter filler_param;
+    UniformFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_);
+    blob_bottom_vec_.push_back(blob_bottom_);
+    blob_top_vec_.push_back(blob_top_);
+    layer_param_.MutableExtension(reshape_param)->mutable_shape()->
+        add_dim(2 * 3 * 4 * 5);
+  }
+  virtual ~ReshapeLayerTest() {
+    delete blob_bottom_;
+    delete blob_top_;
+  }
+  LayerParameter layer_param_;
+  Blob<Dtype>* const blob_bottom_;
+  Blob<Dtype>* const blob_top_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(ReshapeLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(ReshapeLayerTest, TestSetUp) {
+  typedef typename TypeParam::Dtype Dtype;
+  shared_ptr<ReshapeLayer<Dtype> > layer(
+      new ReshapeLayer<Dtype>(this->layer_param_));
+  layer->SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  ASSERT_EQ(1, this->blob_top_->num_axes());
+  EXPECT_EQ(2 * 3 * 4 * 5, this->blob_top_->shape(0));
+}
+
+TYPED_TEST(ReshapeLayerTest, TestForward) {
+  typedef typename TypeParam::Dtype Dtype;
+  shared_ptr<ReshapeLayer<Dtype> > layer(
+      new ReshapeLayer<Dtype>(this->layer_param_));
+  layer->SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  const int count = this->blob_bottom_->count();
+  const Dtype* bottom_data = this->blob_bottom_->cpu_data();
+  const Dtype* top_data = this->blob_top_->cpu_data();
+  for (int i = 0; i < count; ++i) {
+    EXPECT_EQ(bottom_data[i], top_data[i]);
+  }
+}
+
+TYPED_TEST(ReshapeLayerTest, TestGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  ReshapeLayer<Dtype> layer(this->layer_param_);
+  GradientChecker<Dtype> checker(1e-2, 1e-3);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_);
+}
+
+}  // namespace caffe


### PR DESCRIPTION
This is the proof-of-concept mentioned by @shelhamer in #1896.  **DO NOT MERGE** -- I'm not really sure if this is a good way to go, this PR is just for discussion for now.

This would facilitate self-contained independent development of layers by addressing one of the major current pain points with that -- conflicting proto field numbers.  The idea is that instead of picking a field number consecutively after the previous one, which of course causes conflicts whenever other new layers are added, as long as your field *name* (e.g., `convolution_param`) doesn't conflict with anything else in `LayerParameter`, the field number is generated as a function of the name, and (with high probability) you get a unique number.  (The collision odds for any given pair of extensions are 1 in 536850911; haven't done the birthday problem analysis to figure out what that actually means in practice, but if we were going to use this we might need to eventually add a "salt" field to escape collisions.)

See `src/caffe/proto/reshape_param.proto.varextnum` for an example of what it looks like to declare a LayerParameter extension this way.  The script `scripts/fill_proto_ext_num.py` creates the actual `reshape_param.proto` file from the `*.varextnum` version.

Build notes: there is currently something finicky about my Makefile changes such that parallel builds with `make -j` sometimes don't work, and I haven't attempted add CMake support.