### PR TITLE
improved to load RGB image as grayscale image

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -285,7 +285,7 @@ def load_image(filename, color=True):
         of size (H x W x 3) in RGB or
         of size (H x W x 1) in grayscale.
     """
-    img = skimage.img_as_float(skimage.io.imread(filename)).astype(np.float32)
+    img = skimage.img_as_float(skimage.io.imread(filename, as_grey=not color)).astype(np.float32)
     if img.ndim == 2:
         img = img[:, :, np.newaxis]
         if color:


### PR DESCRIPTION
You can load RGB image as grayscale by using python io function, load_image.

I had some troubles with loading RGB image as grayscale image in python interface.
We need this improvment when trying to classify by models trained with grayscale images such as mnist.
So I got this solution and found a person who has same suggestion in #462.