### PR TITLE
LogLayer gpu functionality moved to .cu file

### DIFF
--- a/src/caffe/layers/log_layer.cpp
+++ b/src/caffe/layers/log_layer.cpp
@@ -79,53 +79,6 @@ void LogLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
 
 #ifdef CPU_ONLY
 STUB_GPU(LogLayer);
-#else
-
-template <typename Dtype>
-void LogLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
-    const vector<Blob<Dtype>*>& top) {
-  const int count = bottom[0]->count();
-  const Dtype* bottom_data = bottom[0]->gpu_data();
-  Dtype* top_data = top[0]->mutable_gpu_data();
-  if (input_scale_ == Dtype(1) && input_shift_ == Dtype(0)) {
-    caffe_gpu_log(count, bottom_data, top_data);
-  } else {
-    caffe_copy(count, bottom_data, top_data);
-    if (input_scale_ != Dtype(1)) {
-      caffe_gpu_scal(count, input_scale_, top_data);
-    }
-    if (input_shift_ != Dtype(0)) {
-      caffe_gpu_add_scalar(count, input_shift_, top_data);
-    }
-    caffe_gpu_log(count, top_data, top_data);
-  }
-  if (base_scale_ != Dtype(1)) {
-    caffe_gpu_scal(count, base_scale_, top_data);
-  }
-}
-
-template <typename Dtype>
-void LogLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
-    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  if (!propagate_down[0]) { return; }
-  const int count = bottom[0]->count();
-  const Dtype* bottom_data = bottom[0]->gpu_data();
-  const Dtype* top_diff = top[0]->gpu_diff();
-  Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
-  caffe_copy(count, bottom_data, bottom_diff);
-  if (input_scale_ != Dtype(1)) {
-    caffe_gpu_scal(count, input_scale_, bottom_diff);
-  }
-  if (input_shift_ != Dtype(0)) {
-    caffe_gpu_add_scalar(count, input_shift_, bottom_diff);
-  }
-  caffe_gpu_powx(count, bottom_diff, Dtype(-1), bottom_diff);
-  if (backward_num_scale_ != Dtype(1)) {
-    caffe_gpu_scal(count, backward_num_scale_, bottom_diff);
-  }
-  caffe_gpu_mul(count, top_diff, bottom_diff, bottom_diff);
-}
-
 #endif
 
 INSTANTIATE_CLASS(LogLayer);

--- a/src/caffe/layers/log_layer.cu
+++ b/src/caffe/layers/log_layer.cu
@@ -1,0 +1,57 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/neuron_layers.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void LogLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const int count = bottom[0]->count();
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  Dtype* top_data = top[0]->mutable_gpu_data();
+  if (input_scale_ == Dtype(1) && input_shift_ == Dtype(0)) {
+    caffe_gpu_log(count, bottom_data, top_data);
+  } else {
+    caffe_copy(count, bottom_data, top_data);
+    if (input_scale_ != Dtype(1)) {
+      caffe_gpu_scal(count, input_scale_, top_data);
+    }
+    if (input_shift_ != Dtype(0)) {
+      caffe_gpu_add_scalar(count, input_shift_, top_data);
+    }
+    caffe_gpu_log(count, top_data, top_data);
+  }
+  if (base_scale_ != Dtype(1)) {
+    caffe_gpu_scal(count, base_scale_, top_data);
+  }
+}
+
+template <typename Dtype>
+void LogLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  if (!propagate_down[0]) { return; }
+    const int count = bottom[0]->count();
+    const Dtype* bottom_data = bottom[0]->gpu_data();
+    const Dtype* top_diff = top[0]->gpu_diff();
+    Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
+    caffe_copy(count, bottom_data, bottom_diff);
+    if (input_scale_ != Dtype(1)) {
+      caffe_gpu_scal(count, input_scale_, bottom_diff);
+    }
+    if (input_shift_ != Dtype(0)) {
+      caffe_gpu_add_scalar(count, input_shift_, bottom_diff);
+    }
+    caffe_gpu_powx(count, bottom_diff, Dtype(-1), bottom_diff);
+    if (backward_num_scale_ != Dtype(1)) {
+      caffe_gpu_scal(count, backward_num_scale_, bottom_diff);
+    }
+    caffe_gpu_mul(count, top_diff, bottom_diff, bottom_diff);
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(LogLayer);
+
+}  // namespace caffe


### PR DESCRIPTION
Additional "fix" of #2543
Splitting of log_layer.cpp by moving Forward_gpu and Backward_gpu into the new log_layer.cu-file.