### PR TITLE
Parsing of HDF5 input file allowing whitespace in paths

### DIFF
--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -82,7 +82,7 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   std::ifstream source_file(source.c_str());
   if (source_file.is_open()) {
     std::string line;
-    while (source_file >> line) {
+    while (std::getline(source_file,line)) {
       hdf_filenames_.push_back(line);
     }
   } else {


### PR DESCRIPTION
The parsing of txt files specifying HDF5 data files allows spaces in file paths by splitting on lines instead of whitespace.