### PR TITLE
ImageData layer image resize that preserves aspect ratio

### DIFF
--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -128,6 +128,9 @@ cv::Mat ReadImageToCVMat(const string& filename,
     const int height, const int width, const bool is_color);
 
 cv::Mat ReadImageToCVMat(const string& filename,
+    const int height, const int width, const int min_dim, const bool is_color);
+
+cv::Mat ReadImageToCVMat(const string& filename,
     const int height, const int width);
 
 cv::Mat ReadImageToCVMat(const string& filename,

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -25,12 +25,15 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   const int new_height = this->layer_param_.image_data_param().new_height();
   const int new_width  = this->layer_param_.image_data_param().new_width();
+  const int new_dim  = this->layer_param_.image_data_param().new_dim();
   const bool is_color  = this->layer_param_.image_data_param().is_color();
   string root_folder = this->layer_param_.image_data_param().root_folder();
 
   CHECK((new_height == 0 && new_width == 0) ||
       (new_height > 0 && new_width > 0)) << "Current implementation requires "
       "new_height and new_width to be set at the same time.";
+  CHECK(!(new_dim > 0 && new_height > 0 && new_width > 0))
+      << "Both new_dim and (new_height + new_width) cannot be non-zero at the same time";
   // Read the file with filenames and labels
   const string& source = this->layer_param_.image_data_param().source();
   LOG(INFO) << "Opening file " << source;
@@ -61,7 +64,7 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   }
   // Read an image, and use it to initialize the top blob.
   cv::Mat cv_img = ReadImageToCVMat(root_folder + lines_[lines_id_].first,
-                                    new_height, new_width, is_color);
+                                    new_height, new_width, new_dim, is_color);
   // Use data_transformer to infer the expected blob shape from a cv_image.
   vector<int> top_shape = this->data_transformer_->InferBlobShape(cv_img);
   this->transformed_data_.Reshape(top_shape);
@@ -101,13 +104,14 @@ void ImageDataLayer<Dtype>::InternalThreadEntry() {
   const int batch_size = image_data_param.batch_size();
   const int new_height = image_data_param.new_height();
   const int new_width = image_data_param.new_width();
+  const int new_dim  = image_data_param.new_dim();
   const bool is_color = image_data_param.is_color();
   string root_folder = image_data_param.root_folder();
 
   // Reshape according to the first image of each batch
   // on single input batches allows for inputs of varying dimension.
   cv::Mat cv_img = ReadImageToCVMat(root_folder + lines_[lines_id_].first,
-      new_height, new_width, is_color);
+      new_height, new_width, new_dim, is_color);
   // Use data_transformer to infer the expected blob shape from a cv_img.
   vector<int> top_shape = this->data_transformer_->InferBlobShape(cv_img);
   this->transformed_data_.Reshape(top_shape);
@@ -125,7 +129,7 @@ void ImageDataLayer<Dtype>::InternalThreadEntry() {
     timer.Start();
     CHECK_GT(lines_size, lines_id_);
     cv::Mat cv_img = ReadImageToCVMat(root_folder + lines_[lines_id_].first,
-        new_height, new_width, is_color);
+        new_height, new_width, new_dim, is_color);
     CHECK(cv_img.data) << "Could not load " << lines_[lines_id_].first;
     read_time += timer.MicroSeconds();
     timer.Start();

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -574,6 +574,8 @@ message ImageDataParameter {
   // It will also resize images if new_height or new_width are not zero.
   optional uint32 new_height = 9 [default = 0];
   optional uint32 new_width = 10 [default = 0];
+  // Resize image so that the smaller dimension is new_dim
+  optional uint32 new_dim = 13 [default = 0];
   // Specify if the images are color or gray
   optional bool is_color = 11 [default = true];
   // DEPRECATED. See TransformationParameter. For data pre-processing, we can do

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -85,6 +85,35 @@ cv::Mat ReadImageToCVMat(const string& filename,
   return cv_img;
 }
 
+cv::Mat ReadImageToCVMat(const string& filename, const int height, const int width, const int min_dim, const bool is_color) {
+    if(min_dim == 0) return ReadImageToCVMat(filename, height, width, is_color);
+    else {
+        cv::Mat cv_img;
+        int cv_read_flag = (is_color ? CV_LOAD_IMAGE_COLOR :
+                CV_LOAD_IMAGE_GRAYSCALE);
+        cv::Mat cv_img_origin = cv::imread(filename, cv_read_flag);
+        if (!cv_img_origin.data) {
+            LOG(ERROR) << "Could not open or find file " << filename;
+            return cv_img_origin;
+        }
+        if (min_dim > 0) {
+            float scale_factor = float(min_dim) / std::min(cv_img_origin.rows, cv_img_origin.cols);
+            int new_height, new_width;
+            if(cv_img_origin.rows >= cv_img_origin.cols) {
+                new_width = min_dim;
+                new_height = round(scale_factor * cv_img_origin.rows);
+            } else {
+                new_height = min_dim;
+                new_width = round(scale_factor * cv_img_origin.cols);
+            }
+            cv::resize(cv_img_origin, cv_img, cv::Size(new_width, new_height));
+        } else {
+            cv_img = cv_img_origin;
+        }
+        return cv_img;
+    }
+}
+
 cv::Mat ReadImageToCVMat(const string& filename,
     const int height, const int width) {
   return ReadImageToCVMat(filename, height, width, true);


### PR DESCRIPTION
This adds a parameter `new_dim` in the ImageData layer parameters that allows the layer to resize the image without destroying the aspect ratio.

The image is resized such that `smallest side = new_dim`.