### PR TITLE
fix #1362. prefetch HDF5DataLayer

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,6 +27,7 @@ Caffe has several dependencies.
 * [OpenCV](http://opencv.org/) >= 2.4 including 3.0
 * `protobuf`, `glog`, `gflags`
 * IO libraries `hdf5`, `leveldb`, `snappy`, `lmdb`
+    * hdf5 needs to be built with thread-safe enabled, if you need to access the same HDF5 file concurrently. (See [this](http://www.hdfgroup.org/hdf5-quest.html#gconc))
 
 Pycaffe and Matcaffe interfaces have their own natural needs.
 

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -140,16 +140,18 @@ class DummyDataLayer : public Layer<Dtype> {
  * TODO(dox): thorough documentation for Forward and proto params.
  */
 template <typename Dtype>
-class HDF5DataLayer : public Layer<Dtype> {
+class HDF5DataLayer : public BasePrefetchingDataLayer<Dtype> {
  public:
   explicit HDF5DataLayer(const LayerParameter& param)
-      : Layer<Dtype>(param) {}
+      : BasePrefetchingDataLayer<Dtype>(param) {}
   virtual ~HDF5DataLayer();
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   // Data layers have no bottoms, so reshaping is trivial.
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {}
+  virtual void Reset();
+  virtual void InternalThreadEntry();
 
   virtual inline const char* type() const { return "HDF5Data"; }
   virtual inline int ExactNumBottomBlobs() const { return 0; }
@@ -160,16 +162,12 @@ class HDF5DataLayer : public Layer<Dtype> {
       const vector<Blob<Dtype>*>& top);
   virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
-      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {}
-  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
-      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {}
-  virtual void LoadHDF5FileData(const char* filename);
+  virtual void FillHDF5FileData();
 
   std::vector<std::string> hdf_filenames_;
   unsigned int num_files_;
   unsigned int current_file_;
-  hsize_t current_row_;
+  int current_row_;
   std::vector<shared_ptr<Blob<Dtype> > > hdf_blobs_;
   std::vector<unsigned int> data_permutation_;
   std::vector<unsigned int> file_permutation_;

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -145,7 +145,7 @@ class HDF5DataLayer : public BasePrefetchingDataLayer<Dtype> {
   explicit HDF5DataLayer(const LayerParameter& param)
       : BasePrefetchingDataLayer<Dtype>(param) {}
   virtual ~HDF5DataLayer();
-  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+  virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   // Data layers have no bottoms, so reshaping is trivial.
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
@@ -169,7 +169,6 @@ class HDF5DataLayer : public BasePrefetchingDataLayer<Dtype> {
   unsigned int current_file_;
   int current_row_;
   std::vector<shared_ptr<Blob<Dtype> > > hdf_blobs_;
-  std::vector<unsigned int> data_permutation_;
   std::vector<unsigned int> file_permutation_;
 };
 

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -150,12 +150,7 @@ void CVMatToDatum(const cv::Mat& cv_img, Datum* datum);
  *                     or num == -1 for the number of rows in the HDF5 dataset
  * @param blob         the Blob to shape
  *
- * The HDF5 dataset must have 1-4 dimensions. blob will be shaped like the
- * the HDF5 dataset, except that the HDF5 dataset's first dimension is ignored
- * and replaced by num, and if the dataset has \@$ D < 4 \@$ dimensions, the
- * remaining \@$ 4 - D \@$ dimensions are replaced with 1's -- so an
- * \@$ N \times D \times H \@$ HDF5 dataset will result in a
- * \@$ \mathrm{num} \times D \times H \times 1 \@$ Blob.
+ * The HDF5 dataset could be N(>=1) dimensions as long as N doesn't exceed Blob's maximum dimension.
  */
 template <typename Dtype>
 void HDF5PrepareBlob(hid_t file_id, const char* dataset_name, int num,

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -140,15 +140,34 @@ cv::Mat DecodeDatumToCVMat(const Datum& datum, bool is_color);
 
 void CVMatToDatum(const cv::Mat& cv_img, Datum* datum);
 
+/**
+ * @brief Shapes a Blob to read "num" rows of HDF5 data.  If num == -1, take
+ *        the num of the HDF5 dataset.
+ *
+ * @param file_id      the HDF5 file handle
+ * @param dataset_name the name of the HDF5 dataset to read
+ * @param num          the number of rows to read: either num >= 0,
+ *                     or num == -1 for the number of rows in the HDF5 dataset
+ * @param blob         the Blob to shape
+ *
+ * The HDF5 dataset must have 1-4 dimensions. blob will be shaped like the
+ * the HDF5 dataset, except that the HDF5 dataset's first dimension is ignored
+ * and replaced by num, and if the dataset has \@$ D < 4 \@$ dimensions, the
+ * remaining \@$ 4 - D \@$ dimensions are replaced with 1's -- so an
+ * \@$ N \times D \times H \@$ HDF5 dataset will result in a
+ * \@$ \mathrm{num} \times D \times H \times 1 \@$ Blob.
+ */
 template <typename Dtype>
-void hdf5_load_nd_dataset_helper(
-    hid_t file_id, const char* dataset_name_, int min_dim, int max_dim,
-    Blob<Dtype>* blob);
+void HDF5PrepareBlob(hid_t file_id, const char* dataset_name, int num,
+                     Blob<Dtype>* blob);
 
+/**
+ * @brief Reads rows [offset, offset + data->num() - 1] into Blob* data, which
+ *        must have been pre-shaped using HDF5PrepareBlob (or otherwise).
+ */
 template <typename Dtype>
-void hdf5_load_nd_dataset(
-    hid_t file_id, const char* dataset_name_, int min_dim, int max_dim,
-    Blob<Dtype>* blob);
+int HDF5ReadRowsToBlob(hid_t file_id, const char* dataset_name,
+                       int h5_offset, int blob_offset, Blob<Dtype>* blob);
 
 template <typename Dtype>
 void hdf5_save_nd_dataset(

--- a/scripts/cpp_lint.py
+++ b/scripts/cpp_lint.py
@@ -1609,6 +1609,7 @@ def CheckCaffeDataLayerSetUp(filename, clean_lines, linenum, error):
   ix = line.find('DataLayer<Dtype>::LayerSetUp')
   if ix >= 0 and (
        line.find('void DataLayer<Dtype>::LayerSetUp') != -1 or
+       line.find('void HDF5DataLayer<Dtype>::LayerSetUp') == -1 and
        line.find('void ImageDataLayer<Dtype>::LayerSetUp') != -1 or
        line.find('void MemoryDataLayer<Dtype>::LayerSetUp') != -1 or
        line.find('void WindowDataLayer<Dtype>::LayerSetUp') != -1):
@@ -1621,6 +1622,7 @@ def CheckCaffeDataLayerSetUp(filename, clean_lines, linenum, error):
   if ix >= 0 and (
        line.find('void Base') == -1 and
        line.find('void DataLayer<Dtype>::DataLayerSetUp') == -1 and
+       line.find('void HDF5DataLayer<Dtype>::DataLayerSetUp') == -1 and
        line.find('void ImageDataLayer<Dtype>::DataLayerSetUp') == -1 and
        line.find('void MemoryDataLayer<Dtype>::DataLayerSetUp') == -1 and
        line.find('void WindowDataLayer<Dtype>::DataLayerSetUp') == -1):

--- a/scripts/cpp_lint.py
+++ b/scripts/cpp_lint.py
@@ -1609,7 +1609,7 @@ def CheckCaffeDataLayerSetUp(filename, clean_lines, linenum, error):
   ix = line.find('DataLayer<Dtype>::LayerSetUp')
   if ix >= 0 and (
        line.find('void DataLayer<Dtype>::LayerSetUp') != -1 or
-       line.find('void HDF5DataLayer<Dtype>::LayerSetUp') == -1 and
+       line.find('void HDF5DataLayer<Dtype>::LayerSetUp') != -1 or
        line.find('void ImageDataLayer<Dtype>::LayerSetUp') != -1 or
        line.find('void MemoryDataLayer<Dtype>::LayerSetUp') != -1 or
        line.find('void WindowDataLayer<Dtype>::LayerSetUp') != -1):

--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -117,7 +117,7 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   Reset();
 
   DLOG(INFO) << "Initializing prefetch";
-  this->InternalThreadEntry();
+  this->CreatePrefetchThread();
   DLOG(INFO) << "Prefetch initialized.";
 }
 
@@ -135,11 +135,12 @@ void HDF5DataLayer<Dtype>::InternalThreadEntry() {
 template <typename Dtype>
 void HDF5DataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+  this->JoinPrefetchThread();
   for (int i = 0; i < top.size(); ++i) {
     const int count = top[i]->count();
     caffe_copy(count, hdf_blobs_[i]->cpu_data(), top[i]->mutable_cpu_data());
   }
-  this->InternalThreadEntry();
+  this->CreatePrefetchThread();
 }
 
 #ifdef CPU_ONLY

--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -25,47 +25,48 @@ HDF5DataLayer<Dtype>::~HDF5DataLayer<Dtype>() { }
 
 // Load data and label from HDF5 filename into the class property blobs.
 template <typename Dtype>
-void HDF5DataLayer<Dtype>::LoadHDF5FileData(const char* filename) {
-  DLOG(INFO) << "Loading HDF5 file: " << filename;
-  hid_t file_id = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
-  if (file_id < 0) {
-    LOG(FATAL) << "Failed opening HDF5 file: " << filename;
-  }
-
-  int top_size = this->layer_param_.top_size();
-  hdf_blobs_.resize(top_size);
-
-  const int MIN_DATA_DIM = 1;
-  const int MAX_DATA_DIM = INT_MAX;
-
-  for (int i = 0; i < top_size; ++i) {
-    hdf_blobs_[i] = shared_ptr<Blob<Dtype> >(new Blob<Dtype>());
-    hdf5_load_nd_dataset(file_id, this->layer_param_.top(i).c_str(),
-        MIN_DATA_DIM, MAX_DATA_DIM, hdf_blobs_[i].get());
-  }
-
-  herr_t status = H5Fclose(file_id);
-  CHECK_GE(status, 0) << "Failed to close HDF5 file: " << filename;
-
-  // MinTopBlobs==1 guarantees at least one top blob
-  CHECK_GE(hdf_blobs_[0]->num_axes(), 1) << "Input must have at least 1 axis.";
-  const int num = hdf_blobs_[0]->shape(0);
-  for (int i = 1; i < top_size; ++i) {
-    CHECK_EQ(hdf_blobs_[i]->shape(0), num);
-  }
-  // Default to identity permutation.
-  data_permutation_.clear();
-  data_permutation_.resize(hdf_blobs_[0]->shape(0));
-  for (int i = 0; i < hdf_blobs_[0]->shape(0); i++)
-    data_permutation_[i] = i;
-
-  // Shuffle if needed.
-  if (this->layer_param_.hdf5_data_param().shuffle()) {
-    std::random_shuffle(data_permutation_.begin(), data_permutation_.end());
-    DLOG(INFO) << "Successully loaded " << hdf_blobs_[0]->shape(0)
-               << " rows (shuffled)";
-  } else {
-    DLOG(INFO) << "Successully loaded " << hdf_blobs_[0]->shape(0) << " rows";
+void HDF5DataLayer<Dtype>::FillHDF5FileData() {
+  int num_rows_filled = 0;
+  while (true) {
+    CHECK_LT(current_file_, hdf_filenames_.size());
+    const char* filename = hdf_filenames_[current_file_].c_str();
+    DLOG(INFO) << "Loading HDF5 file: " << filename;
+    hid_t file_id = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+    if (file_id < 0) {
+      LOG(FATAL) << "Failed opening HDF5 file: " << filename;
+    }
+    int rows_read = -1;
+    for (int i = 0; i < hdf_blobs_.size(); ++i) {
+      const int current_rows_read = HDF5ReadRowsToBlob(
+          file_id, this->layer_param_.top(i).c_str(),
+          current_row_, num_rows_filled, hdf_blobs_[i].get());
+      if (rows_read == -1) {
+        CHECK_GE(current_rows_read, 0);
+        rows_read = current_rows_read;
+      }
+      CHECK_EQ(rows_read, current_rows_read);
+    }
+    num_rows_filled += rows_read;
+    CHECK_LE(num_rows_filled, hdf_blobs_[0]->num());
+    herr_t status = H5Fclose(file_id);
+    CHECK_GE(status, 0) << "Failed to close HDF5 file: " << filename;
+    DLOG(INFO) << "Successully loaded " << rows_read << " rows from: "
+               << filename;
+    // If we didn't fill up the blob, should move onto the next file.
+    // If we did fill the blob, we may or may not be at the end.
+    if (num_rows_filled < hdf_blobs_[0]->num()) {
+      if (num_files_ > 1) {
+        ++current_file_;
+        if (current_file_ == num_files_) {
+          current_file_ = 0;
+          DLOG(INFO) << "Looping around to first file.";
+        }
+      }
+      current_row_ = 0;
+    } else {
+      current_row_ += rows_read;
+      break;
+    }
   }
 }
 
@@ -88,6 +89,8 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   } else {
     LOG(FATAL) << "Failed to open source file: " << source;
   }
+  CHECK_GT(hdf_filenames_.size(), 0)
+      << "Source file must contain at least 1 filename: " << source;
   source_file.close();
   num_files_ = hdf_filenames_.size();
   current_file_ = 0;
@@ -95,66 +98,48 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   CHECK_GE(num_files_, 1) << "Must have at least 1 HDF5 filename listed in "
     << source;
 
-  file_permutation_.clear();
-  file_permutation_.resize(num_files_);
-  // Default to identity permutation.
-  for (int i = 0; i < num_files_; i++) {
-    file_permutation_[i] = i;
-  }
-
-  // Shuffle if needed.
-  if (this->layer_param_.hdf5_data_param().shuffle()) {
-    std::random_shuffle(file_permutation_.begin(), file_permutation_.end());
-  }
-
-  // Load the first HDF5 file and initialize the line counter.
-  LoadHDF5FileData(hdf_filenames_[file_permutation_[current_file_]].c_str());
-  current_row_ = 0;
-
   // Reshape blobs.
   const int batch_size = this->layer_param_.hdf5_data_param().batch_size();
   const int top_size = this->layer_param_.top_size();
-  vector<int> top_shape;
+  hdf_blobs_.resize(top_size);
+  hid_t file_id = H5Fopen(hdf_filenames_[0].c_str(), H5F_ACC_RDONLY,
+                          H5P_DEFAULT);
   for (int i = 0; i < top_size; ++i) {
-    top_shape.resize(hdf_blobs_[i]->num_axes());
-    top_shape[0] = batch_size;
-    for (int j = 1; j < top_shape.size(); ++j) {
-      top_shape[j] = hdf_blobs_[i]->shape(j);
-    }
-    top[i]->Reshape(top_shape);
+    hdf_blobs_[i].reset(new Blob<Dtype>(1, 1, 1, 1));
+    HDF5PrepareBlob(file_id, this->layer_param_.top(i).c_str(), batch_size,
+                    hdf_blobs_[i].get());
+    hdf_blobs_[i]->mutable_cpu_data();
+    top[i]->ReshapeLike(*hdf_blobs_[i]);
   }
+  herr_t status = H5Fclose(file_id);
+  CHECK_GE(status, 0) << "Failed to close HDF5 file: " << hdf_filenames_[0];
+
+  Reset();
+
+  DLOG(INFO) << "Initializing prefetch";
+  this->InternalThreadEntry();
+  DLOG(INFO) << "Prefetch initialized.";
+}
+
+template <typename Dtype>
+void HDF5DataLayer<Dtype>::Reset() {
+  current_file_ = 0;
+  current_row_ = 0;
+}
+
+template <typename Dtype>
+void HDF5DataLayer<Dtype>::InternalThreadEntry() {
+  FillHDF5FileData();
 }
 
 template <typename Dtype>
 void HDF5DataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-  const int batch_size = this->layer_param_.hdf5_data_param().batch_size();
-  for (int i = 0; i < batch_size; ++i, ++current_row_) {
-    if (current_row_ == hdf_blobs_[0]->shape(0)) {
-      if (num_files_ > 1) {
-        ++current_file_;
-        if (current_file_ == num_files_) {
-          current_file_ = 0;
-          if (this->layer_param_.hdf5_data_param().shuffle()) {
-            std::random_shuffle(file_permutation_.begin(),
-                                file_permutation_.end());
-          }
-          DLOG(INFO) << "Looping around to first file.";
-        }
-        LoadHDF5FileData(
-            hdf_filenames_[file_permutation_[current_file_]].c_str());
-      }
-      current_row_ = 0;
-      if (this->layer_param_.hdf5_data_param().shuffle())
-        std::random_shuffle(data_permutation_.begin(), data_permutation_.end());
-    }
-    for (int j = 0; j < this->layer_param_.top_size(); ++j) {
-      int data_dim = top[j]->count() / top[j]->shape(0);
-      caffe_copy(data_dim,
-          &hdf_blobs_[j]->cpu_data()[data_permutation_[current_row_]
-            * data_dim], &top[j]->mutable_cpu_data()[i * data_dim]);
-    }
+  for (int i = 0; i < top.size(); ++i) {
+    const int count = top[i]->count();
+    caffe_copy(count, hdf_blobs_[i]->cpu_data(), top[i]->mutable_cpu_data());
   }
+  this->InternalThreadEntry();
 }
 
 #ifdef CPU_ONLY

--- a/src/caffe/layers/hdf5_data_layer.cu
+++ b/src/caffe/layers/hdf5_data_layer.cu
@@ -19,35 +19,13 @@ namespace caffe {
 template <typename Dtype>
 void HDF5DataLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-  const int batch_size = this->layer_param_.hdf5_data_param().batch_size();
-  for (int i = 0; i < batch_size; ++i, ++current_row_) {
-    if (current_row_ == hdf_blobs_[0]->shape(0)) {
-      if (num_files_ > 1) {
-        current_file_ += 1;
-        if (current_file_ == num_files_) {
-          current_file_ = 0;
-          if (this->layer_param_.hdf5_data_param().shuffle()) {
-            std::random_shuffle(file_permutation_.begin(),
-                                file_permutation_.end());
-          }
-          DLOG(INFO) << "Looping around to first file.";
-        }
-        LoadHDF5FileData(
-            hdf_filenames_[file_permutation_[current_file_]].c_str());
-      }
-      current_row_ = 0;
-      if (this->layer_param_.hdf5_data_param().shuffle())
-        std::random_shuffle(data_permutation_.begin(), data_permutation_.end());
-    }
-    for (int j = 0; j < this->layer_param_.top_size(); ++j) {
-      int data_dim = top[j]->count() / top[j]->shape(0);
-      caffe_copy(data_dim,
-          &hdf_blobs_[j]->cpu_data()[data_permutation_[current_row_]
-            * data_dim], &top[j]->mutable_gpu_data()[i * data_dim]);
-    }
+  for (int i = 0; i < top.size(); ++i) {
+    const int count = top[i]->count();
+    caffe_copy(count, hdf_blobs_[i]->gpu_data(), top[i]->mutable_gpu_data());
   }
+  this->InternalThreadEntry();
 }
 
-INSTANTIATE_LAYER_GPU_FUNCS(HDF5DataLayer);
+INSTANTIATE_LAYER_GPU_FORWARD(HDF5DataLayer);
 
 }  // namespace caffe

--- a/src/caffe/layers/hdf5_data_layer.cu
+++ b/src/caffe/layers/hdf5_data_layer.cu
@@ -19,11 +19,12 @@ namespace caffe {
 template <typename Dtype>
 void HDF5DataLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+  this->JoinPrefetchThread();
   for (int i = 0; i < top.size(); ++i) {
     const int count = top[i]->count();
     caffe_copy(count, hdf_blobs_[i]->gpu_data(), top[i]->mutable_gpu_data());
   }
-  this->InternalThreadEntry();
+  this->CreatePrefetchThread();
 }
 
 INSTANTIATE_LAYER_GPU_FORWARD(HDF5DataLayer);

--- a/src/caffe/layers/hdf5_data_layer.cu
+++ b/src/caffe/layers/hdf5_data_layer.cu
@@ -22,7 +22,7 @@ void HDF5DataLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   this->JoinPrefetchThread();
   for (int i = 0; i < top.size(); ++i) {
     const int count = top[i]->count();
-    caffe_copy(count, hdf_blobs_[i]->gpu_data(), top[i]->mutable_gpu_data());
+    caffe_copy(count, hdf_blobs_[i]->cpu_data(), top[i]->mutable_gpu_data());
   }
   this->CreatePrefetchThread();
 }

--- a/src/caffe/test/test_hdf5_output_layer.cpp
+++ b/src/caffe/test/test_hdf5_output_layer.cpp
@@ -76,10 +76,10 @@ TYPED_TEST(HDF5OutputLayerTest, TestForward) {
                           H5P_DEFAULT);
   ASSERT_GE(file_id, 0)<< "Failed to open HDF5 file" <<
       this->input_file_name_;
-  hdf5_load_nd_dataset(file_id, HDF5_DATA_DATASET_NAME, 0, 4,
-                       this->blob_data_);
-  hdf5_load_nd_dataset(file_id, HDF5_DATA_LABEL_NAME, 0, 4,
-                       this->blob_label_);
+  HDF5PrepareBlob(file_id, HDF5_DATA_DATASET_NAME, -1, this->blob_data_);
+  HDF5ReadRowsToBlob(file_id, HDF5_DATA_DATASET_NAME, 0, 0, this->blob_data_);
+  HDF5PrepareBlob(file_id, HDF5_DATA_LABEL_NAME, -1, this->blob_label_);
+  HDF5ReadRowsToBlob(file_id, HDF5_DATA_LABEL_NAME, 0, 0, this->blob_label_);
   herr_t status = H5Fclose(file_id);
   EXPECT_GE(status, 0)<< "Failed to close HDF5 file " <<
       this->input_file_name_;
@@ -103,13 +103,13 @@ TYPED_TEST(HDF5OutputLayerTest, TestForward) {
           this->input_file_name_;
 
   Blob<Dtype>* blob_data = new Blob<Dtype>();
-  hdf5_load_nd_dataset(file_id, HDF5_DATA_DATASET_NAME, 0, 4,
-                       blob_data);
+  HDF5PrepareBlob(file_id, HDF5_DATA_DATASET_NAME, -1, blob_data);
+  HDF5ReadRowsToBlob(file_id, HDF5_DATA_DATASET_NAME, 0, 0, blob_data);
   this->CheckBlobEqual(*(this->blob_data_), *blob_data);
 
   Blob<Dtype>* blob_label = new Blob<Dtype>();
-  hdf5_load_nd_dataset(file_id, HDF5_DATA_LABEL_NAME, 0, 4,
-                       blob_label);
+  HDF5PrepareBlob(file_id, HDF5_DATA_LABEL_NAME, -1, blob_label);
+  HDF5ReadRowsToBlob(file_id, HDF5_DATA_LABEL_NAME, 0, 0, blob_label);
   this->CheckBlobEqual(*(this->blob_label_), *blob_label);
 
   status = H5Fclose(file_id);

--- a/src/caffe/test/test_hdf5data_layer.cpp
+++ b/src/caffe/test/test_hdf5data_layer.cpp
@@ -47,89 +47,87 @@ class HDF5DataLayerTest : public MultiDeviceTest<TypeParam> {
   Blob<Dtype>* const blob_top_label2_;
   vector<Blob<Dtype>*> blob_bottom_vec_;
   vector<Blob<Dtype>*> blob_top_vec_;
-};
 
-TYPED_TEST_CASE(HDF5DataLayerTest, TestDtypesAndDevices);
+  void TestRead(int batch_size) {
+    // Create LayerParameter with the known parameters.
+    // The data file we are reading has 10 rows and 8 columns,
+    // with values from 0 to 10*8 reshaped in row-major order.
+    LayerParameter param;
+    param.add_top("data");
+    param.add_top("label");
+    param.add_top("label2");
+    // number of records in sample HDF5 data file (see generate_sample_data).
+    const int num_data_records = 10;
 
-TYPED_TEST(HDF5DataLayerTest, TestRead) {
-  typedef typename TypeParam::Dtype Dtype;
-  // Create LayerParameter with the known parameters.
-  // The data file we are reading has 10 rows and 8 columns,
-  // with values from 0 to 10*8 reshaped in row-major order.
-  LayerParameter param;
-  param.add_top("data");
-  param.add_top("label");
-  param.add_top("label2");
+    HDF5DataParameter* hdf5_data_param = param.mutable_hdf5_data_param();
+    hdf5_data_param->set_batch_size(batch_size);
+    hdf5_data_param->set_source(*(this->filename));
+    const int num_cols = 8;
+    const int height = 6;
+    const int width = 5;
 
-  HDF5DataParameter* hdf5_data_param = param.mutable_hdf5_data_param();
-  int batch_size = 5;
-  hdf5_data_param->set_batch_size(batch_size);
-  hdf5_data_param->set_source(*(this->filename));
-  int num_cols = 8;
-  int height = 6;
-  int width = 5;
+    // Test that the layer setup got the correct parameters.
+    HDF5DataLayer<Dtype> layer(param);
+    layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+    EXPECT_EQ(this->blob_top_data_->num(), batch_size);
+    EXPECT_EQ(this->blob_top_data_->channels(), num_cols);
+    EXPECT_EQ(this->blob_top_data_->height(), height);
+    EXPECT_EQ(this->blob_top_data_->width(), width);
 
-  // Test that the layer setup got the correct parameters.
-  HDF5DataLayer<Dtype> layer(param);
-  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
-  EXPECT_EQ(this->blob_top_data_->num(), batch_size);
-  EXPECT_EQ(this->blob_top_data_->channels(), num_cols);
-  EXPECT_EQ(this->blob_top_data_->height(), height);
-  EXPECT_EQ(this->blob_top_data_->width(), width);
+    EXPECT_EQ(this->blob_top_label_->num_axes(), 2);
+    EXPECT_EQ(this->blob_top_label_->shape(0), batch_size);
+    EXPECT_EQ(this->blob_top_label_->shape(1), 1);
 
-  EXPECT_EQ(this->blob_top_label_->num_axes(), 2);
-  EXPECT_EQ(this->blob_top_label_->shape(0), batch_size);
-  EXPECT_EQ(this->blob_top_label_->shape(1), 1);
+    EXPECT_EQ(this->blob_top_label2_->num_axes(), 2);
+    EXPECT_EQ(this->blob_top_label2_->shape(0), batch_size);
+    EXPECT_EQ(this->blob_top_label2_->shape(1), 1);
 
-  EXPECT_EQ(this->blob_top_label2_->num_axes(), 2);
-  EXPECT_EQ(this->blob_top_label2_->shape(0), batch_size);
-  EXPECT_EQ(this->blob_top_label2_->shape(1), 1);
+    // Go through the data 10 times.
+    const int data_size = num_cols * height * width;
+    for (int iter = 0; iter < 10; ++iter) {
+      layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
 
-  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+      const int label_offset = iter * batch_size;
+      const int data_offset = label_offset * data_size;
 
-  // Go through the data 10 times (5 batches).
-  const int data_size = num_cols * height * width;
-  for (int iter = 0; iter < 10; ++iter) {
-    layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+      for (int i = 0; i < batch_size; ++i) {
+        // label is 1-indexed
+        EXPECT_EQ(((label_offset + i) % num_data_records) + 1,
+                  this->blob_top_label_->cpu_data()[i]);
 
-    // On even iterations, we're reading the first half of the data.
-    // On odd iterations, we're reading the second half of the data.
-    // NB: label is 1-indexed
-    int label_offset = 1 + ((iter % 2 == 0) ? 0 : batch_size);
-    int label2_offset = 1 + label_offset;
-    int data_offset = (iter % 2 == 0) ? 0 : batch_size * data_size;
-
-    // Every two iterations we are reading the second file,
-    // which has the same labels, but data is offset by total data size,
-    // which is 2400 (see generate_sample_data).
-    int file_offset = (iter % 4 < 2) ? 0 : 2400;
-
-    for (int i = 0; i < batch_size; ++i) {
-      EXPECT_EQ(
-        label_offset + i,
-        this->blob_top_label_->cpu_data()[i]);
-      EXPECT_EQ(
-        label2_offset + i,
-        this->blob_top_label2_->cpu_data()[i]);
-    }
-    for (int i = 0; i < batch_size; ++i) {
-      for (int j = 0; j < num_cols; ++j) {
-        for (int h = 0; h < height; ++h) {
-          for (int w = 0; w < width; ++w) {
-            int idx = (
-              i * num_cols * height * width +
-              j * height * width +
-              h * width + w);
-            EXPECT_EQ(
-              file_offset + data_offset + idx,
-              this->blob_top_data_->cpu_data()[idx])
-              << "debug: i " << i << " j " << j
-              << " iter " << iter;
+        // label2 is 2-indexed
+        EXPECT_EQ(((label_offset + i) % num_data_records) + 2,
+                  this->blob_top_label2_->cpu_data()[i]);
+      }
+      for (int i = 0; i < batch_size; ++i) {
+        for (int j = 0; j < num_cols; ++j) {
+          for (int h = 0; h < height; ++h) {
+            for (int w = 0; w < width; ++w) {
+              int idx = (i * num_cols * height * width +
+                         j * height * width +
+                         h * width + w);
+              EXPECT_EQ((data_offset + idx)
+                          % (2 * num_data_records * data_size),
+                        this->blob_top_data_->cpu_data()[idx])
+                << "debug: i " << i << " j " << j
+                << " iter " << iter;
+            }
           }
         }
       }
     }
   }
+};
+
+TYPED_TEST_CASE(HDF5DataLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(HDF5DataLayerTest, TestRead) {
+  this->TestRead(5);
 }
+
+TYPED_TEST(HDF5DataLayerTest, TestInterleavingRead) {
+  this->TestRead(3);
+}
+
 
 }  // namespace caffe

--- a/src/caffe/test/test_hdf5data_layer.cpp
+++ b/src/caffe/test/test_hdf5data_layer.cpp
@@ -30,8 +30,8 @@ class HDF5DataLayerTest : public MultiDeviceTest<TypeParam> {
 
     // Check out generate_sample_data.py in the same directory.
     filename = new string(
-    CMAKE_SOURCE_DIR "caffe/test/test_data/sample_data_list.txt" CMAKE_EXT);
-    LOG(INFO)<< "Using sample HDF5 data file " << filename;
+        CMAKE_SOURCE_DIR "caffe/test/test_data/sample_data_list.txt" CMAKE_EXT);
+    LOG(INFO) << "Using sample HDF5 data file " << *filename;
   }
 
   virtual ~HDF5DataLayerTest() {


### PR DESCRIPTION
@jeffdonahue , @shelhamer 

This PR attempts to fix #1362.
I highly recommend you to read #1362's description first to see what this PR tries to achieve.
To be short, we want to prefetch HDF5 files and avoid excessive memory usage by reading HDF5 files partially.

The below is the summary of modifications made on top of #1362.
- override `DataLayerSetUp()` instead of `LayerSetUp()` following [the existing design](https://github.com/BVLC/caffe/blob/249aba49ab3100d0409d93ef187ebcd5a53865b9/include/caffe/data_layers.hpp#L35)
- Blobs are N-D arrays now since #1970
- wait until a thread is joined in when destructing `HDF5DataLayer`
- preserve the ability of shuffling files
- add a unit test case where a batch is loaded from interleaving HDF5 files to cover the found error on the index math.
- plus a few minor bug fixes

# Caveats
- don't shuffle rows in a HDF5 file due to the introduction of partial reading
  - I believe this is also true for LMDB/LevelDB cases where the users are supposed to shuffle the data when they construct them.
- If someone needs to access the same HDF5 file concurrently, they need to make sure to have a thread-safe version of hdf5 library. (See [this](http://www.hdfgroup.org/hdf5-quest.html#gconc))
