### PR TITLE
Fixed wrong io import in Python 3

### DIFF
--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -3,4 +3,4 @@ from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector
-import io
+from . import io


### PR DESCRIPTION
The Python standard lib has a module called `io`, so instead of Python 3
throwing an error at `import io`, it imports the wrong module without complaining.