### PR TITLE
Correct the REPO_DIRNAME in `examples/web_demo/app.py`

### DIFF
--- a/examples/web_demo/app.py
+++ b/examples/web_demo/app.py
@@ -17,7 +17,7 @@ import exifutil
 
 import caffe
 
-REPO_DIRNAME = os.path.abspath(os.path.dirname(__file__) + '/../..')
+REPO_DIRNAME = os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + '/../..')
 UPLOAD_FOLDER = '/tmp/caffe_demos_uploads'
 ALLOWED_IMAGE_EXTENSIONS = set(['png', 'bmp', 'jpg', 'jpe', 'jpeg', 'gif'])
 


### PR DESCRIPTION
The variable `REPO_DIRNAME` in line 20 should be `os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + '/../..')`,
 for the `os.path.dirname(__file__)` always return EMPTY,
 and an exception `File for class_labels_file is missing. Should be at: //data/ilsvrc12/synset.words.txt` would be threw out. 
(http://stackoverflow.com/questions/7783308/os-path-dirname-file-returns-empty)

To get the dirname of the absolute path, we should use `os.path.dirname(os.path.abspath(__file__))`.

Tested on Python 2.7 and Python 3.4 .