### PR TITLE
One of n layer

### DIFF
--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -181,69 +181,6 @@ class EltwiseLayer : public Layer<Dtype> {
 };
 
 /**
- * @brief Takes two+ Blobs, interprets last Blob as a selector and
- *  filter remaining Blobs accordingly with selector data (0 means that
- * the corresponding item has to be filtered, non-zero means that corresponding
- * item needs to stay).
- */
-template <typename Dtype>
-class FilterLayer : public Layer<Dtype> {
- public:
-  explicit FilterLayer(const LayerParameter& param)
-      : Layer<Dtype>(param) {}
-  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top);
-  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top);
-
-  virtual inline const char* type() const { return "Filter"; }
-  virtual inline int MinBottomBlobs() const { return 2; }
-  virtual inline int MinTopBlobs() const { return 1; }
-
- protected:
-  /**
-   * @param bottom input Blob vector (length 2+)
-   *   -# @f$ (N \times C \times H \times W) @f$
-   *      the inputs to be filtered @f$ x_1 @f$
-   *   -# ...
-   *   -# @f$ (N \times C \times H \times W) @f$
-   *      the inputs to be filtered @f$ x_K @f$
-   *   -# @f$ (N \times 1 \times 1 \times 1) @f$
-   *      the selector blob
-   * @param top output Blob vector (length 1+)
-   *   -# @f$ (S \times C \times H \times W) @f$ ()
-   *        the filtered output @f$ x_1 @f$
-   *        where S is the number of items
-   *        that haven't been filtered
-   *      @f$ (S \times C \times H \times W) @f$
-   *        the filtered output @f$ x_K @f$
-   *        where S is the number of items
-   *        that haven't been filtered
-   */
-  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top);
-  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
-    const vector<Blob<Dtype>*>& top);
-
-  /**
-   * @brief Computes the error gradient w.r.t. the forwarded inputs.
-   *
-   * @param top output Blob vector (length 1+), providing the error gradient with
-   *        respect to the outputs
-   * @param propagate_down see Layer::Backward.
-   * @param bottom input Blob vector (length 2+), into which the top error
-   *        gradient is copied
-   */
-  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
-      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
-    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-
-  bool first_reshape_;
-  vector<int> indices_to_forward_;
-};
-
-/**
  * @brief Reshapes the input Blob into flat vectors.
  *
  * Note: because this layer does not change the input values -- merely the
@@ -358,90 +295,52 @@ class MVNLayer : public Layer<Dtype> {
 
   /// sum_multiplier is used to carry out sum using BLAS
   Blob<Dtype> sum_multiplier_;
-  Dtype eps_;
-};
-
-/*
- * @brief Reshapes the input Blob into an arbitrary-sized output Blob.
- *
- * Note: similarly to FlattenLayer, this layer does not change the input values
- * (see FlattenLayer, Blob::ShareData and Blob::ShareDiff).
- */
-template <typename Dtype>
-class ReshapeLayer : public Layer<Dtype> {
- public:
-  explicit ReshapeLayer(const LayerParameter& param)
-      : Layer<Dtype>(param) {}
-  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top);
-  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top);
-
-  virtual inline const char* type() const { return "Reshape"; }
-  virtual inline int ExactNumBottomBlobs() const { return 1; }
-  virtual inline int ExactNumTopBlobs() const { return 1; }
-
- protected:
-  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top) {}
-  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
-      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {}
-  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top) {}
-  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
-      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {}
-
-  /// @brief vector of axes indices whose dimensions we'll copy from the bottom
-  vector<int> copy_axes_;
-  /// @brief the index of the axis whose dimension we infer, or -1 if none
-  int inferred_axis_;
-  /// @brief the product of the "constant" output dimensions
-  int constant_count_;
 };
 
 /**
- * @brief Compute "reductions" -- operations that return a scalar output Blob
- *        for an input Blob of arbitrary size, such as the sum, absolute sum,
- *        and sum of squares.
+ * @brief output the one-of-n vector for language inputs
  *
- * TODO(dox): thorough documentation for Forward, Backward, and proto params.
+ * Intended for use expand labels into features that are suitable for 
+ *        convolution with language data
+ *
+ * NOTE: does not implement Backwards operation.
  */
 template <typename Dtype>
