### PR TITLE
CMAKE: Adding missing hdf5 include directory

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -25,7 +25,7 @@ include(cmake/ProtoBuf.cmake)
 
 # ---[ HDF5
 find_package(HDF5 COMPONENTS HL REQUIRED)
-include_directories(SYSTEM ${HDF5_INCLUDE_DIRS})
+include_directories(SYSTEM ${HDF5_INCLUDE_DIRS} ${HDF5_HL_INCLUDE_DIR})
 list(APPEND Caffe_LINKER_LIBS ${HDF5_LIBRARIES})
 
 # ---[ LMDB


### PR DESCRIPTION
If ```hdf5.h``` is not located in ```/usr/include``` ```HDF5_INCLUDE_DIRS``` might not be set correctly, but ```HDF5_HL_INCLUDE_DIR``` still contains the correct directory.