### PR TITLE
Wrangle (some) Caffe dependencies through CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(Caffe C CXX)
 # ---[ Using cmake scripts and modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
+include(ExternalProject)
+
 include(cmake/Utils.cmake)
 include(cmake/Targets.cmake)
 include(cmake/Misc.cmake)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -11,12 +11,12 @@ find_package(Threads REQUIRED)
 list(APPEND Caffe_LINKER_LIBS ${CMAKE_THREAD_LIBS_INIT})
 
 # ---[ Google-glog
-find_package(Glog REQUIRED)
+include("cmake/External/glog.cmake")
 include_directories(SYSTEM ${GLOG_INCLUDE_DIRS})
 list(APPEND Caffe_LINKER_LIBS ${GLOG_LIBRARIES})
 
 # ---[ Google-gflags
-find_package(GFlags REQUIRED)
+include("cmake/External/gflags.cmake")
 include_directories(SYSTEM ${GFLAGS_INCLUDE_DIRS})
 list(APPEND Caffe_LINKER_LIBS ${GFLAGS_LIBRARIES})
 

--- a/cmake/External/gflags.cmake
+++ b/cmake/External/gflags.cmake
@@ -1,0 +1,56 @@
+if (NOT __GFLAGS_INCLUDED) # guard against multiple includes
+  set(__GFLAGS_INCLUDED TRUE)
+
+  # use the system-wide gflags if present
+  find_package(GFlags)
+  if (GFLAGS_FOUND)
+    set(GFLAGS_EXTERNAL FALSE)
+  else()
+    # gflags will use pthreads if it's available in the system, so we must link with it
+    find_package(Threads)
+
+    # build directory
+    set(gflags_PREFIX ${CMAKE_BINARY_DIR}/external/gflags-prefix)
+    # install directory
+    set(gflags_INSTALL ${CMAKE_BINARY_DIR}/external/gflags-install)
+
+    # we build gflags statically, but want to link it into the caffe shared library
+    # this requires position-independent code
+    if (UNIX)
+        set(GFLAGS_EXTRA_COMPILER_FLAGS "-fPIC")
+    endif()
+
+    set(GFLAGS_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${GFLAGS_EXTRA_COMPILER_FLAGS})
+    set(GFLAGS_C_FLAGS ${CMAKE_C_FLAGS} ${GFLAGS_EXTRA_COMPILER_FLAGS})
+
+    ExternalProject_Add(gflags
+      PREFIX ${gflags_PREFIX}
+      GIT_REPOSITORY "https://github.com/gflags/gflags.git"
+      GIT_TAG "v2.1.2"
+      UPDATE_COMMAND ""
+      INSTALL_DIR ${gflags_INSTALL}
+      CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                 -DCMAKE_INSTALL_PREFIX=${gflags_INSTALL}
+                 -DBUILD_SHARED_LIBS=OFF
+                 -DBUILD_STATIC_LIBS=ON
+                 -DBUILD_PACKAGING=OFF
+                 -DBUILD_TESTING=OFF
+                 -DBUILD_NC_TESTS=OFF
+                 -BUILD_CONFIG_TESTS=OFF
+                 -DINSTALL_HEADERS=ON
+                 -DCMAKE_C_FLAGS=${GFLAGS_C_FLAGS}
+                 -DCMAKE_CXX_FLAGS=${GFLAGS_CXX_FLAGS}
+      LOG_DOWNLOAD 1
+      LOG_INSTALL 1
+      )
+  
+    set(GFLAGS_FOUND TRUE)
+    set(GFLAGS_INCLUDE_DIRS ${gflags_INSTALL}/include)
+    set(GFLAGS_LIBRARIES ${gflags_INSTALL}/lib/libgflags.a ${CMAKE_THREAD_LIBS_INIT})    
+    set(GFLAGS_LIBRARY_DIRS ${gflags_INSTALL}/lib)
+    set(GFLAGS_EXTERNAL TRUE)
+
+    list(APPEND external_project_dependencies gflags)
+  endif()
+
+endif()

