### PR TITLE
First attemp to remove boost dependecies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ include(cmake/Dependencies.cmake)
 
 # ---[ Flags
 if(UNIX OR APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -std=c++11")
 endif()
 
 if(USE_libstdcpp)

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ ifneq ($(CPU_ONLY), 1)
 	LIBRARIES := cudart cublas curand
 endif
 LIBRARIES += glog gflags protobuf leveldb snappy \
-	lmdb boost_system hdf5_hl hdf5 m \
+	lmdb hdf5_hl hdf5 m \
 	opencv_core opencv_highgui opencv_imgproc
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare
@@ -233,7 +233,7 @@ ifeq ($(LINUX), 1)
 	endif
 	# boost::thread is reasonably called boost_thread (compare OS X)
 	# We will also explicitly add stdc++ to the link target.
-	LIBRARIES += boost_thread stdc++
+	LIBRARIES += stdc++
 endif
 
 # OS X:
@@ -253,7 +253,7 @@ ifeq ($(OSX), 1)
 	# gtest needs to use its own tuple to not conflict with clang
 	COMMON_FLAGS += -DGTEST_USE_OWN_TR1_TUPLE=1
 	# boost::thread is called boost_thread-mt to mark multithreading on OS X
-	LIBRARIES += boost_thread-mt
+	#LIBRARIES += boost_thread-mt
 	# we need to explicitly ask for the rpath to be obeyed
 	DYNAMIC_FLAGS := -install_name @rpath/libcaffe.so
 	ORIGIN := @loader_path
@@ -344,16 +344,18 @@ LIBRARY_DIRS += $(BLAS_LIB)
 
 LIBRARY_DIRS += $(LIB_BUILD_DIR)
 
+INCLUDE_DIRS += /usr/include/hdf5/serial
+
 # Automatic dependency generation (nvcc is handled separately)
 CXXFLAGS += -MMD -MP
 
 # Complete build flags.
 COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
-CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
-NVCCFLAGS += -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS)
+CXXFLAGS += -pthread -fPIC -std=c++11 $(COMMON_FLAGS) $(WARNINGS)
+NVCCFLAGS += -ccbin=$(CXX) -Xcompiler -fPIC -std=c++11 $(COMMON_FLAGS)
 # mex may invoke an older gcc that is too liberal with -Wuninitalized
 MATLAB_CXXFLAGS := $(CXXFLAGS) -Wno-uninitialized
-LINKFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
+LINKFLAGS += -pthread -fPIC -std=c++11 $(COMMON_FLAGS) $(WARNINGS)
 
 USE_PKG_CONFIG ?= 0
 ifeq ($(USE_PKG_CONFIG), 1)
@@ -441,7 +443,7 @@ py: $(PY$(PROJECT)_SO) $(PROTO_GEN_PY)
 
 $(PY$(PROJECT)_SO): $(PY$(PROJECT)_SRC) $(PY$(PROJECT)_HXX) | $(DYNAMIC_NAME)
 	@ echo CXX/LD -o $@ $<
-	$(Q)$(CXX) -shared -o $@ $(PY$(PROJECT)_SRC) \
+	$(Q)$(CXX) -std=c++11 -shared -o $@ $(PY$(PROJECT)_SRC) \
 		-o $@ $(LINKFLAGS) -l$(PROJECT) $(PYTHON_LDFLAGS) \
 		-Wl,-rpath,$(ORIGIN)/../../build/lib
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -2,9 +2,9 @@
 set(Caffe_LINKER_LIBS "")
 
 # ---[ Boost
-find_package(Boost 1.46 REQUIRED COMPONENTS system thread)
-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
-list(APPEND Caffe_LINKER_LIBS ${Boost_LIBRARIES})
+#find_package(Boost 1.46 REQUIRED COMPONENTS system thread)
+#include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+#list(APPEND Caffe_LINKER_LIBS ${Boost_LIBRARIES})
 
 # ---[ Threads
 find_package(Threads REQUIRED)

--- a/examples/cifar10/convert_cifar_data.cpp
+++ b/examples/cifar10/convert_cifar_data.cpp
@@ -7,9 +7,9 @@
 //    http://www.cs.toronto.edu/~kriz/cifar.html
 
 #include <fstream>  // NOLINT(readability/streams)
+#include <memory>
 #include <string>
 
-#include "boost/scoped_ptr.hpp"
 #include "glog/logging.h"
 #include "google/protobuf/text_format.h"
 #include "stdint.h"
@@ -18,7 +18,7 @@
 #include "caffe/util/db.hpp"
 
 using caffe::Datum;
-using boost::scoped_ptr;
+using std::unique_ptr;
 using std::string;
 namespace db = caffe::db;
 
