### PR TITLE
Add leading zeros (up to 10 digits) to keys in feature DB files + Bug fix regarding multiple features to be extracted

### DIFF
--- a/tools/extract_features.cpp
+++ b/tools/extract_features.cpp
@@ -157,7 +157,7 @@ int feature_extraction_pipeline(int argc, char** argv) {
         for (int d = 0; d < dim_features; ++d) {
           datum.add_float_data(feature_blob_data[d]);
         }
-        int length = snprintf(key_str, kMaxKeyStrLength, "%d",
+        int length = snprintf(key_str, kMaxKeyStrLength, "%010d",
             image_indices[i]);
         string out;
         CHECK(datum.SerializeToString(&out));

--- a/tools/extract_features.cpp
+++ b/tools/extract_features.cpp
@@ -122,9 +122,10 @@ int feature_extraction_pipeline(int argc, char** argv) {
 
   std::vector<shared_ptr<db::DB> > feature_dbs;
   std::vector<shared_ptr<db::Transaction> > txns;
+  const char* db_type = argv[++arg_pos];
   for (size_t i = 0; i < num_features; ++i) {
     LOG(INFO)<< "Opening dataset " << dataset_names[i];
-    shared_ptr<db::DB> db(db::GetDB(argv[++arg_pos]));
+    shared_ptr<db::DB> db(db::GetDB(db_type));
     db->Open(dataset_names.at(i), db::NEW);
     feature_dbs.push_back(db);
     shared_ptr<db::Transaction> txn(db->NewTransaction());


### PR DESCRIPTION
The feature extraction code, stores the features in a DB file using string keys generated from integer ids. The string keys are sorted alphabetically, and therefore, the order of features in the feature DB file becomes different from the order of images in the input DB file. (My experience is based on LMDB database.)

I have added some leading zeros to fix this.

There is also a bug with regard to the db_type when the number of features to be extracted is larger than 1. This bug happens because ++arg_pos is run multiple times.

I added a bug fix fir this to the PR too.
