### PR TITLE
Add gpu device id option in python command lines

### DIFF
--- a/python/classify.py
+++ b/python/classify.py
@@ -42,7 +42,7 @@ def main(argv):
     )
     parser.add_argument(
         "--gpu",
-        action='store_true',
+        default='0',
         help="Switch for gpu computation."
     )
     parser.add_argument(
@@ -98,7 +98,8 @@ def main(argv):
 
     if args.gpu:
         caffe.set_mode_gpu()
-        print("GPU mode")
+        caffe.set_device(int(args.gpu))
+        print("GPU mode [device id: %s]" % args.gpu)
     else:
         caffe.set_mode_cpu()
         print("CPU mode")

--- a/python/detect.py
+++ b/python/detect.py
@@ -63,7 +63,7 @@ def main(argv):
     )
     parser.add_argument(
         "--gpu",
-        action='store_true',
+        default='0',
         help="Switch for gpu computation."
     )
     parser.add_argument(
@@ -109,7 +109,8 @@ def main(argv):
 
     if args.gpu:
         caffe.set_mode_gpu()
-        print("GPU mode")
+        caffe.set_device(int(args.gpu))
+        print("GPU mode [device id: %s]" % args.gpu)
     else:
         caffe.set_mode_cpu()
         print("CPU mode")


### PR DESCRIPTION
Add gpu device id option in python command lines.

In python classification and detection examples, one can select a specific gpu to run a model if there are more than 1 gpu.
