### PR TITLE
Add Layer::Reset method to reinitialize internal state

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -85,10 +85,12 @@ template <typename Dtype>
 class DataLayer : public BasePrefetchingDataLayer<Dtype> {
  public:
   explicit DataLayer(const LayerParameter& param)
-      : BasePrefetchingDataLayer<Dtype>(param) {}
+      : BasePrefetchingDataLayer<Dtype>(param),
+        skip_initialized_(false) {}
   virtual ~DataLayer();
   virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
+  virtual void Reset();
 
   virtual inline const char* type() const { return "Data"; }
   virtual inline int ExactNumBottomBlobs() const { return 0; }
@@ -100,6 +102,9 @@ class DataLayer : public BasePrefetchingDataLayer<Dtype> {
 
   shared_ptr<db::DB> db_;
   shared_ptr<db::Cursor> cursor_;
+
+  unsigned int skip_;
+  bool skip_initialized_;
 };
 
 /**

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -122,6 +122,7 @@ class DummyDataLayer : public Layer<Dtype> {
   // Data layers have no bottoms, so reshaping is trivial.
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {}
+  virtual void Reset();
 
   virtual inline const char* type() const { return "DummyData"; }
   virtual inline int ExactNumBottomBlobs() const { return 0; }

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -155,6 +155,7 @@ class HDF5DataLayer : public Layer<Dtype> {
   // Data layers have no bottoms, so reshaping is trivial.
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {}
+  virtual void Reset();
 
   virtual inline const char* type() const { return "HDF5Data"; }
   virtual inline int ExactNumBottomBlobs() const { return 0; }

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -309,6 +309,9 @@ class WindowDataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual ~WindowDataLayer();
   virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
+  // Reset isn't implemented for WindowDataLayer -- for a working
+  // implementation, the RNG would need to be reset to its initial state.
+  virtual void Reset() { NOT_IMPLEMENTED; }
 
   virtual inline const char* type() const { return "WindowData"; }
   virtual inline int ExactNumBottomBlobs() const { return 0; }

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -234,6 +234,7 @@ class ImageDataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual ~ImageDataLayer();
   virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
+  virtual void Reset();
 
   virtual inline const char* type() const { return "ImageData"; }
   virtual inline int ExactNumBottomBlobs() const { return 0; }

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -101,6 +101,12 @@ class Layer {
       const vector<Blob<Dtype>*>& top) = 0;
 
   /**
+   * @brief Resets the Layer&'s internal state (not including any
+   *        parameter Blob&s, which keep their values).
+   */
+  virtual void Reset() {}
+
+  /**
    * @brief Given the bottom blobs, compute the top blobs and the loss.
    *
    * @param bottom

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -75,6 +75,15 @@ class Net {
    */
   void Reshape();
 
+  /**
+   * @brief Resets the internal state of all Layer&s (not including any
+   *        parameter Blob&s, which keep their values).
+   *
+   * This is called by the Solver on each test Net to give consistent results
+   * between test instances (e.g., test on the same part of the dataset).
+   */
+  void Reset();
+
   Dtype ForwardBackward(const vector<Blob<Dtype>* > & bottom) {
     Dtype loss;
     Forward(bottom, &loss);

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -59,6 +59,9 @@ class Solver {
   shared_ptr<Net<Dtype> > net_;
   vector<shared_ptr<Net<Dtype> > > test_nets_;
 
+  /// @brief Specifies whether each test net should be "Reset" on each test.
+  vector<bool> test_net_reset_;
+
   DISABLE_COPY_AND_ASSIGN(Solver);
 };
 

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -27,17 +27,10 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   // Initialize DB
   db_.reset(db::GetDB(this->layer_param_.data_param().backend()));
   db_->Open(this->layer_param_.data_param().source(), db::READ);
-  cursor_.reset(db_->NewCursor());
 
-  // Check if we should randomly skip a few data points
-  if (this->layer_param_.data_param().rand_skip()) {
-    unsigned int skip = caffe_rng_rand() %
-                        this->layer_param_.data_param().rand_skip();
-    LOG(INFO) << "Skipping first " << skip << " data points.";
-    while (skip-- > 0) {
-      cursor_->Next();
-    }
-  }
+  // Initialize the cursor and rand_skip.
+  Reset();
+
   // Read a data point, and use it to initialize the top blob.
   Datum datum;
   datum.ParseFromString(cursor_->value());
@@ -158,6 +151,23 @@ void DataLayer<Dtype>::InternalThreadEntry() {
   DLOG(INFO) << "Prefetch batch: " << batch_timer.MilliSeconds() << " ms.";
   DLOG(INFO) << "     Read time: " << read_time / 1000 << " ms.";
   DLOG(INFO) << "Transform time: " << trans_time / 1000 << " ms.";
+}
+
+template <typename Dtype>
+void DataLayer<Dtype>::Reset() {
+  cursor_.reset(db_->NewCursor());
+  // Check if we should randomly skip a few data points
+  if (this->layer_param_.data_param().rand_skip()) {
+    if (!skip_initialized_) {
+      skip_ = caffe_rng_rand() % this->layer_param_.data_param().rand_skip();
+      skip_initialized_ = true;
+    }
+    LOG(INFO) << "Skipping first " << skip_ << " data points.";
+    int skip = skip_;
+    while (skip-- > 0) {
+      cursor_->Next();
+    }
+  }
 }
 
 INSTANTIATE_CLASS(DataLayer);

--- a/src/caffe/layers/dummy_data_layer.cpp
+++ b/src/caffe/layers/dummy_data_layer.cpp
@@ -99,6 +99,20 @@ void DummyDataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
 }
 
 template <typename Dtype>
+void DummyDataLayer<Dtype>::Reset() {
+  // If refill_ is set for any of the top Blobs, Reset would need to
+  // somehow re-initialize the RNG state for a working implementation.
+  // Otherwise, all the fillers are ConstantFillers and we can trivially
+  // Reset by doing nothing.
+  for (int i = 0; i < refill_.size(); ++i) {
+    if (refill_[i]) {
+      LOG(FATAL) << "DummyDataLayer::Reset not implemented for "
+                 << "non-deterministic outputs.";
+    }
+  }
+}
+
+template <typename Dtype>
 void DummyDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   for (int i = 0; i < top.size(); ++i) {

--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -76,14 +76,12 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   }
   source_file.close();
   num_files_ = hdf_filenames_.size();
-  current_file_ = 0;
   LOG(INFO) << "Number of HDF5 files: " << num_files_;
   CHECK_GE(num_files_, 1) << "Must have at least 1 HDF5 filename listed in "
     << source;
 
   // Load the first HDF5 file and initialize the line counter.
-  LoadHDF5FileData(hdf_filenames_[current_file_].c_str());
-  current_row_ = 0;
+  Reset();
 
   // Reshape blobs.
   const int batch_size = this->layer_param_.hdf5_data_param().batch_size();
@@ -97,6 +95,13 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     }
     top[i]->Reshape(top_shape);
   }
