### PR TITLE
GPU in Python: converting Blob to PyCuda.gpuarray (no copy)

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -147,6 +147,8 @@ class Caffe {
   // Sets the device. Since we have cublas and curand stuff, set device also
   // requires us to reset those values.
   static void SetDevice(const int device_id);
+  // Get the device.
+  static int GetDevice();
   // Prints the current GPU status.
   static void DeviceQuery();
 

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -2,6 +2,7 @@ from .pycaffe import Net, SGDSolver
 from ._caffe import (
     set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver,
     get_device,
+    check_mode_cpu, check_mode_gpu,
 )
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,5 +1,8 @@
 from .pycaffe import Net, SGDSolver
-from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver
+from ._caffe import (
+    set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver,
+    get_device,
+)
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -3,6 +3,7 @@ from ._caffe import (
     set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver,
     get_device,
     check_mode_cpu, check_mode_gpu,
+    get_cuda_num_threads, get_blocks,
 )
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -199,6 +199,7 @@ BOOST_PYTHON_MODULE(_caffe) {
   bp::def("set_mode_cpu", &set_mode_cpu);
   bp::def("set_mode_gpu", &set_mode_gpu);
   bp::def("set_device", &Caffe::SetDevice);
+  bp::def("get_device", &Caffe::GetDevice);
 
   bp::class_<Net<Dtype>, shared_ptr<Net<Dtype> >, boost::noncopyable >("Net",
     bp::no_init)

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -35,6 +35,9 @@ const int NPY_DTYPE = NPY_FLOAT32;
 // Selecting mode.
 void set_mode_cpu() { Caffe::set_mode(Caffe::CPU); }
 void set_mode_gpu() { Caffe::set_mode(Caffe::GPU); }
+// Checking current mode.
+bool check_mode_cpu() { return Caffe::mode() == Caffe::CPU; }
+bool check_mode_gpu() { return Caffe::mode() == Caffe::GPU; }
 
 // For convenience, check that input files can be opened, and raise an
 // exception that boost will send to Python if not (caffe could still crash
@@ -198,6 +201,8 @@ BOOST_PYTHON_MODULE(_caffe) {
   // Caffe utility functions
   bp::def("set_mode_cpu", &set_mode_cpu);
   bp::def("set_mode_gpu", &set_mode_gpu);
+  bp::def("check_mode_cpu", &check_mode_cpu);
+  bp::def("check_mode_gpu", &check_mode_gpu);
   bp::def("set_device", &Caffe::SetDevice);
   bp::def("get_device", &Caffe::GetDevice);
 

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -38,6 +38,8 @@ void set_mode_gpu() { Caffe::set_mode(Caffe::GPU); }
 // Checking current mode.
 bool check_mode_cpu() { return Caffe::mode() == Caffe::CPU; }
 bool check_mode_gpu() { return Caffe::mode() == Caffe::GPU; }
+// Cuda num threads
+int get_cuda_num_threads() { return CAFFE_CUDA_NUM_THREADS; }
 
 // For convenience, check that input files can be opened, and raise an
 // exception that boost will send to Python if not (caffe could still crash
@@ -218,6 +220,8 @@ BOOST_PYTHON_MODULE(_caffe) {
   bp::def("check_mode_gpu", &check_mode_gpu);
   bp::def("set_device", &Caffe::SetDevice);
   bp::def("get_device", &Caffe::GetDevice);
+  bp::def("get_cuda_num_threads", &get_cuda_num_threads);
+  bp::def("get_blocks", &CAFFE_GET_BLOCKS);
 
   bp::class_<Net<Dtype>, shared_ptr<Net<Dtype> >, boost::noncopyable >("Net",
     bp::no_init)

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -208,6 +208,24 @@ bp::object Blob_Reshape(bp::tuple args, bp::dict kwargs) {
   return bp::object();
 }
 
+#ifndef CPU_ONLY
+bp::object Blob_GpuDataPtr(bp::tuple args, bp::dict kwargs) {
+  if (bp::len(kwargs) > 0) {
+    throw std::runtime_error("Blob.gpu_data_ptr takes no kwargs");
+  }
+  Blob<Dtype>* self = bp::extract<Blob<Dtype>*>(args[0]);
+  return bp::object((size_t)(self->mutable_gpu_data()));
+}
+
+bp::object Blob_GpuDiffPtr(bp::tuple args, bp::dict kwargs) {
+  if (bp::len(kwargs) > 0) {
+    throw std::runtime_error("Blob.gpu_diff_ptr takes no kwargs");
+  }
+  Blob<Dtype>* self = bp::extract<Blob<Dtype>*>(args[0]);
+  return bp::object((size_t)(self->mutable_gpu_diff()));
+}
+#endif
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SolveOverloads, Solve, 0, 1);
 
 BOOST_PYTHON_MODULE(_caffe) {
@@ -261,6 +279,10 @@ BOOST_PYTHON_MODULE(_caffe) {
         &Blob<Dtype>::count))
     .add_property("shape", bp::raw_function(&Blob_Shape))
     .def("reshape",           bp::raw_function(&Blob_Reshape))
+#ifndef CPU_ONLY
+    .add_property("gpu_data_ptr", bp::raw_function(&Blob_GpuDataPtr))
+    .add_property("gpu_diff_ptr", bp::raw_function(&Blob_GpuDiffPtr))
+#endif
     .add_property("data",     bp::make_function(&Blob<Dtype>::mutable_cpu_data,
           NdarrayCallPolicies()))
     .add_property("diff",     bp::make_function(&Blob<Dtype>::mutable_cpu_diff,

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -179,6 +179,19 @@ struct NdarrayCallPolicies : public bp::default_call_policies {
   }
 };
 
+bp::object Blob_Shape(bp::tuple args, bp::dict kwargs) {
+  if (bp::len(kwargs) > 0) {
+    throw std::runtime_error("Blob.shape takes no kwargs");
+  }
+  Blob<Dtype>* self = bp::extract<Blob<Dtype>*>(args[0]);
+  const vector<int> &shape = self->shape();
+  bp::list shape_list;
+  BOOST_FOREACH(int s, shape) {
+    shape_list.append(s);
+  }
+  return bp::tuple(shape_list);
+}
+
 bp::object Blob_Reshape(bp::tuple args, bp::dict kwargs) {
   if (bp::len(kwargs) > 0) {
     throw std::runtime_error("Blob.reshape takes no kwargs");
@@ -242,6 +255,7 @@ BOOST_PYTHON_MODULE(_caffe) {
     .add_property("width",    &Blob<Dtype>::width)
     .add_property("count",    static_cast<int (Blob<Dtype>::*)() const>(
         &Blob<Dtype>::count))
+    .add_property("shape", bp::raw_function(&Blob_Shape))
     .def("reshape",           bp::raw_function(&Blob_Reshape))
     .add_property("data",     bp::make_function(&Blob<Dtype>::mutable_cpu_data,
           NdarrayCallPolicies()))

--- a/python/caffe/_pycuda_util.py
+++ b/python/caffe/_pycuda_util.py
@@ -1,0 +1,57 @@
+import os
+from contextlib import contextmanager
+
+import pycuda.driver as cuda
+import pycuda.gpuarray
+
+from ._caffe import Blob
+
+# Set pycuda array getter to Blob class
+
+
+def _Blob_data_as_pycuda_gpuarray(self):
+    return pycuda.gpuarray.GPUArray(self.shape, 'float32', base=self,
+                                    gpudata=self.gpu_data_ptr)
+
+
+def _Blob_diff_as_pycuda_gpuarray(self):
+    return pycuda.gpuarray.GPUArray(self.shape, 'float32', base=self,
+                                    gpudata=self.gpu_diff_ptr)
+Blob.data_as_pycuda_gpuarray = _Blob_data_as_pycuda_gpuarray
+Blob.diff_as_pycuda_gpuarray = _Blob_diff_as_pycuda_gpuarray
+
+
+def block_and_grid(count):
+    import caffe
+    d = {}
+    d['block'] = (caffe.get_cuda_num_threads(), 1, 1)
+    d['grid'] = (caffe.get_blocks(count), 1)
+    return d
+
+
+caffe_include_dirs = [
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__), '..', '..', 'include'))]
+
+@contextmanager
+def caffe_cuda_context():
+    """Borrow CUDA context from CAFFE duraing `with` statement. See
+        `test_pycuda.py` for usage. We strongly recommend to use this context
+        manager if you use PyCuda with CAFFE. Do not use `pycuda.autoinit`.
+
+    NOTE: This context manager uses `cuCtxAttach` and `cuCtxDetach` functions
+        (see Driver API in CUDA programing guide, and they are exposed as
+        `attach` and `detach` in PyCuda) to get the current CUDA context used
+        in CAFFE. Actually these functions are deprecated and the CUDA
+        programing guide (v6.5) recommends to use `cuCtxGetCurrent` instead,
+        but PyCuda does not expose it to Python I/F. Hence, here we use
+        `attach` and `detach` function so far.
+    """
+    import caffe
+    if not caffe.check_mode_gpu():
+        raise ValueError(
+            "PyCuda cannot be used if Caffe is not in GPU mode.")
+    ctx = cuda.Context.attach()
+    yield
+    ctx.detach()

--- a/python/caffe/pycuda_util.py
+++ b/python/caffe/pycuda_util.py
@@ -1,0 +1,10 @@
+from ._caffe import Blob
+# Enable PyCuda only if Cafffe is bulilt with GPU
+if hasattr(Blob, 'gpu_data_ptr'):
+	try:
+		import pycuda.gpuarray
+		pycuda_available = True
+		from _pycuda_util import *
+	except ImportError:
+		# PyCuda does not exist
+		pycuda_available = False

--- a/python/caffe/test/test_pycuda.py
+++ b/python/caffe/test/test_pycuda.py
@@ -1,0 +1,111 @@
+from caffe import pycuda_util
+
+if pycuda_util.pycuda_available:
+    import unittest
+    import tempfile
+    import os
+
+    import numpy as np
+
+    import caffe
+    from pycuda.compiler import SourceModule
+
+    caffe_include_dirs = pycuda_util.caffe_include_dirs
+
+    kernel_set_value = """
+#include <caffe/util/device_alternate.hpp>
+__global__ void set_value(float *x, float value, int n) {
+    CUDA_KERNEL_LOOP(i, n) {
+        x[i] = value;
+    }
+}
+    """
+    kernel_axpb = """
+#include <caffe/util/device_alternate.hpp>
+__global__ void axpb(float a, float *x, float b, int n) {
+    CUDA_KERNEL_LOOP(i, n) {
+        x[i] = a * x[i] + b;
+    }
+}
+    """
+
+    def python_net_file():
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write("""name: 'blobonly'
+            input: 'data' input_shape { dim: 10 dim: 9 dim: 8 }
+            """)
+            return f.name
+
+    def get_test_gpuid_from_makefile():
+        path_makefile = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                '..', '..', '..', 'Makefile.config'))
+        try:
+            test_gpuid = filter(
+                lambda x: x.startswith("TEST_GPUID"),
+                open(path_makefile, 'r'))[0]
+            test_gpuid = int(test_gpuid.split(' ')[2])
+            return test_gpuid
+        except IndexError:
+            pass
+        except ValueError:
+            pass
+        return 0
+
+    class TestPyCuda(unittest.TestCase):
+
+        def setUp(self):
+            test_gpuid = get_test_gpuid_from_makefile()
+            caffe.set_mode_gpu()
+            caffe.set_device(test_gpuid)
+            net_proto = python_net_file()
+            net = caffe.Net(net_proto, caffe.TRAIN)
+            self.blob = net.blobs["data"]
+            os.remove(net_proto)
+
+        def test_blob_to_gpuarray(self):
+            with pycuda_util.caffe_cuda_context():
+                self.blob.data_as_pycuda_gpuarray()
+                self.blob.diff_as_pycuda_gpuarray()
+
+        def test_pycuda_set_data(self):
+            with pycuda_util.caffe_cuda_context():
+                mod = SourceModule(
+                    kernel_set_value, include_dirs=caffe_include_dirs)
+                set_value = mod.get_function("set_value")
+                set_value(
+                    self.blob.data_as_pycuda_gpuarray(), np.float32(5),
+                    np.int32(self.blob.count),
+                    ** pycuda_util.block_and_grid(self.blob.count))
+            for v in self.blob.data.flat:
+                self.assertEqual(v, np.float32(5))
+
+        def test_pycuda_set_diff(self):
+            a = np.float32(5.0)
+            with pycuda_util.caffe_cuda_context():
+                mod = SourceModule(
+                    kernel_set_value, include_dirs=caffe_include_dirs)
+                set_value = mod.get_function("set_value")
+                set_value(
+                    self.blob.diff_as_pycuda_gpuarray(), a,
+                    np.int32(self.blob.count),
+                    **pycuda_util.block_and_grid(self.blob.count))
+            for v in self.blob.diff.flat:
+                self.assertEqual(v, np.float32(5))
+
+        def test_pycuda_axpb(self):
+            a = np.float32(-2.0)
+            b = np.float32(3.5)
+            with pycuda_util.caffe_cuda_context():
+                mod = SourceModule(
+                    kernel_axpb, include_dirs=caffe_include_dirs)
+                axpb = mod.get_function("axpb")
+                base = np.random.rand(*self.blob.shape)
+                self.blob.data[...] = base
+                axpb(
+                    a, self.blob.data_as_pycuda_gpuarray(),
+                    b, np.int32(self.blob.count),
+                    **pycuda_util.block_and_grid(self.blob.count))
+            for v, w in zip(self.blob.data.flat, base.flat):
+                self.assertEqual(v, a * np.float32(w) + b)

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -146,6 +146,12 @@ void Caffe::SetDevice(const int device_id) {
       cluster_seedgen()));
 }
 
+int Caffe::GetDevice() {
+  int current_device;
+  CUDA_CHECK(cudaGetDevice(&current_device));
+  return current_device;
+}
+
 void Caffe::DeviceQuery() {
   cudaDeviceProp prop;
   int device;


### PR DESCRIPTION
This changes many things as described in individual commits. First 4 commits are just for utilities. Last 2 commits are main parts of this PR.  I exposed GPU pointers of `data` and `diff` in `Blob` to Python as integer, and use them to initialize `gpuarray` in PyCuda without copying memory. Please see `python/caffe/test/test_pycuda.py` for usage. I think the exposed gpu pointers could be used more other libraries such as gnumpy, Threano, etc.

* Add GetDevice and expose it to Python	 feb8e4d
* Expose functions check_mode_{cpu,gpu} to Python …	 879a450
* Expose Blob.shape to Python	 32cb250
* Expose CUDA_BLOCKS CUDA_NUM_THREADS to Python	 f5c7333
* Expose GPU pointer to Python …	 73e3540
* Add PyCuda utilities and test for Python I/F.	 022dc2c