### PR TITLE
Extend Neuron layers to handle input Blob vectors.

### DIFF
--- a/src/caffe/layers/relu_layer.cpp
+++ b/src/caffe/layers/relu_layer.cpp
@@ -9,29 +9,32 @@ namespace caffe {
 template <typename Dtype>
 void ReLULayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
-  const Dtype* bottom_data = bottom[0]->cpu_data();
-  Dtype* top_data = top[0]->mutable_cpu_data();
-  const int count = bottom[0]->count();
-  Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
-  for (int i = 0; i < count; ++i) {
-    top_data[i] = std::max(bottom_data[i], Dtype(0))
-        + negative_slope * std::min(bottom_data[i], Dtype(0));
+  for (int i = 0; i < bottom.size(); ++i) {
+    const Dtype* bottom_data = bottom[i]->cpu_data();
+    Dtype* top_data = top[i]->mutable_cpu_data();
+    const int count = bottom[i]->count();
+    Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
+    for (int j = 0; j < count; ++j) {
+      top_data[j] = std::max(bottom_data[j], Dtype(0))
+          + negative_slope * std::min(bottom_data[j], Dtype(0));
+    }
   }
 }
 
 template <typename Dtype>
 void ReLULayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
-    const vector<bool>& propagate_down,
-    const vector<Blob<Dtype>*>& bottom) {
-  if (propagate_down[0]) {
-    const Dtype* bottom_data = bottom[0]->cpu_data();
-    const Dtype* top_diff = top[0]->cpu_diff();
-    Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
-    const int count = bottom[0]->count();
-    Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
-    for (int i = 0; i < count; ++i) {
-      bottom_diff[i] = top_diff[i] * ((bottom_data[i] > 0)
-          + negative_slope * (bottom_data[i] <= 0));
+  const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  for (int i = 0; i < bottom.size(); ++i) {
+    if (propagate_down[i]) {
+      const Dtype* bottom_data = bottom[i]->cpu_data();
+      const Dtype* top_diff = top[i]->cpu_diff();
+      Dtype* bottom_diff = bottom[i]->mutable_cpu_diff();
+      const int count = bottom[i]->count();
+      Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
+      for (int j = 0; j < count; ++j) {
+        bottom_diff[j] = top_diff[j] * ((bottom_data[j] > 0)
+            + negative_slope * (bottom_data[j] <= 0));
+      }
     }
   }
 }


### PR DESCRIPTION
At the moment all Neuron Layers ( ReLU etc. ) only process the first Blob vector entry. It would be good to extend the Layers to handle bigger input vectors, like the convolution layer does.

The pull request is incomplete, I only changed the ReLU code as an example, in case this is a desired change please drop a note and I will do the other layers + test too.

BR. Max
