### PR TITLE
Changing Image import to be imported from PIL.

### DIFF
--- a/examples/web_demo/app.py
+++ b/examples/web_demo/app.py
@@ -10,7 +10,7 @@ import tornado.wsgi
 import tornado.httpserver
 import numpy as np
 import pandas as pd
-import Image
+from PIL import Image
 import cStringIO as StringIO
 import urllib
 import exifutil


### PR DESCRIPTION
I noticed the `web_demo` was changed to use `import Image` as part of 5c84795572cf08f020dab31af43e7d8478628f44, I think `import Image` is [deprecated in Pillow](http://pillow.readthedocs.org/en/latest/installation.html) and has been removed for newer version.