### PR TITLE
error and weight trace

### DIFF
--- a/examples/mnist/lenet_solver.prototxt
+++ b/examples/mnist/lenet_solver.prototxt
@@ -23,3 +23,8 @@ snapshot: 5000
 snapshot_prefix: "examples/mnist/lenet"
 # solver mode: CPU or GPU
 solver_mode: GPU
+
+test_compute_loss:true
+human_readable_trace:true
+snapshot_trace:1000
+

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -24,8 +24,12 @@ class Solver {
   void InitTestNets();
   // The main entry of the solver function. In default, iter will be zero. Pass
   // in a non-zero iter number to resume training for a pre-trained net.
-  virtual void Solve(const char* resume_file = NULL);
+  virtual void Solve(const char* resume_file, const char* trace_file);
+  inline void Solve(const char* resume_file = NULL) { Solve(resume_file, NULL);}
   inline void Solve(const string resume_file) { Solve(resume_file.c_str()); }
+  inline void Solve(const string resume_file, const string trace_file) {
+    Solve(resume_file.c_str(), trace_file.c_str());
+  }
   void Step(int iters);
   // The Restore function implements how one should restore the solver to a
   // previously snapshotted state. You should implement the RestoreSolverState()
@@ -56,6 +60,7 @@ class Solver {
   void WeightTrace();
   virtual void SnapshotSolverState(SolverState* state) = 0;
   virtual void RestoreSolverState(const SolverState& state) = 0;
+  void RestoreTrace(const char* trace_file);
   void DisplayOutputBlobs(const int net_id);
 
   SolverParameter param_;

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -52,6 +52,8 @@ class Solver {
   // The test routine
   void TestAll();
   void Test(const int test_net_id = 0);
+  // Update trace_ with selected weights of individual layers
+  void WeightTrace();
   virtual void SnapshotSolverState(SolverState* state) = 0;
   virtual void RestoreSolverState(const SolverState& state) = 0;
   void DisplayOutputBlobs(const int net_id);

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -46,6 +46,9 @@ class Solver {
   // function that produces a SolverState protocol buffer that needs to be
   // written to disk together with the learned net.
   void Snapshot();
+  // The Solver::SnapshotTrace function saves the trace of the weights and
+  // errors that have been recorded so far to disk
+  void SnapshotTrace() const;
   // The test routine
   void TestAll();
   void Test(const int test_net_id = 0);
@@ -54,6 +57,7 @@ class Solver {
   void DisplayOutputBlobs(const int net_id);
 
   SolverParameter param_;
+  SolverTrace trace_;
   int iter_;
   int current_step_;
   shared_ptr<Net<Dtype> > net_;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -88,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 36 (last added: clip_gradients)
+// SolverParameter next available ID: 41 (last added: human_readable_trace)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -192,6 +192,22 @@ message SolverParameter {
 
   // If false, don't save a snapshot after training finishes.
   optional bool snapshot_after_train = 28 [default = true];
+
+  // How often the weight and error trace should be saved to disk
+  // determines the IO to disk load that the weight / error traces will create
+  optional int32 snapshot_trace = 37 [default = 0];
+
+  // If false, don't save a snapshot after training finishes.
+  optional bool snapshot_trace_after_train = 38 [default = true];
+
+  // tells us how often we should record the training error
+  // set to zero if no error trace should be made
+  // determines how detailed the error trace will be
+  optional int32 train_trace_interval = 39 [default = 100];
+
+  // if the caffe trace should also be saved in a human readable format,
+  // then set this to true
+  optional bool human_readable_trace = 40 [default = false];
 }
 
 // A message that stores the solver snapshots
@@ -965,3 +981,20 @@ message PReLUParameter {
   // Whether or not slope paramters are shared across channels.
   optional bool channel_shared = 2 [default = false];
 }
+
+message TrainTracePoint{
+  // The iteration where the training loss is saved
+  optional int32 iter = 1;
+
+  // The training loss in that iteration
+  optional float train_loss = 2;
+
+  // Like the train loss, but smoothed over the past
+  optional float train_smoothed_loss = 3;
+}
+
+// Contains a bunch of points describing how the state of the network changes over time
+message SolverTrace {
+  repeated TrainTracePoint  train_trace_point = 1;
+}
+

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -88,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 42 (last added: create_test_trace)
+// SolverParameter next available ID: 44 (last added: num_weight_traces)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -211,6 +211,14 @@ message SolverParameter {
 
   // during test phase, record the loss / accuracy in the caffetrace prototext file
   optional bool create_test_trace = 41 [default = true];
+
+  // tells us how often we should take weight trace values.
+  // set to zero if no snapshot should be made
+  // determines how detailed the weight trace will be
+  optional int32 weight_trace_interval = 42 [default = 100];
+
+  // number of parameters to track from every layer 
+  optional int32 num_weight_traces = 43 [default = 10];
 }
 
 // A message that stores the solver snapshots
@@ -1018,8 +1026,17 @@ message TestTracePoint{
   optional float loss_weight = 6;
 }
 
+message WeightTracePoint {
+  optional int32  iter = 1;
+  optional string layer_name = 2;
+  optional int32  blob_id = 3;
+  optional string blob_name = 4;
+  repeated float  weight = 5;
+}
+
 message SolverTrace {
   repeated TrainTracePoint  train_trace_point = 1;
   repeated TestTracePoint   test_trace_point = 2;
+  repeated WeightTracePoint weight_trace_point = 3;
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -88,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 41 (last added: human_readable_trace)
+// SolverParameter next available ID: 42 (last added: create_test_trace)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -208,6 +208,9 @@ message SolverParameter {
   // if the caffe trace should also be saved in a human readable format,
   // then set this to true
   optional bool human_readable_trace = 40 [default = false];
+
+  // during test phase, record the loss / accuracy in the caffetrace prototext file
+  optional bool create_test_trace = 41 [default = true];
 }
 
 // A message that stores the solver snapshots
@@ -993,8 +996,30 @@ message TrainTracePoint{
   optional float train_smoothed_loss = 3;
 }
 
-// Contains a bunch of points describing how the state of the network changes over time
+//the test output of one forward pass of one net
+message TestTracePoint{
+
+  //the id of the test net we test the loss of
+  optional int32 test_net_id = 1;
+  
+  //number of training iterations up until this point
+  optional int32 iter = 2;
+
+  //the index of the data blob we send through the net to test it
+  optional string score_name = 3;
+
+  //the loss of this net at this point
+  optional float test_loss = 4;
+
+  //the mean score of the net on this test blob
+  optional float mean_score = 5;
+
+  //the weight given to this blob of test data
+  optional float loss_weight = 6;
+}
+
 message SolverTrace {
   repeated TrainTracePoint  train_trace_point = 1;
+  repeated TestTracePoint   test_trace_point = 2;
 }
 

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -53,9 +53,12 @@ void Solver<Dtype>::InitTrainNet() {
       << "using one of these fields: " << field_names;
   CHECK_LE(num_train_nets, 1) << "SolverParameter must not contain more than "
       << "one of these fields specifying a train_net: " << field_names;
+  CHECK_GE(param_.weight_trace_interval(), 0) << "weight_trace_interval "
+      << "paramter must be >= 0, currently " << param_.weight_trace_interval();
   CHECK_GE(param_.train_trace_interval(), 0) << "train_trace_interval paramter "
       << "must be non negative, currently " << param_.train_trace_interval();
   CHECK_GE(param_.snapshot_trace(), 0) << "snapshot_trace interval must be >=0";
+  CHECK_GE(param_.num_weight_traces(), 0) << "num_weight_traces must be >=0";
 
   NetParameter net_param;
   if (param_.has_train_net_param()) {
@@ -172,6 +175,11 @@ void Solver<Dtype>::Step(int iters) {
   Dtype smoothed_loss = 0;
 
   for (; iter_ < stop_iter; ++iter_) {
+    if (param_.weight_trace_interval()
+        && iter_% param_.weight_trace_interval() == 0
+        && (start_iter == 0 || iter_ > start_iter)) {
+      WeightTrace();
+    }
     if (param_.test_interval() && iter_ % param_.test_interval() == 0
         && (iter_ > 0 || param_.test_initialization())) {
       TestAll();
@@ -352,6 +360,34 @@ void Solver<Dtype>::Test(const int test_net_id) {
   }
 }
 
+template <typename Dtype>
+void Solver<Dtype>::WeightTrace() {
+  const vector<shared_ptr<Layer<Dtype> > >& layers = this->net_->layers();
+  const vector<string>& layer_names = this->net_->layer_names();
+  const vector<string>& blob_names  = this->net_->blob_names();
+  for (int layer_id = 0; layer_id < layers.size(); ++layer_id) {
+    const vector<shared_ptr<Blob<Dtype> > >& blobs = layers[layer_id]->blobs();
+    for (int blob_id = 0; blob_id  < blobs.size(); ++blob_id) {
+      WeightTracePoint* new_point = trace_.add_weight_trace_point();
+      new_point->set_iter(iter_);
+      new_point->set_layer_name(layer_names[layer_id]);
+      new_point->set_blob_id(blob_id);
+      new_point->set_blob_name(blob_names[blob_id]);
+      int count = blobs[blob_id]->count();
+      if (count > param_.num_weight_traces()) {
+        int start = count / (param_.num_weight_traces() * 2 + 2);
+        int step  = count / (param_.num_weight_traces() + 1);
+        for (int i = 0; i < param_.num_weight_traces(); ++i) {
+          new_point->add_weight(*(blobs[blob_id]->cpu_data() + start + i*step));
+        }
+      } else {
+        for (int i = 0; i < count; ++i) {
+          new_point->add_weight(*(blobs[blob_id]->cpu_data() + i));
+        }
+      }
+    }
+  }
+}
 
 template <typename Dtype>
 void Solver<Dtype>::Snapshot() {

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -320,7 +320,14 @@ void Solver<Dtype>::Test(const int test_net_id) {
   if (param_.test_compute_loss()) {
     loss /= param_.test_iter(test_net_id);
     LOG(INFO) << "Test loss: " << loss;
+    if (param_.create_test_trace()) {
+      TestTracePoint* new_point = trace_.add_test_trace_point();
+      new_point->set_test_net_id(test_net_id);
+      new_point->set_iter(iter_);
+      new_point->set_test_loss(loss);
+    }
   }
+
   for (int i = 0; i < test_score.size(); ++i) {
     const int output_blob_index =
         test_net->output_blob_indices()[test_score_output_id[i]];
@@ -334,6 +341,14 @@ void Solver<Dtype>::Test(const int test_net_id) {
     }
     LOG(INFO) << "    Test net output #" << i << ": " << output_name << " = "
         << mean_score << loss_msg_stream.str();
+    if (param_.create_test_trace()) {
+      TestTracePoint* new_point = trace_.add_test_trace_point();
+      new_point->set_test_net_id(test_net_id);
+      new_point->set_iter(iter_);
+      new_point->set_score_name(output_name);
+      new_point->set_loss_weight(loss_weight);
+      new_point->set_mean_score(mean_score);
+    }
   }
 }
 
@@ -448,9 +463,12 @@ template <typename Dtype>
 void SGDSolver<Dtype>::PreSolve() {
   // Initialize the history
   const vector<shared_ptr<Blob<Dtype> > >& net_params = this->net_->params();
-  history_.clear();
-  update_.clear();
-  temp_.clear();
+  if (history_.size())
+    history_.clear();
+  if (update_.size())
+    update_.clear();
+  if (temp_.size())
+    temp_.clear();
   for (int i = 0; i < net_params.size(); ++i) {
     const vector<int>& shape = net_params[i]->shape();
     history_.push_back(shared_ptr<Blob<Dtype> >(new Blob<Dtype>(shape)));

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -53,6 +53,10 @@ void Solver<Dtype>::InitTrainNet() {
       << "using one of these fields: " << field_names;
   CHECK_LE(num_train_nets, 1) << "SolverParameter must not contain more than "
       << "one of these fields specifying a train_net: " << field_names;
+  CHECK_GE(param_.train_trace_interval(), 0) << "train_trace_interval paramter "
+      << "must be non negative, currently " << param_.train_trace_interval();
+  CHECK_GE(param_.snapshot_trace(), 0) << "snapshot_trace interval must be >=0";
+
   NetParameter net_param;
   if (param_.has_train_net_param()) {
     LOG(INFO) << "Creating training net specified in train_net_param.";
@@ -185,6 +189,15 @@ void Solver<Dtype>::Step(int iters) {
       smoothed_loss += (loss - losses[idx]) / average_loss;
       losses[idx] = loss;
     }
+    if (param_.train_trace_interval()
+       && iter_ % param_.train_trace_interval() == 0
+       && (start_iter == 0 || iter_ > start_iter)) {
+      TrainTracePoint* new_point = trace_.add_train_trace_point();
+      new_point->set_iter(iter_);
+      new_point->set_train_loss(loss);
+      new_point->set_train_smoothed_loss(smoothed_loss);
+    }
+
     if (display) {
       LOG(INFO) << "Iteration " << iter_ << ", loss = " << smoothed_loss;
       const vector<Blob<Dtype>*>& result = net_->output_blobs();
@@ -214,6 +227,9 @@ void Solver<Dtype>::Step(int iters) {
     if (param_.snapshot() && (iter_ + 1) % param_.snapshot() == 0) {
       Snapshot();
     }
+    if (param_.snapshot_trace() && (iter_ + 1) % param_.snapshot_trace() == 0) {
+      SnapshotTrace();
+    }
   }
 }
 
@@ -235,6 +251,10 @@ void Solver<Dtype>::Solve(const char* resume_file) {
   if (param_.snapshot_after_train()
       && (!param_.snapshot() || iter_ % param_.snapshot() != 0)) {
     Snapshot();
+  }
+  if (param_.snapshot_trace_after_train()
+      && (!param_.snapshot_trace() || iter_ % param_.snapshot_trace() != 0)) {
+    SnapshotTrace();
   }
   // After the optimization is done, run an additional train and test pass to
   // display the train and test loss/outputs if appropriate (based on the
@@ -341,6 +361,18 @@ void Solver<Dtype>::Snapshot() {
   snapshot_filename = filename + ".solverstate";
   LOG(INFO) << "Snapshotting solver state to " << snapshot_filename;
   WriteProtoToBinaryFile(state, snapshot_filename.c_str());
+}
+
+template <typename Dtype>
+void Solver<Dtype>::SnapshotTrace() const {
+  string filename(param_.snapshot_prefix());
+  string trace_filename = filename + ".caffetrace";
+  LOG(INFO) << "Snapshotting trace to " << trace_filename;
+  WriteProtoToBinaryFile(trace_, trace_filename.c_str());
+  if (param_.human_readable_trace()) {
+    string trace_filename_txt = trace_filename + "_txt";
+    WriteProtoToTextFile(trace_, trace_filename_txt.c_str());
+  }
 }
 
 template <typename Dtype>

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -25,6 +25,9 @@ DEFINE_string(model, "",
     "The model definition protocol buffer text file..");
 DEFINE_string(snapshot, "",
     "Optional; the snapshot solver state to resume training.");
+DEFINE_string(trace, "",
+    "Optional; the trace file to resume training, "
+    "can only be defined if snapshot is defined.");
 DEFINE_string(weights, "",
     "Optional; the pretrained weights to initialize finetuning. "
     "Cannot be set simultaneously with snapshot.");
@@ -97,7 +100,9 @@ int train() {
   CHECK(!FLAGS_snapshot.size() || !FLAGS_weights.size())
       << "Give a snapshot to resume training or weights to finetune "
       "but not both.";
-
+  if (FLAGS_trace.size())
+    CHECK(FLAGS_snapshot.size()) << "You can not restore a trace without also "
+    << "giving a snapshot from which to restore";
   caffe::SolverParameter solver_param;
   caffe::ReadProtoFromTextFileOrDie(FLAGS_solver, &solver_param);
 


### PR DESCRIPTION
Added functionality that allows a trace of the weights, training errors and test errors to be created. This allows the user to then create plots of how the net learns like the plots here

![plot1](https://cloud.githubusercontent.com/assets/4824567/7206752/cfaada46-e534-11e4-876d-14a8f9bf9a32.jpg)

![plot2](https://cloud.githubusercontent.com/assets/4824567/7206754/d5749534-e534-11e4-8d39-6fd9a5e7ddbd.jpg)

In addition, if the net is restored from a snapshot, the saved weights and errors are also restored so that the trace is continuous
