### PR TITLE
Fix Travis: rm: cannot remove `/home/travis/miniconda/lib/libm.*': No such file or directory

### DIFF
--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -67,4 +67,3 @@ export PATH=/home/travis/miniconda/bin:$PATH
 conda update --yes conda
 conda install --yes numpy scipy matplotlib scikit-image pip
 pip install protobuf
-rm /home/travis/miniconda/lib/libm.*


### PR DESCRIPTION
I am not sure the reason, but the latest Miniconda installation process doesn't leave libm.* in $HOME/miniconda/lib, and then all Travis test fails.

I got the Travis errors from some of my PRs like the following:
```
Requirement already satisfied (use --upgrade to upgrade): setuptools in /home/travis/miniconda/lib/python2.7/site-packages/setuptools-14.3-py2.7.egg (from protobuf)
Installing collected packages: protobuf
  Running setup.py install for protobuf
    Skipping installation of /home/travis/miniconda/lib/python2.7/site-packages/google/__init__.py (namespace package)
    Installing /home/travis/miniconda/lib/python2.7/site-packages/protobuf-2.6.1-py2.7-nspkg.pth
Successfully installed protobuf-2.6.1
rm: cannot remove `/home/travis/miniconda/lib/libm.*': No such file or directory
The command "sudo -E $SCRIPTS/travis_install.sh" failed and exited with 1 during .
Your build has been stopped.
```