### PR TITLE
Import Pandas in HDF5 IPython notebook. Fix for issue BVLC/caffe#2247

### DIFF
--- a/examples/hdf5_classification.ipynb
+++ b/examples/hdf5_classification.ipynb
@@ -25,6 +25,7 @@
      "collapsed": false,
      "input": [
       "import numpy as np\n",
+      "import pandas as pd\n",
       "import matplotlib.pyplot as plt\n",
       "%matplotlib inline\n",
       "\n",


### PR DESCRIPTION
This is a fix for issue #2247 : PyCaffe: in examples/hdf5_classification.ipynb: name 'pd' is not defined

Also, a comment, when I opened the IPython notebook it said that:

>>This notebook has been converted from an older notebook format (v3) to the current notebook format (v4). The next time you save this notebook, the current notebook format will be used. Older versions of IPython may not be able to read the new format. To preserve the original version, close the notebook without saving it.

I didn't save it in the new format, I don't know if you want it converted, so, I updated the notebook with vim, just to import Pandas and fix the issue, using the old (v3) notebook format.