### PR TITLE
Small platform-specific bugfix for draw.py

### DIFF
--- a/python/caffe/draw.py
+++ b/python/caffe/draw.py
@@ -72,7 +72,7 @@ def get_layer_label(layer, rankdir):
     else:
         # If graph orientation is horizontal, vertical space is free and
         # horizontal space is not; separate words with newlines
-        separator = '\n'
+        separator = '\\n'
 
     if layer.type == 'Convolution':
         # Outer double quotes needed or else colon characters don't parse


### PR DESCRIPTION
Close #2376

On Gentoo and CentOS (and others?), you get this error:

    Warning: /tmp/tmpjqPQBC:6: string ran past end of line

This issue was reported by @Pastafarianist here: NVIDIA/DIGITS#90 and then here: #2376, and by @Chamunsu here: https://github.com/NVIDIA/DIGITS/issues/112#issuecomment-103149490. Solution suggested by @bahaugen [here on SO](http://stackoverflow.com/a/29173396/2404152).