### PR TITLE
cmake detects Atlas BLAS and Lapack under Fedora/RHEL/CentOS

### DIFF
--- a/cmake/Modules/FindAtlas.cmake
+++ b/cmake/Modules/FindAtlas.cmake
@@ -10,6 +10,7 @@
 #  Atlas_LIBRARYRARY_DIRS
 
 set(Atlas_INCLUDE_SEARCH_PATHS
+  /usr/include
   /usr/include/atlas
   /usr/include/atlas-base
   $ENV{Atlas_ROOT_DIR}
@@ -19,6 +20,8 @@ set(Atlas_INCLUDE_SEARCH_PATHS
 set(Atlas_LIB_SEARCH_PATHS
   /usr/lib/atlas
   /usr/lib/atlas-base
+  /usr/lib64
+  /usr/lib64/atlas
   $ENV{Atlas_ROOT_DIR}
   $ENV{Atlas_ROOT_DIR}/lib
 )
@@ -26,9 +29,9 @@ set(Atlas_LIB_SEARCH_PATHS
 find_path(Atlas_CBLAS_INCLUDE_DIR   NAMES cblas.h   PATHS ${Atlas_INCLUDE_SEARCH_PATHS})
 find_path(Atlas_CLAPACK_INCLUDE_DIR NAMES clapack.h PATHS ${Atlas_INCLUDE_SEARCH_PATHS})
 
-find_library(Atlas_CBLAS_LIBRARY NAMES  ptcblas_r ptcblas cblas_r cblas PATHS ${Atlas_LIB_SEARCH_PATHS})
-find_library(Atlas_BLAS_LIBRARY NAMES   atlas_r   atlas                 PATHS ${Atlas_LIB_SEARCH_PATHS})
-find_library(Atlas_LAPACK_LIBRARY NAMES alapack_r alapack lapack_atlas  PATHS ${Atlas_LIB_SEARCH_PATHS})
+find_library(Atlas_CBLAS_LIBRARY  NAMES ptcblas_r ptcblas cblas_r cblas blas   PATHS ${Atlas_LIB_SEARCH_PATHS})
+find_library(Atlas_BLAS_LIBRARY   NAMES atlas_r atlas tatlas satlas            PATHS ${Atlas_LIB_SEARCH_PATHS})
+find_library(Atlas_LAPACK_LIBRARY NAMES alapack_r alapack lapack_atlas lapacke PATHS ${Atlas_LIB_SEARCH_PATHS})
 
 set(LOOKED_FOR
   Atlas_CBLAS_INCLUDE_DIR

--- a/docs/install_yum.md
+++ b/docs/install_yum.md
@@ -38,7 +38,7 @@ Note that glog does not compile with the most recent gflags version (2.1), so be
 Install the library and latest driver separately; the driver bundled with the library is usually out-of-date.
     + CentOS/RHEL/Fedora:
 
-**BLAS**: install ATLAS by `sudo yum install atlas-devel` or install OpenBLAS or MKL for better CPU performance. For the Makefile build, uncomment and set `BLAS_LIB` accordingly as ATLAS is usually installed under `/usr/lib[64]/atlas`).
+**BLAS**: install ATLAS by `sudo yum install atlas-devel blas-devel lapack-devel` or install OpenBLAS or MKL for better CPU performance. For the Makefile build, uncomment and set `BLAS_LIB` accordingly as ATLAS is usually installed under `/usr/lib[64]/atlas`).
 
 **Python** (optional): if you use the default Python you will need to `sudo yum install` the `python-devel` package to have the Python headers for building the pycaffe wrapper.
 


### PR DESCRIPTION
Currently Fedora Core package for ATLAS doesn't contain neither `cblas` nor `lapack` libraries included. That's why a separate steps have to be made by installing `blas-devel` and `lapack-devel`.

Adjustments in `FindAtlas.cmake` help to find the libraries and headers under said systems family.