### PR TITLE
Feature: Creating a siamese database from images

### DIFF
--- a/examples/siamese/convert_imageset_siamese_data.cpp
+++ b/examples/siamese/convert_imageset_siamese_data.cpp
@@ -1,0 +1,176 @@
+/** \file convert_imageset_siamese_data.cpp
+ * \brief small executable to convert a set of image pairs (files) into a caffe supported format.
+ *
+ * Converts a set of image pairs (2 filenames on a line in a text file) and the label (last
+ * value in the line) into a two channel datum with label provided. This output format is of
+ * the same format as the one used in the siamese mnist example.
+ *
+ * \Notes:
+ * Based on code from the Caffe examples and tools
+ *
+ * \version
+ * -	v0.1a	Initial version
+ *
+ * Future versions:
+ * \todo
+ * -	add LMDB support
+ * -	add RGB channel support -> 6 channels possible?
+ * -	Optional encoding of the image so it stored in a smaller format.
+ * 		+	It might be not possible without influencing data between the two
+ * 			images as they are stored as channels
+ *
+ * \author    	Floris Gaisser <f.gaisser@tudelft.nl>
+ * \date      	v0.1a 2015-06-04
+ *
+ * \copyright \verbatim
+ * Copyright (c) 2015, Floris Gaisser, Delft University of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * \endverbatim
+ */
+
+
+//	C/C++
+#include <fstream>
+#include <string>
+#include <vector>
+
+//	Google logging
+#include "glog/logging.h"
+#include "google/protobuf/text_format.h"
+
+//	Caffe
+#include "caffe/common.hpp"
+#include "leveldb/db.h"
+#include <lmdb.h>
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/io.hpp"
+
+//	OpenCV
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+void convert_dataset(const char* input_filename, const char* db_filename, bool signed_data) {
+
+	// Open files
+	std::ifstream input_file(input_filename, std::ios::in | std::ios::binary);
+	CHECK(input_file) << "Unable to open file " << input_filename;
+
+	// load file contents line by line: [filename] [filename] [label]
+	// vector of lines; containing a pair of filenames and a label
+	std::vector<std::pair<std::pair<std::string, std::string>, int> > lines;
+	std::string filename_1, filename_2;
+	int label;
+	// read the file
+	while (input_file >> filename_1 >> filename_2 >> label) {
+		lines.push_back(std::make_pair(std::make_pair(filename_1, filename_2), label));
+	}
+
+	// Open leveldb
+	leveldb::DB* db;
+	leveldb::Options options;
+	options.create_if_missing = true;
+	options.error_if_exists = true;
+	leveldb::Status status = leveldb::DB::Open(
+			options, db_filename, &db);
+	CHECK(status.ok()) << "Failed to open leveldb " << db_filename
+			<< ". Is it already existing?";
+	const int kMaxKeyLength = 10;
+	char key[kMaxKeyLength];
+
+	//	loop over the lines
+	caffe::Datum datum;
+	for (int line_id = 0; line_id < lines.size(); ++line_id) {
+		datum.clear_data();
+		datum.clear_float_data();
+		datum.set_encoded(false);
+		//	ToDo load color images!
+		cv::Mat cv_img_1 = cv::imread(lines[line_id].first.first, 0);
+		cv::Mat cv_img_2 = cv::imread(lines[line_id].first.second, 0);
+		datum.set_channels(2); // one channel for each image in the pair
+		datum.set_height(cv_img_1.rows);
+		datum.set_width(cv_img_1.cols);
+		datum.set_label(lines[line_id].second);
+
+		// if the stored data was originally signed, but converted to unsigned; convert back.
+		if(signed_data) {
+			cv_img_1.convertTo(cv_img_1, CV_8SC1, 1., -128);
+			cv_img_2.convertTo(cv_img_2, CV_8SC1, 1., -128);
+		}
+		if(	!cv_img_1.empty() && !cv_img_2.empty() &&
+			cv_img_1.rows == cv_img_2.rows &&
+			cv_img_1.cols == cv_img_2.cols) {
+			if(	cv_img_1.depth() == CV_8S &&
+				cv_img_2.depth() == CV_8S) {
+					std::vector<char> vec_img_1, vec_img_2;
+					vec_img_1.assign(cv_img_1.datastart, cv_img_1.dataend);
+					vec_img_2.assign(cv_img_2.datastart, cv_img_2.dataend);
+
+					vec_img_1.insert(vec_img_1.end(), vec_img_2.begin(), vec_img_2.end());
+					datum.set_data(reinterpret_cast<char*>(&vec_img_1[0]), vec_img_1.size());
+			} else
+			if(	cv_img_1.depth() == CV_8U &&
+				cv_img_2.depth() == CV_8U) {
+				std::vector<uchar> vec_img_1, vec_img_2;
+				vec_img_1.assign(cv_img_1.datastart, cv_img_1.dataend);
+				vec_img_2.assign(cv_img_2.datastart, cv_img_2.dataend);
+
+				vec_img_1.insert(vec_img_1.end(), vec_img_2.begin(), vec_img_2.end());
+				datum.set_data(reinterpret_cast<uchar*>(&vec_img_1[0]), vec_img_1.size());
+			}
+			std::string out;
+			datum.SerializeToString(&out);
+			snprintf(key, kMaxKeyLength, "%08d", line_id);
+			db->Put(leveldb::WriteOptions(), std::string(key), out);
+		} else {
+			std::cerr 	<< "ERROR!\t one or both input images are empty:\n"
+						<< "1: " << lines[line_id].first.first
+						<< " is empty: " << cv_img_1.empty() << "\n"
+						<< "2: " << lines[line_id].first.second
+						<< " is empty: " << cv_img_2.empty() << "\n";
+		}
+	}
+
+	delete db;
+}
+
+int main(int argc, char** argv) {
+	switch(argc) {
+		case 3:
+			google::InitGoogleLogging(argv[0]);
+			convert_dataset(argv[1], argv[2], false);
+			break;
+		case 4:
+			google::InitGoogleLogging(argv[0]);
+			convert_dataset(argv[1], argv[2], argv[3]);
+			break;
+		default:
+			printf(	"This script converts a image dataset to the leveldb format used\n"
+					"by caffe to train a siamese network.\n"
+					"Usage:\n"
+					"   convert_imageset_siamese_data input_text_file output_db_file signed_data\n"
+					"The format of the text file should be:\n"
+					"[filename] [filename] [label]\n");
+			break;
+	}
+}
+