@@ -37,9 +37,9 @@ void read_image(std::ifstream* file, int* label, char* buffer) {
 
 void convert_dataset(const string& input_folder, const string& output_folder,
     const string& db_type) {
-  scoped_ptr<db::DB> train_db(db::GetDB(db_type));
+  unique_ptr<db::DB> train_db(db::GetDB(db_type));
   train_db->Open(output_folder + "/cifar10_train_" + db_type, db::NEW);
-  scoped_ptr<db::Transaction> txn(train_db->NewTransaction());
+  unique_ptr<db::Transaction> txn(train_db->NewTransaction());
   // Data buffer
   int label;
   char str_buffer[kCIFARImageNBytes];
@@ -71,7 +71,7 @@ void convert_dataset(const string& input_folder, const string& output_folder,
   train_db->Close();
 
   LOG(INFO) << "Writing Testing data";
-  scoped_ptr<db::DB> test_db(db::GetDB(db_type));
+  unique_ptr<db::DB> test_db(db::GetDB(db_type));
   test_db->Open(output_folder + "/cifar10_test_" + db_type, db::NEW);
   txn.reset(test_db->NewTransaction());
   // Open files

--- a/examples/cpp_classification/classification.cpp
+++ b/examples/cpp_classification/classification.cpp
@@ -1,12 +1,17 @@
-#include <caffe/caffe.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
+
+#include <caffe/caffe.hpp>
+
+#include <iomanip>
 #include <iosfwd>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+
 
 using namespace caffe;  // NOLINT(build/namespaces)
 using std::string;

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -1,7 +1,6 @@
 #ifndef CAFFE_BLOB_HPP_
 #define CAFFE_BLOB_HPP_
 
-#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -1,7 +1,6 @@
 #ifndef CAFFE_COMMON_HPP_
 #define CAFFE_COMMON_HPP_
 
-#include <boost/shared_ptr.hpp>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
@@ -10,6 +9,7 @@
 #include <fstream>  // NOLINT(readability/streams)
 #include <iostream>  // NOLINT(readability/streams)
 #include <map>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <string>
@@ -70,9 +70,8 @@ namespace cv { class Mat; }
 
 namespace caffe {
 
-// We will use the boost shared_ptr instead of the new C++11 one mainly
-// because cuda does not work (at least now) well with C++11 features.
-using boost::shared_ptr;
+
+using std::shared_ptr;
 
 // Common functions and classes from std that caffe often uses.
 using std::fstream;
@@ -106,7 +105,7 @@ class Caffe {
   }
   enum Brew { CPU, GPU };
 
-  // This random number generator facade hides boost and CUDA rng
+  // This random number generator facade hides std and CUDA rng
   // implementation from one another (for cross-platform compatibility).
   class RNG {
    public:
@@ -117,10 +116,10 @@ class Caffe {
     void* generator();
    private:
     class Generator;
-    shared_ptr<Generator> generator_;
+    std::shared_ptr<Generator> generator_;
   };
 
-  // Getters for boost rng, curand, and cublas handles
+  // Getters for std rng, curand, and cublas handles
   inline static RNG& rng_stream() {
     if (!Get().random_generator_) {
       Get().random_generator_.reset(new RNG());
@@ -142,7 +141,7 @@ class Caffe {
   // freed in a non-pinned way, which may cause problems - I haven't verified
   // it personally but better to note it here in the header file.
   inline static void set_mode(Brew mode) { Get().mode_ = mode; }
-  // Sets the random seed of both boost and curand
+  // Sets the random seed of both std and curand
   static void set_random_seed(const unsigned int seed);
   // Sets the device. Since we have cublas and curand stuff, set device also
   // requires us to reset those values.

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -5,7 +5,6 @@
 #include <utility>
 #include <vector>
 
-#include "boost/scoped_ptr.hpp"
 #include "hdf5.h"
 
 #include "caffe/blob.hpp"

--- a/include/caffe/internal_thread.hpp
+++ b/include/caffe/internal_thread.hpp
@@ -1,18 +1,13 @@
 #ifndef CAFFE_INTERNAL_THREAD_HPP_
 #define CAFFE_INTERNAL_THREAD_HPP_
+#include <thread>
 
 #include "caffe/common.hpp"
-
-/**
- Forward declare boost::thread instead of including boost/thread.hpp
- to avoid a boost/NVCC issues (#1009, #1010) on OSX.
- */
-namespace boost { class thread; }
 
 namespace caffe {
 
 /**
- * Virtual class encapsulate boost::thread for use in base class
+ * Virtual class encapsulate std::thread for use in base class
  * The child class will acquire the ability to run a single thread,
  * by reimplementing the virutal function InternalThreadEntry.
  */
@@ -34,7 +29,7 @@ class InternalThread {
       with the code you want your thread to run. */
   virtual void InternalThreadEntry() {}
 
-  shared_ptr<boost::thread> thread_;
+  shared_ptr<std::thread> thread_;
 };
 
 }  // namespace caffe

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -1,7 +1,6 @@
 #ifndef CAFFE_LAYER_H_
 #define CAFFE_LAYER_H_
 
-#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/include/caffe/util/benchmark.hpp
+++ b/include/caffe/util/benchmark.hpp
@@ -1,7 +1,7 @@
 #ifndef CAFFE_UTIL_BENCHMARK_H_
 #define CAFFE_UTIL_BENCHMARK_H_
 
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <chrono>
 
 #include "caffe/util/device_alternate.hpp"
 
@@ -31,8 +31,11 @@ class Timer {
   cudaEvent_t start_gpu_;
   cudaEvent_t stop_gpu_;
 #endif
-  boost::posix_time::ptime start_cpu_;
-  boost::posix_time::ptime stop_cpu_;
+  typedef std::chrono::high_resolution_clock clock;
+  typedef std::chrono::microseconds microseconds;
+  typedef std::chrono::milliseconds milliseconds;
+  clock::time_point start_cpu_;
+  clock::time_point stop_cpu_;
   float elapsed_milliseconds_;
   float elapsed_microseconds_;
 };

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -3,6 +3,8 @@
 
 #include <unistd.h>
 #include <string>
+#include <vector>
+
 
 #include "google/protobuf/message.h"
 #include "hdf5.h"
@@ -140,6 +142,21 @@ cv::Mat DecodeDatumToCVMat(const Datum& datum, bool is_color);
 
 void CVMatToDatum(const cv::Mat& cv_img, Datum* datum);
 
+inline void string_split(vector<string>* tokens, const string& str,
+    const string& delimiters) {
+  // Skip delimiters at beginning.
+  string::size_type lastPos = str.find_first_not_of(delimiters, 0);
+  // Find first "non-delimiter".
+  string::size_type pos     = str.find_first_of(delimiters, lastPos);
+  while (string::npos != pos || string::npos != lastPos) {
+    // Found a token, add it to the vector.
+    tokens->push_back(str.substr(lastPos, pos - lastPos));
+    // Skip delimiters.  Note the "not_of"
+    lastPos = str.find_first_not_of(delimiters, pos);
+    // Find next "non-delimiter"
+    pos = str.find_first_of(delimiters, lastPos);
+  }
+}
 template <typename Dtype>
 void hdf5_load_nd_dataset_helper(
     hid_t file_id, const char* dataset_name_, int min_dim, int max_dim,

--- a/include/caffe/util/rng.hpp
+++ b/include/caffe/util/rng.hpp
@@ -4,14 +4,13 @@
 #include <algorithm>
 #include <iterator>
 
-#include "boost/random/mersenne_twister.hpp"
-#include "boost/random/uniform_int.hpp"
+#include <random>
 
 #include "caffe/common.hpp"
 
 namespace caffe {
 
-typedef boost::mt19937 rng_t;
+typedef std::mt19937_64 rng_t;
 
 inline rng_t* caffe_rng() {
   return static_cast<caffe::rng_t*>(Caffe::rng_stream().generator());
@@ -23,7 +22,7 @@ inline void shuffle(RandomAccessIterator begin, RandomAccessIterator end,
                     RandomGenerator* gen) {
   typedef typename std::iterator_traits<RandomAccessIterator>::difference_type
       difference_type;
-  typedef typename boost::uniform_int<difference_type> dist_type;
+  typedef typename std::uniform_int_distribution<difference_type> dist_type;
 
   difference_type length = std::distance(begin, end);
   if (length <= 0) return;

--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -1,6 +1,7 @@
 #ifndef CAFFE_VISION_LAYERS_HPP_
 #define CAFFE_VISION_LAYERS_HPP_
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -103,7 +103,7 @@ void Net_SetInputArrays(Net<Dtype>* net, bp::object data_obj,
     bp::object labels_obj) {
   // check that this network has an input MemoryDataLayer
   shared_ptr<MemoryDataLayer<Dtype> > md_layer =
-    boost::dynamic_pointer_cast<MemoryDataLayer<Dtype> >(net->layers()[0]);
+    std::dynamic_pointer_cast<MemoryDataLayer<Dtype> >(net->layers()[0]);
   if (!md_layer) {
     throw std::runtime_error("set_input_arrays may only be called if the"
         " first layer is a MemoryDataLayer");

--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -9,17 +9,23 @@ MAKE="make --jobs=$NUM_THREADS"
 
 # This ppa is for gflags and glog
 add-apt-repository -y ppa:tuleu/precise-backports
+# This ppa is for boost 1.54
+add-apt-repository -y ppa:boost-latest/ppa
+# This ppa is for g++ 4.8
+add-apt-repository -y ppa:ubuntu-toolchain-r/test
+
 apt-get -y update
 apt-get install \
-    wget git curl \
+    g++-4.8 wget git curl \
     python-dev python-numpy \
     libleveldb-dev libsnappy-dev libopencv-dev \
-    libboost-dev libboost-system-dev libboost-python-dev libboost-thread-dev \
+    libboost-python1.54-dev \
     libprotobuf-dev protobuf-compiler \
     libatlas-dev libatlas-base-dev \
     libhdf5-serial-dev libgflags-dev libgoogle-glog-dev \
     bc
 
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
 # Add a special apt-repository to install CMake 2.8.9 for CMake Caffe build,
 # if needed.  By default, Aptitude in Ubuntu 12.04 installs CMake 2.8.7, but
 # Caffe requires a minimum CMake version of 2.8.8.
@@ -31,7 +37,7 @@ fi
 
 # Install CUDA, if needed
 if $WITH_CUDA; then
-  CUDA_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_6.5-14_amd64.deb
+  CUDA_URL=http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1204/x86_64/cuda-repo-ubuntu1204_7.0-28_amd64.deb
   CUDA_FILE=/tmp/cuda_install.deb
   curl $CUDA_URL -o $CUDA_FILE
   dpkg -i $CUDA_FILE
@@ -39,11 +45,11 @@ if $WITH_CUDA; then
   apt-get -y update
   # Install the minimal CUDA subpackages required to test Caffe build.
   # For a full CUDA installation, add 'cuda' to the list of packages.
-  apt-get -y install cuda-core-6-5 cuda-cublas-6-5 cuda-cublas-dev-6-5 cuda-cudart-6-5 cuda-cudart-dev-6-5 cuda-curand-6-5 cuda-curand-dev-6-5
+  apt-get -y install cuda-core-7-0 cuda-cublas-7-0 cuda-cublas-dev-7-0 cuda-cudart-7-0 cuda-cudart-dev-7-0 cuda-curand-7-0 cuda-curand-dev-7-0
   # Create CUDA symlink at /usr/local/cuda
   # (This would normally be created by the CUDA installer, but we create it
   # manually since we did a partial installation.)
-  ln -s /usr/local/cuda-6.5 /usr/local/cuda
+  ln -s /usr/local/cuda-7.0 /usr/local/cuda
 fi
 
 # Install LMDB

--- a/src/caffe/internal_thread.cpp
+++ b/src/caffe/internal_thread.cpp
@@ -1,4 +1,4 @@
-#include <boost/thread.hpp>
+#include <thread>
 #include "caffe/internal_thread.hpp"
 
 namespace caffe {
@@ -18,7 +18,7 @@ bool InternalThread::StartInternalThread() {
   }
   try {
     thread_.reset(
-        new boost::thread(&InternalThread::InternalThreadEntry, this));
+        new std::thread(&InternalThread::InternalThreadEntry, this));
   } catch (...) {
     return false;
   }

--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -6,6 +6,7 @@ TODO:
   :: don't forget to update hdf5_daa_layer.cu accordingly
 - add ability to shuffle filenames if flag is set
 */
+#include <algorithm>
 #include <fstream>  // NOLINT(readability/streams)
 #include <string>
 #include <vector>

--- a/src/caffe/layers/hdf5_data_layer.cu
+++ b/src/caffe/layers/hdf5_data_layer.cu
@@ -4,6 +4,7 @@ TODO:
 */
 
 #include <stdint.h>
+#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/src/caffe/test/test_data_layer.cpp
+++ b/src/caffe/test/test_data_layer.cpp
@@ -1,7 +1,7 @@
+#include <memory>
 #include <string>
 #include <vector>
 
-#include "boost/scoped_ptr.hpp"
 #include "gtest/gtest.h"
 
 #include "caffe/blob.hpp"
@@ -16,7 +16,7 @@
 
 namespace caffe {
 
-using boost::scoped_ptr;
+using std::unique_ptr;
 
 template <typename TypeParam>
 class DataLayerTest : public MultiDeviceTest<TypeParam> {
@@ -42,9 +42,9 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
   void Fill(const bool unique_pixels, DataParameter_DB backend) {
     backend_ = backend;
     LOG(INFO) << "Using temporary dataset " << *filename_;
-    scoped_ptr<db::DB> db(db::GetDB(backend));
+    unique_ptr<db::DB> db(db::GetDB(backend));
     db->Open(*filename_, db::NEW);
-    scoped_ptr<db::Transaction> txn(db->NewTransaction());
+    unique_ptr<db::Transaction> txn(db->NewTransaction());
     for (int i = 0; i < 5; ++i) {
       Datum datum;
       datum.set_label(i);
@@ -108,9 +108,9 @@ class DataLayerTest : public MultiDeviceTest<TypeParam> {
     const int num_inputs = 5;
     // Save data of varying shapes.
     LOG(INFO) << "Using temporary dataset " << *filename_;
-    scoped_ptr<db::DB> db(db::GetDB(backend));
+    unique_ptr<db::DB> db(db::GetDB(backend));
     db->Open(*filename_, db::NEW);
-    scoped_ptr<db::Transaction> txn(db->NewTransaction());
+    unique_ptr<db::Transaction> txn(db->NewTransaction());
     for (int i = 0; i < num_inputs; ++i) {
       Datum datum;
       datum.set_label(i);

--- a/src/caffe/test/test_db.cpp
+++ b/src/caffe/test/test_db.cpp
@@ -1,6 +1,6 @@
+#include <memory>
 #include <string>
 
-#include "boost/scoped_ptr.hpp"
 #include "gtest/gtest.h"
 
 #include "caffe/common.hpp"
@@ -12,7 +12,7 @@
 
 namespace caffe {
 
-using boost::scoped_ptr;
+using std::unique_ptr;
 
 template <typename TypeParam>
 class DBTest : public ::testing::Test {
@@ -26,9 +26,9 @@ class DBTest : public ::testing::Test {
     source_ += "/db";
     string keys[] = {"cat.jpg", "fish-bike.jpg"};
     LOG(INFO) << "Using temporary db " << source_;
-    scoped_ptr<db::DB> db(db::GetDB(TypeParam::backend));
+    unique_ptr<db::DB> db(db::GetDB(TypeParam::backend));
     db->Open(this->source_, db::NEW);
-    scoped_ptr<db::Transaction> txn(db->NewTransaction());
+    unique_ptr<db::Transaction> txn(db->NewTransaction());
     for (int i = 0; i < 2; ++i) {
       Datum datum;
       ReadImageToDatum(root_images_ + keys[i], i, &datum);
@@ -62,13 +62,13 @@ typedef ::testing::Types<TypeLevelDB, TypeLMDB> TestTypes;
 TYPED_TEST_CASE(DBTest, TestTypes);
 
 TYPED_TEST(DBTest, TestGetDB) {
-  scoped_ptr<db::DB> db(db::GetDB(TypeParam::backend));
+  unique_ptr<db::DB> db(db::GetDB(TypeParam::backend));
 }
 
 TYPED_TEST(DBTest, TestNext) {
-  scoped_ptr<db::DB> db(db::GetDB(TypeParam::backend));
+  unique_ptr<db::DB> db(db::GetDB(TypeParam::backend));
   db->Open(this->source_, db::READ);
-  scoped_ptr<db::Cursor> cursor(db->NewCursor());
+  unique_ptr<db::Cursor> cursor(db->NewCursor());
   EXPECT_TRUE(cursor->valid());
   cursor->Next();
   EXPECT_TRUE(cursor->valid());
@@ -77,9 +77,9 @@ TYPED_TEST(DBTest, TestNext) {
 }
 
 TYPED_TEST(DBTest, TestSeekToFirst) {
-  scoped_ptr<db::DB> db(db::GetDB(TypeParam::backend));
+  unique_ptr<db::DB> db(db::GetDB(TypeParam::backend));
   db->Open(this->source_, db::READ);
-  scoped_ptr<db::Cursor> cursor(db->NewCursor());
+  unique_ptr<db::Cursor> cursor(db->NewCursor());
   cursor->Next();
   cursor->SeekToFirst();
   EXPECT_TRUE(cursor->valid());
@@ -93,9 +93,9 @@ TYPED_TEST(DBTest, TestSeekToFirst) {
 }
 
 TYPED_TEST(DBTest, TestKeyValue) {
-  scoped_ptr<db::DB> db(db::GetDB(TypeParam::backend));
+  unique_ptr<db::DB> db(db::GetDB(TypeParam::backend));
   db->Open(this->source_, db::READ);
-  scoped_ptr<db::Cursor> cursor(db->NewCursor());
+  unique_ptr<db::Cursor> cursor(db->NewCursor());
   EXPECT_TRUE(cursor->valid());
   string key = cursor->key();
   Datum datum;
@@ -117,9 +117,9 @@ TYPED_TEST(DBTest, TestKeyValue) {
 }
 
 TYPED_TEST(DBTest, TestWrite) {
-  scoped_ptr<db::DB> db(db::GetDB(TypeParam::backend));
+  unique_ptr<db::DB> db(db::GetDB(TypeParam::backend));
   db->Open(this->source_, db::WRITE);
-  scoped_ptr<db::Transaction> txn(db->NewTransaction());
+  unique_ptr<db::Transaction> txn(db->NewTransaction());
   Datum datum;
   ReadFileToDatum(this->root_images_ + "cat.jpg", 0, &datum);
   string out;

--- a/src/caffe/test/test_reduction_layer.cpp
+++ b/src/caffe/test/test_reduction_layer.cpp
@@ -72,7 +72,7 @@ class ReductionLayerTest : public MultiDeviceTest<TypeParam> {
       }
       expected_result *= coeff;
       const Dtype computed_result = this->blob_top_->cpu_data()[n];
-      EXPECT_FLOAT_EQ(expected_result, computed_result)
+      EXPECT_NEAR(expected_result, computed_result, 4e-5)
           << "Incorrect result computed with op "
           << ReductionParameter_ReductionOp_Name(op) << ", coeff " << coeff;
     }

--- a/src/caffe/test/test_softmax_with_loss_layer.cpp
+++ b/src/caffe/test/test_softmax_with_loss_layer.cpp
@@ -1,9 +1,9 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <vector>
 
-#include "boost/scoped_ptr.hpp"
 #include "gtest/gtest.h"
 
 #include "caffe/blob.hpp"
@@ -14,7 +14,7 @@
 #include "caffe/test/test_caffe_main.hpp"
 #include "caffe/test/test_gradient_check_util.hpp"
 
-using boost::scoped_ptr;
+using std::unique_ptr;
 
 namespace caffe {
 
@@ -68,7 +68,7 @@ TYPED_TEST(SoftmaxWithLossLayerTest, TestForwardIgnoreLabel) {
   LayerParameter layer_param;
   layer_param.mutable_loss_param()->set_normalize(false);
   // First, compute the loss with all labels
-  scoped_ptr<SoftmaxWithLossLayer<Dtype> > layer(
+  unique_ptr<SoftmaxWithLossLayer<Dtype> > layer(
       new SoftmaxWithLossLayer<Dtype>(layer_param));
   layer->SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);

--- a/src/caffe/util/benchmark.cpp
+++ b/src/caffe/util/benchmark.cpp
@@ -1,5 +1,3 @@
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 #include "caffe/common.hpp"
 #include "caffe/util/benchmark.hpp"
 
@@ -32,7 +30,7 @@ void Timer::Start() {
       NO_GPU;
 #endif
     } else {
-      start_cpu_ = boost::posix_time::microsec_clock::local_time();
+      start_cpu_ = std::chrono::high_resolution_clock::now();
     }
     running_ = true;
     has_run_at_least_once_ = true;
@@ -49,7 +47,7 @@ void Timer::Stop() {
       NO_GPU;
 #endif
     } else {
-      stop_cpu_ = boost::posix_time::microsec_clock::local_time();
+      stop_cpu_ = std::chrono::high_resolution_clock::now();
     }
     running_ = false;
   }
@@ -74,7 +72,8 @@ float Timer::MicroSeconds() {
       NO_GPU;
 #endif
   } else {
-    elapsed_microseconds_ = (stop_cpu_ - start_cpu_).total_microseconds();
+    elapsed_microseconds_ = std::chrono::duration_cast
+        <std::chrono::milliseconds>(stop_cpu_ - start_cpu_).count();
   }
   return elapsed_microseconds_;
 }
@@ -95,7 +94,8 @@ float Timer::MilliSeconds() {
       NO_GPU;
 #endif
   } else {
-    elapsed_milliseconds_ = (stop_cpu_ - start_cpu_).total_milliseconds();
+    elapsed_milliseconds_ = std::chrono::duration_cast
+        <std::chrono::milliseconds>(stop_cpu_ - start_cpu_).count();
   }
   return elapsed_milliseconds_;
 }
@@ -126,7 +126,7 @@ CPUTimer::CPUTimer() {
 
 void CPUTimer::Start() {
   if (!running()) {
-    this->start_cpu_ = boost::posix_time::microsec_clock::local_time();
+    this->start_cpu_ = std::chrono::high_resolution_clock::now();
     this->running_ = true;
     this->has_run_at_least_once_ = true;
   }
@@ -134,7 +134,7 @@ void CPUTimer::Start() {
 
 void CPUTimer::Stop() {
   if (running()) {
-    this->stop_cpu_ = boost::posix_time::microsec_clock::local_time();
+    this->stop_cpu_ = std::chrono::high_resolution_clock::now();
     this->running_ = false;
   }
 }
@@ -147,8 +147,8 @@ float CPUTimer::MilliSeconds() {
   if (running()) {
     Stop();
   }
-  this->elapsed_milliseconds_ = (this->stop_cpu_ -
-                                this->start_cpu_).total_milliseconds();
+  this->elapsed_milliseconds_ = std::chrono::duration_cast
+      <std::chrono::milliseconds>(stop_cpu_ - start_cpu_).count();
   return this->elapsed_milliseconds_;
 }
 
@@ -160,8 +160,8 @@ float CPUTimer::MicroSeconds() {
   if (running()) {
     Stop();
   }
-  this->elapsed_microseconds_ = (this->stop_cpu_ -
-                                this->start_cpu_).total_microseconds();
+  this->elapsed_microseconds_ = std::chrono::duration_cast
+      <std::chrono::milliseconds>(stop_cpu_ - start_cpu_).count();
   return this->elapsed_microseconds_;
 }
 

--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -1,8 +1,6 @@
-#include <boost/math/special_functions/next.hpp>
-#include <boost/random.hpp>
+#include <random>
 
 #include <limits>
-
 #include "caffe/common.hpp"
 #include "caffe/util/math_functions.hpp"
 #include "caffe/util/rng.hpp"
@@ -232,8 +230,7 @@ unsigned int caffe_rng_rand() {
 
 template <typename Dtype>
 Dtype caffe_nextafter(const Dtype b) {
-  return boost::math::nextafter<Dtype>(
-      b, std::numeric_limits<Dtype>::max());
+  return std::nextafter(b, std::numeric_limits<Dtype>::max());
 }
 
 template
@@ -247,9 +244,10 @@ void caffe_rng_uniform(const int n, const Dtype a, const Dtype b, Dtype* r) {
   CHECK_GE(n, 0);
   CHECK(r);
   CHECK_LE(a, b);
-  boost::uniform_real<Dtype> random_distribution(a, caffe_nextafter<Dtype>(b));
-  boost::variate_generator<caffe::rng_t*, boost::uniform_real<Dtype> >
-      variate_generator(caffe_rng(), random_distribution);
+  std::uniform_real_distribution<Dtype>
+       random_distribution(a, caffe_nextafter<Dtype>(b));
+       std::function<Dtype()>
+      variate_generator = bind(random_distribution, std::ref(*caffe_rng()));
   for (int i = 0; i < n; ++i) {
     r[i] = variate_generator();
   }
@@ -269,9 +267,9 @@ void caffe_rng_gaussian(const int n, const Dtype a,
   CHECK_GE(n, 0);
   CHECK(r);
   CHECK_GT(sigma, 0);
-  boost::normal_distribution<Dtype> random_distribution(a, sigma);
-  boost::variate_generator<caffe::rng_t*, boost::normal_distribution<Dtype> >
-      variate_generator(caffe_rng(), random_distribution);
+  std::normal_distribution<> random_distribution(a, sigma);
+  std::function<Dtype()>
+      variate_generator= bind(random_distribution, std::ref(*caffe_rng()));
   for (int i = 0; i < n; ++i) {
     r[i] = variate_generator();
   }
@@ -291,9 +289,10 @@ void caffe_rng_bernoulli(const int n, const Dtype p, int* r) {
   CHECK(r);
   CHECK_GE(p, 0);
   CHECK_LE(p, 1);
-  boost::bernoulli_distribution<Dtype> random_distribution(p);
-  boost::variate_generator<caffe::rng_t*, boost::bernoulli_distribution<Dtype> >
-      variate_generator(caffe_rng(), random_distribution);
+  std::bernoulli_distribution random_distribution(p);
+  std::function<Dtype()>
+      variate_generator = bind(random_distribution,
+      std::ref(*caffe_rng()));
   for (int i = 0; i < n; ++i) {
     r[i] = variate_generator();
   }
@@ -311,9 +310,9 @@ void caffe_rng_bernoulli(const int n, const Dtype p, unsigned int* r) {
   CHECK(r);
   CHECK_GE(p, 0);
   CHECK_LE(p, 1);
-  boost::bernoulli_distribution<Dtype> random_distribution(p);
-  boost::variate_generator<caffe::rng_t*, boost::bernoulli_distribution<Dtype> >
-      variate_generator(caffe_rng(), random_distribution);
+  std::bernoulli_distribution random_distribution(p);
+  std::function<Dtype() >
+      variate_generator = bind(random_distribution, std::ref(*caffe_rng()));
   for (int i = 0; i < n; ++i) {
     r[i] = static_cast<unsigned int>(variate_generator());
   }

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -1,11 +1,12 @@
 #include <glog/logging.h>
 
 #include <cstring>
+#include <iomanip>
 #include <map>
 #include <string>
 #include <vector>
 
-#include "boost/algorithm/string.hpp"
+
 #include "caffe/caffe.hpp"
 
 using caffe::Blob;
@@ -81,7 +82,7 @@ RegisterBrewFunction(device_query);
 // test nets.
 void CopyLayers(caffe::Solver<float>* solver, const std::string& model_list) {
   std::vector<std::string> model_names;
-  boost::split(model_names, model_list, boost::is_any_of(",") );
+  caffe::string_split(&model_names, model_list, ",");
   for (int i = 0; i < model_names.size(); ++i) {
     LOG(INFO) << "Finetuning from " << model_names[i];
     solver->net()->CopyTrainedLayersFrom(model_names[i]);

--- a/tools/compute_image_mean.cpp
+++ b/tools/compute_image_mean.cpp
@@ -1,10 +1,11 @@
 #include <stdint.h>
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "boost/scoped_ptr.hpp"
+
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 
@@ -16,7 +17,7 @@ using namespace caffe;  // NOLINT(build/namespaces)
 
 using std::max;
 using std::pair;
-using boost::scoped_ptr;
+using std::unique_ptr;
 
 DEFINE_string(backend, "lmdb",
         "The backend {leveldb, lmdb} containing the images");
@@ -40,9 +41,9 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  scoped_ptr<db::DB> db(db::GetDB(FLAGS_backend));
+  unique_ptr<db::DB> db(db::GetDB(FLAGS_backend));
   db->Open(argv[1], db::READ);
-  scoped_ptr<db::Cursor> cursor(db->NewCursor());
+  unique_ptr<db::Cursor> cursor(db->NewCursor());
 
   BlobProto sum_blob;
   int count = 0;

--- a/tools/convert_imageset.cpp
+++ b/tools/convert_imageset.cpp
@@ -10,11 +10,11 @@
 
 #include <algorithm>
 #include <fstream>  // NOLINT(readability/streams)
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "boost/scoped_ptr.hpp"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
 
@@ -25,7 +25,7 @@
 
 using namespace caffe;  // NOLINT(build/namespaces)
 using std::pair;
-using boost::scoped_ptr;
+using std::unique_ptr;
 
 DEFINE_bool(gray, false,
     "When this option is on, treat images as grayscale ones");
@@ -88,9 +88,9 @@ int main(int argc, char** argv) {
   int resize_width = std::max<int>(0, FLAGS_resize_width);
 
   // Create new DB
-  scoped_ptr<db::DB> db(db::GetDB(FLAGS_backend));
+  unique_ptr<db::DB> db(db::GetDB(FLAGS_backend));
   db->Open(argv[3], db::NEW);
-  scoped_ptr<db::Transaction> txn(db->NewTransaction());
+  unique_ptr<db::Transaction> txn(db->NewTransaction());
 
   // Storing to db
   std::string root_folder(argv[1]);

--- a/tools/extract_features.cpp
+++ b/tools/extract_features.cpp
@@ -2,7 +2,6 @@
 #include <string>
 #include <vector>
 
-#include "boost/algorithm/string.hpp"
 #include "google/protobuf/text_format.h"
 
 #include "caffe/blob.hpp"
@@ -17,7 +16,7 @@ using caffe::Blob;
 using caffe::Caffe;
 using caffe::Datum;
 using caffe::Net;
-using boost::shared_ptr;
+using std::shared_ptr;
 using std::string;
 namespace db = caffe::db;
 
@@ -102,12 +101,11 @@ int feature_extraction_pipeline(int argc, char** argv) {
 
   std::string extract_feature_blob_names(argv[++arg_pos]);
   std::vector<std::string> blob_names;
-  boost::split(blob_names, extract_feature_blob_names, boost::is_any_of(","));
+  caffe::string_split(&blob_names, extract_feature_blob_names, ",");
 
   std::string save_feature_dataset_names(argv[++arg_pos]);
   std::vector<std::string> dataset_names;
-  boost::split(dataset_names, save_feature_dataset_names,
-               boost::is_any_of(","));
+  caffe::string_split(&dataset_names, save_feature_dataset_names, ",");
   CHECK_EQ(blob_names.size(), dataset_names.size()) <<
       " the number of blob names and dataset names must be equal";
   size_t num_features = blob_names.size();


### PR DESCRIPTION
This is an initial effort to generally remove boost dependencies and leave it only for python wrapper.
I think that c++11 support it is quite stable now, enabled by default in gcc 5.x series, full supported by LLVM and almost supported in the android NDK.
With https://github.com/BVLC/caffe/pull/2523 modularity we could really strip caffe dependencies on embedded systems and especially for android NDK builds.
@shelhamer @longjon Can you take a look at this?
@Nerei Generally the Travis build matrix of caffe doesn't seems coherent to me between Cmake and Make (Cmake really build cuda?).
I think that @shelhamer can make a run on OSX because we don't have it in Travis.
Generally this seems in a good shape, CPU and GPU tests pass fine. 
There is still a problem with a python test as you can see in Travis logs. 
Can you give me some feedback on this?
