### PR TITLE
Expose some global utility functions to Python

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -147,6 +147,8 @@ class Caffe {
   // Sets the device. Since we have cublas and curand stuff, set device also
   // requires us to reset those values.
   static void SetDevice(const int device_id);
+  // Get the device.
+  static int GetDevice();
   // Prints the current GPU status.
   static void DeviceQuery();
 

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -2,6 +2,7 @@ from .pycaffe import Net, SGDSolver
 from ._caffe import (
     set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver,
     get_device,
+    check_mode_cpu, check_mode_gpu,
 )
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,5 +1,8 @@
 from .pycaffe import Net, SGDSolver
-from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver
+from ._caffe import (
+    set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver,
+    get_device,
+)
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -3,6 +3,7 @@ from ._caffe import (
     set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver,
     get_device,
     check_mode_cpu, check_mode_gpu,
+    set_random_seed,
 )
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -205,6 +205,7 @@ BOOST_PYTHON_MODULE(_caffe) {
   bp::def("check_mode_gpu", &check_mode_gpu);
   bp::def("set_device", &Caffe::SetDevice);
   bp::def("get_device", &Caffe::GetDevice);
+  bp::def("set_random_seed", &Caffe::set_random_seed);
 
   bp::class_<Net<Dtype>, shared_ptr<Net<Dtype> >, boost::noncopyable >("Net",
     bp::no_init)

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -199,6 +199,7 @@ BOOST_PYTHON_MODULE(_caffe) {
   bp::def("set_mode_cpu", &set_mode_cpu);
   bp::def("set_mode_gpu", &set_mode_gpu);
   bp::def("set_device", &Caffe::SetDevice);
+  bp::def("get_device", &Caffe::GetDevice);
 
   bp::class_<Net<Dtype>, shared_ptr<Net<Dtype> >, boost::noncopyable >("Net",
     bp::no_init)

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -35,6 +35,9 @@ const int NPY_DTYPE = NPY_FLOAT32;
 // Selecting mode.
 void set_mode_cpu() { Caffe::set_mode(Caffe::CPU); }
 void set_mode_gpu() { Caffe::set_mode(Caffe::GPU); }
+// Checking current mode.
+bool check_mode_cpu() { return Caffe::mode() == Caffe::CPU; }
+bool check_mode_gpu() { return Caffe::mode() == Caffe::GPU; }
 
 // For convenience, check that input files can be opened, and raise an
 // exception that boost will send to Python if not (caffe could still crash
@@ -198,6 +201,8 @@ BOOST_PYTHON_MODULE(_caffe) {
   // Caffe utility functions
   bp::def("set_mode_cpu", &set_mode_cpu);
   bp::def("set_mode_gpu", &set_mode_gpu);
+  bp::def("check_mode_cpu", &check_mode_cpu);
+  bp::def("check_mode_gpu", &check_mode_gpu);
   bp::def("set_device", &Caffe::SetDevice);
   bp::def("get_device", &Caffe::GetDevice);
 

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -55,6 +55,10 @@ void Caffe::SetDevice(const int device_id) {
   NO_GPU;
 }
 
+int Caffe::GetDevice() {
+  NO_GPU;
+}
+
 void Caffe::DeviceQuery() {
   NO_GPU;
 }
@@ -144,6 +148,12 @@ void Caffe::SetDevice(const int device_id) {
       CURAND_RNG_PSEUDO_DEFAULT));
   CURAND_CHECK(curandSetPseudoRandomGeneratorSeed(Get().curand_generator_,
       cluster_seedgen()));
+}
+
+int Caffe::GetDevice() {
+  int current_device;
+  CUDA_CHECK(cudaGetDevice(&current_device));
+  return current_device;
 }
 
 void Caffe::DeviceQuery() {


### PR DESCRIPTION
This PR is split from #2102. Just exposing the following functions: `get_device`, `check_mode_cpu`, `check_mode_gpu`, `set_random_seed`.
