### PR TITLE
Die on NaN loss

### DIFF
--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -88,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 36 (last added: clip_gradients)
+// SolverParameter next available ID: 37 (last added: die_on_nan)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -192,6 +192,9 @@ message SolverParameter {
 
   // If false, don't save a snapshot after training finishes.
   optional bool snapshot_after_train = 28 [default = true];
+
+  // If true (the default), training terminates immediately when a loss is NaN.
+  optional bool die_on_nan = 36 [default = true];
 }
 
 // A message that stores the solver snapshots

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -176,6 +176,8 @@ void Solver<Dtype>::Step(int iters) {
     const bool display = param_.display() && iter_ % param_.display() == 0;
     net_->set_debug_info(display && param_.debug_info());
     Dtype loss = net_->ForwardBackward(bottom_vec);
+    CHECK(!isnan(loss) || !param_.die_on_nan())
+        << "loss is NaN at iteration " << iter_ << " (die_on_nan is set)";
     if (losses.size() < average_loss) {
       losses.push_back(loss);
       int size = losses.size();


### PR DESCRIPTION
This will make training die on a NaN loss, unless turned off by setting `SolverParameter.die_on_nan == false`.  It's been saving the GPUs I've been using many pointless cycles...