### PR TITLE
Remove obsolete loss layer check

### DIFF
--- a/src/caffe/layers/loss_layer.cpp
+++ b/src/caffe/layers/loss_layer.cpp
@@ -22,8 +22,6 @@ void LossLayer<Dtype>::LayerSetUp(
 template <typename Dtype>
 void LossLayer<Dtype>::Reshape(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
-  CHECK_EQ(bottom[0]->num(), bottom[1]->num())
-      << "The data and label should have the same number.";
   vector<int> loss_shape(0);  // Loss layers output a scalar; 0 axes.
   top[0]->Reshape(loss_shape);
 }


### PR DESCRIPTION
With the `n`d blob update, it's no longer true that the `num` dimension has to be the same for both bottoms of every loss layer (e.g., softmax loss layer with `axis = 0`).

I'm not sure if additional checks should be added to other specific loss layers to compensate.