### PR TITLE
Make IO dependencies optional (leveldb lmdb snappy hdf5 opencv)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
-# Use a build matrix to do two builds in parallel:
-# one using CMake, and one using make.
+# Use a build matrix to do builds in parallel:
 env:
   matrix:
     - WITH_CUDA=false WITH_CMAKE=false
     - WITH_CUDA=false WITH_CMAKE=true
     - WITH_CUDA=true WITH_CMAKE=false
     - WITH_CUDA=true WITH_CMAKE=true
+    - NO_IO_DEPENDENCIES=true WITH_CMAKE=false
 
 language: cpp
 

--- a/Makefile
+++ b/Makefile
@@ -165,9 +165,11 @@ ifneq ($(CPU_ONLY), 1)
 	LIBRARY_DIRS += $(CUDA_LIB_DIR)
 	LIBRARIES := cudart cublas curand
 endif
-LIBRARIES += glog gflags protobuf leveldb snappy \
-	lmdb boost_system hdf5_hl hdf5 m \
-	opencv_core opencv_highgui opencv_imgproc
+ifneq ($(NO_IO_DEPENDENCIES), 1)
+	LIBRARIES += leveldb lmdb snappy hdf5_hl hdf5 \
+               opencv_core opencv_highgui opencv_imgproc
+endif
+LIBRARIES += glog gflags protobuf m boost_system
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare
 
@@ -294,6 +296,11 @@ ifeq ($(CPU_ONLY), 1)
 	ALL_WARNS := $(ALL_CXX_WARNS)
 	TEST_FILTER := --gtest_filter="-*GPU*"
 	COMMON_FLAGS += -DCPU_ONLY
+endif
+
+# No IO dependencies
+ifeq ($(NO_IO_DEPENDENCIES), 1)
+	COMMON_FLAGS += -DNO_IO_DEPENDENCIES
 endif
 
 # Python layer support

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -7,6 +7,9 @@
 # CPU-only switch (uncomment to build without GPU support).
 # CPU_ONLY := 1
 
+# Removes IO dependencies and related code: leveldb lmdb snappy hdf5 opencv
+# NO_IO_DEPENDENCIES := 1
+
 # To customize your choice of compiler, uncomment and set the following.
 # N.B. the default for Linux is g++ and the default for OSX is clang++
 # CUSTOM_CXX := g++

--- a/examples/mnist/convert_mnist_data.cpp
+++ b/examples/mnist/convert_mnist_data.cpp
@@ -6,6 +6,8 @@
 // The MNIST dataset could be downloaded at
 //    http://yann.lecun.com/exdb/mnist/
 
+#ifndef NO_IO_DEPENDENCIES
+
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <google/protobuf/text_format.h>
@@ -196,3 +198,10 @@ int main(int argc, char** argv) {
   }
   return 0;
 }
+
+#else
+#include <stdio.h>
+int main(int argc, char** argv) {
+  fprintf(stderr, "NO_IO_DEPENDENCIES false");
+}
+#endif

--- a/examples/siamese/convert_mnist_siamese_data.cpp
+++ b/examples/siamese/convert_mnist_siamese_data.cpp
@@ -5,6 +5,9 @@
 //    convert_mnist_data input_image_file input_label_file output_db_file
 // The MNIST dataset could be downloaded at
 //    http://yann.lecun.com/exdb/mnist/
+
+#ifndef NO_IO_DEPENDENCIES
+
 #include <fstream>  // NOLINT(readability/streams)
 #include <string>
 
@@ -121,3 +124,10 @@ int main(int argc, char** argv) {
   }
   return 0;
 }
+
+#else
+#include <stdio.h>
+int main(int argc, char** argv) {
+  fprintf(stderr, "NO_IO_DEPENDENCIES false");
+}
+#endif

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -65,8 +65,16 @@ private:\
 // is executed we will see a fatal log.
 #define NOT_IMPLEMENTED LOG(FATAL) << "Not Implemented Yet"
 
+#ifndef NO_IO_DEPENDENCIES
 // See PR #1236
 namespace cv { class Mat; }
