### PR TITLE
Allow python solver creation from prototxt string (not just file)

### DIFF
--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,5 +1,5 @@
+from ._caffe import *
 from .pycaffe import Net, SGDSolver
-from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector


### PR DESCRIPTION
A simple change that allows us to specify prototxt strings for solver settings from python, instead of just filenames. It makes it easier to train models using the new python interface.