### PR TITLE
Remove python2 from matlab CMakeLists.txt

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -45,9 +45,11 @@ string(REPLACE ";" ":"  rpath_folders   "${folders}")
 if(build_using MATCHES "Matlab")
   set(libflags -lcaffe${CAffe_POSTFIX} ${libflags}) # Matlab R2014a complans for -Wl,--whole-archive
 
+  string(REPLACE ";-lpython2" "" matlab_libflags "${libflags}")
+
   caffe_fetch_and_set_proper_mexext(Matlab_caffe_mex)
   add_custom_command(OUTPUT ${Matlab_caffe_mex} COMMAND ${Matlab_mex}
-      ARGS -output ${Matlab_caffe_mex} ${Matlab_srcs} ${cflags} ${link_folders} ${libflags}
+      ARGS -output ${Matlab_caffe_mex} ${Matlab_srcs} ${cflags} ${link_folders} ${matlab_libflags}
       DEPENDS caffe COMMENT "Building Matlab interface: ${Matlab_caffe_mex}" VERBATIM)
   add_custom_target(matlab ALL DEPENDS ${Matlab_caffe_mex} SOURCES ${Matlab_srcs})
 


### PR DESCRIPTION
This is a proposed fix for Issue #2078 

Builds with MATLAB support are complaining `library not found for -lpython2` when Python support is enabled. Linking to Python is not necessary for the MATLAB build, so that library should be stripped out.