### PR TITLE
Suppress output for python bindings

### DIFF
--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,6 +1,19 @@
+# Suppress GLOG output for python bindings
+# unless explicitly requested in environment
+import os
+if 'GLOG_minloglevel' not in os.environ:
+    # Hide INFO and WARNING, show ERROR and FATAL
+    os.environ['GLOG_minloglevel'] = '2'
+    _unset_glog_level = True
+else:
+    _unset_glog_level = False
+
 from .pycaffe import Net, SGDSolver
 from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector
 from . import io
+
+if _unset_glog_level:
+    del os.environ['GLOG_minloglevel']


### PR DESCRIPTION
I'm tired of pycaffe printing hundreds of lines to stderr. See #789, #858 and #872 for discussions on why this was done by default for C++.

Is suppressing the output when using python a bad idea for any reason? Is there a better way to suppress the output than this (it's kinda hacky)? GLOG flags explained [here](https://google-glog.googlecode.com/svn/trunk/doc/glog.html#flags).