+#else
+#define NO_IO LOG(FATAL) << "IO dependencies disabled, c.f. build options."
+
+namespace cv {
+class Mat {};
+}
+#endif
 
 namespace caffe {
 

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -6,7 +6,10 @@
 #include <vector>
 
 #include "boost/scoped_ptr.hpp"
+
+#ifndef NO_IO_DEPENDENCIES
 #include "hdf5.h"
+#endif
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
@@ -134,6 +137,8 @@ class DummyDataLayer : public Layer<Dtype> {
   vector<bool> refill_;
 };
 
+#ifndef NO_IO_DEPENDENCIES
+
 /**
  * @brief Provides data to the Net from HDF5 files.
  *
@@ -244,6 +249,8 @@ class ImageDataLayer : public BasePrefetchingDataLayer<Dtype> {
   int lines_id_;
 };
 
+#endif
+
 /**
  * @brief Provides data to the Net from memory.
  *
@@ -289,6 +296,8 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   bool has_new_data_;
 };
 
+#ifndef NO_IO_DEPENDENCIES
+
 /**
  * @brief Provides data to the Net from windows of images files, specified
  *        by a window data file.
@@ -324,6 +333,8 @@ class WindowDataLayer : public BasePrefetchingDataLayer<Dtype> {
   bool cache_images_;
   vector<std::pair<std::string, Datum > > image_database_cache_;
 };
+
+#endif
 
 }  // namespace caffe
 

--- a/include/caffe/util/db.hpp
+++ b/include/caffe/util/db.hpp
@@ -3,9 +3,11 @@
 
 #include <string>
 
+#ifndef NO_IO_DEPENDENCIES
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
 #include "lmdb.h"
+#endif
 
 #include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"
@@ -48,6 +50,8 @@ class DB {
 
   DISABLE_COPY_AND_ASSIGN(DB);
 };
+
+#ifndef NO_IO_DEPENDENCIES
 
 class LevelDBCursor : public Cursor {
  public:
@@ -180,6 +184,8 @@ class LMDB : public DB {
   MDB_env* mdb_env_;
   MDB_dbi mdb_dbi_;
 };
+
+#endif
 
 DB* GetDB(DataParameter::DB backend);
 DB* GetDB(const string& backend);

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -5,8 +5,10 @@
 #include <string>
 
 #include "google/protobuf/message.h"
+#ifndef NO_IO_DEPENDENCIES
 #include "hdf5.h"
 #include "hdf5_hl.h"
+#endif
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
@@ -140,6 +142,7 @@ cv::Mat DecodeDatumToCVMat(const Datum& datum, bool is_color);
 
 void CVMatToDatum(const cv::Mat& cv_img, Datum* datum);
 
+#ifndef NO_IO_DEPENDENCIES
 template <typename Dtype>
 void hdf5_load_nd_dataset_helper(
     hid_t file_id, const char* dataset_name_, int min_dim, int max_dim,
@@ -153,6 +156,7 @@ void hdf5_load_nd_dataset(
 template <typename Dtype>
 void hdf5_save_nd_dataset(
     const hid_t file_id, const string& dataset_name, const Blob<Dtype>& blob);
+#endif
 
 }  // namespace caffe
 

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -1,4 +1,6 @@
+#ifndef NO_IO_DEPENDENCIES
 #include <opencv2/core/core.hpp>
+#endif
 
 #include <string>
 #include <vector>
@@ -196,6 +198,7 @@ void DataTransformer<Dtype>::Transform(const vector<cv::Mat> & mat_vector,
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
                                        Blob<Dtype>* transformed_blob) {
+#ifndef NO_IO_DEPENDENCIES
   const int img_channels = cv_img.channels();
   const int img_height = cv_img.rows;
   const int img_width = cv_img.cols;
@@ -292,6 +295,9 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
       }
     }
   }
+#else
+  NO_IO;
+#endif
 }
 
 template<typename Dtype>

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -1,5 +1,6 @@
+#ifndef NO_IO_DEPENDENCIES
 #include <opencv2/core/core.hpp>
-
+#endif
 #include <stdint.h>
 
 #include <string>
@@ -125,12 +126,16 @@ void DataLayer<Dtype>::InternalThreadEntry() {
       } else {
         cv_img = DecodeDatumToCVMatNative(datum);
       }
+#ifndef NO_IO_DEPENDENCIES
       if (cv_img.channels() != this->transformed_data_.channels()) {
         LOG(WARNING) << "Your dataset contains encoded images with mixed "
         << "channel sizes. Consider adding a 'force_color' flag to the "
         << "model definition, or rebuild your dataset using "
         << "convert_imageset.";
       }
+#else
+  NO_IO;
+#endif
     }
     read_time += timer.MicroSeconds();
     timer.Start();

--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -6,6 +6,9 @@ TODO:
   :: don't forget to update hdf5_daa_layer.cu accordingly
 - add ability to shuffle filenames if flag is set
 */
+
+#ifndef NO_IO_DEPENDENCIES
+
 #include <fstream>  // NOLINT(readability/streams)
 #include <string>
 #include <vector>
@@ -165,3 +168,5 @@ INSTANTIATE_CLASS(HDF5DataLayer);
 REGISTER_LAYER_CLASS(HDF5Data);
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/layers/hdf5_data_layer.cu
+++ b/src/caffe/layers/hdf5_data_layer.cu
@@ -3,6 +3,8 @@ TODO:
 - only load parts of the file, in accordance with a prototxt param "max_mem"
 */
 
+#ifndef NO_IO_DEPENDENCIES
+
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -51,3 +53,5 @@ void HDF5DataLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 INSTANTIATE_LAYER_GPU_FUNCS(HDF5DataLayer);
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/layers/hdf5_output_layer.cpp
+++ b/src/caffe/layers/hdf5_output_layer.cpp
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <vector>
 
 #include "hdf5.h"
@@ -75,3 +77,5 @@ INSTANTIATE_CLASS(HDF5OutputLayer);
 REGISTER_LAYER_CLASS(HDF5Output);
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/layers/hdf5_output_layer.cu
+++ b/src/caffe/layers/hdf5_output_layer.cu
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <vector>
 
 #include "hdf5.h"
@@ -41,3 +43,5 @@ void HDF5OutputLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
 INSTANTIATE_LAYER_GPU_FUNCS(HDF5OutputLayer);
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -1,5 +1,6 @@
-#include <opencv2/core/core.hpp>
+#ifndef NO_IO_DEPENDENCIES
 
+#include <opencv2/core/core.hpp>
 #include <fstream>  // NOLINT(readability/streams)
 #include <iostream>  // NOLINT(readability/streams)
 #include <string>
@@ -163,3 +164,6 @@ INSTANTIATE_CLASS(ImageDataLayer);
 REGISTER_LAYER_CLASS(ImageData);
 
 }  // namespace caffe
