### PR TITLE
Thread-specific singleton (from @cypof)

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -2,7 +2,6 @@
 #define CAFFE_COMMON_HPP_
 
 #include <boost/shared_ptr.hpp>
-#include <boost/thread.hpp>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
@@ -69,6 +68,9 @@ private:\
 // See PR #1236
 namespace cv { class Mat; }
 
+// Avoid issues with including boost/thread in NVCC source (#1009).
+namespace boost { template <typename T> class thread_specific_ptr; }
+
 namespace caffe {
 
 // We will use the boost shared_ptr instead of the new C++11 one mainly
@@ -99,12 +101,7 @@ void GlobalInit(int* pargc, char*** pargv);
 class Caffe {
  public:
   ~Caffe();
-  inline static Caffe& Get() {
-    if (!singleton_.get()) {
-      singleton_.reset(new Caffe());
-    }
-    return *singleton_;
-  }
+  static Caffe& Get();
   enum Brew { CPU, GPU };
 
   // This random number generator facade hides boost and CUDA rng

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -2,6 +2,7 @@
 #define CAFFE_COMMON_HPP_
 
 #include <boost/shared_ptr.hpp>
+#include <boost/thread.hpp>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
@@ -158,7 +159,7 @@ class Caffe {
   shared_ptr<RNG> random_generator_;
 
   Brew mode_;
-  static shared_ptr<Caffe> singleton_;
+  static boost::thread_specific_ptr<Caffe> singleton_;
 
  private:
   // The private constructor to avoid duplicate instantiation.

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -7,7 +7,7 @@
 
 namespace caffe {
 
-shared_ptr<Caffe> Caffe::singleton_;
+boost::thread_specific_ptr<Caffe> Caffe::singleton_;
 
 // random seeding
 int64_t cluster_seedgen(void) {

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -1,3 +1,4 @@
+#include <boost/thread.hpp>
 #include <glog/logging.h>
 #include <cstdio>
 #include <ctime>
@@ -37,6 +38,13 @@ void GlobalInit(int* pargc, char*** pargv) {
   ::google::InitGoogleLogging(*(pargv)[0]);
   // Provide a backtrace on segfault.
   ::google::InstallFailureSignalHandler();
+}
+
+Caffe& Caffe::Get() {
+  if (!singleton_.get()) {
+    singleton_.reset(new Caffe());
+  }
+  return *singleton_;
 }
 
 #ifdef CPU_ONLY  // CPU-only Caffe.


### PR DESCRIPTION
This is the first in a series of PRs pulling some work from the parallel branch/@cypof that's ready for immediate consideration, and that will be also be used by future PRs implementing orthogonal work on synchronous parallelism.

This PR switches from a single, global `Caffe` singleton to a per-thread singleton, and then performs the necessary circumlocutions to avoid boost/nvcc conflicts. This is both necessary and sufficient for most multi-device work. (Further refactoring to eliminate the singleton is possible, but this is a much simpler sufficient step.)

Using the same singleton in different threads is pretty certainly a bad idea, so I see no reason not to merge this change as soon it's verified to be in good working order.

@cypof, your other commits seem to be missing your name and have a different email from your github account. I used your github information for the commit I added here; please confirm that the author information is as you desire.
