### PR TITLE
Downgrade Pillow pip requirement

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,4 +14,4 @@ python-dateutil>=1.4,<2
 protobuf>=2.5.0
 python-gflags>=2.0
 pyyaml>=3.10
-Pillow>=2.7.0
+Pillow>=2.3.0


### PR DESCRIPTION
>2.7.0 isn't really necessary - 2.3.0 is sufficient. This is the version available on Ubuntu 14.04 via apt-get, and seems to be a reasonable lowest common denominator in general.
http://pillow.readthedocs.org/installation.html#old-versions

See my comment on #2010. I haven't gotten any feedback from @danielhamngren or anyone else about this. As with #2192, the tests pass. And I haven't seen any problems on my end with 2.3.0.