### PR TITLE
Python 2.7 and 3.4 compatible code using Six

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This is a fork of Caffe that works with Python 2.7 and Python 3.4
+
 # Caffe
 
 Caffe is a deep learning framework made with expression, speed, and modularity in mind.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# This is a fork of Caffe that works with Python 2.7 and Python 3.4
+This is a fork of Caffe that works with Python 2.7 and Python 3.4
 
 # Caffe
 

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -3,4 +3,4 @@ from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector
-import io
+from .io import Transformer, load_image, resize_image


### PR DESCRIPTION
The proposed code has been tested using Python 2.7 and 3.4 in Ubuntu 14.04 using CMake. 

To run the Caffe bindings with Python 3.4 you'll need two things:
* Your code needs to be compiled using **[Protocol Buffers v3.0.0-alpha-2](https://github.com/google/protobuf/releases/tag/v3.0.0-alpha-2)**.
* You need to compile **[Opencv 3.0 beta](http://opencv.org/downloads.html)** for Python 3.4.

To initiate our build directory with CMake 2.8 you need to type the following code so that your Python 3.4 libs are detected:

`cmake ..  -Dpython_version=3 -DPython_ADDITIONAL_VERSIONS=3.4`

