### PR TITLE
Little CMake fix (can be reviewed and merged quickly)

### DIFF
--- a/cmake/Modules/FindGFlags.cmake
+++ b/cmake/Modules/FindGFlags.cmake
@@ -38,7 +38,7 @@ else()
     find_library(GFLAGS_LIBRARY gflags)
 endif()
 
-find_package_handle_standard_args(GFLAGS DEFAULT_MSG GFLAGS_INCLUDE_DIR GFLAGS_LIBRARY)
+find_package_handle_standard_args(GFlags DEFAULT_MSG GFLAGS_INCLUDE_DIR GFLAGS_LIBRARY)
 
 
 if(GFLAGS_FOUND)

--- a/cmake/Modules/FindGlog.cmake
+++ b/cmake/Modules/FindGlog.cmake
@@ -37,7 +37,7 @@ else()
         PATH_SUFFIXES lib lib64)
 endif()
 
-find_package_handle_standard_args(GLOG DEFAULT_MSG GLOG_INCLUDE_DIR GLOG_LIBRARY)
+find_package_handle_standard_args(Glog DEFAULT_MSG GLOG_INCLUDE_DIR GLOG_LIBRARY)
 
 if(GLOG_FOUND)
   set(GLOG_INCLUDE_DIRS ${GLOG_INCLUDE_DIR})


### PR DESCRIPTION
* After the fix Caffe will complain if glog/gflags are not found at CMake time (without waiting compilation error). The bug was in `FindGlog/FindGFlag.cmake` scripts due to case sensitiveness of CMake.

