### PR TITLE
Remove superfluous empty destructors

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -29,7 +29,6 @@ template <typename Dtype>
 class BaseDataLayer : public Layer<Dtype> {
  public:
   explicit BaseDataLayer(const LayerParameter& param);
-  virtual ~BaseDataLayer() {}
   // LayerSetUp: implements common data layer setup functionality, and calls
   // DataLayerSetUp to do special data layer setup for individual layer types.
   // This method may not be overridden except by the BasePrefetchingDataLayer.
@@ -58,7 +57,6 @@ class BasePrefetchingDataLayer :
  public:
   explicit BasePrefetchingDataLayer(const LayerParameter& param)
       : BaseDataLayer<Dtype>(param) {}
-  virtual ~BasePrefetchingDataLayer() {}
   // LayerSetUp: implements common data layer setup functionality, and calls
   // DataLayerSetUp to do special data layer setup for individual layer types.
   // This method may not be overridden.


### PR DESCRIPTION
As described at https://github.com/BVLC/caffe/pull/2396#issuecomment-97634152, defining empty (virtual) destructors in derived classes does nothing. This PR simply removes existing superfluous destructors.