### PR TITLE
[bug] fix blob_loss_weights index in test() in caffe.cpp

### DIFF
--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -187,8 +187,8 @@ int test() {
   for (int i = 0; i < test_score.size(); ++i) {
     const std::string& output_name = caffe_net.blob_names()[
         caffe_net.output_blob_indices()[test_score_output_id[i]]];
-    const float loss_weight =
-        caffe_net.blob_loss_weights()[caffe_net.output_blob_indices()[i]];
+    const float loss_weight = caffe_net.blob_loss_weights()[
+        caffe_net.output_blob_indices()[test_score_output_id[i]]];
     std::ostringstream loss_msg_stream;
     const float mean_score = test_score[i] / FLAGS_iterations;
     if (loss_weight) {


### PR DESCRIPTION
This PR fix a simple yet annoying bug in test() in caffe.cpp.
Currently `caffe test` crashes when there are many outputs in an output blob

A simple example to reproduce this bug:
`caffe test -model sample_net.prototxt -weights /dev/null`

where `sample_net.prototxt` is

    layer {
      name: 'data'
      type: 'DummyData'
      top: 'data'
      dummy_data_param {
        # it crashes when output blob has count >= 2, because of the bug in caffe.cpp
        shape { dim: 3 }
      }
    }
    layer {
      name: 'relu'
      type: 'ReLU'
      bottom: 'data'
      top: 'relu'
    }