### PR TITLE
Use CUDA 7's per-thread default stream, with automatic syncing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ CXXFLAGS += -MMD -MP
 # Complete build flags.
 COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
 CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
-NVCCFLAGS += -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS)
+NVCCFLAGS += -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS) --default-stream per-thread
 # mex may invoke an older gcc that is too liberal with -Wuninitalized
 MATLAB_CXXFLAGS := $(CXXFLAGS) -Wno-uninitialized
 LINKFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)

--- a/Makefile
+++ b/Makefile
@@ -227,16 +227,15 @@ ifeq ($(LINUX), 1)
 	LIBRARIES += boost_thread stdc++
 endif
 
+CUDA_VERSION := $(shell $(CUDA_DIR)/bin/nvcc -V | grep -Eo 'release [^,]+' | cut -f2 -d' ')
+ifeq ($(shell echo $(CUDA_VERSION) \< 7.0 | bc), 1)
+  $(error CUDA 7 is required.)
+endif
+
 # OS X:
 # clang++ instead of g++
-# libstdc++ for NVCC compatibility on OS X >= 10.9 with CUDA < 7.0
 ifeq ($(OSX), 1)
 	CXX := /usr/bin/clang++
-	CUDA_VERSION := $(shell $(CUDA_DIR)/bin/nvcc -V | grep -o 'release \d' | grep -o '\d')
-	ifeq ($(shell echo $(CUDA_VERSION) \< 7.0 | bc), 1)
-		CXXFLAGS += -stdlib=libstdc++
-		LINKFLAGS += -stdlib=libstdc++
-	endif
 	# clang throws this warning for cuda headers
 	WARNINGS += -Wno-unneeded-internal-declaration
 	# gtest needs to use its own tuple to not conflict with clang

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -420,6 +420,7 @@ inline Dtype Layer<Dtype>::Forward(const vector<Blob<Dtype>*>& bottom,
   case Caffe::GPU:
     Forward_gpu(bottom, top);
 #ifndef CPU_ONLY
+    CUDA_CHECK(cudaStreamSynchronize(cudaStreamPerThread));
     for (int top_id = 0; top_id < top.size(); ++top_id) {
       if (!this->loss(top_id)) { continue; }
       const int count = top[top_id]->count();
@@ -447,6 +448,9 @@ inline void Layer<Dtype>::Backward(const vector<Blob<Dtype>*>& top,
     break;
   case Caffe::GPU:
     Backward_gpu(top, propagate_down, bottom);
+#ifndef CPU_ONLY
+    CUDA_CHECK(cudaStreamSynchronize(cudaStreamPerThread));
+#endif
     break;
   default:
     LOG(FATAL) << "Unknown caffe mode.";

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -92,6 +92,7 @@ Caffe::Caffe()
   if (cublasCreate(&cublas_handle_) != CUBLAS_STATUS_SUCCESS) {
     LOG(ERROR) << "Cannot create Cublas handle. Cublas won't be available.";
   }
+  CUBLAS_CHECK(cublasSetStream(cublas_handle_, cudaStreamPerThread));
   // Try to create a curand handler.
   if (curandCreateGenerator(&curand_generator_, CURAND_RNG_PSEUDO_DEFAULT)
       != CURAND_STATUS_SUCCESS ||

--- a/src/caffe/layers/cudnn_pooling_layer.cpp
+++ b/src/caffe/layers/cudnn_pooling_layer.cpp
@@ -17,6 +17,7 @@ void CuDNNPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   CHECK_EQ(this->pad_h_, 0);
   CHECK_EQ(this->pad_w_, 0);
   CUDNN_CHECK(cudnnCreate(&handle_));
+  CUDNN_CHECK(cudnnSetStream(handle_, cudaStreamPerThread));
   cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
   cudnn::createTensor4dDesc<Dtype>(&top_desc_);
   cudnn::createPoolingDesc<Dtype>(&pooling_desc_,

--- a/src/caffe/layers/cudnn_relu_layer.cpp
+++ b/src/caffe/layers/cudnn_relu_layer.cpp
@@ -13,6 +13,7 @@ void CuDNNReLULayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   ReLULayer<Dtype>::LayerSetUp(bottom, top);
   // initialize cuDNN
   CUDNN_CHECK(cudnnCreate(&handle_));
+  CUDNN_CHECK(cudnnSetStream(handle_, cudaStreamPerThread));
   cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
   cudnn::createTensor4dDesc<Dtype>(&top_desc_);
   handles_setup_ = true;

--- a/src/caffe/layers/cudnn_softmax_layer.cpp
+++ b/src/caffe/layers/cudnn_softmax_layer.cpp
@@ -17,6 +17,7 @@ void CuDNNSoftmaxLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   SoftmaxLayer<Dtype>::LayerSetUp(bottom, top);
   // Initialize CUDNN.
   CUDNN_CHECK(cudnnCreate(&handle_));
+  CUDNN_CHECK(cudnnSetStream(handle_, cudaStreamPerThread));
   cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
   cudnn::createTensor4dDesc<Dtype>(&top_desc_);
   handles_setup_ = true;


### PR DESCRIPTION
Currently Caffe treats CUDA streams like this: we normally only use the default (NULL) stream, although a few layers use explicit streams which they are responsible for synchronizing.

Since we do not explicitly synchronize the default stream at the end of any layers, layer calls can actually be asynchronous with respect to the host. This normally goes unnoticed because all future CUDA calls (including `memcpy`s) synch with the default stream. However, this use of the default stream also prevents GPU concurrency between threads.

CUDA 7 introduces the `nvcc` flag `--default-stream per-thread`, which turns the default stream into a normal, per-thread stream. This automatically allows concurrency with our existing layers, but also makes consecutive layer calls potentially asynchronous with respect to each other, which breaks normal net computation.

We could eliminate all use of the default stream, and insist that layers always block until their computation actually completes. This would require additional code in all existing CUDA layers. An alternative, presented here, is to introduce the convention that the null stream is always implicitly synchronized after a forward or backward. This maintains the old semantics of writing layers using the default stream in CUDA <7, while allowing layer concurrency despite the default stream in CUDA 7 with the appropriate flag. Since the default stream will block the whole device anyway in CUDA <7, there is no reason to avoid synchronizing it between layer calls.

After this patch, it should be okay to compile with `--default-stream per-thread`.
