### PR TITLE
Test for Snapshot and Restore in Solver

### DIFF
--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -31,6 +31,12 @@ class Solver {
   // previously snapshotted state. You should implement the RestoreSolverState()
   // function that restores the state from a SolverState protocol buffer.
   void Restore(const char* resume_file);
+  // The Solver::Snapshot function implements the basic snapshotting utility
+    // that stores the learned net. You should implement the SnapshotSolverState()
+    // function that produces a SolverState protocol buffer that needs to be
+    // written to disk together with the learned net.
+  void Snapshot();
+
   virtual ~Solver() {}
   inline shared_ptr<Net<Dtype> > net() { return net_; }
   inline const vector<shared_ptr<Net<Dtype> > >& test_nets() {
@@ -41,11 +47,6 @@ class Solver {
  protected:
   // Get the update value for the current iteration.
   virtual void ComputeUpdateValue() = 0;
-  // The Solver::Snapshot function implements the basic snapshotting utility
-  // that stores the learned net. You should implement the SnapshotSolverState()
-  // function that produces a SolverState protocol buffer that needs to be
-  // written to disk together with the learned net.
-  void Snapshot();
   // The test routine
   void TestAll();
   void Test(const int test_net_id = 0);
@@ -76,14 +77,14 @@ class SGDSolver : public Solver<Dtype> {
       : Solver<Dtype>(param_file) { PreSolve(); }
 
   const vector<shared_ptr<Blob<Dtype> > >& history() { return history_; }
+  virtual void SnapshotSolverState(SolverState * state);
+  virtual void RestoreSolverState(const SolverState& state);
 
  protected:
   void PreSolve();
   Dtype GetLearningRate();
   virtual void ComputeUpdateValue();
   virtual void ClipGradients();
-  virtual void SnapshotSolverState(SolverState * state);
-  virtual void RestoreSolverState(const SolverState& state);
   // history maintains the historical momentum data.
   // update maintains update related data and is not needed in snapshots.
   // temp maintains other information that might be needed in computation

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -32,9 +32,9 @@ class Solver {
   // function that restores the state from a SolverState protocol buffer.
   void Restore(const char* resume_file);
   // The Solver::Snapshot function implements the basic snapshotting utility
-    // that stores the learned net. You should implement the SnapshotSolverState()
-    // function that produces a SolverState protocol buffer that needs to be
-    // written to disk together with the learned net.
+  // that stores the learned net. You should implement the SnapshotSolverState()
+  // function that produces a SolverState protocol buffer that needs to be
+  // written to disk together with the learned net.
   void Snapshot();
 
   virtual ~Solver() {}

--- a/src/caffe/test/test_gradient_based_solver.cpp
+++ b/src/caffe/test/test_gradient_based_solver.cpp
@@ -32,7 +32,6 @@ class GradientBasedSolverTest : public MultiDeviceTest<TypeParam> {
 
   virtual SolverParameter_SolverType solver_type() = 0;
   virtual void InitSolver(const SolverParameter& param) = 0;
-
   virtual void InitSolverFromProtoString(const string& proto) {
     SolverParameter param;
     CHECK(google::protobuf::TextFormat::ParseFromString(proto, &param));
@@ -304,78 +303,72 @@ class GradientBasedSolverTest : public MultiDeviceTest<TypeParam> {
     CheckLeastSquaresUpdate(updated_params);
   }
 
-void TestHistorySnapshot()
-  {
-	const Dtype learning_rate = 1.0;
-	const Dtype weight_decay = 0.0;
-	const Dtype momentum = 0.9;
-	const int num_iters = 0;
-	ostringstream proto;
-		proto <<
-		   "max_iter: " << num_iters << " "
-		   "net_param { "
-		   "  name: 'TestNetwork' "
-		   "  layer { "
-		   "    name: 'data' "
-		   "    type: 'DummyData' "
-		   "    dummy_data_param { "
-		   "      num: " << num_ << " "
-		   "      channels: " << channels_ << " "
-		   "      height: " << height_ << " "
-		   "      width: " << width_ << " "
-		   "      channels: 1 "
-		   "      height: 1 "
-		   "      width: 1 "
-		   "      data_filler { "
-		   "        type: 'gaussian' "
-		   "        std: 1.0 "
-		   "      } "
-		   "    } "
-		   "    top: 'data' "
-		   "    top: 'targets' "
-		   "  } "
-		   "  layer { "
-		   "    name: 'innerprod' "
-		   "    type: 'InnerProduct' "
-		   "    inner_product_param { "
-		   "      num_output: 1 "
-		   "      weight_filler { "
-		   "        type: 'gaussian' "
-		   "        std: 1.0 "
-		   "      } "
-		   "      bias_filler { "
-		   "        type: 'gaussian' "
-		   "        std: 1.0 "
-		   "      } "
-		   "    } "
-		   "    bottom: 'data' "
-		   "    top: 'innerprod' "
-		   "  } "
-		   "  layer { "
-		   "    name: 'loss' "
-		   "    type: 'EuclideanLoss' "
-		   "    bottom: 'innerprod' "
-		   "    bottom: 'targets' "
-		   "  } "
-		   "} ";
-
-	this->InitSolverFromProtoString(proto.str());
-	this->solver_->Solve();
-	vector<shared_ptr<Blob<Dtype> > > historyBefore,historyAfter;
-	int sizeBeforeSnapshot,sizeAfterSnapshot;
-	SolverState state;
-	historyBefore=this->solver_->history();
-	sizeBeforeSnapshot=historyBefore.size();
-	this->solver_->SnapshotSolverState(&state);
-	this->solver_->RestoreSolverState(state);
-	historyAfter=this->solver_->history();
-	sizeAfterSnapshot=historyAfter.size();
-	ASSERT_EQ(sizeAfterSnapshot,sizeBeforeSnapshot);
-	for (unsigned i=0;i<sizeBeforeSnapshot;i++){
-	EXPECT_EQ(historyBefore[i]->cpu_data(),historyAfter[i]->cpu_data());
-	}
-
-  }
+void TestHistorySnapshot(){
+    const int num_iters = 0;
+    ostringstream proto;
+    proto <<
+        "max_iter: " << num_iters << " "
+        "net_param { "
+        "  name: 'TestNetwork' "
+        "  layer { "
+        "    name: 'data' "
+        "    type: 'DummyData' "
+        "    dummy_data_param { "
+        "      num: " << num_ << " "
+        "      channels: " << channels_ << " "
+        "      height: " << height_ << " "
+        "      width: " << width_ << " "
+        "      channels: 1 "
+        "      height: 1 "
+        "      width: 1 "
+        "      data_filler { "
+        "        type: 'gaussian' "
+        "        std: 1.0 "
+        "      } "
+        "    } "
+        "    top: 'data' "
+        "    top: 'targets' "
+        "  } "
+        "  layer { "
+        "    name: 'innerprod' "
+        "    type: 'InnerProduct' "
+        "    inner_product_param { "
+        "      num_output: 1 "
+        "      weight_filler { "
+        "        type: 'gaussian' "
+        "        std: 1.0 "
+        "      } "
+        "      bias_filler { "
+        "        type: 'gaussian' "
+        "        std: 1.0 "
+        "      } "
+        "    } "
+        "    bottom: 'data' "
+        "    top: 'innerprod' "
+        "  } "
+        "  layer { "
+        "    name: 'loss' "
+        "    type: 'EuclideanLoss' "
+        "    bottom: 'innerprod' "
+        "    bottom: 'targets' "
+        "  } "
+        "} ";
+    this->InitSolverFromProtoString(proto.str());
+    this->solver_->Solve();
+    vector<shared_ptr<Blob<Dtype> > > historyBefore, historyAfter;
+    int sizeBeforeSnapshot, sizeAfterSnapshot;
+    SolverState state;
+    historyBefore = this->solver_->history();
+    sizeBeforeSnapshot = historyBefore.size();
+    this->solver_->SnapshotSolverState(&state);
+    this->solver_->RestoreSolverState(state);
+    historyAfter = this->solver_->history();
+    sizeAfterSnapshot = historyAfter.size();
+    ASSERT_EQ(sizeAfterSnapshot, sizeBeforeSnapshot);
+    for (unsigned i = 0; i < sizeBeforeSnapshot; i++){
+    EXPECT_EQ(historyBefore[i]->cpu_data(), historyAfter[i]->cpu_data());
+}
+}
 };
 
 template <typename TypeParam>

--- a/src/caffe/test/test_gradient_based_solver.cpp
+++ b/src/caffe/test/test_gradient_based_solver.cpp
@@ -303,11 +303,9 @@ class GradientBasedSolverTest : public MultiDeviceTest<TypeParam> {
     // Check that the solver's solution matches ours.
     CheckLeastSquaresUpdate(updated_params);
   }
-};
 
 void TestHistorySnapshot()
   {
-
 	const Dtype learning_rate = 1.0;
 	const Dtype weight_decay = 0.0;
 	const Dtype momentum = 0.9;
@@ -378,6 +376,7 @@ void TestHistorySnapshot()
 	}
 
   }
+};
 
 template <typename TypeParam>
 class SGDSolverTest : public GradientBasedSolverTest<TypeParam> {


### PR DESCRIPTION
I have written some preliminary code to test Snapshot and Restore in the Solver. However, it wrecks the current interfaces by converting Snapshot, SnapshotSolverState and RestoreSolverState from protected members to public members. 

Is testing non public code frowned upon? If the answer to the previous question is no, then how do I go about testing protected members?
