### PR TITLE
Typo fix: the label titles in plot_log.gnuplot.example

### DIFF
--- a/tools/extra/plot_log.gnuplot.example
+++ b/tools/extra/plot_log.gnuplot.example
@@ -39,8 +39,8 @@ set key right
 
 # Training loss vs. training iterations
 set title "Training loss vs. training iterations"
-set xlabel "Training loss"
-set ylabel "Training iterations"
+set xlabel "Training iterations"
+set ylabel "Training loss"
 plot "mnist.log.train" using 1:3 title "mnist"
 
 # Training loss vs. training time


### PR DESCRIPTION
Fixed a tiny mistake that the titles of xlabel (Training loss) and ylabel (Training iterations) were swapped in the output image of `gnuplot plot_log.gnuplot.example`.