--- a/cmake/External/glog.cmake
+++ b/cmake/External/glog.cmake
@@ -1,0 +1,56 @@
+# glog depends on gflags
+include("cmake/External/gflags.cmake")
+
+if (NOT __GLOG_INCLUDED)
+  set(__GLOG_INCLUDED TRUE)
+
+  # try the system-wide glog first
+  find_package(Glog)
+  if (GLOG_FOUND)
+      set(GLOG_EXTERNAL FALSE)
+  else()
+    # fetch and build glog from github
+
+    # build directory
+    set(glog_PREFIX ${CMAKE_BINARY_DIR}/external/glog-prefix)
+    # install directory
+    set(glog_INSTALL ${CMAKE_BINARY_DIR}/external/glog-install)
+
+    # we build glog statically, but want to link it into the caffe shared library
+    # this requires position-independent code
+    if (UNIX)
+      set(GLOG_EXTRA_COMPILER_FLAGS "-fPIC")
+    endif()
+
+    set(GLOG_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${GLOG_EXTRA_COMPILER_FLAGS})
+    set(GLOG_C_FLAGS ${CMAKE_C_FLAGS} ${GLOG_EXTRA_COMPILER_FLAGS})
+
+    # depend on gflags if we're also building it
+    if (GFLAGS_EXTERNAL)
+      set(GLOG_DEPENDS gflags)
+    endif()
+    
+    ExternalProject_Add(glog
+      DEPENDS ${GLOG_DEPENDS}
+      PREFIX ${glog_PREFIX}
+      GIT_REPOSITORY "https://github.com/google/glog"
+      GIT_TAG "v0.3.4"
+      UPDATE_COMMAND ""
+      INSTALL_DIR ${gflags_INSTALL}
+      CONFIGURE_COMMAND env "CFLAGS=${GLOG_C_FLAGS}" "CXXFLAGS=${GLOG_CXX_FLAGS}" ${glog_PREFIX}/src/glog/configure --prefix=${glog_INSTALL} --enable-shared=no --enable-static=yes --with-gflags=${GFLAGS_LIBRARY_DIRS}/..
+      LOG_DOWNLOAD 1
+      LOG_CONFIGURE 1
+      LOG_INSTALL 1
+      )
+
+    set(GLOG_FOUND TRUE)
+    set(GLOG_INCLUDE_DIRS ${glog_INSTALL}/include)
+    set(GLOG_LIBRARIES ${GFLAGS_LIBRARIES} ${glog_INSTALL}/lib/libglog.a)
+    set(GLOG_LIBRARY_DIRS ${glog_INSTALL}/lib)
+    set(GLOG_EXTERNAL TRUE)
+
+    list(APPEND external_project_dependencies glog)
+  endif()
+
+endif()
+

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -110,6 +110,10 @@ function(caffe_default_properties target)
     ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+  # make sure we build all external depepdencies first
+  if (DEFINED external_project_dependencies)
+    add_dependencies(${target} ${external_project_dependencies})
+  endif()
 endfunction()
 
 ################################################################################################


### PR DESCRIPTION
Caffe has many dependencies, some of which seem quite esoteric. In order to alleviate the problem, I propose to modify the CMake build to fetch and build some dependencies as part of the Caffe build itself.

This can be done through the ExternalProject module in CMake. At build time, if a system-wide version of a given library is not found, CMake can be instructed to download and build it. Any dependencies built this way are always built as static libraries, to avoid having to pollute the user's system with extra shared libraries at install time.

Right now, this PR only handles glog and gflags. The same method can be extended to pretty much anything, although I'd recommend only doing this for libraries not commonly installed on a user's system. I've used this technique successfully in the past to tackle software that depends on, e.g., specific versions of Boost, or libraries that are not packaged yet and therefore hard to install for end users.

There are a few advantages to doing this: less dependencies to worry about when compiling Caffe, plus we can ensure that the build uses known-good versions of the libraries we depend on.

This method is not without it's drawbacks, though, and there are a few open questions: is it OK to depend on GitHub being accessible during the build? Are we concerned about bloating binary sizes due to static vs. dynamic linking? This will increase build times when our dependencies are not installed, would that be a concern for automated build systems?

Even though this is technically ready to merge, this PR is expected to be more of a starting point for discussion. Does this sound like a viable/interesting option to pursue?
