### PR TITLE
skip empty top in backward propagation in filter layer

### DIFF
--- a/src/caffe/layers/filter_layer.cpp
+++ b/src/caffe/layers/filter_layer.cpp
@@ -88,6 +88,7 @@ void FilterLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     // bottom[last] is the selector and never needs backpropagation
     // so we can iterate over top vector because top.size() == bottom.size() -1
     if (propagate_down[i]) {
+      if (top[i]->shape(0) == 0) continue;
       const int dim = top[i]->count() / top[i]->shape(0);
       int next_to_backward_offset = 0;
       int batch_offset = 0;

--- a/src/caffe/layers/filter_layer.cu
+++ b/src/caffe/layers/filter_layer.cu
@@ -35,6 +35,7 @@ void FilterLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     // bottom[last] is the selector and never needs backpropagation
     // so we can iterate over top vector because top.size() == bottom.size() -1
     if (propagate_down[i]) {
+      if (top[i]->shape(0) == 0) continue;
       const int dim = top[i]->count() / top[i]->shape(0);
       int next_to_backward_offset = 0;
       int batch_offset = 0;


### PR DESCRIPTION
An empty top, i.e. `top[i]->shape(0) == 0` could happen when the selector is full of 0s.