### PR TITLE
Fix matcaffe init_key initialization

### DIFF
--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -44,8 +44,8 @@ void mxCHECK_FILE_EXIST(const char* file) {
 // The pointers to caffe::Solver and caffe::Net instances
 static vector<shared_ptr<Solver<float> > > solvers_;
 static vector<shared_ptr<Net<float> > > nets_;
-// init_key is generated at the beginning and everytime you call reset
-static double init_key = static_cast<double>(caffe_rng_rand());
+// init_key is re-generated everytime you call reset
+static double init_key = -2.;
 
 /** -----------------------------------------------------------------
  ** data conversion functions


### PR DESCRIPTION
Previously in matcaffe (#2505), `init_key` is initialized with `caffe_rng_rand()`. However, `caffe_rng_rand()` relies on `static shared_ptr<Caffe> Caffe::singleton_` (in common.hpp), and there is no guarantee in C++ that `Caffe::singleton_` will be constructed before `init_key` is initialized.

Although current implementation work with g++, it may break with other compilers. Instead of generating random init_key at the beginning, use a constant number (-2.) for its first value.