### PR TITLE
Makefile bugfix: debug/release dir link not toggled properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@ CONFIG_FILE := Makefile.config
 include $(CONFIG_FILE)
 
 BUILD_DIR_LINK := $(BUILD_DIR)
-RELEASE_BUILD_DIR ?= .$(BUILD_DIR)_release
-DEBUG_BUILD_DIR ?= .$(BUILD_DIR)_debug
+ifeq ($(RELEASE_BUILD_DIR),)
+	RELEASE_BUILD_DIR := .$(BUILD_DIR)_release
+endif
+ifeq ($(DEBUG_BUILD_DIR),)
+	DEBUG_BUILD_DIR := .$(BUILD_DIR)_debug
+endif
 
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)


### PR DESCRIPTION
This fixes a bug that was causing the `build` link to not properly toggle between `.build_release` and `.build_debug`.  Due to the lazy variable expansion when using the `?=` assignment operator, `$OTHER_BUILD_DIR` was getting assigned to `..build_release_debug` rather than `.build_debug` (or `..build_debug_release` rather than `.build_release`) and the `.linked` file wasn't getting removed to tell make to move the link when the `DEBUG` option is toggled.