### PR TITLE
Any Layer can be created/used in Python, expose LayerParameter

### DIFF
--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,5 +1,8 @@
 from .pycaffe import Net, SGDSolver, LayerParameter
-from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver
+from ._caffe import (
+    set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver,
+    create_layer,
+)
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,4 +1,4 @@
-from .pycaffe import Net, SGDSolver
+from .pycaffe import Net, SGDSolver, LayerParameter
 from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -3,6 +3,8 @@
 // Produce deprecation warnings (needs to come before arrayobject.h inclusion).
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
+#include <google/protobuf/text_format.h>
+
 #include <boost/make_shared.hpp>
 #include <boost/python.hpp>
 #include <boost/python/raw_function.hpp>
@@ -15,6 +17,7 @@
 #include <fstream>  // NOLINT
 
 #include "caffe/caffe.hpp"
+#include "caffe/proto/caffe.pb.h"
 #include "caffe/python_layer.hpp"
 
 // Temporary solution for numpy < 1.7 versions: old macro, no promises.
@@ -190,6 +193,45 @@ bp::object Blob_Reshape(bp::tuple args, bp::dict kwargs) {
   return bp::object();
 }
 
+// LayerParameter
+shared_ptr<LayerParameter> LayerParameter_Init(bp::object py_layer_param) {
+  shared_ptr<LayerParameter> layer_param(new LayerParameter);
+  if (PyObject_HasAttrString(py_layer_param.ptr(), "SerializeToString")) {
+    string dump = bp::extract<string>(
+        py_layer_param.attr("SerializeToString")());
+    layer_param->ParseFromString(dump);
+  } else {
+    try {
+      string dump = bp::extract<string>(py_layer_param);
+      google::protobuf::TextFormat::ParseFromString(dump, layer_param.get());
+    } catch(...) {
+      throw std::runtime_error("1st arg must be LayerPrameter or string.");
+    }
+  }
+  if (!layer_param->IsInitialized()) {
+    throw std::runtime_error(
+      "LayerParameter not initialized: Missing required fields.");
+  }
+  return layer_param;
+}
+bp::object LayerParameter_FromPython(bp::tuple args, bp::dict kwargs) {
+  LayerParameter *layer_param = bp::extract<LayerParameter*>(args[0]);
+  bp::object py_layer_param = args[1];
+  shared_ptr<LayerParameter> copy = \
+      LayerParameter_Init(py_layer_param);
+  layer_param->Clear();
+  layer_param->CopyFrom(*copy);
+  return bp::object();
+}
+bp::object LayerParameter_ToPython(bp::tuple args, bp::dict kwargs) {
+  LayerParameter *layer_param = bp::extract<LayerParameter*>(args[0]);
+  bp::object py_layer_param = args[1];
+  string dump;
+  layer_param->SerializeToString(&dump);
+  py_layer_param.attr("ParseFromString")(bp::object(dump));
+  return py_layer_param;
+}
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SolveOverloads, Solve, 0, 1);
 
 BOOST_PYTHON_MODULE(_caffe) {
@@ -251,7 +293,11 @@ BOOST_PYTHON_MODULE(_caffe) {
     .add_property("type", bp::make_function(&Layer<Dtype>::type));
   bp::register_ptr_to_python<shared_ptr<Layer<Dtype> > >();
 
-  bp::class_<LayerParameter>("LayerParameter", bp::no_init);
+  bp::class_<LayerParameter, shared_ptr<LayerParameter> >(
+      "LayerParameter", bp::no_init)
+    .def("__init__", bp::make_constructor(&LayerParameter_Init))
+    .def("from_python", bp::raw_function(&LayerParameter_FromPython))
+    .def("_to_python", bp::raw_function(&LayerParameter_ToPython));
 
   bp::class_<Solver<Dtype>, shared_ptr<Solver<Dtype> >, boost::noncopyable>(
     "Solver", bp::no_init)

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -17,6 +17,7 @@
 #include <fstream>  // NOLINT
 
 #include "caffe/caffe.hpp"
+#include "caffe/layer_factory.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/python_layer.hpp"
 
@@ -193,6 +194,45 @@ bp::object Blob_Reshape(bp::tuple args, bp::dict kwargs) {
   return bp::object();
 }
 
+// Layer
+template <class T>
+vector<T> py_to_vector(bp::object pyiter) {
+  vector<T> vec;
+  for (int i = 0; i < bp::len(pyiter); ++i) {
+    vec.push_back(bp::extract<T>(pyiter[i]));
+  }
+  return vec;
+}
+bp::object Layer_SetUp(bp::tuple args, bp::dict kwargs) {
+    Layer<Dtype> *layer = bp::extract<Layer<Dtype>*>(args[0]);
+    vector<Blob<Dtype>*> bottom = py_to_vector<Blob<Dtype>*>(args[1]);
+    vector<Blob<Dtype>*> top = py_to_vector<Blob<Dtype>*>(args[2]);
+    layer->SetUp(bottom, top);
+    return bp::object();
+}
+bp::object Layer_Reshape(bp::tuple args, bp::dict kwargs) {
+    Layer<Dtype> *layer = bp::extract<Layer<Dtype>*>(args[0]);
+    vector<Blob<Dtype>*> bottom = py_to_vector<Blob<Dtype>*>(args[1]);
+    vector<Blob<Dtype>*> top = py_to_vector<Blob<Dtype>*>(args[2]);
+    layer->Reshape(bottom, top);
+    return bp::object();
+}
+Dtype Layer_Forward(bp::tuple args, bp::dict kwargs) {
+    Layer<Dtype> *layer = bp::extract<Layer<Dtype>*>(args[0]);
+    vector<Blob<Dtype>*> bottom = py_to_vector<Blob<Dtype>*>(args[1]);
+    vector<Blob<Dtype>*> top = py_to_vector<Blob<Dtype>*>(args[2]);
+    Dtype loss = layer->Forward(bottom, top);
+    return loss;
+}
+bp::object Layer_Backward(bp::tuple args, bp::dict kwargs) {
+    Layer<Dtype> *layer = bp::extract<Layer<Dtype>*>(args[0]);
+    vector<Blob<Dtype>*> top = py_to_vector<Blob<Dtype>*>(args[1]);
+    vector<bool> propagate_down = py_to_vector<bool>(args[2]);
+    vector<Blob<Dtype>*> bottom = py_to_vector<Blob<Dtype>*>(args[3]);
+    layer->Backward(top, propagate_down, bottom);
+    return bp::object();
+}
+
 // LayerParameter
 shared_ptr<LayerParameter> LayerParameter_Init(bp::object py_layer_param) {
   shared_ptr<LayerParameter> layer_param(new LayerParameter);
@@ -230,6 +270,12 @@ bp::object LayerParameter_ToPython(bp::tuple args, bp::dict kwargs) {
   layer_param->SerializeToString(&dump);
   py_layer_param.attr("ParseFromString")(bp::object(dump));
   return py_layer_param;
+}
+
+// Create layer from caffe_pb2.LayerParameter in Python
+shared_ptr<Layer<Dtype> > create_layer(bp::object py_layer_param) {
+  shared_ptr<LayerParameter> layer_param(LayerParameter_Init(py_layer_param));
+  return LayerRegistry<Dtype>::CreateLayer(*layer_param.get());
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SolveOverloads, Solve, 0, 1);
@@ -285,11 +331,16 @@ BOOST_PYTHON_MODULE(_caffe) {
           NdarrayCallPolicies()));
 
   bp::class_<Layer<Dtype>, shared_ptr<PythonLayer<Dtype> >,
-    boost::noncopyable>("Layer", bp::init<const LayerParameter&>())
+      boost::noncopyable>(
+      "Layer", bp::init<const LayerParameter&>())
     .add_property("blobs", bp::make_function(&Layer<Dtype>::blobs,
           bp::return_internal_reference<>()))
     .def("setup", &Layer<Dtype>::LayerSetUp)
+    .def("SetUp", bp::raw_function(&Layer_SetUp))
     .def("reshape", &Layer<Dtype>::Reshape)
+    .def("Reshape", bp::raw_function(&Layer_Reshape))
+    .def("Forward", bp::raw_function(&Layer_Forward))
+    .def("Backward", bp::raw_function(&Layer_Backward))
     .add_property("type", bp::make_function(&Layer<Dtype>::type));
   bp::register_ptr_to_python<shared_ptr<Layer<Dtype> > >();
 
@@ -298,6 +349,8 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("__init__", bp::make_constructor(&LayerParameter_Init))
     .def("from_python", bp::raw_function(&LayerParameter_FromPython))
     .def("_to_python", bp::raw_function(&LayerParameter_ToPython));
+
+  bp::def("create_layer", &create_layer);
 
   bp::class_<Solver<Dtype>, shared_ptr<Solver<Dtype> >, boost::noncopyable>(
     "Solver", bp::no_init)

--- a/python/caffe/pycaffe.py
+++ b/python/caffe/pycaffe.py
@@ -10,7 +10,7 @@ except:
 	from itertools import zip_longest as izip_longest
 import numpy as np
 
-from ._caffe import Net, SGDSolver
+from ._caffe import Net, SGDSolver, LayerParameter
 import caffe.io
 
 # We directly update methods from Net here (rather than using composition or
@@ -267,3 +267,11 @@ Net.set_input_arrays = _Net_set_input_arrays
 Net._batch = _Net_batch
 Net.inputs = _Net_inputs
 Net.outputs = _Net_outputs
+
+# LayerParameter
+def _LayerParameter_to_python(self):
+    from caffe.proto import caffe_pb2
+    layer_param = caffe_pb2.LayerParameter()
+    return self._to_python(layer_param)
+# Attach method
+LayerParameter.to_python = _LayerParameter_to_python

--- a/python/caffe/test/test_layer_parameter.py
+++ b/python/caffe/test/test_layer_parameter.py
@@ -1,0 +1,30 @@
+import unittest
+
+import caffe
+from caffe.proto import caffe_pb2
+
+
+class TestLayerParameter(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_create_from_string(self):
+        lp = caffe.LayerParameter("type: 'Convolution' name: 'conv1'")
+
+    def test_create_from_py_layer_parameter(self):
+        plp = caffe_pb2.LayerParameter()
+        plp.type = 'Convolution'
+        plp.name = 'conv1'
+        lp = caffe.LayerParameter(plp)
+        plp2 = lp.to_python()
+        self.assertEqual(plp, plp2)
+
+    def test_from_python(self):
+        plp = caffe_pb2.LayerParameter()
+        plp.type = 'Convolution'
+        plp.name = 'conv1'
+        lp = caffe.LayerParameter("")
+        lp.from_python(plp)
+        plp2 = lp.to_python()
+        self.assertEqual(plp, plp2)


### PR DESCRIPTION
This PR is split from #2102.

* LayerParameter is deliverable between Python and C++.
* Any type of `Layer` can be created by `create_layer` function with `LayerParamter` of Python Protobuf.