### PR TITLE
Add support for multiple images per line in ImageDataLayer

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -238,7 +238,7 @@ class ImageDataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual void ShuffleImages();
   virtual void InternalThreadEntry();
 
-  vector<std::pair<std::string, int> > lines_;
+  vector<std::pair<std::vector<std::string>, int> > lines_;
   int lines_id_;
 };
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -564,6 +564,9 @@ message ImageDataParameter {
   // data.
   optional bool mirror = 6 [default = false];
   optional string root_folder = 12 [default = ""];
+  // Number of simultaneous images, which will be concatenated along the channels
+  // dimension.
+  optional uint32 num_images = 13 [default = 1];
 }
 
 // Message that stores parameters InfogainLossLayer

--- a/src/caffe/test/test_image_data_layer.cpp
+++ b/src/caffe/test/test_image_data_layer.cpp
@@ -33,16 +33,26 @@ class ImageDataLayerTest : public MultiDeviceTest<TypeParam> {
     std::ofstream outfile(filename_.c_str(), std::ofstream::out);
     LOG(INFO) << "Using temporary file " << filename_;
     for (int i = 0; i < 5; ++i) {
-      outfile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << i;
+      outfile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << i << std::endl;
     }
     outfile.close();
     // Create test input file for images of distinct sizes.
     MakeTempFilename(&filename_reshape_);
     std::ofstream reshapefile(filename_reshape_.c_str(), std::ofstream::out);
     LOG(INFO) << "Using temporary file " << filename_reshape_;
-    reshapefile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << 0;
-    reshapefile << EXAMPLES_SOURCE_DIR "images/fish-bike.jpg " << 1;
+    reshapefile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << 0 << std::endl;
+    reshapefile << EXAMPLES_SOURCE_DIR "images/fish-bike.jpg "
+        << 1 << std::endl;
     reshapefile.close();
+    // Create test input file for multiple images.
+    MakeTempFilename(&filename_multi_);
+    std::ofstream multifile(filename_multi_.c_str(), std::ofstream::out);
+    LOG(INFO) << "Using temporary file " << filename_multi_;
+    for (int i = 0; i < 5; ++i) {
+      multifile << EXAMPLES_SOURCE_DIR "images/cat.jpg "
+          EXAMPLES_SOURCE_DIR "images/cat.jpg " << i << std::endl;
+    }
+    multifile.close();
   }
 
   virtual ~ImageDataLayerTest() {
@@ -53,6 +63,7 @@ class ImageDataLayerTest : public MultiDeviceTest<TypeParam> {
   int seed_;
   string filename_;
   string filename_reshape_;
+  string filename_multi_;
   Blob<Dtype>* const blob_top_data_;
   Blob<Dtype>* const blob_top_label_;
   vector<Blob<Dtype>*> blob_bottom_vec_;
@@ -87,6 +98,33 @@ TYPED_TEST(ImageDataLayerTest, TestRead) {
   }
 }
 
+TYPED_TEST(ImageDataLayerTest, TestReadMulti) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter param;
+  ImageDataParameter* image_data_param = param.mutable_image_data_param();
+  image_data_param->set_batch_size(5);
+  image_data_param->set_source(this->filename_multi_.c_str());
+  image_data_param->set_shuffle(false);
+  image_data_param->set_num_images(2);
+  ImageDataLayer<Dtype> layer(param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  EXPECT_EQ(this->blob_top_data_->num(), 5);
+  EXPECT_EQ(this->blob_top_data_->channels(), 6);
+  EXPECT_EQ(this->blob_top_data_->height(), 360);
+  EXPECT_EQ(this->blob_top_data_->width(), 480);
+  EXPECT_EQ(this->blob_top_label_->num(), 5);
+  EXPECT_EQ(this->blob_top_label_->channels(), 1);
+  EXPECT_EQ(this->blob_top_label_->height(), 1);
+  EXPECT_EQ(this->blob_top_label_->width(), 1);
+  // Go through the data twice
+  for (int iter = 0; iter < 2; ++iter) {
+    layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+    for (int i = 0; i < 5; ++i) {
+      EXPECT_EQ(i, this->blob_top_label_->cpu_data()[i]);
+    }
+  }
+}
+
 TYPED_TEST(ImageDataLayerTest, TestResize) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter param;
@@ -100,6 +138,35 @@ TYPED_TEST(ImageDataLayerTest, TestResize) {
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   EXPECT_EQ(this->blob_top_data_->num(), 5);
   EXPECT_EQ(this->blob_top_data_->channels(), 3);
+  EXPECT_EQ(this->blob_top_data_->height(), 256);
+  EXPECT_EQ(this->blob_top_data_->width(), 256);
+  EXPECT_EQ(this->blob_top_label_->num(), 5);
+  EXPECT_EQ(this->blob_top_label_->channels(), 1);
+  EXPECT_EQ(this->blob_top_label_->height(), 1);
+  EXPECT_EQ(this->blob_top_label_->width(), 1);
+  // Go through the data twice
+  for (int iter = 0; iter < 2; ++iter) {
+    layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+    for (int i = 0; i < 5; ++i) {
+      EXPECT_EQ(i, this->blob_top_label_->cpu_data()[i]);
+    }
+  }
+}
+
+TYPED_TEST(ImageDataLayerTest, TestResizeMulti) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter param;
+  ImageDataParameter* image_data_param = param.mutable_image_data_param();
+  image_data_param->set_batch_size(5);
+  image_data_param->set_source(this->filename_multi_.c_str());
+  image_data_param->set_new_height(256);
+  image_data_param->set_new_width(256);
+  image_data_param->set_shuffle(false);
+  image_data_param->set_num_images(2);
+  ImageDataLayer<Dtype> layer(param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  EXPECT_EQ(this->blob_top_data_->num(), 5);
+  EXPECT_EQ(this->blob_top_data_->channels(), 6);
   EXPECT_EQ(this->blob_top_data_->height(), 256);
   EXPECT_EQ(this->blob_top_data_->width(), 256);
   EXPECT_EQ(this->blob_top_label_->num(), 5);


### PR DESCRIPTION
Add support for two or more images per line in ImageDataLayer. The images are concatenated along the channels dimension and returned in a single top blob. Backwards compatibility is preserved while making it easy to load n-uples of images (e.g. for siamese networks).

**NOTE**: while the documentation states that ImageDataLayer expects an image/label pair for each line of the input text file, the upstream implementation can parse image/label pairs separated by any whitespace character (or even no separator at all). This new implementation instead parses the text file line-by-line.