### PR TITLE
move CPU_ONLY to right place

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -19,7 +19,7 @@
 #include "caffe/util/device_alternate.hpp"
 
 // gflags 2.1 issue: namespace google was changed to gflags without warning.
-// Luckily we will be able to use GFLAGS_GFAGS_H_ to detect if it is version
+// Luckily we will be able to use GFLAGS_GFLAGS_H_ to detect if it is version
 // 2.1. If yes, we will add a temporary solution to redirect the namespace.
 // TODO(Yangqing): Once gflags solves the problem in a more elegant way, let's
 // remove the following hack.

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -756,15 +756,15 @@ void Net<Dtype>::Update() {
       owner_diff = params_[param_owners_[i]]->mutable_cpu_diff();
       caffe_add(count, this_diff, owner_diff, owner_diff);
       break;
-#ifndef CPU_ONLY
     case Caffe::GPU:
+#ifndef CPU_ONLY
       this_diff = params_[i]->gpu_diff();
       owner_diff = params_[param_owners_[i]]->mutable_gpu_diff();
       caffe_gpu_add(count, this_diff, owner_diff, owner_diff);
-      break;
 #else
       NO_GPU;
 #endif
+      break;
     default:
       LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
     }


### PR DESCRIPTION
At other places, `CPU_ONLY` are used on such a way:
```
    case Caffe::GPU:
#ifndef CPU_ONLY
      ...
#else
    NO_GPU;
#endif
      break;
```

A typo in comment is also fixed.