### PR TITLE
Plain Datumfile input format for minimum memory usage

### DIFF
--- a/examples/imagenet/create_imagenet.sh
+++ b/examples/imagenet/create_imagenet.sh
@@ -9,6 +9,9 @@ TOOLS=build/tools
 TRAIN_DATA_ROOT=/path/to/imagenet/train/
 VAL_DATA_ROOT=/path/to/imagenet/val/
 
+# leveldb|lmdb|datumfile
+DB_TYPE=datumfile
+
 # Set RESIZE=true to resize the images to 256x256. Leave as false if images have
 # already been resized using another tool.
 RESIZE=false
@@ -34,24 +37,26 @@ if [ ! -d "$VAL_DATA_ROOT" ]; then
   exit 1
 fi
 
-echo "Creating train lmdb..."
+echo "Creating train $DB_TYPE ..."
 
 GLOG_logtostderr=1 $TOOLS/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \
     --shuffle \
+    --backend=$DB_TYPE \
     $TRAIN_DATA_ROOT \
     $DATA/train.txt \
-    $EXAMPLE/ilsvrc12_train_lmdb
+    $EXAMPLE/ilsvrc12_train_$DB_TYPE
 
-echo "Creating val lmdb..."
+echo "Creating val $DB_TYPE ..."
 
 GLOG_logtostderr=1 $TOOLS/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \
     --shuffle \
+    --backend=$DB_TYPE \
     $VAL_DATA_ROOT \
     $DATA/val.txt \
-    $EXAMPLE/ilsvrc12_val_lmdb
+    $EXAMPLE/ilsvrc12_val_$DB_TYPE
 
 echo "Done."