+
+#endif
+

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -1,4 +1,6 @@
+#ifndef NO_IO_DEPENDENCIES
 #include <opencv2/core/core.hpp>
+#endif
 
 #include <vector>
 

--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <opencv2/highgui/highgui_c.h>
 #include <stdint.h>
 
@@ -7,9 +9,11 @@
 #include <utility>
 #include <vector>
 
+#ifndef NO_IO_DEPENDENCIES
 #include "opencv2/core/core.hpp"
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
+#endif
 
 #include "caffe/common.hpp"
 #include "caffe/data_layers.hpp"
@@ -464,3 +468,5 @@ INSTANTIATE_CLASS(WindowDataLayer);
 REGISTER_LAYER_CLASS(WindowData);
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/test/test_data_layer.cpp
+++ b/src/caffe/test/test_data_layer.cpp
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <string>
 #include <vector>
 
@@ -425,3 +427,5 @@ TYPED_TEST(DataLayerTest, TestReadCropTestLMDB) {
 }
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/test/test_data_transformer.cpp
+++ b/src/caffe/test/test_data_transformer.cpp
@@ -2,7 +2,6 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "leveldb/db.h"
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"

--- a/src/caffe/test/test_db.cpp
+++ b/src/caffe/test/test_db.cpp
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <string>
 
 #include "boost/scoped_ptr.hpp"
@@ -132,3 +134,5 @@ TYPED_TEST(DBTest, TestWrite) {
 }
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/test/test_hdf5_output_layer.cpp
+++ b/src/caffe/test/test_hdf5_output_layer.cpp
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <string>
 #include <vector>
 
