### PR TITLE
int->size_t to support large datasets more than 2G instances

### DIFF
--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -41,6 +41,7 @@ bool ReadProtoFromTextFile(const char* filename, Message* proto) {
 
 void WriteProtoToTextFile(const Message& proto, const char* filename) {
   int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  CHECK_NE(fd, -1) << "Filei path not exists: " << filename;
   FileOutputStream* output = new FileOutputStream(fd);
   CHECK(google::protobuf::TextFormat::Print(proto, output));
   delete output;
@@ -64,6 +65,7 @@ bool ReadProtoFromBinaryFile(const char* filename, Message* proto) {
 
 void WriteProtoToBinaryFile(const Message& proto, const char* filename) {
   fstream output(filename, ios::out | ios::trunc | ios::binary);
+  CHECK(output) << "File path not exists: " << filename;
   CHECK(proto.SerializeToOstream(&output));
 }
 


### PR DESCRIPTION
When I was trying to use Caffe to train my large dataset (billions of instances), I found the class 'SyncedMemory' uses data type 'size_t' to alloc memories, while blob.count_ and blob.capacity_ is of type 'int'. As a result, this have cut off the alloc size to less than 2GB, and my experiment was failed due to the pointer overflow.
This patch fixed the data size related types from int to size_t that guarantee to use the correct size on 64bit machine, even though dataset size is over 2 billions.

Thanks for the review.