### PR TITLE
Log the average gradient norm

### DIFF
--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -80,10 +80,16 @@ class SGDSolver : public Solver<Dtype> {
  protected:
   void PreSolve();
   Dtype GetLearningRate();
+  Dtype GetGradNorm();
+  void TrackAvgGradNorm();
+  Dtype ResetAvgGradNorm();
+  Dtype grad_norm;
+  int n_grad_norm_iters;
   virtual void ComputeUpdateValue();
   virtual void ClipGradients();
   virtual void SnapshotSolverState(SolverState * state);
   virtual void RestoreSolverState(const SolverState& state);
+
   // history maintains the historical momentum data.
   // update maintains update related data and is not needed in snapshots.
   // temp maintains other information that might be needed in computation

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -80,6 +80,7 @@ class SGDSolver : public Solver<Dtype> {
  protected:
   void PreSolve();
   Dtype GetLearningRate();
+  void DisplayIterInfo(Dtype rate);
   Dtype GetGradNorm();
   void TrackAvgGradNorm();
   Dtype ResetAvgGradNorm();

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -88,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 36 (last added: clip_gradients)
+// SolverParameter next available ID: 37 (last added: log_avg_gradient_norm)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -157,6 +157,9 @@ message SolverParameter {
   // Set clip_gradients to >= 0 to clip parameter gradients to that L2 norm,
   // whenever their actual L2 norm is larger.
   optional float clip_gradients = 35 [default = -1];
+  // Track and log the average L2 norm of minibatch gradients.  Disable for a 
+  // slight performance increase.  
+  optional bool log_avg_gradient_norm = 36 [default = true];
 
   optional int32 snapshot = 14 [default = 0]; // The snapshot interval
   optional string snapshot_prefix = 15; // The prefix for the snapshot.

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -480,6 +480,18 @@ Dtype SGDSolver<Dtype>::ResetAvgGradNorm() {
   return avg_grad_norm;
 }
 
+template<typename Dtype>
+void SGDSolver<Dtype>::DisplayIterInfo(Dtype rate) {
+  if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
+    LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate;
+    if (this->param_.log_avg_gradient_norm()) {
+      Dtype avg_grad_norm = ResetAvgGradNorm();
+      LOG(INFO)<< "Iteration " << this->iter_ << \
+          ", avg_grad_norm = " << avg_grad_norm;
+    }
+  }
+}
+
 template <typename Dtype>
 void SGDSolver<Dtype>::ComputeUpdateValue() {
   const vector<shared_ptr<Blob<Dtype> > >& net_params = this->net_->params();
@@ -489,15 +501,7 @@ void SGDSolver<Dtype>::ComputeUpdateValue() {
   // get the learning rate
   Dtype rate = GetLearningRate();
   TrackAvgGradNorm();
-  if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
-    if (this->param_.log_avg_gradient_norm()) {
-      Dtype avg_grad_norm = ResetAvgGradNorm();
-      LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate << \
-          ", avg_grad_norm = " << avg_grad_norm;
-    } else {
-      LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate;
-    }
-  }
+  DisplayIterInfo(rate);
   ClipGradients();
   Dtype momentum = this->param_.momentum();
   Dtype weight_decay = this->param_.weight_decay();
@@ -611,16 +615,7 @@ void NesterovSolver<Dtype>::ComputeUpdateValue() {
   // get the learning rate
   Dtype rate = this->GetLearningRate();
   this->TrackAvgGradNorm();
-  if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
-    if (this->param_.log_avg_gradient_norm()) {
-      Dtype avg_grad_norm = this->ResetAvgGradNorm();
-      LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate << \
-          ", avg_grad_norm = " << avg_grad_norm;
-      // reset sufficient statistic totals
-    } else {
-      LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate;
-    }
-  }
+  this->DisplayIterInfo(rate);
   SGDSolver<Dtype>::ClipGradients();
   Dtype momentum = this->param_.momentum();
   Dtype weight_decay = this->param_.weight_decay();
@@ -737,15 +732,7 @@ void AdaGradSolver<Dtype>::ComputeUpdateValue() {
   Dtype rate = this->GetLearningRate();
   Dtype delta = this->param_.delta();
   this->TrackAvgGradNorm();
-  if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
-    if (this->param_.log_avg_gradient_norm()) {
-      Dtype avg_grad_norm = this->ResetAvgGradNorm();
-      LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate << \
-          ", avg_grad_norm = " << avg_grad_norm;
-    } else {
-      LOG(INFO) << "Iteration " << this->iter_ << ", lr = " << rate;
-    }
-  }
+  this->DisplayIterInfo(rate);
   SGDSolver<Dtype>::ClipGradients();
   Dtype weight_decay = this->param_.weight_decay();
   string regularization_type = this->param_.regularization_type();

--- a/tools/extra/parse_log.py
+++ b/tools/extra/parse_log.py
@@ -41,14 +41,16 @@ def parse_log(path_to_log):
     re_train_loss = re.compile('Iteration \d+, loss = ([\.\d]+)')
     re_output_loss = re.compile('output #\d+: loss = ([\.\d]+)')
     re_lr = re.compile('lr = ([\.\d]+)')
+    re_grad_norm = re.compile('avg_grad_norm = ([\.\d]+)')
 
     # Pick out lines of interest
     iteration = -1
     test_accuracy = -1
     learning_rate = float('NaN')
+    avg_grad_norm = float('NaN')
     train_dict_list = []
     test_dict_list = []
-    train_dict_names = ('NumIters', 'Seconds', 'TrainingLoss', 'LearningRate')
+    train_dict_names = ('NumIters', 'Seconds', 'TrainingLoss', 'LearningRate', 'AvgGradientNorm')
     test_dict_names = ('NumIters', 'Seconds', 'TestAccuracy', 'TestLoss')
 
     logfile_year = extract_seconds.get_log_created_year(path_to_log)
@@ -71,6 +73,10 @@ def parse_log(path_to_log):
             if lr_match:
                 learning_rate = float(lr_match.group(1))
 
+            grad_norm_match = re_grad_norm.search(line)
+            if grad_norm_match:
+                avg_grad_norm = float(grad_norm_match.group(1))
+
             accuracy_match = re_accuracy.search(line)
             if accuracy_match and get_line_type(line) == 'test':
                 test_accuracy = float(accuracy_match.group(1))
@@ -81,7 +87,8 @@ def parse_log(path_to_log):
                 train_dict_list.append({'NumIters': iteration,
                                         'Seconds': seconds,
                                         'TrainingLoss': train_loss,
-                                        'LearningRate': learning_rate})
+                                        'LearningRate': learning_rate,
+                                        'AvgGradientNorm': avg_grad_norm})
 
             output_loss_match = re_output_loss.search(line)
             if output_loss_match and get_line_type(line) == 'test':

