### PR TITLE
Handle Python layer exceptions correctly

### DIFF
--- a/include/caffe/python_layer.hpp
+++ b/include/caffe/python_layer.hpp
@@ -18,22 +18,11 @@ class PythonLayer : public Layer<Dtype> {
 
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-    try {
-      self_.attr("setup")(bottom, top);
-    } catch (bp::error_already_set) {
-      PyErr_Print();
-      throw;
-    }
+    self_.attr("setup")(bottom, top);
   }
-
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-    try {
-      self_.attr("reshape")(bottom, top);
-    } catch (bp::error_already_set) {
-      PyErr_Print();
-      throw;
-    }
+    self_.attr("reshape")(bottom, top);
   }
 
   virtual inline const char* type() const { return "Python"; }
@@ -41,21 +30,11 @@ class PythonLayer : public Layer<Dtype> {
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-    try {
-      self_.attr("forward")(bottom, top);
-    } catch (bp::error_already_set) {
-      PyErr_Print();
-      throw;
-    }
+    self_.attr("forward")(bottom, top);
   }
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-    try {
-      self_.attr("backward")(top, propagate_down, bottom);
-    } catch (bp::error_already_set) {
-      PyErr_Print();
-      throw;
-    }
+    self_.attr("backward")(top, propagate_down, bottom);
   }
 
  private:

--- a/python/caffe/test/test_python_layer.py
+++ b/python/caffe/test/test_python_layer.py
@@ -21,6 +21,13 @@ class SimpleLayer(caffe.Layer):
         bottom[0].diff[...] = 10 * top[0].diff
 
 
+class ExceptionLayer(caffe.Layer):
+    """A layer for checking exceptions from Python"""
+
+    def setup(self, bottom, top):
+        raise RuntimeError
+
+
 def python_net_file():
     with tempfile.NamedTemporaryFile(delete=False) as f:
         f.write("""name: 'pythonnet' force_backward: true
@@ -31,6 +38,16 @@ def python_net_file():
           python_param { module: 'test_python_layer' layer: 'SimpleLayer' } }
         layer { type: 'Python' name: 'three' bottom: 'two' top: 'three'
           python_param { module: 'test_python_layer' layer: 'SimpleLayer' } }""")
+        return f.name
+
+
+def exception_net_file():
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write("""name: 'pythonnet' force_backward: true
+        input: 'data' input_shape { dim: 10 dim: 9 dim: 8 }
+        layer { type: 'Python' name: 'layer' bottom: 'data' top: 'top'
+          python_param { module: 'test_python_layer' layer: 'ExceptionLayer' } }
+          """)
         return f.name
 
 
@@ -61,3 +78,8 @@ class TestPythonLayer(unittest.TestCase):
         for blob in self.net.blobs.itervalues():
             for d in blob.data.shape:
                 self.assertEqual(s, d)
+
+    def test_exception(self):
+        net_file = exception_net_file()
+        self.assertRaises(RuntimeError, caffe.Net, net_file, caffe.TEST)
+        os.remove(net_file)

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -8,6 +8,11 @@
 #include "boost/algorithm/string.hpp"
 #include "caffe/caffe.hpp"
 
+#ifdef WITH_PYTHON_LAYER
+#include "boost/python.hpp"
+namespace bp = boost::python;
+#endif
+
 using caffe::Blob;
 using caffe::Caffe;
 using caffe::Net;
@@ -304,7 +309,16 @@ int main(int argc, char** argv) {
   // Run tool or show usage.
   caffe::GlobalInit(&argc, &argv);
   if (argc == 2) {
-    return GetBrewFunction(caffe::string(argv[1]))();
+#ifdef WITH_PYTHON_LAYER
+    try {
+#endif
+      return GetBrewFunction(caffe::string(argv[1]))();
+#ifdef WITH_PYTHON_LAYER
+    } catch (bp::error_already_set) {
+      PyErr_Print();
+      return 1;
+    }
+#endif
   } else {
     gflags::ShowUsageWithFlagsRestrict(argv[0], "tools/caffe");
   }


### PR DESCRIPTION
(This is a simplified alternative implementation of part of the first commit of #2001, plus a test.)

As noted by @tnarihi, Python layer exceptions are not handled correctly in pycaffe. `PyErr_Print` is used to display exception text on stderr, but this has the side effect of clearing the exception, which results in an additional `SystemError: NULL return without exception set`.

The exceptions get passed through correctly if we simply don't try to catch and print them; that's the first commit. (Note that the Python interpreter _will_ print these exceptions, if uncaught; it's only the `caffe` tool that won't.) Since we'd still like to see the exception text when using the `caffe` tool, the second commit adds a single, `ifdef`ed, `catch`/`PyErr_Print` block to the tool code. (There's no harm in calling `PyErr_Print` since we know we're not in the interpreter.)

I prefer this approach to the one in #2001, for these reasons:
* it simplifies the Python wrapper code, removing the duplicate error catching blocks
* it removes the need to think about where exceptions might occur in future wrapper code
* it avoids the business of embedding Python calls to read (and restore) the exception
* calling code (from C++) has the option of avoiding the exception printout (e.g., and dealing with the exception)

The disadvantage of this approach is that:
* Python exceptions won't be automatically printed when invoking nets with Python layers from C++ code (outside the Python interpreter) other than the `caffe` tool

Let me know what you think @tnarihi and others, and thanks @tnarihi for pointing out this issue. (Note also that this does not include _all_ of the exception-fixing functionality from #2001, which I'll plan to check out separately.)