-class ReductionLayer : public Layer<Dtype> {
+class OneOfNLayer : public Layer<Dtype> {
  public:
-  explicit ReductionLayer(const LayerParameter& param)
+  /**
+   * @param param provides OneOfNParameter oneOfN_param,
+   *      with OneOfNLayer options:
+   *    - output_n (\b optional uint, default 2).
+   *      the number @f$ n @f$ of one-of-n mapping
+   */
+  explicit OneOfNLayer(const LayerParameter& param)
       : Layer<Dtype>(param) {}
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
 
-  virtual inline const char* type() const { return "Reduction"; }
+  virtual inline const char* type() const { return "OneOfN"; }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
 
  protected:
+  /**
+   * @param bottom input Blob vector (length 1)
+   *   -# @f$ (N \times 1 \times 1 \times W) @f$
+   *      the inputs @f$ x @f$
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (N \times n \times 1 \times W) @f$ 
+   */
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top);
+  /// @brief Not implemented (non-differentiable function)
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
-      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
-      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-
-  /// @brief the reduction operation performed by the layer
-  ReductionParameter_ReductionOp op_;
-  /// @brief a scalar coefficient applied to all outputs
-  Dtype coeff_;
-  /// @brief the index of the first input axis to reduce
-  int axis_;
-  /// @brief the number of reductions performed
-  int num_;
-  /// @brief the input size of each reduction
-  int dim_;
-  /// @brief a helper Blob used for summation (op_ == SUM)
-  Blob<Dtype> sum_multiplier_;
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+  size_t output_n_;
 };
 
 /**

--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -298,9 +298,9 @@ class MVNLayer : public Layer<Dtype> {
 };
 
 /**
- * @brief output the one-of-n vector for language inputs
+ * @brief convert integer valued data into the one-of-n vectors
  *
- * Intended for use expand labels into features that are suitable for 
+ * Intended for expanding labels into features that are suitable for 
  *        convolution with language data
  *
  * NOTE: does not implement Backwards operation.

--- a/src/caffe/layers/one_of_n_layer.cpp
+++ b/src/caffe/layers/one_of_n_layer.cpp
@@ -1,0 +1,52 @@
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void OneOfNLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  output_n_ = this->layer_param_.one_of_n_param().output_n();
+  
+  CHECK_GE(output_n_, 2) << " output n must not be less than 2.";
+}
+
+template <typename Dtype>
+void OneOfNLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  top[0]->Reshape(bottom[0]->num(), output_n_, 1, bottom[0]->count(3, 4));
+}
+
+template <typename Dtype>
+void OneOfNLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  int num = bottom[0]->num();
+  int dim = bottom[0]->count(3, 4);
+  for (int i = 0; i < num; ++i) {
+    for (int j = 0; j < dim; ++j) {
+      int label = bottom_data[i * dim + j];
+      if (label < 0) {
+        label = 0;
+      }
+      if (label >= output_n_) {
+        label = output_n_ - 1;
+      }
+      for (int k = 0; k < output_n_; ++k) {
+          top_data[i * dim * output_n_ + j + k * dim] = 0;
+      } 
+      top_data[i * dim * output_n_ + j + label * dim] = 1;
+    }
+  }
+}
+
+INSTANTIATE_CLASS(OneOfNLayer);
+REGISTER_LAYER_CLASS(OneOfN);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -49,14 +49,6 @@ message FillerParameter {
   // The expected number of non-zero output weights for a given input in
   // Gaussian filler -- the default -1 means don't perform sparsification.
   optional int32 sparse = 7 [default = -1];
-  // Normalize the filler variance by fan_in, fan_out, or their average.
-  // Applies to 'xavier' and 'msra' fillers.
-  enum VarianceNorm {
-    FAN_IN = 0;
-    FAN_OUT = 1;
-    AVERAGE = 2;
-  }
-  optional VarianceNorm variance_norm = 8 [default = FAN_IN];
 }
 
 message NetParameter {
@@ -96,7 +88,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 37 (last added: iter_size)
+// SolverParameter next available ID: 36 (last added: clip_gradients)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -149,8 +141,6 @@ message SolverParameter {
   // Display the loss averaged over the last average_loss iterations
   optional int32 average_loss = 33 [default = 1];
   optional int32 max_iter = 7; // the maximum number of iterations
-  // accumulate gradients over `iter_size` x `batch_size` instances
-  optional int32 iter_size = 36 [default = 1];
   optional string lr_policy = 8; // The learning rate decay policy.
   optional float gamma = 9; // The parameter to compute the learning rate.
   optional float power = 10; // The parameter to compute the learning rate.
@@ -269,7 +259,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 137 (last added: reduction_param)
+// LayerParameter next available layer-specific ID: 133 (last added: one_of_n_param)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -290,10 +280,6 @@ message LayerParameter {
 
   // The blobs containing the numeric parameters of the layer.
   repeated BlobProto blobs = 7;
-  
-  // Specifies on which bottoms the backpropagation should be skipped.
-  // The size must be either 0 or equal to the number of bottoms.
-  repeated bool propagate_down = 11;
 
   // Rules controlling whether and when a layer is included in the network,
   // based on the current NetState.  You may specify a non-zero number of rules
@@ -326,27 +312,23 @@ message LayerParameter {
   optional DummyDataParameter dummy_data_param = 109;
   optional EltwiseParameter eltwise_param = 110;
   optional ExpParameter exp_param = 111;
-  optional FlattenParameter flatten_param = 135;
   optional HDF5DataParameter hdf5_data_param = 112;
   optional HDF5OutputParameter hdf5_output_param = 113;
   optional HingeLossParameter hinge_loss_param = 114;
   optional ImageDataParameter image_data_param = 115;
   optional InfogainLossParameter infogain_loss_param = 116;
   optional InnerProductParameter inner_product_param = 117;
-  optional LogParameter log_param = 134;
   optional LRNParameter lrn_param = 118;
   optional MemoryDataParameter memory_data_param = 119;
   optional MVNParameter mvn_param = 120;
+  optional OneOfNParameter one_of_n_param = 132;
   optional PoolingParameter pooling_param = 121;
   optional PowerParameter power_param = 122;
   optional PReLUParameter prelu_param = 131;
   optional PythonParameter python_param = 130;
-  optional ReductionParameter reduction_param = 136;
   optional ReLUParameter relu_param = 123;
-  optional ReshapeParameter reshape_param = 133;
   optional SigmoidParameter sigmoid_param = 124;
   optional SoftmaxParameter softmax_param = 125;
-  optional SPPParameter spp_param = 132;
   optional SliceParameter slice_param = 126;
   optional TanHParameter tanh_param = 127;
   optional ThresholdParameter threshold_param = 128;
@@ -370,10 +352,6 @@ message TransformationParameter {
   // or can be repeated the same number of times as channels
   // (would subtract them from the corresponding channel)
   repeated float mean_value = 5;
-  // Force the decoded image to have 3 color channels.
-  optional bool force_color = 6 [default = false];
-  // Force the decoded image to have 1 color channels.
-  optional bool force_gray = 7 [default = false];
 }
 
 // Message that stores parameters shared by loss layers
@@ -385,9 +363,7 @@ message LossParameter {
   optional bool normalize = 2 [default = true];
 }
 
-// Messages that store parameters used by individual layer types follow, in
-// alphabetical order.
-
+// Message that stores parameters used by AccuracyLayer
 message AccuracyParameter {
   // When computing accuracy, count as correct by comparing the true label to
   // the top k scoring classes.  By default, only compare to the top scoring
@@ -405,12 +381,14 @@ message AccuracyParameter {
   optional int32 ignore_label = 3;
 }
 
+// Message that stores parameters used by ArgMaxLayer
 message ArgMaxParameter {
   // If true produce pairs (argmax, maxval)
   optional bool out_max_val = 1 [default = false];
   optional uint32 top_k = 2 [default = 1];
 }
 
+// Message that stores parameters used by ConcatLayer
 message ConcatParameter {
   // The axis along which to concatenate -- may be negative to index from the
   // end (e.g., -1 for the last axis).  Other axes must have the
@@ -422,18 +400,13 @@ message ConcatParameter {
   optional uint32 concat_dim = 1 [default = 1];
 }
 
+// Message that stores parameters used by ContrastiveLossLayer
 message ContrastiveLossParameter {
-  // margin for dissimilar pair
+  //margin for dissimilar pair
   optional float margin = 1 [default = 1.0];
-  // The first implementation of this cost did not exactly match the cost of
-  // Hadsell et al 2006 -- using (margin - d^2) instead of (margin - d)^2.
-  // legacy_version = false (the default) uses (margin - d)^2 as proposed in the
-  // Hadsell paper. New models should probably use this version.
-  // legacy_version = true uses (margin - d^2). This is kept to support /
-  // reproduce existing models and results
-  optional bool legacy_version = 2 [default = false]; 
 }
 
+// Message that stores parameters used by ConvolutionLayer
 message ConvolutionParameter {
   optional uint32 num_output = 1; // The number of outputs for the layer
   optional bool bias_term = 2 [default = true]; // whether to have bias terms
@@ -459,6 +432,7 @@ message ConvolutionParameter {
   optional Engine engine = 15 [default = DEFAULT];
 }
 
+// Message that stores parameters used by DataLayer
 message DataParameter {
   enum DB {
     LEVELDB = 0;
@@ -489,10 +463,12 @@ message DataParameter {
   optional bool force_encoded_color = 9 [default = false];
 }
 
+// Message that stores parameters used by DropoutLayer
 message DropoutParameter {
   optional float dropout_ratio = 1 [default = 0.5]; // dropout ratio
 }
 
+// Message that stores parameters used by DummyDataLayer.
 // DummyDataLayer fills any number of arbitrarily shaped blobs with random
 // (or constant) data generated by "Fillers" (see "message FillerParameter").
 message DummyDataParameter {
@@ -512,6 +488,7 @@ message DummyDataParameter {
   repeated uint32 width = 5;
 }
 
+// Message that stores parameters used by EltwiseLayer
 message EltwiseParameter {
   enum EltwiseOp {
     PROD = 0;
@@ -526,6 +503,7 @@ message EltwiseParameter {
   optional bool stable_prod_grad = 3 [default = true];
 }
 
+// Message that stores parameters used by ExpLayer
 message ExpParameter {
   // ExpLayer computes outputs y = base ^ (shift + scale * x), for base > 0.
   // Or if base is set to the default (-1), base is set to e,
@@ -533,18 +511,6 @@ message ExpParameter {
   optional float base = 1 [default = -1.0];
   optional float scale = 2 [default = 1.0];
   optional float shift = 3 [default = 0.0];
-}
-
-/// Message that stores parameters used by FlattenLayer
-message FlattenParameter {
-  // The first axis to flatten: all preceding axes are retained in the output.
-  // May be negative to index from the end (e.g., -1 for the last axis).
-  optional int32 axis = 1 [default = 1];
-
-  // The last axis to flatten: all following axes are retained in the output.
-  // May be negative to index from the end (e.g., the default -1 for the last
-  // axis).
-  optional int32 end_axis = 2 [default = -1];
 }
 
 // Message that stores parameters used by HDF5DataLayer
@@ -562,6 +528,7 @@ message HDF5DataParameter {
   optional bool shuffle = 3 [default = false];
 }
 
+// Message that stores parameters used by HDF5OutputLayer
 message HDF5OutputParameter {
   optional string file_name = 1;
 }
@@ -575,6 +542,7 @@ message HingeLossParameter {
   optional Norm norm = 1 [default = L1];
 }
 
+// Message that stores parameters used by ImageDataLayer
 message ImageDataParameter {
   // Specify the data source.
   optional string source = 1;
@@ -606,11 +574,13 @@ message ImageDataParameter {
   optional string root_folder = 12 [default = ""];
 }
 
+// Message that stores parameters InfogainLossLayer
 message InfogainLossParameter {
   // Specify the infogain matrix source.
   optional string source = 1;
 }
 
+// Message that stores parameters used by InnerProductLayer
 message InnerProductParameter {
   optional uint32 num_output = 1; // The number of outputs for the layer
   optional bool bias_term = 2 [default = true]; // whether to have bias terms
@@ -621,16 +591,6 @@ message InnerProductParameter {
   // all preceding axes are retained in the output.
   // May be negative to index from the end (e.g., -1 for the last axis).
   optional int32 axis = 5 [default = 1];
-}
-
-// Message that stores parameters used by LogLayer
-message LogParameter {
-  // LogLayer computes outputs y = log_base(shift + scale * x), for base > 0.
-  // Or if base is set to the default (-1), base is set to e,
-  // so y = ln(shift + scale * x) = log_e(shift + scale * x)
-  optional float base = 1 [default = -1.0];
-  optional float scale = 2 [default = 1.0];
-  optional float shift = 3 [default = 0.0];
 }
 
 // Message that stores parameters used by LRNLayer
@@ -646,6 +606,7 @@ message LRNParameter {
   optional float k = 5 [default = 1.];
 }
 
+// Message that stores parameters used by MemoryDataLayer
 message MemoryDataParameter {
   optional uint32 batch_size = 1;
   optional uint32 channels = 2;
@@ -653,17 +614,22 @@ message MemoryDataParameter {
   optional uint32 width = 4;
 }
 
+// Message that stores parameters used by MVNLayer
 message MVNParameter {
   // This parameter can be set to false to normalize mean only
   optional bool normalize_variance = 1 [default = true];
 
   // This parameter can be set to true to perform DNN-like MVN
   optional bool across_channels = 2 [default = false];
-
-  // Epsilon for not dividing by zero while normalizing variance
-  optional float eps = 3 [default = 1e-9];
 }
 
+// Message that stores parameters used by oneOfN common layer
+message OneOfNParameter {
+  // This parameter sets the n for the one-of-n mapping
+  optional uint32 output_n = 1 [default = 2];
+}
+
+// Message that stores parameters used by PoolingLayer
 message PoolingParameter {
   enum PoolMethod {
     MAX = 0;
@@ -693,6 +659,7 @@ message PoolingParameter {
   optional bool global_pooling = 12 [default = false];
 }
 
+// Message that stores parameters used by PowerLayer
 message PowerParameter {
   // PowerLayer computes outputs y = (shift + scale * x) ^ power.
   optional float power = 1 [default = 1.0];
@@ -700,38 +667,10 @@ message PowerParameter {
   optional float shift = 3 [default = 0.0];
 }
 
+// Message that stores parameters used by PythonLayer
 message PythonParameter {
   optional string module = 1;
   optional string layer = 2;
-}
-
-// Message that stores parameters used by ReductionLayer
-message ReductionParameter {
-  enum ReductionOp {
-    SUM = 1;
-    ASUM = 2;
-    SUMSQ = 3;
-    MEAN = 4;
-  }
-
-  optional ReductionOp operation = 1 [default = SUM]; // reduction operation
-
-  // The first axis to reduce to a scalar -- may be negative to index from the
-  // end (e.g., -1 for the last axis).
-  // (Currently, only reduction along ALL "tail" axes is supported; reduction
-  // of axis M through N, where N < num_axes - 1, is unsupported.)
-  // Suppose we have an n-axis bottom Blob with shape:
-  //     (d0, d1, d2, ..., d(m-1), dm, d(m+1), ..., d(n-1)).
-  // If axis == m, the output Blob will have shape
-  //     (d0, d1, d2, ..., d(m-1)),
-  // and the ReductionOp operation is performed (d0 * d1 * d2 * ... * d(m-1))
-  // times, each including (dm * d(m+1) * ... * d(n-1)) individual data.
-  // If axis == 0 (the default), the output Blob always has the empty shape
-  // (count 1), performing reduction across the entire input --
-  // often useful for creating new loss functions.
-  optional int32 axis = 2 [default = 0];
-
-  optional float coeff = 3 [default = 1.0]; // coefficient for output
 }
 
 // Message that stores parameters used by ReLULayer
@@ -750,70 +689,7 @@ message ReLUParameter {
   optional Engine engine = 2 [default = DEFAULT];
 }
 
-message ReshapeParameter {
-  // Specify the output dimensions. If some of the dimensions are set to 0,
-  // the corresponding dimension from the bottom layer is used (unchanged).
-  // Exactly one dimension may be set to -1, in which case its value is
-  // inferred from the count of the bottom blob and the remaining dimensions.
-  // For example, suppose we want to reshape a 2D blob "input" with shape 2 x 8:
-  //
-  //   layer {
-  //     type: "Reshape" bottom: "input" top: "output"
-  //     reshape_param { ... }
-  //   }
-  //
-  // If "input" is 2D with shape 2 x 8, then the following reshape_param
-  // specifications are all equivalent, producing a 3D blob "output" with shape
-  // 2 x 2 x 4:
-  //
-  //   reshape_param { shape { dim:  2  dim: 2  dim:  4 } }
-  //   reshape_param { shape { dim:  0  dim: 2  dim:  4 } }
-  //   reshape_param { shape { dim:  0  dim: 2  dim: -1 } }
-  //   reshape_param { shape { dim: -1  dim: 0  dim:  2 } }
-  //
-  optional BlobShape shape = 1;
-
-  // axis and num_axes control the portion of the bottom blob's shape that are
-  // replaced by (included in) the reshape. By default (axis == 0 and
-  // num_axes == -1), the entire bottom blob shape is included in the reshape,
-  // and hence the shape field must specify the entire output shape.
-  //
-  // axis may be non-zero to retain some portion of the beginning of the input
-  // shape (and may be negative to index from the end; e.g., -1 to begin the
-  // reshape after the last axis, including nothing in the reshape,
-  // -2 to include only the last axis, etc.).
-  //
-  // For example, suppose "input" is a 2D blob with shape 2 x 8.
-  // Then the following ReshapeLayer specifications are all equivalent,
-  // producing a blob "output" with shape 2 x 2 x 4:
-  //
-  //   reshape_param { shape { dim: 2  dim: 2  dim: 4 } }
-  //   reshape_param { shape { dim: 2  dim: 4 } axis:  1 }
-  //   reshape_param { shape { dim: 2  dim: 4 } axis: -3 }
-  //
-  // num_axes specifies the extent of the reshape.
-  // If num_axes >= 0 (and axis >= 0), the reshape will be performed only on
-  // input axes in the range [axis, axis+num_axes].
-  // num_axes may also be -1, the default, to include all remaining axes
-  // (starting from axis).
-  //
-  // For example, suppose "input" is a 2D blob with shape 2 x 8.
-  // Then the following ReshapeLayer specifications are equivalent,
-  // producing a blob "output" with shape 1 x 2 x 8.
-  //
-  //   reshape_param { shape { dim:  1  dim: 2  dim:  8 } }
-  //   reshape_param { shape { dim:  1  dim: 2  }  num_axes: 1 }
-  //   reshape_param { shape { dim:  1  }  num_axes: 0 }
-  //
-  // On the other hand, these would produce output blob shape 2 x 1 x 8:
-  //
-  //   reshape_param { shape { dim: 2  dim: 1  dim: 8  }  }
-  //   reshape_param { shape { dim: 1 }  axis: 1  num_axes: 0 }
-  //
-  optional int32 axis = 2 [default = 0];
-  optional int32 num_axes = 3 [default = -1];
-}
-
+// Message that stores parameters used by SigmoidLayer
 message SigmoidParameter {
   enum Engine {
     DEFAULT = 0;
@@ -823,6 +699,7 @@ message SigmoidParameter {
   optional Engine engine = 1 [default = DEFAULT];
 }
 
+// Message that stores parameters used by SliceLayer
 message SliceParameter {
   // The axis along which to slice -- may be negative to index from the end
   // (e.g., -1 for the last axis).
@@ -849,6 +726,7 @@ message SoftmaxParameter {
   optional int32 axis = 2 [default = 1];
 }
 
+// Message that stores parameters used by TanHLayer
 message TanHParameter {
   enum Engine {
     DEFAULT = 0;
@@ -858,10 +736,12 @@ message TanHParameter {
   optional Engine engine = 1 [default = DEFAULT];
 }
 
+// Message that stores parameters used by ThresholdLayer
 message ThresholdParameter {
   optional float threshold = 1 [default = 0]; // Strictly positive values
 }
 
+// Message that stores parameters used by WindowDataLayer
 message WindowDataParameter {
   // Specify the data source.
   optional string source = 1;
@@ -893,22 +773,6 @@ message WindowDataParameter {
   optional bool cache_images = 12 [default = false];
   // append root_folder to locate images
   optional string root_folder = 13 [default = ""];
-}
-
-message SPPParameter {
-  enum PoolMethod {
-    MAX = 0;
-    AVE = 1;
-    STOCHASTIC = 2;
-  }
-  optional uint32 pyramid_height = 1;
-  optional PoolMethod pool = 2 [default = MAX]; // The pooling method
-  enum Engine {
-    DEFAULT = 0;
-    CAFFE = 1;
-    CUDNN = 2;
-  }
-  optional Engine engine = 6 [default = DEFAULT];
 }
 
 // DEPRECATED: use LayerParameter.
@@ -1098,6 +962,7 @@ message V0LayerParameter {
   optional HDF5OutputParameter hdf5_output_param = 1001;
 }
 
+// Message that stores parameters used by PReLULayer
 message PReLUParameter {
   // Parametric ReLU described in K. He et al, Delving Deep into Rectifiers:
   // Surpassing Human-Level Performance on ImageNet Classification, 2015.
@@ -1107,3 +972,10 @@ message PReLUParameter {
   // Whether or not slope paramters are shared across channels.
   optional bool channel_shared = 2 [default = false];
 }
+
+
+
+
+
+
+

--- a/src/caffe/test/test_one_of_n_layer.cpp
+++ b/src/caffe/test/test_one_of_n_layer.cpp
@@ -1,0 +1,97 @@
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/vision_layers.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+class OneOfNLayerTest : public ::testing::Test {
+ protected:
+  OneOfNLayerTest()
+      : blob_bottom_(new Blob<Dtype>(10, 1, 1, 1024)),
+        blob_top_(new Blob<Dtype>()),
+        output_n_(69) {
+    Caffe::set_mode(Caffe::CPU);
+   
+    // fill the values
+    FillerParameter filler_param;
+    filler_param.set_min(0);
+    filler_param.set_max(68);
+    UniformFiller<Dtype> filler(filler_param);
+
+    blob_bottom_vec_.push_back(blob_bottom_);
+    blob_top_vec_.push_back(blob_top_);
+  }
+  virtual ~OneOfNLayerTest() { delete blob_bottom_; delete blob_top_; }
+  Blob<Dtype>* const blob_bottom_;
+  Blob<Dtype>* const blob_top_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+  size_t output_n_;
+};
+
+TYPED_TEST_CASE(OneOfNLayerTest, TestDtypes);
+
+TYPED_TEST(OneOfNLayerTest, TestSetup) {
+  
+  // Create LayerParameter with the known parameters.
+  // with output_n set as 69
+  LayerParameter param;
+
+  OneOfNParameter* one_of_n_param = param.mutable_one_of_n_param();
+  int output_n = this->output_n_;
+  one_of_n_param->set_output_n(output_n);
+
+  // Test that the layer setup got the correct parameters.
+  OneOfNLayer<TypeParam> layer(param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  EXPECT_EQ(this->blob_top_->num(), this->blob_bottom_->num());
+  EXPECT_EQ(this->blob_top_->channels(), output_n);
+  EXPECT_EQ(this->blob_top_->height(), 1);
+  EXPECT_EQ(this->blob_top_->width(), 1024);
+
+}
+
+
+TYPED_TEST(OneOfNLayerTest, TestCPU) {
+
+  LayerParameter layer_param;
+
+  OneOfNParameter* one_of_n_param = layer_param.mutable_one_of_n_param();
+  int output_n = this->output_n_;
+  one_of_n_param->set_output_n(output_n);
+
+  OneOfNLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+
+  // Now, check values
+  const TypeParam* bottom_data = this->blob_bottom_->cpu_data();
+  const TypeParam* top_data = this->blob_top_->cpu_data();
+  int num = this->blob_bottom_->num();
+  int dim = this->blob_bottom_->count(3, 4);
+  for (int i = 0; i < num; ++i) {
+    for (int j = 0; j < dim; ++j) {
+      int label = bottom_data[i * dim + j];
+      for (int k = 0; k < output_n; ++k) {
+        if (k == label) {
+          EXPECT_EQ(top_data[i * dim * output_n + j + k * dim], 1);
+        }
+        else {
+          EXPECT_EQ(top_data[i * dim * output_n + j + k * dim], 0);
+        }
+      }
+      EXPECT_GE(top_data[i], 0);
+    }
+  }
+}
+
+}  // namespace caffe


### PR DESCRIPTION
In light of the one_of_n encoding being a popular way to represent integer labeled data (i.e. characters for text data), we have written a common layer that takes one-channeled data with integer values and expands into n-channeled one-of-n encoding vectors.

The protobuf is updated with a new type called OneOfN, that takes a single optional parameter called option_n (default = 2) that specifies the number of distinct possible values of the input data, which will be expanded into one-of-n vectors. 

contributing authors:
Nathan Hurst  @njhurst 
Chen-Ping Yu @cpu90 
