### PR TITLE
Fix RCNN model fetching script

### DIFF
--- a/examples/detection.ipynb
+++ b/examples/detection.ipynb
@@ -27,7 +27,7 @@
       "\n",
       "- [Selective Search](http://koen.me/research/selectivesearch/) is the region proposer used by R-CNN. The [selective_search_ijcv_with_python](https://github.com/sergeyk/selective_search_ijcv_with_python) Python module takes care of extracting proposals through the selective search MATLAB implementation. To install it, download the module and name its directory `selective_search_ijcv_with_python`, run the demo in MATLAB to compile the necessary functions, then add it to your `PYTHONPATH` for importing. (If you have your own region proposals prepared, or would rather not bother with this step, [detect.py](https://github.com/BVLC/caffe/blob/master/python/detect.py) accepts a list of images and bounding boxes as CSV.)\n",
       "\n",
-      "-Run `./scripts/download_model_binary.py models/bvlc_reference_caffenet` to get the Caffe R-CNN ImageNet model.\n",
+      "-Run `./scripts/download_model_binary.py models/bvlc_reference_rcnn_ilsvrc13` to get the Caffe R-CNN ImageNet model.\n",
       "\n",
       "With that done, we'll call the bundled `detect.py` to generate the region proposals and run the network. For an explanation of the arguments, do `./detect.py --help`."
      ]


### PR DESCRIPTION
I think the R-CNN example has an incorrect script. The current example fetches the ImageNet model without R-CNN (bvlc_reference_caffenet), but to run the example we would need bvlc_reference_rcnn_ilsvrc13, as is referenced in the command-line args to detect.py later in the example.