@@ -118,3 +120,5 @@ TYPED_TEST(HDF5OutputLayerTest, TestForward) {
 }
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/test/test_hdf5data_layer.cpp
+++ b/src/caffe/test/test_hdf5data_layer.cpp
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <string>
 #include <vector>
 
@@ -133,3 +135,5 @@ TYPED_TEST(HDF5DataLayerTest, TestRead) {
 }
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/test/test_image_data_layer.cpp
+++ b/src/caffe/test/test_image_data_layer.cpp
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <map>
 #include <string>
 #include <vector>
@@ -177,3 +179,5 @@ TYPED_TEST(ImageDataLayerTest, TestShuffle) {
 }
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/test/test_io.cpp
+++ b/src/caffe/test/test_io.cpp
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/highgui/highgui_c.h>
@@ -420,3 +422,5 @@ TEST_F(IOTest, TestDecodeDatumToCVMatContentNative) {
 }
 
 }  // namespace caffe
+
+#endif

--- a/src/caffe/test/test_memory_data_layer.cpp
+++ b/src/caffe/test/test_memory_data_layer.cpp
@@ -1,4 +1,6 @@
+#ifndef NO_IO_DEPENDENCIES
 #include <opencv2/core/core.hpp>
+#endif
 
 #include <string>
 #include <vector>
@@ -167,6 +169,8 @@ TYPED_TEST(MemoryDataLayerTest, AddDatumVectorDefaultTransform) {
   }
 }
 
+#ifndef NO_IO_DEPENDENCIES
+
 TYPED_TEST(MemoryDataLayerTest, AddMatVectorDefaultTransform) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter param;
@@ -292,5 +296,7 @@ TYPED_TEST(MemoryDataLayerTest, TestSetBatchSize) {
     }
   }
 }
+
+#endif
 
 }  // namespace caffe

--- a/src/caffe/test/test_upgrade_proto.cpp
+++ b/src/caffe/test/test_upgrade_proto.cpp
@@ -1,3 +1,5 @@
+#ifndef NO_IO_DEPENDENCIES
+
 #include <cstring>
 #include <string>
 #include <vector>
@@ -2907,3 +2909,5 @@ TEST_F(NetUpgradeTest, TestUpgradeV1LayerType) {
 }
 
 }  // NOLINT(readability/fn_size)  // namespace caffe
+
+#endif

--- a/src/caffe/util/db.cpp
+++ b/src/caffe/util/db.cpp
@@ -5,6 +5,8 @@
 
 namespace caffe { namespace db {
 
+#ifndef NO_IO_DEPENDENCIES
+
 const size_t LMDB_MAP_SIZE = 1099511627776;  // 1 TB
 
 void LevelDB::Open(const string& source, Mode mode) {
@@ -59,25 +61,30 @@ void LMDBTransaction::Put(const string& key, const string& value) {
   MDB_CHECK(mdb_put(mdb_txn_, *mdb_dbi_, &mdb_key, &mdb_value, 0));
 }
 
+#endif
+
 DB* GetDB(DataParameter::DB backend) {
   switch (backend) {
+#ifndef NO_IO_DEPENDENCIES
   case DataParameter_DB_LEVELDB:
     return new LevelDB();
   case DataParameter_DB_LMDB:
     return new LMDB();
+#endif
   default:
     LOG(FATAL) << "Unknown database backend";
   }
 }
 
 DB* GetDB(const string& backend) {
+#ifndef NO_IO_DEPENDENCIES
   if (backend == "leveldb") {
     return new LevelDB();
   } else if (backend == "lmdb") {
     return new LMDB();
-  } else {
-    LOG(FATAL) << "Unknown database backend";
   }
+#endif
+  LOG(FATAL) << "Unknown database backend";
 }
 
 }  // namespace db


### PR DESCRIPTION
It's probably not what you want to do in the long run, but it's simple and fits the use case of embedding Caffe in another framework. That's by far the most important aspect of dependency management for us and probably a lot of people. As you suggested last week data can be processed externally and provided through the memory_data_layer.

The cmake build would need to get updated, I can look at it if you are interested to merge this. 