### PR TITLE
Check that count does not overflow in Blob::Reshape

### DIFF
--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -26,6 +26,7 @@ void Blob<Dtype>::Reshape(const vector<int>& shape) {
   shape_.resize(shape.size());
   for (int i = 0; i < shape.size(); ++i) {
     CHECK_GE(shape[i], 0);
+    CHECK_LE(shape[i], INT_MAX / count_) << "blob size exceeds INT_MAX";
     count_ *= shape[i];
     shape_[i] = shape[i];
   }


### PR DESCRIPTION
`master`/nd blob edition of #1584, using the method suggested by @jeffdonahue.

As far as I can tell, it's still possible to overflow `count`, leading to bad allocations and other incorrect behavior; this should prevent that.