### PR TITLE
Use bp::object instead of PyObject* for self in Python layer

### DIFF
--- a/include/caffe/python_layer.hpp
+++ b/include/caffe/python_layer.hpp
@@ -14,12 +14,12 @@ template <typename Dtype>
 class PythonLayer : public Layer<Dtype> {
  public:
   PythonLayer(PyObject* self, const LayerParameter& param)
-      : Layer<Dtype>(param), self_(self) { }
+      : Layer<Dtype>(param), self_(bp::handle<>(bp::borrowed(self))) { }
 
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
     try {
-      bp::call_method<bp::object>(self_, "setup", bottom, top);
+      self_.attr("setup")(bottom, top);
     } catch (bp::error_already_set) {
       PyErr_Print();
       throw;
@@ -29,7 +29,7 @@ class PythonLayer : public Layer<Dtype> {
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
     try {
-      bp::call_method<bp::object>(self_, "reshape", bottom, top);
+      self_.attr("reshape")(bottom, top);
     } catch (bp::error_already_set) {
       PyErr_Print();
       throw;
@@ -42,7 +42,7 @@ class PythonLayer : public Layer<Dtype> {
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
     try {
-      bp::call_method<bp::object>(self_, "forward", bottom, top);
+      self_.attr("forward")(bottom, top);
     } catch (bp::error_already_set) {
       PyErr_Print();
       throw;
@@ -51,8 +51,7 @@ class PythonLayer : public Layer<Dtype> {
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
     try {
-      bp::call_method<bp::object>(self_, "backward", top, propagate_down,
-          bottom);
+      self_.attr("backward")(top, propagate_down, bottom);
     } catch (bp::error_already_set) {
       PyErr_Print();
       throw;
@@ -60,7 +59,7 @@ class PythonLayer : public Layer<Dtype> {
   }
 
  private:
-  PyObject* self_;
+  bp::object self_;
 };
 
 }  // namespace caffe


### PR DESCRIPTION
From @tnarihi in #2001. Rather than couple it to the other changes in that PR, I've extracted this little cleanup for immediate review and merge.

@tnarihi, I've used your author information here; let me know if there are any issues with that.