--- a/examples/siamese/convert_mnist_siamese_images.cpp
+++ b/examples/siamese/convert_mnist_siamese_images.cpp
@@ -1,0 +1,191 @@
+/** \file convert_mnist_siamese_images.cpp
+ * \brief small executable to convert the MNIST database into separate images stored
+ * on the filesystem and write pairs in to a file with a similarity label.
+ *
+ * \Notes:
+ * Based on code from the Caffe examples and tools
+ *
+ * \version
+ * -	v0.1a	Initial version
+ *
+ * Future versions:
+ * \todo
+ * -	Add image encoding (compression) -> not needed for mnist
+ * -	(Re)move the creation of the imageset text file to separate executable
+ *
+ * \author    	Floris Gaisser <f.gaisser@tudelft.nl>
+ * \date      	v0.1a 2015-06-04
+ *
+ * \copyright \verbatim
+ * Copyright (c) 2015, Floris Gaisser, Delft University of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * \endverbatim
+ */
+
+//	C/C++
+#include <fstream>
+#include <string>
+#include <vector>
+#include <sys/stat.h>
+
+//	Google logging
+#include "glog/logging.h"
+#include "google/protobuf/text_format.h"
+
+//	Caffe
+#include "caffe/common.hpp"
+#include "leveldb/db.h"
+#include <lmdb.h>
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/io.hpp"
+#include "caffe/util/rng.hpp"
+
+//	OpenCV
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+uint32_t swap_endian(uint32_t val) {
+    val = ((val << 8) & 0xFF00FF00) | ((val >> 8) & 0xFF00FF);
+    return (val << 16) | (val >> 16);
+}
+
+void convert_dataset(const char* image_filename, const char* label_filename, const char* path) {
+	// Check dir
+	std::string output_path = path;
+	if(output_path.find_last_of("/") != output_path.size()-1)
+		output_path.append("/");
+	struct stat info;
+	if(stat( output_path.c_str(), &info ) != 0) {
+	    CHECK_EQ(mkdir(output_path.c_str(), 0744), 0)
+	        << "mkdir " << output_path << " failed";
+	}
+
+    std::ifstream image_file(image_filename, std::ios::in | std::ios::binary);
+    std::ifstream label_file(label_filename, std::ios::in | std::ios::binary);
+    CHECK(image_file) << "Unable to open file " << image_filename;
+    CHECK(label_file) << "Unable to open file " << label_filename;
+    // Read the magic and the meta data
+    uint32_t magic;
+    uint32_t num_items;
+    uint32_t num_labels;
+    uint32_t rows;
+    uint32_t cols;
+
+    image_file.read(reinterpret_cast<char*>(&magic), 4);
+    magic = swap_endian(magic);
+    CHECK_EQ(magic, 2051) << "Incorrect image file magic.";
+    label_file.read(reinterpret_cast<char*>(&magic), 4);
+    magic = swap_endian(magic);
+    CHECK_EQ(magic, 2049) << "Incorrect label file magic.";
+    image_file.read(reinterpret_cast<char*>(&num_items), 4);
+    num_items = swap_endian(num_items);
+    label_file.read(reinterpret_cast<char*>(&num_labels), 4);
+    num_labels = swap_endian(num_labels);
+    CHECK_EQ(num_items, num_labels)
+    		<< "number of images (" << num_items << ")"
+    		<< "and labels (" << num_labels << ") is not the same.";
+    image_file.read(reinterpret_cast<char*>(&rows), 4);
+    rows = swap_endian(rows);
+    image_file.read(reinterpret_cast<char*>(&cols), 4);
+    cols = swap_endian(cols);
+
+    LOG(INFO) << "A total of " << num_items << " items.";
+    LOG(INFO) << "Rows: " << rows << " Cols: " << cols;
+
+    //	load the images and save them
+    char* pixels = new char[rows * cols];
+    char label;
+    std::string label_folder_base = output_path + "label_";
+    cv::Mat image;
+    std::map<char, int> labels;
+    std::vector<std::pair<std::string, char> >	image_file_labels;
+    for (int itemid = 0; itemid < num_items; ++itemid) {
+        image_file.read(pixels, rows * cols);
+        label_file.read(&label, 1);
+
+        label += 48;
+        std::stringstream ss;
+        ss << label_folder_base << std::atoi(&label) << "/";
+        // The mnist database is signed, only unsigned values can be stored.
+        // ToDo: make it work with signed and unsigned data.
+        image = cv::Mat(rows, cols, CV_8SC1, pixels);
+        image.convertTo(image, CV_8UC1, 1., 128);
+
+        if(labels.find(label) == labels.end()) {
+        	if(stat(ss.str().c_str(), &info ) != 0) {
+				CHECK_EQ(mkdir(ss.str().c_str(), 0744), 0)
+					<< "mkdir " << ss.str() << " failed";
+        	}
+    	    labels[label] = 0;
+        }
+        ss << labels[label] << ".pgm";
+        cv::imwrite(ss.str(), image);
+        labels[label]++;
+        image_file_labels.push_back(std::make_pair(ss.str(), label));
+    }
+
+    //	shuffle the image files
+    caffe::shuffle(image_file_labels.begin(), image_file_labels.end());
+
+    // create a text file with the file names and the similarity label
+	std::ofstream output_file(std::string(output_path + "siamese_set.txt").c_str(), std::ios::out | std::ios::binary);
+	CHECK(output_file) << "Unable to open file " << output_file;
+    // At least 1 times the total number of images, preferred would be a full cross.
+	int scale = 1;
+	// round the number of pairs to 100.
+	int num_pairs = scale*image_file_labels.size() - ((scale*image_file_labels.size()) % 100);
+	std::cout << "making " << num_pairs << " pairs\n";
+
+	// ToDo: change the output amount by param
+	// Feature: make a full cross or select only a few closest as similar
+    for(int counter = 0; counter < num_pairs; ++counter) {
+    	// pick a random  pair
+        int i = caffe::caffe_rng_rand() % num_items;
+        int j = caffe::caffe_rng_rand() % num_items;
+    	// ToDo: check if there are no random double entries
+
+        output_file << image_file_labels.at(i).first << " ";
+        output_file << image_file_labels.at(j).first << " ";
+        output_file << (image_file_labels.at(i).second == image_file_labels.at(j).second) << "\n";
+
+    }
+    output_file.close();
+
+    delete pixels;
+}
+
+int main(int argc, char** argv) {
+	switch(argc) {
+	case 4:
+		google::InitGoogleLogging(argv[0]);
+		convert_dataset(argv[1], argv[2], argv[3]);
+		break;
+	default:
+		printf(	"This script converts mnist dataset into seperate images and a siamese input textfile\n"
+				"This could the be used by create_imageset_siamese.sh\n"
+				"Usage:\n"
+				"   convert_mnist_siamese_images input_image_file input_label_file output_folder\n");
+		break;
+	}
+	return 0;
+}

