### PR TITLE
error and weight trace

### DIFF
--- a/examples/mnist/lenet_solver.prototxt
+++ b/examples/mnist/lenet_solver.prototxt
@@ -23,3 +23,8 @@ snapshot: 5000
 snapshot_prefix: "examples/mnist/lenet"
 # solver mode: CPU or GPU
 solver_mode: GPU
+
+test_compute_loss:true
+human_readable_trace:true
+snapshot_trace:1000
+

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -24,8 +24,10 @@ class Solver {
   void InitTestNets();
   // The main entry of the solver function. In default, iter will be zero. Pass
   // in a non-zero iter number to resume training for a pre-trained net.
-  virtual void Solve(const char* resume_file = NULL);
+  virtual void Solve(const char* resume_file, const char* trace_file);
+  inline void Solve(const char* resume_file = NULL) { Solve(resume_file, NULL);}
   inline void Solve(const string resume_file) { Solve(resume_file.c_str()); }
+  inline void Solve(const string resume_file, const string trace_file) { Solve(resume_file.c_str(), trace_file.c_str()); }
   void Step(int iters);
   // The Restore function implements how one should restore the solver to a
   // previously snapshotted state. You should implement the RestoreSolverState()
@@ -56,6 +58,7 @@ class Solver {
   void WeightTrace();
   virtual void SnapshotSolverState(SolverState* state) = 0;
   virtual void RestoreSolverState(const SolverState& state) = 0;
+  void RestoreTrace(const char* trace_file);
   void DisplayOutputBlobs(const int net_id);
 
   SolverParameter param_;

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -46,6 +46,9 @@ class Solver {
   // function that produces a SolverState protocol buffer that needs to be
   // written to disk together with the learned net.
   void Snapshot();
+  // The Solver::SnapshotTrace function saves the trace of the weights and errors 
+  // that have been recorded so far to disk
+  void SnapshotTrace() const;
   // The test routine
   void TestAll();
   void Test(const int test_net_id = 0);
@@ -54,6 +57,7 @@ class Solver {
   void DisplayOutputBlobs(const int net_id);
 
   SolverParameter param_;
+  SolverTrace trace_;
   int iter_;
   int current_step_;
   shared_ptr<Net<Dtype> > net_;

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -52,6 +52,8 @@ class Solver {
   // The test routine
   void TestAll();
   void Test(const int test_net_id = 0);
+  // Update trace_ with selected weights of individual layers
+  void WeightTrace();
   virtual void SnapshotSolverState(SolverState* state) = 0;
   virtual void RestoreSolverState(const SolverState& state) = 0;
   void DisplayOutputBlobs(const int net_id);

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -88,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 36 (last added: clip_gradients)
+// SolverParameter next available ID: 41 (last added: human_readable_trace)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -192,6 +192,22 @@ message SolverParameter {
 
   // If false, don't save a snapshot after training finishes.
   optional bool snapshot_after_train = 28 [default = true];
+
+  // How often the weight and error trace should be saved to disk
+  // determines the IO to disk load that the weight / error traces will create
+  optional int32 snapshot_trace = 37 [default = 0];
+
+  // If false, don't save a snapshot after training finishes.
+  optional bool snapshot_trace_after_train = 38 [default = true];
+
+  // tells us how often we should record the training error
+  // set to zero if no error trace should be made
+  // determines how detailed the error trace will be
+  optional int32 train_trace_interval = 39 [default = 100];
+
+  // if the caffe trace should also be saved in a human readable format,
+  // then set this to true
+  optional bool human_readable_trace = 40 [default = false];
 }
 
 // A message that stores the solver snapshots
@@ -965,3 +981,20 @@ message PReLUParameter {
   // Whether or not slope paramters are shared across channels.
   optional bool channel_shared = 2 [default = false];
 }
+
+message TrainTracePoint{
+  // The iteration where the training loss is saved
+  optional int32 iter = 1;
+
+  // The training loss in that iteration
+  optional float train_loss = 2;
+
+  // Like the train loss, but smoothed over the past
+  optional float train_smoothed_loss = 3;
+}
+
+// Contains a bunch of points describing how the state of the network changes over time
+message SolverTrace {
+  repeated TrainTracePoint  train_trace_point = 1;
+}
+

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -88,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 42 (last added: create_test_trace)
+// SolverParameter next available ID: 44 (last added: num_weight_traces)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -211,6 +211,14 @@ message SolverParameter {
 
   // during test phase, record the loss / accuracy in the caffetrace prototext file
   optional bool create_test_trace = 41 [default = true];
+
+  // tells us how often we should take weight trace values.
+  // set to zero if no snapshot should be made
+  // determines how detailed the weight trace will be
+  optional int32 weight_trace_interval = 42 [default = 100];
+
+  // number of parameters to track from every layer 
+  optional int32 num_weight_traces = 43 [default = 10];
 }
 
 // A message that stores the solver snapshots
@@ -1018,8 +1026,17 @@ message TestTracePoint{
   optional float loss_weight = 6;
 }
 
+message WeightTracePoint {
+  optional int32  iter = 1;
+  optional string layer_name = 2;
+  optional int32  blob_id = 3;
+  optional string blob_name = 4;
+  repeated float  weight = 5;
+}
+
 message SolverTrace {
   repeated TrainTracePoint  train_trace_point = 1;
   repeated TestTracePoint   test_trace_point = 2;
+  repeated WeightTracePoint weight_trace_point = 3;
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -88,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 41 (last added: human_readable_trace)
+// SolverParameter next available ID: 42 (last added: create_test_trace)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -208,6 +208,9 @@ message SolverParameter {
   // if the caffe trace should also be saved in a human readable format,
   // then set this to true
   optional bool human_readable_trace = 40 [default = false];
+
+  // during test phase, record the loss / accuracy in the caffetrace prototext file
+  optional bool create_test_trace = 41 [default = true];
 }
 
 // A message that stores the solver snapshots
@@ -993,8 +996,30 @@ message TrainTracePoint{
   optional float train_smoothed_loss = 3;
 }
 
-// Contains a bunch of points describing how the state of the network changes over time
+//the test output of one forward pass of one net
+message TestTracePoint{
+
+  //the id of the test net we test the loss of
+  optional int32 test_net_id = 1;
+  
+  //number of training iterations up until this point
+  optional int32 iter = 2;
+
+  //the index of the data blob we send through the net to test it
+  optional string score_name = 3;
+
+  //the loss of this net at this point
+  optional float test_loss = 4;
+
+  //the mean score of the net on this test blob
+  optional float mean_score = 5;
+
+  //the weight given to this blob of test data
+  optional float loss_weight = 6;
+}
+
 message SolverTrace {
   repeated TrainTracePoint  train_trace_point = 1;
+  repeated TestTracePoint   test_trace_point = 2;
 }
 

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -75,6 +75,7 @@ void Solver<Dtype>::InitTrainNet() {
     LOG(INFO) << "Creating training net from net file: " << param_.net();
     ReadNetParamsFromTextFileOrDie(param_.net(), &net_param);
   }
+
   // Set the correct NetState.  We start with the solver defaults (lowest
   // precedence); then, merge in any NetState specified by the net_param itself;
   // finally, merge in any NetState specified by the train_state (highest

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -317,7 +317,14 @@ void Solver<Dtype>::Test(const int test_net_id) {
   if (param_.test_compute_loss()) {
     loss /= param_.test_iter(test_net_id);
     LOG(INFO) << "Test loss: " << loss;
+    if(param_.create_test_trace()) {
+      TestTracePoint* new_point = trace_.add_test_trace_point();
+      new_point->set_test_net_id(test_net_id);
+      new_point->set_iter(iter_);
+      new_point->set_test_loss(loss);
+    }
   }
+  
   for (int i = 0; i < test_score.size(); ++i) {
     const int output_blob_index =
         test_net->output_blob_indices()[test_score_output_id[i]];
@@ -331,6 +338,14 @@ void Solver<Dtype>::Test(const int test_net_id) {
     }
     LOG(INFO) << "    Test net output #" << i << ": " << output_name << " = "
         << mean_score << loss_msg_stream.str();
+    if(param_.create_test_trace()) {
+      TestTracePoint* new_point = trace_.add_test_trace_point();
+      new_point->set_test_net_id(test_net_id);
+      new_point->set_iter(iter_);
+      new_point->set_score_name(output_name);
+      new_point->set_loss_weight(loss_weight);
+      new_point->set_mean_score(mean_score);
+    }
   }
 }
 
@@ -445,9 +460,12 @@ template <typename Dtype>
 void SGDSolver<Dtype>::PreSolve() {
   // Initialize the history
   const vector<shared_ptr<Blob<Dtype> > >& net_params = this->net_->params();
-  history_.clear();
-  update_.clear();
-  temp_.clear();
+  if(history_.size())
+    history_.clear();
+  if(update_.size())
+    update_.clear();
+  if(temp_.size())
+    temp_.clear();
   for (int i = 0; i < net_params.size(); ++i) {
     const vector<int>& shape = net_params[i]->shape();
     history_.push_back(shared_ptr<Blob<Dtype> >(new Blob<Dtype>(shape)));

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -235,13 +235,17 @@ void Solver<Dtype>::Step(int iters) {
 }
 
 template <typename Dtype>
-void Solver<Dtype>::Solve(const char* resume_file) {
+void Solver<Dtype>::Solve(const char* resume_file, const char* trace_file) {
   LOG(INFO) << "Solving " << net_->name();
   LOG(INFO) << "Learning Rate Policy: " << param_.lr_policy();
 
   if (resume_file) {
     LOG(INFO) << "Restoring previous solver status from " << resume_file;
     Restore(resume_file);
+  }
+  if (trace_file) {
+    LOG(INFO) << "Restoring previous solver trace status from " << trace_file;
+    RestoreTrace(trace_file);
   }
 
   // For a network that is trained by the solver, no bottom or top vecs
@@ -434,6 +438,35 @@ void Solver<Dtype>::Restore(const char* state_file) {
   RestoreSolverState(state);
 }
 
+template <typename Dtype>
+void Solver<Dtype>::RestoreTrace(const char* trace_file) {
+  SolverTrace trace;
+  ReadProtoFromBinaryFileOrDie(trace_file, &trace);
+  //clear out any garbage that may be in here
+  trace_.clear_train_trace_point();
+  trace_.clear_test_trace_point();
+  trace_.clear_weight_trace_point();
+ 
+  //add all the fields from the trace that happend when iter <= current iter 
+  for(int i = 0; i < trace.train_trace_point_size(); i++) {
+    if(trace.train_trace_point(i).iter() <= iter_) {
+      TrainTracePoint* point = trace_.add_train_trace_point();
+      *point = trace.train_trace_point(i);
+    }
+  }
+  for(int i = 0; i < trace.test_trace_point_size(); i++) {
+    if(trace.test_trace_point(i).iter() <= iter_) {
+      TestTracePoint* point = trace_.add_test_trace_point();
+      *point = trace.test_trace_point(i);
+    }
+  }
+  for(int i = 0; i < trace.weight_trace_point_size(); i++) {
+    if(trace.weight_trace_point(i).iter() <= iter_) {
+      WeightTracePoint* point = trace_.add_weight_trace_point();
+      *point = trace.weight_trace_point(i);
+    }
+  }
+}
 
 // Return the current learning rate. The currently implemented learning rate
 // policies are as follows:

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -25,6 +25,8 @@ DEFINE_string(model, "",
     "The model definition protocol buffer text file..");
 DEFINE_string(snapshot, "",
     "Optional; the snapshot solver state to resume training.");
+DEFINE_string(trace, "",
+    "Optional; the trace file to resume training, can only be defined if snapshot is defined.");
 DEFINE_string(weights, "",
     "Optional; the pretrained weights to initialize finetuning. "
     "Cannot be set simultaneously with snapshot.");
@@ -97,7 +99,8 @@ int train() {
   CHECK(!FLAGS_snapshot.size() || !FLAGS_weights.size())
       << "Give a snapshot to resume training or weights to finetune "
       "but not both.";
-
+  if(FLAGS_trace.size())
+    CHECK(FLAGS_snapshot.size()) << "You can not restore a trace without also giving a snapshot from which to restore";
   caffe::SolverParameter solver_param;
   caffe::ReadProtoFromTextFileOrDie(FLAGS_solver, &solver_param);
 


### PR DESCRIPTION
I added some functionality that allows a trace of the weights, training errors and test errors to be created.  This allows the user to then create plots of how the net learns like the first plot here http://code.google.com/p/cuda-convnet2/wiki/ShowNet

In addition, if the net is restored from a snapshot, the saved weights and errors are also restored so that the trace is continuous