### PR TITLE
Expose Blob.__init__(shape_iterable) and Blob.shape()

### DIFF
--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,5 +1,8 @@
 from .pycaffe import Net, SGDSolver
-from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver
+from ._caffe import (
+    set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver,
+    Blob,
+)
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -176,6 +176,19 @@ struct NdarrayCallPolicies : public bp::default_call_policies {
   }
 };
 
+bp::object Blob_Shape(bp::tuple args, bp::dict kwargs) {
+  if (bp::len(kwargs) > 0) {
+    throw std::runtime_error("Blob.shape takes no kwargs");
+  }
+  Blob<Dtype>* self = bp::extract<Blob<Dtype>*>(args[0]);
+  const vector<int> &shape = self->shape();
+  bp::list shape_list;
+  BOOST_FOREACH(int s, shape) {
+    shape_list.append(s);
+  }
+  return bp::tuple(shape_list);
+}
+
 bp::object Blob_Reshape(bp::tuple args, bp::dict kwargs) {
   if (bp::len(kwargs) > 0) {
     throw std::runtime_error("Blob.reshape takes no kwargs");
@@ -236,6 +249,7 @@ BOOST_PYTHON_MODULE(_caffe) {
     .add_property("width",    &Blob<Dtype>::width)
     .add_property("count",    static_cast<int (Blob<Dtype>::*)() const>(
         &Blob<Dtype>::count))
+    .add_property("shape", bp::raw_function(&Blob_Shape))
     .def("reshape",           bp::raw_function(&Blob_Reshape))
     .add_property("data",     bp::make_function(&Blob<Dtype>::mutable_cpu_data,
           NdarrayCallPolicies()))

--- a/python/caffe/test/test_blob.py
+++ b/python/caffe/test/test_blob.py
@@ -1,0 +1,25 @@
+import unittest
+import numpy as np
+
+import caffe
+
+class TestBlob(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_constructor(self):
+        # empty shape blob
+        b = caffe.Blob([])
+        self.assertEqual(b.shape, ())
+        # init with list
+        b = caffe.Blob([1, 2, 3])
+        self.assertEqual(b.shape, (1, 2, 3))
+        a = np.random.randn(1, 2, 3)
+        b.data[...] = a
+        self.assertTrue(np.all(a.astype('float32') == b.data))
+        # init with tuple
+        b = caffe.Blob((1, 2, 3))
+        self.assertEqual(b.shape, (1, 2, 3))
+        # init with generator
+        b = caffe.Blob(xrange(2, 6))
+        self.assertEqual(b.shape, tuple(xrange(2, 6)))


### PR DESCRIPTION
This PR is split from #2102. Just exposing the following functions with tests: `Blob.__init__(shape_iterable)`  and `Blob.shape()`.