--- a/examples/siamese/create_siamese_from_imageset.sh
+++ b/examples/siamese/create_siamese_from_imageset.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+# This script converts the mnist data into leveldb format.
+
+EXAMPLES=./build/examples/siamese
+echo "Creating leveldb..."
+
+rm -rf ./examples/siamese/imageset_siamese_train_leveldb
+rm -rf ./examples/siamese/imageset_siamese_test_leveldb
+
+$EXAMPLES/convert_imageset_siamese_data.bin \
+    ./examples/siamese/train_images/siamese_set.txt \
+    ./examples/siamese/imageset_siamese_train_leveldb \
+    1
+
+$EXAMPLES/convert_imageset_siamese_data.bin \
+    ./examples/siamese/test_images/siamese_set.txt \
+    ./examples/siamese/imageset_siamese_test_leveldb \
+    1
+
+echo "Done."

--- a/examples/siamese/create_siamese_images_from_mnist.sh
+++ b/examples/siamese/create_siamese_images_from_mnist.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+# This script converts the mnist data into leveldb format.
+
+EXAMPLES=./build/examples/siamese
+DATA=./data/mnist
+
+$EXAMPLES/convert_mnist_siamese_images.bin \
+    $DATA/train-images-idx3-ubyte \
+    $DATA/train-labels-idx1-ubyte \
+    ./examples/siamese/train_images
+
+$EXAMPLES/convert_mnist_siamese_images.bin \
+    $DATA/t10k-images-idx3-ubyte \
+    $DATA/t10k-labels-idx1-ubyte \
+    ./examples/siamese/test_images
+
+echo "Done."