--- a/include/caffe/util/db.hpp
+++ b/include/caffe/util/db.hpp
@@ -191,8 +191,10 @@ class DatumFileCursor : public Cursor {
     SeekToFirst();
   }
   virtual ~DatumFileCursor() {
-    if (in_ && in_->is_open()) {
+    if (in_ != NULL && in_->is_open()) {
       in_->close();
+      delete in_;
+      in_ = NULL;
     }
   }
   virtual void SeekToFirst();
@@ -245,8 +247,9 @@ class DatumFileDB : public DB {
     this->can_write_ = mode != db::READ;
   }
   virtual void Close() {
-    if (out_) {
+    if (out_ != NULL) {
       out_->close();
+      delete out_;
       out_ = NULL;
     }
   }

--- a/include/caffe/util/db.hpp
+++ b/include/caffe/util/db.hpp
@@ -182,30 +182,29 @@ class LMDB : public DB {
 };
 
 
-#define MAX_BUF 10485760	//max entry size
+#define MAX_BUF 10485760  // max entry size
 class DatumFileCursor : public Cursor {
  public:
-  explicit DatumFileCursor(string& path) {
+  explicit DatumFileCursor(const string& path) {
     this->path = path;
     in = NULL;
     SeekToFirst();
   }
   virtual ~DatumFileCursor() {
-
   }
   virtual void SeekToFirst();
 
   virtual void Next();
 
   virtual string key() {
-    if(!valid()){
-	LOG(WARNING) << "not valid at key()";
-	return "";
+    if (!valid()) {
+      LOG(WARNING) << "not valid at key()";
+      return "";
     }
     return _key;
   }
   virtual string value() {
-    if(!valid()){
+    if (!valid()) {
       LOG(WARNING) << "not valid at value()";
       return "";
     }
@@ -224,7 +223,7 @@ class DatumFileCursor : public Cursor {
 
 class DatumFileTransaction : public Transaction {
  public:
-  explicit DatumFileTransaction(std::ofstream* out){
+  explicit DatumFileTransaction(std::ofstream* out) {
     this->out = out;
   }
 
@@ -235,7 +234,6 @@ class DatumFileTransaction : public Transaction {
   }
 
  private:
-
   std::ofstream* out;
   DISABLE_COPY_AND_ASSIGN(DatumFileTransaction);
 };
@@ -245,17 +243,17 @@ class DatumFileDB : public DB {
  public:
   DatumFileDB() { out = NULL; }
   virtual ~DatumFileDB() { Close(); }
-  virtual void Open(const string& source, Mode mode){
+  virtual void Open(const string& source, Mode mode) {
     path = source;
     this->can_write = mode != db::READ;
   }
   virtual void Close() {
-    if(out){
-	out->close();
-	out = NULL;
+    if (out) {
+      out->close();
+      out = NULL;
     }
   }
-  virtual DatumFileCursor* NewCursor(){return new DatumFileCursor(this->path);}
+  virtual DatumFileCursor* NewCursor() {return new DatumFileCursor(this->path);}
   virtual Transaction* NewTransaction();
 
  private:

--- a/include/caffe/util/db.hpp
+++ b/include/caffe/util/db.hpp
@@ -250,7 +250,9 @@ class DatumFileDB : public DB {
       out_ = NULL;
     }
   }
-  virtual DatumFileCursor* NewCursor() { return new DatumFileCursor(this->path_); }
+  virtual DatumFileCursor* NewCursor() {
+    return new DatumFileCursor(this->path_);
+  }
   virtual Transaction* NewTransaction();
 
  private:

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -436,6 +436,7 @@ message DataParameter {
   enum DB {
     LEVELDB = 0;
     LMDB = 1;
+    DATUMFILE = 2;
   }
   // Specify the data source.
   optional string source = 1;

--- a/src/caffe/util/db.cpp
+++ b/src/caffe/util/db.cpp
@@ -61,75 +61,84 @@ void LMDBTransaction::Put(const string& key, const string& value) {
 
 
 void DatumFileCursor::SeekToFirst() {
-    if(in && in->is_open()){
-	in->close();
+    if (in && in->is_open()) {
+      in->close();
     }
     LOG(INFO) << "reset ifstream" << path;
-    in = new std::ifstream(path.c_str(), std::ifstream::in|std::ifstream::binary);
+    in = new std::ifstream(path.c_str(),
+            std::ifstream::in|std::ifstream::binary);
     Next();
   }
 
 void DatumFileCursor::Next() {
   valid_ = false;
-  if(!in->is_open()){
-      LOG(WARNING) << "file not open!" << path;
+  if (!in->is_open()) {
+    LOG(WARNING) << "file not open!" << path;
   }
   uint32_t record_size, key_size, value_size;
   in->read(reinterpret_cast<char*>(&record_size), sizeof record_size);
-  if(in->gcount() != (sizeof record_size) || record_size > MAX_BUF){
-      if(!in->eof()){
-	LOG(WARNING) << "record_size read error: gcount\t" << in->gcount() << "\trecord_size\t" << record_size;
-      }
-      return;
+  if (in->gcount() != (sizeof record_size) || record_size > MAX_BUF) {
+    if (!in->eof()) {
+      LOG(WARNING) << "record_size read error: gcount\t"
+          << in->gcount() << "\trecord_size\t" << record_size;
+    }
+    return;
   }
   in->read(reinterpret_cast<char*>(&key_size), sizeof key_size);
-  if(in->gcount() != sizeof key_size || key_size > MAX_BUF){
-      LOG(WARNING) << "key_size read error: gcount\t" << in->gcount() << "\tkey_size\t" << key_size;
-      return;
+  if (in->gcount() != sizeof key_size || key_size > MAX_BUF) {
+    LOG(WARNING) << "key_size read error: gcount\t"
+        << in->gcount() << "\tkey_size\t" << key_size;
+    return;
   }
   _key.resize(key_size);
   in->read(&_key[0], key_size);
-  if(in->gcount() != key_size){
-      LOG(WARNING) << "key read error: gcount\t" << in->gcount() << "\tkey_size\t" << key_size;
-      return;
+  if (in->gcount() != key_size) {
+    LOG(WARNING) << "key read error: gcount\t"
+        << in->gcount() << "\tkey_size\t" << key_size;
+    return;
   }
   in->read(reinterpret_cast<char*>(&value_size), sizeof value_size);
-  if(in->gcount() != sizeof value_size || value_size > MAX_BUF){
-      LOG(WARNING) << "value_size read error: gcount\t" << in->gcount() << "\tvalue_size\t" << value_size;
-      return;
+  if (in->gcount() != sizeof value_size || value_size > MAX_BUF) {
+    LOG(WARNING) << "value_size read error: gcount\t"
+        << in->gcount() << "\tvalue_size\t" << value_size;
+    return;
   }
   _value.resize(value_size);
   in->read(&_value[0], value_size);
-  if(in->gcount() != value_size){
-      LOG(WARNING) << "value read error: gcount\t" << in->gcount() << "\tvalue_size\t" << value_size;
-      return;
+  if (in->gcount() != value_size) {
+    LOG(WARNING) << "value read error: gcount\t"
+        << in->gcount() << "\tvalue_size\t" << value_size;
+    return;
   }
-  valid_=true;
+  valid_ = true;
 }
 
-void DatumFileTransaction::Put(const string& key, const string& value){
-  try{
+void DatumFileTransaction::Put(const string& key, const string& value) {
+  try {
     uint32_t key_size = key.size(), value_size = value.size();
-    uint32_t record_size = key_size + value_size + sizeof key_size + sizeof value_size;
+    uint32_t record_size = key_size + value_size
+        + sizeof key_size + sizeof value_size;
     out->write(reinterpret_cast<char*>(&record_size), sizeof record_size);
     out->write(reinterpret_cast<char*>(&key_size), sizeof key_size);
     out->write(key.data(), key_size);
     out->write(reinterpret_cast<char*>(&value_size), sizeof value_size);
     out->write(value.data(), value_size);
-  }catch(std::ios_base::failure& e){
-	LOG(WARNING) << "exception: "<< e.what() << "rdstate: " << out->rdstate() << '\n';
+  } catch(std::ios_base::failure& e) {
+    LOG(WARNING) << "exception: "
+        << e.what() << "rdstate: " << out->rdstate() << '\n';
   }
 }
 
-Transaction* DatumFileDB::NewTransaction(){
-  if(!this->out){
+Transaction* DatumFileDB::NewTransaction() {
+  if (!this->out) {
     out = new std::ofstream();
-    out->open(this->path.c_str(), std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
+    out->open(this->path.c_str(),
+            std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
     out->exceptions(out->exceptions() | std::ios::failbit);
     LOG(INFO) << "out created!" << path << std::endl;
   }
   return new DatumFileTransaction(this->out);
-};
+}
 
 DB* GetDB(DataParameter::DB backend) {
   switch (backend) {


### PR DESCRIPTION
When training with leveldb/lmdb, memory increases linearly with iterations and even with Next()s for DataLayer's `rand_skip`.

Here's simple plain datum file format via std::fstream to address this issue.

Pros
- RAM usage basically stay constant (<1G, on googlenet small batches) during training as expected
- datum file size between leveldb and lmdb format
- no noticeable impact on training speed because of prefetch
- concurrent read for multiple process

Cons
- no random read. But caffe does not need random key-value access anyway.
