### PR TITLE
Remove unnecessary filler parameter in the sample model

### DIFF
--- a/models/bvlc_googlenet/train_val.prototxt
+++ b/models/bvlc_googlenet/train_val.prototxt
@@ -61,7 +61,6 @@ layer {
     stride: 2
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -115,7 +114,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -148,7 +146,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -202,7 +199,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -234,7 +230,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.09
     }
     bias_filler {
       type: "constant"
@@ -267,7 +262,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -299,7 +293,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.2
     }
     bias_filler {
       type: "constant"
@@ -332,7 +325,6 @@ layer {
     kernel_size: 5
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -376,7 +368,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -417,7 +408,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -449,7 +439,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.09
     }
     bias_filler {
       type: "constant"
@@ -482,7 +471,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -514,7 +502,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.2
     }
     bias_filler {
       type: "constant"
@@ -547,7 +534,6 @@ layer {
     kernel_size: 5
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -591,7 +577,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -643,7 +628,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -675,7 +659,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.09
     }
     bias_filler {
       type: "constant"
@@ -708,7 +691,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -740,7 +722,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.2
     }
     bias_filler {
       type: "constant"
@@ -773,7 +754,6 @@ layer {
     kernel_size: 5
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -817,7 +797,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -869,7 +848,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.08
     }
     bias_filler {
       type: "constant"
@@ -900,7 +878,6 @@ layer {
     num_output: 1024
     weight_filler {
       type: "xavier"
-      std: 0.02
     }
     bias_filler {
       type: "constant"
@@ -940,7 +917,6 @@ layer {
     num_output: 1000
     weight_filler {
       type: "xavier"
-      std: 0.0009765625
     }
     bias_filler {
       type: "constant"
@@ -997,7 +973,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1029,7 +1004,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.09
     }
     bias_filler {
       type: "constant"
@@ -1062,7 +1036,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1094,7 +1067,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.2
     }
     bias_filler {
       type: "constant"
@@ -1127,7 +1099,6 @@ layer {
     kernel_size: 5
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1171,7 +1142,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -1212,7 +1182,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1244,7 +1213,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.09
     }
     bias_filler {
       type: "constant"
@@ -1277,7 +1245,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1309,7 +1276,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.2
     }
     bias_filler {
       type: "constant"
@@ -1342,7 +1308,6 @@ layer {
     kernel_size: 5
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1386,7 +1351,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -1427,7 +1391,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1459,7 +1422,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.09
     }
     bias_filler {
       type: "constant"
@@ -1492,7 +1454,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1524,7 +1485,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.2
     }
     bias_filler {
       type: "constant"
@@ -1557,7 +1517,6 @@ layer {
     kernel_size: 5
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1601,7 +1560,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -1653,7 +1611,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.08
     }
     bias_filler {
       type: "constant"
@@ -1684,7 +1641,6 @@ layer {
     num_output: 1024
     weight_filler {
       type: "xavier"
-      std: 0.02
     }
     bias_filler {
       type: "constant"
@@ -1724,7 +1680,6 @@ layer {
     num_output: 1000
     weight_filler {
       type: "xavier"
-      std: 0.0009765625
     }
     bias_filler {
       type: "constant"
@@ -1781,7 +1736,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1813,7 +1767,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.09
     }
     bias_filler {
       type: "constant"
@@ -1846,7 +1799,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1878,7 +1830,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.2
     }
     bias_filler {
       type: "constant"
@@ -1911,7 +1862,6 @@ layer {
     kernel_size: 5
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -1955,7 +1905,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -2007,7 +1956,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -2039,7 +1987,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.09
     }
     bias_filler {
       type: "constant"
@@ -2072,7 +2019,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -2104,7 +2050,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.2
     }
     bias_filler {
       type: "constant"
@@ -2137,7 +2082,6 @@ layer {
     kernel_size: 5
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -2181,7 +2125,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"
@@ -2222,7 +2165,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -2254,7 +2196,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.09
     }
     bias_filler {
       type: "constant"
@@ -2287,7 +2228,6 @@ layer {
     kernel_size: 3
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -2319,7 +2259,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.2
     }
     bias_filler {
       type: "constant"
@@ -2352,7 +2291,6 @@ layer {
     kernel_size: 5
     weight_filler {
       type: "xavier"
-      std: 0.03
     }
     bias_filler {
       type: "constant"
@@ -2396,7 +2334,6 @@ layer {
     kernel_size: 1
     weight_filler {
       type: "xavier"
-      std: 0.1
     }
     bias_filler {
       type: "constant"


### PR DESCRIPTION
Unnecessary filler parameters, 'std', were used with Xavier weight fillers in bvlc_googlenet model.