### PR TITLE
Update leveldb include variable name to match FindLevelDB.cmake

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -35,7 +35,7 @@ list(APPEND Caffe_LINKER_LIBS ${LMDB_LIBRARIES})
 
 # ---[ LevelDB
 find_package(LevelDB REQUIRED)
-include_directories(SYSTEM ${LEVELDB_INCLUDE})
+include_directories(SYSTEM ${LevelDB_INCLUDE})
 list(APPEND Caffe_LINKER_LIBS ${LevelDB_LIBRARIES})
 
 # ---[ Snappy


### PR DESCRIPTION
Currently the variable name used in cmake/Dependencies.cmake does not match the one set in FindLevelDB.cmake (LEVELDB_INCLUDE vs. LeveDB_INCLUDE), so if leveldb is not installed in a standard path cmake will fail. 