--- a/examples/siamese/imageset_siamese_solver.prototxt
+++ b/examples/siamese/imageset_siamese_solver.prototxt
@@ -1,0 +1,28 @@
+# 
+# CHANGE THESE SETTINGS ACCORDING TO YOUR DATASET
+# 
+# The train/test net protocol buffer definition
+net: "examples/siamese/imageset_siamese_train_test.prototxt"
+# test_iter specifies how many forward passes the test should carry out.
+# In the case of MNIST, we have test batch size 100 and 100 test iterations,
+# covering the full 10,000 testing images.
+test_iter: 100
+# Carry out testing every 500 training iterations.
+test_interval: 500
+# The base learning rate, momentum and the weight decay of the network.
+base_lr: 0.01
+momentum: 0.9
+weight_decay: 0.0000
+# The learning rate policy
+lr_policy: "inv"
+gamma: 0.0001
+power: 0.75
+# Display every 100 iterations
+display: 100
+# The maximum number of iterations
+max_iter: 50000
+# snapshot intermediate results
+snapshot: 5000
+snapshot_prefix: "examples/siamese/imageset_siamese"
+# solver mode: CPU or GPU
+solver_mode: GPU

--- a/examples/siamese/imageset_siamese_train_test.prototxt
+++ b/examples/siamese/imageset_siamese_train_test.prototxt
@@ -1,0 +1,349 @@
+name: "imageset_siamese_train_test"
+layer {
+  name: "pair_data"
+  type: "Data"
+  top: "pair_data"
+  top: "sim"
+  include {
+    phase: TRAIN
+  }
+  transform_param {
+    scale: 0.00390625
+  }
+  data_param {
+    source: "examples/siamese/imageset_siamese_train_leveldb"
+    batch_size: 64
+  }
+}
+layer {
+  name: "pair_data"
+  type: "Data"
+  top: "pair_data"
+  top: "sim"
+  include {
+    phase: TEST
+  }
+  transform_param {
+    scale: 0.00390625
+  }
+  data_param {
+    source: "examples/siamese/imageset_siamese_test_leveldb"
+    batch_size: 100
+  }
+}
+layer {
+  name: "slice_pair"
+  type: "Slice"
+  bottom: "pair_data"
+  top: "data"
+  top: "data_p"
+  slice_param {
+    slice_dim: 1
+    slice_point: 1
+  }
+}
+layer {
+  name: "conv1"
+  type: "Convolution"
+  bottom: "data"
+  top: "conv1"
+  param {
+    name: "conv1_w"
+    lr_mult: 1
+  }
+  param {
+    name: "conv1_b"
+    lr_mult: 2
+  }
+  convolution_param {
+    num_output: 20
+    kernel_size: 5
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "pool1"
+  type: "Pooling"
+  bottom: "conv1"
+  top: "pool1"
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layer {
+  name: "conv2"
+  type: "Convolution"
+  bottom: "pool1"
+  top: "conv2"
+  param {
+    name: "conv2_w"
+    lr_mult: 1
+  }
+  param {
+    name: "conv2_b"
+    lr_mult: 2
+  }
+  convolution_param {
+    num_output: 50
+    kernel_size: 5
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "pool2"
+  type: "Pooling"
+  bottom: "conv2"
+  top: "pool2"
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layer {
+  name: "ip1"
+  type: "InnerProduct"
+  bottom: "pool2"
+  top: "ip1"
+  param {
+    name: "ip1_w"
+    lr_mult: 1
+  }
+  param {
+    name: "ip1_b"
+    lr_mult: 2
+  }
+  inner_product_param {
+    num_output: 500
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "relu1"
+  type: "ReLU"
+  bottom: "ip1"
+  top: "ip1"
+}
+layer {
+  name: "ip2"
+  type: "InnerProduct"
+  bottom: "ip1"
+  top: "ip2"
+  param {
+    name: "ip2_w"
+    lr_mult: 1
+  }
+  param {
+    name: "ip2_b"
+    lr_mult: 2
+  }
+  inner_product_param {
+    num_output: 10
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "feat"
+  type: "InnerProduct"
+  bottom: "ip2"
+  top: "feat"
+  param {
+    name: "feat_w"
+    lr_mult: 1
+  }
+  param {
+    name: "feat_b"
+    lr_mult: 2
+  }
+  inner_product_param {
+    num_output: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "conv1_p"
+  type: "Convolution"
+  bottom: "data_p"
+  top: "conv1_p"
+  param {
+    name: "conv1_w"
+    lr_mult: 1
+  }
+  param {
+    name: "conv1_b"
+    lr_mult: 2
+  }
+  convolution_param {
+    num_output: 20
+    kernel_size: 5
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "pool1_p"
+  type: "Pooling"
+  bottom: "conv1_p"
+  top: "pool1_p"
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layer {
+  name: "conv2_p"
+  type: "Convolution"
+  bottom: "pool1_p"
+  top: "conv2_p"
+  param {
+    name: "conv2_w"
+    lr_mult: 1
+  }
+  param {
+    name: "conv2_b"
+    lr_mult: 2
+  }
+  convolution_param {
+    num_output: 50
+    kernel_size: 5
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "pool2_p"
+  type: "Pooling"
+  bottom: "conv2_p"
+  top: "pool2_p"
+  pooling_param {
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layer {
+  name: "ip1_p"
+  type: "InnerProduct"
+  bottom: "pool2_p"
+  top: "ip1_p"
+  param {
+    name: "ip1_w"
+    lr_mult: 1
+  }
+  param {
+    name: "ip1_b"
+    lr_mult: 2
+  }
+  inner_product_param {
+    num_output: 500
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "relu1_p"
+  type: "ReLU"
+  bottom: "ip1_p"
+  top: "ip1_p"
+}
+layer {
+  name: "ip2_p"
+  type: "InnerProduct"
+  bottom: "ip1_p"
+  top: "ip2_p"
+  param {
+    name: "ip2_w"
+    lr_mult: 1
+  }
+  param {
+    name: "ip2_b"
+    lr_mult: 2
+  }
+  inner_product_param {
+    num_output: 10
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "feat_p"
+  type: "InnerProduct"
+  bottom: "ip2_p"
+  top: "feat_p"
+  param {
+    name: "feat_w"
+    lr_mult: 1
+  }
+  param {
+    name: "feat_b"
+    lr_mult: 2
+  }
+  inner_product_param {
+    num_output: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "loss"
+  type: "ContrastiveLoss"
+  bottom: "feat"
+  bottom: "feat_p"
+  bottom: "sim"
+  top: "loss"
+  contrastive_loss_param {
+    margin: 1
+  }
+}

--- a/examples/siamese/readme.md
+++ b/examples/siamese/readme.md
@@ -185,3 +185,62 @@ notebook:
 
     ipython notebook ./examples/siamese/mnist_siamese.ipynb
 
+
+# Creating siamese dataset from a set of images
+
+It is possible to create a siamese database from a set of images and a text 
+file with pairs.
+
+## creating imageset from mnist data file
+
+As an example a set of images can be made from the mnist data file by running 
+`./examples/siamese/create_siamese_images_from_mnist.sh`:
+
+    ./examples/siamese/create_siamese_images_from_mnist.sh
+
+This will make two folders test_images and train_images, both containing labeled 
+folders with images. Further a text file `siamese_set.txt`. This file contains 
+the pairs and the similarity label.
+
+## creating siamese database from an imageset
+
+To create a siamese database from an imageset one needs a text file describing 
+the image pairs line by line in this format:
+    [path_to_image_1] [path_to_image_2] [similarity_label]
+
+To convert this into a database run
+`./examples/siamese/create_siamese_from_imageset.sh`:
+
+    ./examples/siamese/create_siamese_from_imageset.sh
+
+This script takes the text files
+`./examples/siamese/train_image/siamese_set.txt` and 
+`./examples/siamese/test_images/siamese_set.txt` to create the databases.
+
+After running the script there should be two datasets,
+`./examples/siamese/imageset_siamese_train_leveldb` and
+`./examples/siamese/imageset_siamese_test_leveldb`.
+
+Note: be aware that for this to work on the mnist dataset, the images had to be 
+converted into unsigned values before storing. Threfore the executable 
+`convert_imageset_siamese_data.bin` takes in a third parameter describing whether
+the images have to be converted back into signed values. Set this to `0` for 
+natural (unsigned) images and `1` for images with signed values.
+
+# Running siamese database from an imageset
+
+## Define the Solver
+
+This has been coppied from the mnist solver and nothing special needs to be done 
+to the solver besides pointing it at the correct model file. The solver is defined in
+`./examples/siamese/imageset_siamese_solver.prototxt`.
+
+## Training and Testing the Model
+
+This has been coppied from the mnist solver and training the model is simple after 
+you have written the network definition protobuf and solver protobuf files. Simply run
+`./examples/siamese/train_imageset_siamese.sh`:
+
+    ./examples/siamese/train_imageset_siamese.sh
+
+

--- a/examples/siamese/train_mnist_imageset_siamese.sh
+++ b/examples/siamese/train_mnist_imageset_siamese.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+TOOLS=./build/tools
+
+$TOOLS/caffe train --solver=examples/siamese/mnist_imageset_siamese_solver.prototxt


### PR DESCRIPTION
This adds two executatbles and their scripts:
1) create_siamese_images_from_mnist.sh
   to create a set of images pairs from the mnist dataset.
2) create_siames_from_imageset.sh
   to create a leveldb for a set of image pairs and their similarity label.

This also adds a script to train and test these databases. More is explained
in the readme.md

Future work:
Adding an executable that can create an imageset file from just the labeled
images stored in folders.