### PR TITLE
Remove scikit-learn dependency

### DIFF
--- a/examples/hdf5_classification.ipynb
+++ b/examples/hdf5_classification.ipynb
@@ -40,6 +40,7 @@
       "import shutil\n",
       "import tempfile\n",
       "\n",
+      "# You may need to 'pip install scikit-learn'\n",
       "import sklearn\n",
       "import sklearn.datasets\n",
       "import sklearn.linear_model"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,6 @@ Cython>=0.19.2
 numpy>=1.7.1
 scipy>=0.13.2
 scikit-image>=0.9.3
-scikit-learn>=0.14.1
 matplotlib>=1.3.1
 ipython>=1.1.0
 h5py>=2.2.0


### PR DESCRIPTION
As far as I can tell, `scikit-learn` is never used. I get no results when I search for either "scikit-learn" or "sklearn." If it is really not used, can we remove it from requirements.txt? This is the only pip dependency which doesn't have a debian installer in Ubuntu 14.04 (besides `Pillow>=2.7.0`, which I'll address separately).

FWIW, all tests still pass without `scikit-learn` installed, but I don't trust the python test coverage much.