### PR TITLE
CMake: add lapack to library names list to search for

### DIFF
--- a/cmake/Modules/FindAtlas.cmake
+++ b/cmake/Modules/FindAtlas.cmake
@@ -28,7 +28,7 @@ find_path(Atlas_CLAPACK_INCLUDE_DIR NAMES clapack.h PATHS ${Atlas_INCLUDE_SEARCH
 
 find_library(Atlas_CBLAS_LIBRARY NAMES  ptcblas_r ptcblas cblas_r cblas PATHS ${Atlas_LIB_SEARCH_PATHS})
 find_library(Atlas_BLAS_LIBRARY NAMES   atlas_r   atlas                 PATHS ${Atlas_LIB_SEARCH_PATHS})
-find_library(Atlas_LAPACK_LIBRARY NAMES alapack_r alapack lapack_atlas  PATHS ${Atlas_LIB_SEARCH_PATHS})
+find_library(Atlas_LAPACK_LIBRARY NAMES alapack_r alapack lapack_atlas lapack PATHS ${Atlas_LIB_SEARCH_PATHS})
 
 set(LOOKED_FOR
   Atlas_CBLAS_INCLUDE_DIR


### PR DESCRIPTION
This fixes CMake error: Could NOT find Atlas (missing: Atlas_LAPACK_LIBRARY).

On my system (CentOS 6.5) I have installed Atlas 3.8.4-2.el6 with ```yum install atlas-devel```. This provides a library named lapack, but not alapack, hence it is not found.

A PR is made as requested [here](https://github.com/BVLC/caffe/pull/1667#discussion-diff-27041313).