--- a/tools/extra/parse_log.sh
+++ b/tools/extra/parse_log.sh
@@ -36,11 +36,12 @@ grep ', loss = ' $1 >> aux.txt
 grep 'Iteration ' aux.txt | sed  's/.*Iteration \([[:digit:]]*\).*/\1/g' > aux0.txt
 grep ', loss = ' $1 | awk '{print $9}' > aux1.txt
 grep ', lr = ' $1 | awk '{print $9}' > aux2.txt
+grep ', avg_grad_norm = ' $1 | awk '{print $9}' > aux3.txt
 
 # Extracting elapsed seconds
-$DIR/extract_seconds.py aux.txt aux3.txt
+$DIR/extract_seconds.py aux.txt aux4.txt
 
 # Generating
-echo '#Iters Seconds TrainingLoss LearningRate'> $LOG.train
-paste aux0.txt aux3.txt aux1.txt aux2.txt | column -t >> $LOG.train
-rm aux.txt aux0.txt aux1.txt aux2.txt  aux3.txt
+echo '#Iters Seconds TrainingLoss LearningRate AvgGradientNorm'> $LOG.train
+paste aux0.txt aux4.txt aux1.txt aux2.txt aux3.txt | column -t >> $LOG.train
+rm aux.txt aux0.txt aux1.txt aux2.txt aux3.txt aux4.txt


### PR DESCRIPTION
This PR logs the average L2 norm of the minibatch gradient at each display step.  The average is taken across all the minibatches since the last time the gradient norm was logged. This is useful for helping to track the convergence of a solver; gradient norms should go to zero as we approach a local optima on the loss surface induced by the training dataset.

Tracking the gradient norm incurs a small additional cost per iteration (O(d) where d is the number of parameters in the gradient), but this will be dominated by the gradient computation itself.