+}
+
+template <typename Dtype>
+void HDF5DataLayer<Dtype>::Reset() {
+  current_file_ = 0;
+  LoadHDF5FileData(hdf_filenames_[current_file_].c_str());
+  current_row_ = 0;
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -159,6 +159,16 @@ void ImageDataLayer<Dtype>::InternalThreadEntry() {
   DLOG(INFO) << "Transform time: " << trans_time / 1000 << " ms.";
 }
 
+template <typename Dtype>
+void ImageDataLayer<Dtype>::Reset() {
+  // If shuffle is set, Reset would need to somehow re-initialize the RNG state
+  // for a working implementation.
+  if (this->layer_param_.image_data_param().shuffle()) {
+    LOG(FATAL) << "Reset not implemented for ImageDataLayer with shuffle";
+  }
+  lines_id_ = 0;
+}
+
 INSTANTIATE_CLASS(ImageDataLayer);
 REGISTER_LAYER_CLASS(ImageData);
 

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -685,6 +685,13 @@ void Net<Dtype>::Reshape() {
 }
 
 template <typename Dtype>
+void Net<Dtype>::Reset() {
+  for (int i = 0; i < layers_.size(); ++i) {
+    layers_[i]->Reset();
+  }
+}
+
+template <typename Dtype>
 void Net<Dtype>::CopyTrainedLayersFrom(const NetParameter& param) {
   int num_source_layers = param.layer_size();
   for (int i = 0; i < num_source_layers; ++i) {

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -88,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 36 (last added: clip_gradients)
+// SolverParameter next available ID: 37 (last added: test_net_reset)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -127,6 +127,16 @@ message SolverParameter {
 
   // The number of iterations for each test net.
   repeated int32 test_iter = 3;
+
+  // Specify whether to "reset" each test net at the beginning of each test,
+  // such that each test is performed on the same subset of the data.
+  // This feature is not implemented for all layer types -- for example, it is
+  // unimplemented for the WINDOW_DATA layer.
+  //
+  // This should be unspecified (in which case it is set to false for all test
+  // nets), specified once (in which case the setting is applied to all test
+  // nets), or specified exactly once per test net.
+  repeated bool test_net_reset = 36;
 
   // The number of iterations between two testing phases.
   optional int32 test_interval = 4 [default = 0];

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -156,6 +156,19 @@ void Solver<Dtype>::InitTestNets() {
     test_nets_[i].reset(new Net<Dtype>(net_params[i]));
     test_nets_[i]->set_debug_info(param_.debug_info());
   }
+
+  // Setup test_net_reset_ -- default to not resetting any test nets.
+  test_net_reset_.resize(test_nets_.size(), false);
+  if (param_.test_net_reset_size() == 1) {
+    test_net_reset_.assign(test_nets_.size(), param_.test_net_reset(0));
+  } else if (param_.test_net_reset_size() > 0) {
+    CHECK_EQ(num_test_net_instances, param_.test_net_reset_size())
+        << "test_net_reset must be specified 0, 1, or "
+        << num_test_net_instances << " times (once for each test net).";
+    for (int i = 0; i < num_test_net_instances; ++i) {
+      test_net_reset_[i] = param_.test_net_reset(i);
+    }
+  }
 }
 
 template <typename Dtype>
@@ -265,6 +278,10 @@ template <typename Dtype>
 void Solver<Dtype>::Test(const int test_net_id) {
   LOG(INFO) << "Iteration " << iter_
             << ", Testing net (#" << test_net_id << ")";
+  // Reset the test nets as specified by test_net_reset.
+  if (test_net_reset_[test_net_id]) {
+    test_nets_[test_net_id]->Reset();
+  }
   CHECK_NOTNULL(test_nets_[test_net_id].get())->
       ShareTrainedLayersWith(net_.get());
   vector<Dtype> test_score;


### PR DESCRIPTION
Master version of #1194.

> The main purpose is to make testing run over the same set of data in each test pass reliably, without having to worry about setting `test_iter` and `batch_size` to sweep through the dataset exactly once.  Instead, we "Reset" to the beginning of the dataset every time.  Enable by adding `test_net_reset: true` to any SolverParameter.  With the setting enabled (and assuming all the layers in the test net support it), even if `T = test_iter * batch_size` is set to something other than the total dataset size (`D`), the same dataset will be tested in each test pass; you'll just never see some of the dataset (if `T < D`) or will see some of the dataset more than once (if `T > D`), but results will be consistent in the sense that you'll always miss/repeat the same subset of the dataset.

> Current limitations:
> -No unit tests (I've tried it out for `HDF5DataLayer` and it works based on the output of `debug_info`, but completely untested for other `DataLayer`s)
> -Not implemented for anything using the RNG as we don't have a way to save and restore the RNG state (I've looked into this -- it seems to be completely impossible to do for curand...)