### PR TITLE
High level tensor and math API to unify the devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,11 +386,13 @@ endif
 ##############################
 # Define build targets
 ##############################
-.PHONY: all test clean docs linecount lint lintclean tools examples $(DIST_ALIASES) \
+.PHONY: all libs test clean docs linecount lint lintclean tools examples $(DIST_ALIASES) \
 	py mat py$(PROJECT) mat$(PROJECT) proto runtest \
 	superclean supercleanlist supercleanfiles warn everything
 
-all: $(STATIC_NAME) $(DYNAMIC_NAME) tools examples
+all: libs tools examples
+
+libs: $(STATIC_NAME) $(DYNAMIC_NAME)
 
 everything: $(EVERYTHING_TARGETS)
 

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -7,7 +7,7 @@
 
 #include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"
-#include "caffe/syncedmem.hpp"
+#include "caffe/tensor.hpp"
 #include "caffe/util/math_functions.hpp"
 
 const int kMaxBlobAxes = INT_MAX;
@@ -21,11 +21,10 @@ namespace caffe {
  *
  * TODO(dox): more thorough description.
  */
-template <typename Dtype>
+template<typename Dtype>
 class Blob {
  public:
-  Blob()
-       : data_(), diff_(), count_(0), capacity_(0) {}
+  Blob();
 
   /// @brief Deprecated; use <code>Blob(const vector<int>& shape)</code>.
   explicit Blob(const int num, const int channels, const int height,
@@ -60,7 +59,9 @@ class Blob {
     stream << "(" << count_ << ")";
     return stream.str();
   }
-  inline const vector<int>& shape() const { return shape_; }
+  inline const vector<int>& shape() const {
+    return shape_;
+  }
   /**
    * @brief Returns the dimension of the index-th axis (or the negative index-th
    *        axis from the end, if index is negative).
@@ -72,8 +73,12 @@ class Blob {
   inline int shape(int index) const {
     return shape_[CanonicalAxisIndex(index)];
   }
-  inline int num_axes() const { return shape_.size(); }
-  inline int count() const { return count_; }
+  inline int num_axes() const {
+    return shape_.size();
+  }
+  inline int count() const {
+    return count_;
+  }
 
   /**
    * @brief Compute the volume of a slice; i.e., the product of dimensions
@@ -117,12 +122,12 @@ class Blob {
    *        Dies on out of range index.
    */
   inline int CanonicalAxisIndex(int axis_index) const {
-    CHECK_GE(axis_index, -num_axes())
-        << "axis " << axis_index << " out of range for " << num_axes()
-        << "-D Blob with shape " << shape_string();
-    CHECK_LT(axis_index, num_axes())
-        << "axis " << axis_index << " out of range for " << num_axes()
-        << "-D Blob with shape " << shape_string();
+    CHECK_GE(axis_index, -num_axes()) << "axis " << axis_index
+        << " out of range for " << num_axes() << "-D Blob with shape "
+        << shape_string();
+    CHECK_LT(axis_index, num_axes()) << "axis " << axis_index
+        << " out of range for " << num_axes() << "-D Blob with shape "
+        << shape_string();
     if (axis_index < 0) {
       return axis_index + num_axes();
     }
@@ -130,13 +135,21 @@ class Blob {
   }
 
   /// @brief Deprecated legacy shape accessor num: use shape(0) instead.
-  inline int num() const { return LegacyShape(0); }
+  inline int num() const {
+    return LegacyShape(0);
+  }
   /// @brief Deprecated legacy shape accessor channels: use shape(1) instead.
-  inline int channels() const { return LegacyShape(1); }
+  inline int channels() const {
+    return LegacyShape(1);
+  }
   /// @brief Deprecated legacy shape accessor height: use shape(2) instead.
-  inline int height() const { return LegacyShape(2); }
+  inline int height() const {
+    return LegacyShape(2);
+  }
   /// @brief Deprecated legacy shape accessor width: use shape(3) instead.
-  inline int width() const { return LegacyShape(3); }
+  inline int width() const {
+    return LegacyShape(3);
+  }
   inline int LegacyShape(int index) const {
     CHECK_LE(num_axes(), 4)
         << "Cannot use legacy accessors on Blobs with > 4 axes.";
@@ -151,8 +164,8 @@ class Blob {
     return shape(index);
   }
 
-  inline int offset(const int n, const int c = 0, const int h = 0,
-      const int w = 0) const {
+  inline int offset(const int n, const int c = 0, const int h = 0, const int w =
+      0) const {
     CHECK_GE(n, 0);
     CHECK_LE(n, num());
     CHECK_GE(channels(), 0);
@@ -207,14 +220,24 @@ class Blob {
     return cpu_diff()[offset(index)];
   }
 
-  inline const shared_ptr<SyncedMemory>& data() const {
-    CHECK(data_);
-    return data_;
+  inline const shared_ptr<SyncedTensor<Dtype> > data_tensor() const {
+    CHECK(data_tensor_);
+    return data_tensor_;
   }
 
-  inline const shared_ptr<SyncedMemory>& diff() const {
-    CHECK(diff_);
-    return diff_;
+  inline const shared_ptr<SyncedTensor<Dtype> > diff_tensor() const {
+    CHECK(diff_tensor_);
+    return diff_tensor_;
+  }
+
+  inline SyncedTensor<Dtype>& data() const {
+    CHECK(data_tensor_);
+    return *(data_tensor_.get());
+  }
+
+  inline SyncedTensor<Dtype>& diff() const {
+    CHECK(diff_tensor_);
+    return *(diff_tensor_.get());
   }
 
   const Dtype* cpu_data() const;
@@ -266,14 +289,15 @@ class Blob {
   bool ShapeEquals(const BlobProto& other);
 
  protected:
-  shared_ptr<SyncedMemory> data_;
-  shared_ptr<SyncedMemory> diff_;
+  shared_ptr<SyncedTensor<Dtype> > data_tensor_;
+  shared_ptr<SyncedTensor<Dtype> > diff_tensor_;
   vector<int> shape_;
   int count_;
   int capacity_;
 
-  DISABLE_COPY_AND_ASSIGN(Blob);
-};  // class Blob
+DISABLE_COPY_AND_ASSIGN(Blob);
+};
+// class Blob
 
 }  // namespace caffe
 

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -167,6 +167,31 @@ class Caffe {
   DISABLE_COPY_AND_ASSIGN(Caffe);
 };
 
+// Theoretically, CaffeMallocHost and CaffeFreeHost should simply call the
+// cudaMallocHost and cudaFree functions in order to create pinned memory.
+// However, those codes rely on the existence of a cuda GPU (I don't know
+// why that is a must since allocating memory should not be accessing the
+// GPU resource, but it just creates an error as of Cuda 5.0) and will cause
+// problem when running on a machine without GPU. Thus, we simply define
+// these two functions for safety and possible future change if the problem
+// of calling cuda functions disappears in a future version.
+//
+// In practice, although we are creating unpinned memory here, as long as we
+// are constantly accessing them the memory pages almost always stays in
+// the physical memory (assuming we have large enough memory installed), and
+// does not seem to create a memory bottleneck here.
+
+inline void CaffeMallocHost(void** ptr, size_t size) {
+  if (size > 0) {
+    *ptr = malloc(size);
+    CHECK(*ptr) << "host allocation of size " << size << " failed";
+  }
+}
+
+inline void CaffeFreeHost(void* ptr) {
+  free(ptr);
+}
+
 }  // namespace caffe
 
 #endif  // CAFFE_COMMON_HPP_

--- a/include/caffe/filler.hpp
+++ b/include/caffe/filler.hpp
@@ -11,6 +11,7 @@
 #include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/syncedmem.hpp"
+#include "caffe/tensor.hpp"
 #include "caffe/util/math_functions.hpp"
 
 namespace caffe {
@@ -22,6 +23,7 @@ class Filler {
   explicit Filler(const FillerParameter& param) : filler_param_(param) {}
   virtual ~Filler() {}
   virtual void Fill(Blob<Dtype>* blob) = 0;
+  virtual void Fill(Tensor<Dtype>* tensor) = 0;
  protected:
   FillerParameter filler_param_;
 };  // class Filler
@@ -34,6 +36,7 @@ class ConstantFiller : public Filler<Dtype> {
   explicit ConstantFiller(const FillerParameter& param)
       : Filler<Dtype>(param) {}
   virtual void Fill(Blob<Dtype>* blob) {
+    CHECK(blob);
     Dtype* data = blob->mutable_cpu_data();
     const int count = blob->count();
     const Dtype value = this->filler_param_.value();
@@ -44,6 +47,10 @@ class ConstantFiller : public Filler<Dtype> {
     CHECK_EQ(this->filler_param_.sparse(), -1)
          << "Sparsity not supported by this Filler.";
   }
+
+  virtual void Fill(Tensor<Dtype>* tensor) {
+    NOT_IMPLEMENTED;
+  }
 };
 
 /// @brief Fills a Blob with uniformly distributed values @f$ x\sim U(a, b) @f$.
@@ -52,10 +59,17 @@ class UniformFiller : public Filler<Dtype> {
  public:
   explicit UniformFiller(const FillerParameter& param)
       : Filler<Dtype>(param) {}
+
   virtual void Fill(Blob<Dtype>* blob) {
-    CHECK(blob->count());
-    caffe_rng_uniform<Dtype>(blob->count(), Dtype(this->filler_param_.min()),
-        Dtype(this->filler_param_.max()), blob->mutable_cpu_data());
+    CHECK(blob);
+    Fill(blob->data_tensor().get());
+  }
+
+  virtual void Fill(Tensor<Dtype>* tensor) {
+    CHECK(tensor);
+    CHECK(tensor->size());
+    caffe_rng_uniform<Dtype>(tensor->size(), Dtype(this->filler_param_.min()),
+        Dtype(this->filler_param_.max()), tensor->mutable_data());
     CHECK_EQ(this->filler_param_.sparse(), -1)
          << "Sparsity not supported by this Filler.";
   }
@@ -68,6 +82,7 @@ class GaussianFiller : public Filler<Dtype> {
   explicit GaussianFiller(const FillerParameter& param)
       : Filler<Dtype>(param) {}
   virtual void Fill(Blob<Dtype>* blob) {
+    CHECK(blob);
     Dtype* data = blob->mutable_cpu_data();
     CHECK(blob->count());
     caffe_rng_gaussian<Dtype>(blob->count(), Dtype(this->filler_param_.mean()),
@@ -91,6 +106,10 @@ class GaussianFiller : public Filler<Dtype> {
     }
   }
 
+  virtual void Fill(Tensor<Dtype>* tensor) {
+    NOT_IMPLEMENTED;
+  }
+
  protected:
   shared_ptr<SyncedMemory> rand_vec_;
 };
@@ -104,6 +123,7 @@ class PositiveUnitballFiller : public Filler<Dtype> {
   explicit PositiveUnitballFiller(const FillerParameter& param)
       : Filler<Dtype>(param) {}
   virtual void Fill(Blob<Dtype>* blob) {
+    CHECK(blob);
     Dtype* data = blob->mutable_cpu_data();
     DCHECK(blob->count());
     caffe_rng_uniform<Dtype>(blob->count(), 0, 1, blob->mutable_cpu_data());
@@ -122,6 +142,10 @@ class PositiveUnitballFiller : public Filler<Dtype> {
     }
     CHECK_EQ(this->filler_param_.sparse(), -1)
          << "Sparsity not supported by this Filler.";
+  }
+
+  virtual void Fill(Tensor<Dtype>* tensor) {
+    NOT_IMPLEMENTED;
   }
 };
 
@@ -147,6 +171,7 @@ class XavierFiller : public Filler<Dtype> {
   explicit XavierFiller(const FillerParameter& param)
       : Filler<Dtype>(param) {}
   virtual void Fill(Blob<Dtype>* blob) {
+    CHECK(blob);
     CHECK(blob->count());
     int fan_in = blob->count() / blob->num();
     int fan_out = blob->count() / blob->channels();
@@ -163,6 +188,10 @@ class XavierFiller : public Filler<Dtype> {
         blob->mutable_cpu_data());
     CHECK_EQ(this->filler_param_.sparse(), -1)
          << "Sparsity not supported by this Filler.";
+  }
+
+  virtual void Fill(Tensor<Dtype>* tensor) {
+    NOT_IMPLEMENTED;
   }
 };
 
@@ -189,6 +218,7 @@ class MSRAFiller : public Filler<Dtype> {
   explicit MSRAFiller(const FillerParameter& param)
       : Filler<Dtype>(param) {}
   virtual void Fill(Blob<Dtype>* blob) {
+    CHECK(blob);
     CHECK(blob->count());
     int fan_in = blob->count() / blob->num();
     int fan_out = blob->count() / blob->channels();
@@ -205,6 +235,10 @@ class MSRAFiller : public Filler<Dtype> {
         blob->mutable_cpu_data());
     CHECK_EQ(this->filler_param_.sparse(), -1)
          << "Sparsity not supported by this Filler.";
+  }
+
+  virtual void Fill(Tensor<Dtype>* tensor) {
+    NOT_IMPLEMENTED;
   }
 };
 
@@ -247,6 +281,7 @@ class BilinearFiller : public Filler<Dtype> {
   explicit BilinearFiller(const FillerParameter& param)
       : Filler<Dtype>(param) {}
   virtual void Fill(Blob<Dtype>* blob) {
+    CHECK(blob);
     CHECK_EQ(blob->num_axes(), 4) << "Blob must be 4 dim.";
     CHECK_EQ(blob->width(), blob->height()) << "Filter must be square";
     Dtype* data = blob->mutable_cpu_data();
@@ -259,6 +294,10 @@ class BilinearFiller : public Filler<Dtype> {
     }
     CHECK_EQ(this->filler_param_.sparse(), -1)
          << "Sparsity not supported by this Filler.";
+  }
+
+  virtual void Fill(Tensor<Dtype>* tensor) {
+    NOT_IMPLEMENTED;
   }
 };
 

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -8,30 +8,6 @@
 
 namespace caffe {
 
-// Theoretically, CaffeMallocHost and CaffeFreeHost should simply call the
-// cudaMallocHost and cudaFree functions in order to create pinned memory.
-// However, those codes rely on the existence of a cuda GPU (I don't know
-// why that is a must since allocating memory should not be accessing the
-// GPU resource, but it just creates an error as of Cuda 5.0) and will cause
-// problem when running on a machine without GPU. Thus, we simply define
-// these two functions for safety and possible future change if the problem
-// of calling cuda functions disappears in a future version.
-//
-// In practice, although we are creating unpinned memory here, as long as we
-// are constantly accessing them the memory pages almost always stays in
-// the physical memory (assuming we have large enough memory installed), and
-// does not seem to create a memory bottleneck here.
-
-inline void CaffeMallocHost(void** ptr, size_t size) {
-  *ptr = malloc(size);
-  CHECK(*ptr) << "host allocation of size " << size << " failed";
-}
-
-inline void CaffeFreeHost(void* ptr) {
-  free(ptr);
-}
-
-
 /**
  * @brief Manages memory allocation and synchronization between the host (CPU)
  *        and device (GPU).

--- a/include/caffe/tensor.hpp
+++ b/include/caffe/tensor.hpp
@@ -1,0 +1,735 @@
+#ifndef CAFFE_TENSOR_HPP_
+#define CAFFE_TENSOR_HPP_
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/math_functions.hpp"
+
+const int kMaxTensorAxes = INT_MAX;
+
+namespace caffe {
+
+inline vector<int> dimToShape(int dim0, int dim1, int dim2, int dim3) {
+  vector<int> shape(4);
+  shape[0] = dim0;
+  shape[1] = dim1;
+  shape[2] = dim2;
+  shape[3] = dim3;
+  return shape;
+}
+
+enum TensorType {
+  UNKNOWN_TENSOR,
+  CPU_TENSOR,
+  GPU_TENSOR,
+  SYNCED_TENSOR
+};
+
+/**
+ * @brief A wrapper around void pointer serving as the view of the
+ *        underlying memory storage. It's up to the users to specify the
+ *        meanings of the data dimensions.
+ *
+ * TODO(dox): more thorough description.
+ */
+template<typename Dtype>
+class Tensor {
+ public:
+  Tensor();
+
+  explicit Tensor(const vector<int>& shape);
+
+  /// @brief Convenience method for Tensor whose dimensions are equal to or
+  ///        less than 4.
+  explicit Tensor(const int dim0, const int dim1 = 1, const int dim2 = 1,
+      const int dim3 = 1);
+
+  virtual ~Tensor() {
+  }
+
+  TensorType type() const {
+    return type_;
+  }
+
+  /**
+   * @brief Returns the 'canonical' version of a (usually) user-specified axis,
+   *        allowing for negative indexing (e.g., -1 for the last axis).
+   *
+   * @param index the axis index.
+   *        If 0 <= index < num_axes(), return index.
+   *        If -num_axes <= index <= -1, return (num_axes() - (-index)),
+   *        e.g., the last axis index (num_axes() - 1) if index == -1,
+   *        the second to last if index == -2, etc.
+   *        Dies on out of range index.
+   */
+  inline int CanonicalAxisIndex(int axis_index) const {
+    CHECK_GE(axis_index, -num_axes()) << "axis " << axis_index
+        << " out of range for " << num_axes() << "-D Tensor with shape "
+        << shape_string();
+    CHECK_LT(axis_index, num_axes()) << "axis " << axis_index
+        << " out of range for " << num_axes() << "-D Tensor with shape "
+        << shape_string();
+    if (axis_index < 0) {
+      return axis_index + num_axes();
+    }
+    return axis_index;
+  }
+
+  /**
+   * @brief Change the dimensions of the Tensor, allocating new memory if
+   *        necessary.
+   *
+   * This function can be called both to create an initial allocation
+   * of memory, and to adjust the dimensions of a top Tensor during Layer::Reshape
+   * or Layer::Forward. When changing the size of Tensor, memory will only be
+   * reallocated if sufficient memory does not already exist, and excess memory
+   * will never be freed.
+   *
+   * Note that reshaping an input Tensor and immediately calling Net::Backward is
+   * an error; either Net::Forward or Net::Reshape need to be called to
+   * propagate the new input shape to higher layers.
+   */
+  virtual void Reshape(const vector<int>& shape);
+
+  virtual void Reshape(const TensorShape& shape);
+
+  /// @brief Convenience method for Tensor whose dimensions are equal to or
+  ///        less than 4.
+  virtual void Reshape(const int dim0, const int dim1 = 1, const int dim2 = 1,
+      const int dim3 = 1);
+
+  virtual void ReshapeLike(const Tensor<Dtype>& that);
+
+  virtual void resize(const size_t size);
+
+  virtual bool ShapeEquals(const TensorProto& that);
+
+  /**
+   * @brief Copy from a source Tensor.
+   *
+   * @param source the Tensor to copy from
+   * @param reshape if false, require this Tensor to be pre-shaped to the shape
+   *        of other (and die otherwise); if true, Reshape this Tensor to other's
+   *        shape if necessary
+   */
+  virtual void CopyFrom(const Tensor<Dtype>& source, bool reshape = false);
+
+  virtual void FromProto(const TensorProto& proto, bool reshape = true);
+
+  virtual void ToProto(TensorProto* proto);
+
+  inline CBLAS_TRANSPOSE t() {
+    if (transpose_ == CblasNoTrans) {
+      transpose_ = CblasTrans;
+    } else {
+      transpose_ = CblasNoTrans;
+    }
+    return transpose_;
+  }
+
+  CBLAS_TRANSPOSE get_transpose() const {
+    return transpose_;
+  }
+
+  virtual void malloc(const size_t num) {
+    size_ = num;
+    capacity_ = num;
+    own_data_ = true;
+  }
+
+  virtual void free() {
+    if (own_data_ && ptr_ != NULL) {
+      ptr_ = NULL;
+      size_ = 0;
+      capacity_ = 0;
+      own_data_ = false;
+    }
+  }
+
+  virtual void choose_device() {
+  }
+
+  virtual Tensor<Dtype>& tensor() {
+    return *this;
+  }
+
+  const void* ptr() const {
+    return static_cast<const void*>(ptr_);
+  }
+
+  void* mutable_ptr() {
+    return ptr_;
+  }
+
+  virtual const Dtype* data() const {
+    return static_cast<const Dtype*>(ptr_);
+  }
+
+  virtual Dtype* mutable_data() {
+    return static_cast<Dtype*>(ptr_);
+  }
+
+  inline Dtype at(const int n, const int c, const int h, const int w) {
+    return data()[offset(n, c, h, w)];
+  }
+
+  inline Dtype at(const vector<int>& index) {
+    return data()[offset(index)];
+  }
+
+  inline int offset(const int dim0, const int dim1 = 0, const int dim2 = 0,
+      const int dim3 = 0) const {
+    vector<int> indices(4);
+    indices[0] = dim0;
+    indices[1] = dim1;
+    indices[2] = dim2;
+    indices[3] = dim3;
+    return offset(indices);
+  }
+
+  inline int offset(const vector<int>& indices) const {
+    CHECK_LE(indices.size(), num_axes());
+    int offset = 0;
+    for (int i = 0; i < num_axes(); ++i) {
+      offset *= shape(i);
+      if (indices.size() > i) {
+        CHECK_GE(indices[i], 0);
+        CHECK_LT(indices[i], shape(i));
+        offset += indices[i];
+      }
+    }
+    return offset;
+  }
+
+  inline int size() const {
+    return size_;
+  }
+
+  inline int capacity() const {
+    return capacity_;
+  }
+
+  /**
+   * @brief Compute the volume of a slice; i.e., the product of dimensions
+   *        among a range of axes.
+   *
+   * @param start_axis The first axis to include in the slice.
+   *
+   * @param end_axis The first axis to exclude from the slice.
+   */
+  inline int size(int start_axis, int end_axis) const {
+    CHECK_LE(start_axis, end_axis);
+    CHECK_GE(start_axis, 0);
+    CHECK_GE(end_axis, 0);
+    CHECK_LE(start_axis, num_axes());
+    CHECK_LE(end_axis, num_axes());
+    int size = 1;
+    for (int i = start_axis; i < end_axis; ++i) {
+      size *= shape(i);
+    }
+    return size;
+  }
+  /**
+   * @brief Compute the volume of a slice spanning from a particular first
+   *        axis to the final axis.
+   *
+   * @param start_axis The first axis to include in the slice.
+   */
+  inline int size(int start_axis) const {
+    return size(start_axis, num_axes());
+  }
+
+  inline int num_axes() const {
+    return shape_.size();
+  }
+
+  inline const vector<int>& shape() const {
+    return shape_;
+  }
+
+  /**
+   * @brief Returns the dimension of the index-th axis (or the negative index-th
+   *        axis from the end, if index is negative).
+   *
+   * @param index the axis index, which may be negative as it will be
+   *        "canonicalized" using CanonicalAxisIndex.
+   *        Dies on out of range index.
+   */
+  inline int shape(int index) const {
+    return shape_[CanonicalAxisIndex(index)];
+  }
+
+  inline static vector<int> shapeToVector(const TensorShape& shape) {
+    CHECK_LE(shape.dim_size(), kMaxTensorAxes);
+    vector<int> shape_vec(shape.dim_size());
+    for (int i = 0; i < shape.dim_size(); ++i) {
+      shape_vec[i] = shape.dim(i);
+    }
+    return shape_vec;
+  }
+
+  inline string shape_string() const {
+    ostringstream stream;
+    for (int i = 0; i < shape_.size(); ++i) {
+      stream << shape_[i] << " ";
+    }
+    stream << "(" << size_ << ")";
+    return stream.str();
+  }
+
+// The following operations are inspired by Torch Math Functions
+// The methods' @brief docs are from
+// https://github.com/torch/torch7/blob/master/doc/maths.md
+  /*
+   * Construction or extraction functions
+   */
+  virtual void mem_set(const Dtype value) = 0;
+
+//  static Dtype ones(Tensor* result, const vector<int> shape);
+//
+//  static Dtype ones(Tensor* result, const TensorShape& shape);
+//
+//  static Dtype ones(Tensor* result, const int dim0, int dim1 = 1,
+//      int dim2 = 1, int dim3 = 1);
+//
+//  static Dtype zeros(Tensor* result, const vector<int> shape);
+//
+//  static Dtype zeros(Tensor* result, const TensorShape& shape);
+//
+//  static Dtype zeros(Tensor* result, const int dim0, int dim1 = 1,
+//      int dim2 = 1, int dim3 = 1);
+
+  virtual void zeros() {
+    mem_set(0);
+  }
+
+  virtual void mem_copy(const Tensor<Dtype>& that) = 0;
+
+  /*
+   * Element-wise Mathematical Operations
+   */
+  virtual void abs(const Tensor<Dtype>& that) = 0;
+
+  virtual void pow(const Tensor<Dtype>& that, const Dtype value) = 0;
+
+  /**
+   *  @brief Scale the Tensor data by a constant factor.
+   */
+  virtual void scale(Dtype scale_factor) = 0;
+
+  /*
+   * Basic operations
+   */
+  /**
+   * @brief Add the given value to all elements in the that.
+   */
+  virtual void add(const Dtype value) = 0;
+
+  /**
+   *    @brief Add that to this that and put result into res.
+   The number of elements must match, but sizes do not matter.
+   */
+  virtual void add(const Tensor<Dtype>& that) = 0;
+
+  /**
+   *    @brief Multiply elements of that by the scalar value and add it to this
+   that. The number of elements must match, but sizes do not matter.
+   */
+  virtual void add(const Dtype value, const Tensor<Dtype>& that) = 0;
+
+  /**
+   *    @brief Performs the dot product between this that and that.
+   The number of elements must match: both tensors are seen as a 1D
+   vector.
+   */
+  virtual Dtype dot(const Tensor<Dtype>& that) = 0;
+
+  /**
+   * @brief Multiply all elements in the that by the given value.
+   */
+  virtual void mul(const Dtype value) = 0;
+
+  /**
+   * @brief Divide all elements in the that by the given value.
+   */
+  virtual void div(const Dtype value) = 0;
+
+  /**
+   *    @brief Element-wise multiplication of this that by that.
+   The number of elements must match, but sizes do not matter.
+   */
+  virtual void cmul(const Tensor<Dtype>& first,
+      const Tensor<Dtype>& second) = 0;
+
+  /**
+   *  @brief Performs the element-wise division of this that by that.
+   The number of elements must match, but sizes do not matter.
+   */
+  virtual void cdiv(const Tensor<Dtype>& first,
+      const Tensor<Dtype>& second) = 0;
+
+  /**
+   *    @brief Matrix vector product of this matrix (2D that) and vec.
+   *    Sizes must respect the
+   *    matrix-multiplication operation: if this is a n x m matrix, vec
+   *    must be vector of size m and res must be a vector of size n.
+   */
+  virtual void mv(const Tensor<Dtype>& that) = 0;
+
+  /**
+   * @brief Performs a matrix-vector multiplication between mat (2D that) and
+   *  vec2 (1D that) and add it to vec1.
+   *  TODO:  Optional values v1 and v2 are scalars that multiply vec1 and vec2
+   *  respectively. Optional value beta is a scalar that scales the result
+   *  that, before accumulating the result into the that.
+   *  Defaults to 1.0. In other words,
+   *  res = beta * res + v1 * vec1 + v2 * mat * vec2
+   *  Sizes must respect the matrix-multiplication operation:
+   *  if mat is a n x m matrix, vec2 must be vector of size m and vec1
+   *  must be a vector of size n.
+   */
+  virtual void addmv(const Tensor<Dtype>& that) = 0;
+
+  /**
+   * @brief Matrix matrix product of this matrix (2D that) and mat.
+   *  If this is a n x m matrix, mat a m x p matrix, res must be a n x p
+   *  matrix.
+   */
+  virtual void mm(const Tensor<Dtype>& that) = 0;
+
+  /**
+   * @brief Performs a matrix-matrix multiplication between this matrix
+   *  (2D that) and that (2D that).
+   *  Optional values v1 and v2 are scalars that multiply M and mat1 * mat2
+   *  respectively.
+   *  TODO: Optional value beta is a scalar that scales the result that,
+   *  before accumulating the result into the that. Defaults to 1.0.
+   *  In other words, res = res * beta + v1 * M + v2 * mat1*mat2
+   *  If mat1 is a n x m matrix, mat2 a m x p matrix, M must be a n x p matrix.
+   */
+  virtual void addmm(const Tensor<Dtype>& that) = 0;
+
+  /*
+   * Global operations
+   */
+  /**
+   * @brief Compute the sum of absolute values (L1 norm) of the data.
+   */
+  virtual Dtype asum() = 0;
+
+  /**
+   * @brief Compute the sum of squares (L2 norm squared) of the data.
+   */
+  virtual Dtype sumsq() = 0;
+
+ protected:
+  bool own_data_;
+  TensorType type_;
+  void* ptr_;
+  vector<int> shape_;
+  int size_;
+  int capacity_;
+  CBLAS_TRANSPOSE transpose_;
+
+DISABLE_COPY_AND_ASSIGN(Tensor);
+};
+// class Tensor
+
+template<typename Dtype>
+class CPUTensor : public Tensor<Dtype> {
+ public:
+  CPUTensor();
+
+  explicit CPUTensor(const vector<int>& shape);
+
+  explicit CPUTensor(const int dim0, const int dim1 = 1, const int dim2 = 1,
+      const int dim3 = 1);
+
+  virtual ~CPUTensor();
+
+//  virtual void Reshape(const vector<int>& shape);
+//
+//  virtual void Reshape(const TensorShape& shape);
+//
+//  virtual void Reshape(const int dim0, const int dim1 = 1, const int dim2 = 1,
+//      const int dim3 = 1);
+//
+//  virtual void ReshapeLike(const Tensor<Dtype>& that);
+//
+//  virtual void resize(const size_t size);
+//
+//  virtual bool ShapeEquals(const TensorProto& that);
+//
+//  virtual void CopyFrom(const Tensor<Dtype>& source, bool reshape = false);
+//
+  virtual void FromProto(const TensorProto& proto, bool reshape = true);
+
+  virtual void ToProto(TensorProto* proto);
+
+  virtual void malloc(const size_t num);
+
+  virtual void free();
+
+  virtual void set_data(Dtype* data);
+
+  virtual void mem_set(const Dtype value);
+
+  virtual void mem_copy(const Tensor<Dtype>& that);
+
+  virtual void abs(const Tensor<Dtype>& that);
+
+  virtual void pow(const Tensor<Dtype>& that, const Dtype value);
+
+  virtual void scale(Dtype scale_factor);
+
+  virtual void add(const Dtype value);
+
+  virtual void add(const Tensor<Dtype>& that);
+
+  virtual void add(const Dtype value, const Tensor<Dtype>& that);
+
+  virtual Dtype dot(const Tensor<Dtype>& that);
+
+  virtual void mul(const Dtype value);
+
+  virtual void div(const Dtype value);
+
+  virtual void cmul(const Tensor<Dtype>& first, const Tensor<Dtype>& second);
+
+  virtual void cdiv(const Tensor<Dtype>& first, const Tensor<Dtype>& second);
+
+  virtual void mv(const Tensor<Dtype>& that);
+
+  virtual void addmv(const Tensor<Dtype>& that);
+
+  virtual void mm(const Tensor<Dtype>& that);
+
+  virtual void addmm(const Tensor<Dtype>& that);
+
+  virtual Dtype asum();
+
+  virtual Dtype sumsq();
+
+DISABLE_COPY_AND_ASSIGN(CPUTensor);
+};
+// class CPUTensor
+
+#ifndef CPU_ONLY
+template<typename Dtype>
+class GPUTensor : public Tensor<Dtype> {
+ public:
+  GPUTensor();
+
+  explicit GPUTensor(const vector<int>& shape);
+
+  explicit GPUTensor(const int dim0, const int dim1 = 1, const int dim2 = 1,
+      const int dim3 = 1);
+
+  virtual ~GPUTensor();
+
+//  virtual void Reshape(const vector<int>& shape);
+//
+//  virtual void Reshape(const TensorShape& shape);
+//
+//  virtual void Reshape(const int dim0, const int dim1 = 1, const int dim2 = 1,
+//      const int dim3 = 1);
+//
+//  virtual void ReshapeLike(const Tensor<Dtype>& that);
+//
+//  virtual void resize(const size_t size);
+//
+//  virtual bool ShapeEquals(const TensorProto& that);
+//
+//  virtual void CopyFrom(const Tensor<Dtype>& source, bool reshape = false);
+//
+  virtual void FromProto(const TensorProto& proto, bool reshape = true);
+
+  virtual void ToProto(TensorProto* proto);
+
+  virtual void malloc(const size_t num);
+
+  virtual void free();
+
+  virtual void mem_set(const Dtype value);
+
+  virtual void mem_copy(const Tensor<Dtype>& that);
+
+  virtual void abs(const Tensor<Dtype>& that);
+
+  virtual void pow(const Tensor<Dtype>& that, const Dtype value);
+
+  virtual void scale(Dtype scale_factor);
+
+  virtual void add(const Dtype value);
+
+  virtual void add(const Tensor<Dtype>& that);
+
+  virtual void add(const Dtype value, const Tensor<Dtype>& that);
+
+  virtual Dtype dot(const Tensor<Dtype>& that);
+
+  virtual void mul(const Dtype value);
+
+  virtual void div(const Dtype value);
+
+  virtual void cmul(const Tensor<Dtype>& first, const Tensor<Dtype>& second);
+
+  virtual void cdiv(const Tensor<Dtype>& first, const Tensor<Dtype>& second);
+
+  virtual void mv(const Tensor<Dtype>& that);
+
+  virtual void addmv(const Tensor<Dtype>& that);
+
+  virtual void mm(const Tensor<Dtype>& that);
+
+  virtual void addmm(const Tensor<Dtype>& that);
+
+  virtual Dtype asum();
+
+  virtual Dtype sumsq();
+
+DISABLE_COPY_AND_ASSIGN(GPUTensor);
+};
+// class GPUTensor
+#endif  // #ifndef CPU_ONLY
+
+template<typename Dtype>
+class SyncedTensor : public Tensor<Dtype> {
+ public:
+  SyncedTensor();
+
+  explicit SyncedTensor(const vector<int>& shape);
+
+  explicit SyncedTensor(const int dim0, const int dim1 = 1, const int dim2 = 1,
+      const int dim3 = 1);
+
+  virtual ~SyncedTensor();
+
+//  virtual void Reshape(const vector<int>& shape);
+//
+//  virtual void Reshape(const TensorShape& shape);
+//
+//  virtual void Reshape(const int dim0, const int dim1 = 1, const int dim2 = 1,
+//      const int dim3 = 1);
+//
+//  virtual void ReshapeLike(const Tensor<Dtype>& that);
+//
+//  virtual void resize(const size_t size);
+//
+//  virtual bool ShapeEquals(const TensorProto& that);
+//
+//  virtual void CopyFrom(const Tensor<Dtype>& source, bool reshape = false);
+//
+  virtual void FromProto(const TensorProto& proto, bool reshape = true);
+
+  virtual void ToProto(TensorProto* proto);
+
+  virtual void malloc(const size_t num);
+
+  virtual void free();
+
+  virtual void mem_set(const Dtype value);
+
+  virtual void mem_copy(const Tensor<Dtype>& that);
+
+  virtual void choose_device();
+
+  virtual Tensor<Dtype>& tensor() {
+    choose_device();
+    return *(current_tensor_.get());
+  }
+
+  void to_cpu();
+  void to_gpu();
+  const shared_ptr<Tensor<Dtype> > current_tensor() {
+    choose_device();
+    return current_tensor_;
+  }
+  const shared_ptr<CPUTensor<Dtype> > cpu_tensor() {
+    to_cpu();
+    return cpu_tensor_;
+  }
+#ifndef CPU_ONLY
+  const shared_ptr<GPUTensor<Dtype> > gpu_tensor() {
+    to_gpu();
+    return gpu_tensor_;
+  }
+#endif  // #ifndef CPU_ONLY
+
+  virtual const Dtype* data() {
+    return tensor().data();
+  }
+
+  virtual Dtype* mutable_data() {
+    return tensor().mutable_data();
+  }
+  const Dtype* cpu_data();
+  Dtype* mutable_cpu_data();
+  void set_cpu_data(Dtype* data);
+  const Dtype* gpu_data();
+  Dtype* mutable_gpu_data();
+
+  enum SyncedHead {
+    UNINITIALIZED,
+    HEAD_AT_CPU,
+    HEAD_AT_GPU,
+    SYNCED
+  };
+  SyncedHead head() {
+    return head_;
+  }
+
+  virtual void abs(const Tensor<Dtype>& that);
+
+  virtual void pow(const Tensor<Dtype>& that, const Dtype value);
+
+  virtual void scale(Dtype scale_factor);
+
+  virtual void add(const Dtype value);
+
+  virtual void add(const Tensor<Dtype>& that);
+
+  virtual void add(const Dtype value, const Tensor<Dtype>& that);
+
+  virtual Dtype dot(const Tensor<Dtype>& that);
+
+  virtual void mul(const Dtype value);
+
+  virtual void div(const Dtype value);
+
+  virtual void cmul(const Tensor<Dtype>& first, const Tensor<Dtype>& second);
+
+  virtual void cdiv(const Tensor<Dtype>& first, const Tensor<Dtype>& second);
+
+  virtual void mv(const Tensor<Dtype>& that);
+
+  virtual void addmv(const Tensor<Dtype>& that);
+
+  virtual void mm(const Tensor<Dtype>& that);
+
+  virtual void addmm(const Tensor<Dtype>& that);
+
+  virtual Dtype asum();
+
+  virtual Dtype sumsq();
+
+ private:
+  shared_ptr<CPUTensor<Dtype> > cpu_tensor_;
+#ifndef CPU_ONLY
+  shared_ptr<GPUTensor<Dtype> > gpu_tensor_;
+#endif  // #ifndef CPU_ONLY
+  shared_ptr<Tensor<Dtype> > current_tensor_;
+  SyncedHead head_;
+  bool own_cpu_data_;
+
+DISABLE_COPY_AND_ASSIGN(SyncedTensor);
+};
+// class SyncedTensor
+
+}  // namespace caffe
+
+#endif  // CAFFE_TENSOR_HPP_

--- a/include/caffe/util/mkl_alternate.hpp
+++ b/include/caffe/util/mkl_alternate.hpp
@@ -19,7 +19,7 @@ extern "C" {
 #define DEFINE_VSL_UNARY_FUNC(name, operation) \
   template<typename Dtype> \
   void v##name(const int n, const Dtype* a, Dtype* y) { \
-    CHECK_GT(n, 0); CHECK(a); CHECK(y); \
+    CHECK_GE(n, 0); if (n > 0) { CHECK(a); CHECK(y); } \
     for (int i = 0; i < n; ++i) { operation; } \
   } \
   inline void vs##name( \
@@ -41,7 +41,7 @@ DEFINE_VSL_UNARY_FUNC(Abs, y[i] = fabs(a[i]));
 #define DEFINE_VSL_UNARY_FUNC_WITH_PARAM(name, operation) \
   template<typename Dtype> \
   void v##name(const int n, const Dtype* a, const Dtype b, Dtype* y) { \
-    CHECK_GT(n, 0); CHECK(a); CHECK(y); \
+    CHECK_GE(n, 0); if (n > 0) { CHECK(a); CHECK(y); } \
     for (int i = 0; i < n; ++i) { operation; } \
   } \
   inline void vs##name( \
@@ -60,7 +60,7 @@ DEFINE_VSL_UNARY_FUNC_WITH_PARAM(Powx, y[i] = pow(a[i], b));
 #define DEFINE_VSL_BINARY_FUNC(name, operation) \
   template<typename Dtype> \
   void v##name(const int n, const Dtype* a, const Dtype* b, Dtype* y) { \
-    CHECK_GT(n, 0); CHECK(a); CHECK(b); CHECK(y); \
+    CHECK_GE(n, 0); if (n > 0) { CHECK(a); CHECK(b); CHECK(y); } \
     for (int i = 0; i < n; ++i) { operation; } \
   } \
   inline void vs##name( \

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -3,12 +3,40 @@
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
-#include "caffe/syncedmem.hpp"
+#include "caffe/tensor.hpp"
 #include "caffe/util/math_functions.hpp"
 
 namespace caffe {
 
-template <typename Dtype>
+template<typename Dtype>
+Blob<Dtype>::Blob()
+    : data_tensor_(new SyncedTensor<Dtype>()),
+      diff_tensor_(new SyncedTensor<Dtype>()),
+      count_(0),
+      // capacity_ must be initialized before calling Reshape
+      capacity_(0) {
+}
+
+template<typename Dtype>
+Blob<Dtype>::Blob(const int num, const int channels, const int height,
+    const int width)
+    : data_tensor_(new SyncedTensor<Dtype>()),
+      diff_tensor_(new SyncedTensor<Dtype>()),
+      // capacity_ must be initialized before calling Reshape
+      capacity_(0) {
+  Reshape(num, channels, height, width);
+}
+
+template<typename Dtype>
+Blob<Dtype>::Blob(const vector<int>& shape)
+    : data_tensor_(new SyncedTensor<Dtype>()),
+      diff_tensor_(new SyncedTensor<Dtype>()),
+      // capacity_ must be initialized before calling Reshape
+      capacity_(0) {
+  Reshape(shape);
+}
+
+template<typename Dtype>
 void Blob<Dtype>::Reshape(const int num, const int channels, const int height,
     const int width) {
   vector<int> shape(4);
@@ -19,7 +47,7 @@ void Blob<Dtype>::Reshape(const int num, const int channels, const int height,
   Reshape(shape);
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::Reshape(const vector<int>& shape) {
   CHECK_LE(shape.size(), kMaxBlobAxes);
   count_ = 1;
@@ -30,14 +58,11 @@ void Blob<Dtype>::Reshape(const vector<int>& shape) {
     count_ *= shape[i];
     shape_[i] = shape[i];
   }
-  if (count_ > capacity_) {
-    capacity_ = count_;
-    data_.reset(new SyncedMemory(capacity_ * sizeof(Dtype)));
-    diff_.reset(new SyncedMemory(capacity_ * sizeof(Dtype)));
-  }
+  data_tensor_->Reshape(shape);
+  diff_tensor_->Reshape(shape);
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::Reshape(const BlobShape& shape) {
   CHECK_LE(shape.dim_size(), kMaxBlobAxes);
   vector<int> shape_vec(shape.dim_size());
@@ -47,349 +72,183 @@ void Blob<Dtype>::Reshape(const BlobShape& shape) {
   Reshape(shape_vec);
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::ReshapeLike(const Blob<Dtype>& other) {
   Reshape(other.shape());
 }
 
-template <typename Dtype>
-Blob<Dtype>::Blob(const int num, const int channels, const int height,
-    const int width)
-  // capacity_ must be initialized before calling Reshape
-  : capacity_(0) {
-  Reshape(num, channels, height, width);
-}
-
-template <typename Dtype>
-Blob<Dtype>::Blob(const vector<int>& shape)
-  // capacity_ must be initialized before calling Reshape
-  : capacity_(0) {
-  Reshape(shape);
-}
-
-template <typename Dtype>
+template<typename Dtype>
 const Dtype* Blob<Dtype>::cpu_data() const {
-  CHECK(data_);
-  return (const Dtype*)data_->cpu_data();
+  return data_tensor_->cpu_data();
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::set_cpu_data(Dtype* data) {
-  CHECK(data);
-  data_->set_cpu_data(data);
+  data_tensor_->set_cpu_data(data);
 }
 
-template <typename Dtype>
+template<typename Dtype>
 const Dtype* Blob<Dtype>::gpu_data() const {
-  CHECK(data_);
-  return (const Dtype*)data_->gpu_data();
+  return data_tensor_->gpu_data();
 }
 
-template <typename Dtype>
+template<typename Dtype>
 const Dtype* Blob<Dtype>::cpu_diff() const {
-  CHECK(diff_);
-  return (const Dtype*)diff_->cpu_data();
+  return diff_tensor_->cpu_data();
 }
 
-template <typename Dtype>
+template<typename Dtype>
 const Dtype* Blob<Dtype>::gpu_diff() const {
-  CHECK(diff_);
-  return (const Dtype*)diff_->gpu_data();
+  return diff_tensor_->gpu_data();
 }
 
-template <typename Dtype>
+template<typename Dtype>
 Dtype* Blob<Dtype>::mutable_cpu_data() {
-  CHECK(data_);
-  return static_cast<Dtype*>(data_->mutable_cpu_data());
+  return data_tensor_->mutable_cpu_data();
 }
 
-template <typename Dtype>
+template<typename Dtype>
 Dtype* Blob<Dtype>::mutable_gpu_data() {
-  CHECK(data_);
-  return static_cast<Dtype*>(data_->mutable_gpu_data());
+  return data_tensor_->mutable_gpu_data();
 }
 
-template <typename Dtype>
+template<typename Dtype>
 Dtype* Blob<Dtype>::mutable_cpu_diff() {
-  CHECK(diff_);
-  return static_cast<Dtype*>(diff_->mutable_cpu_data());
+  return diff_tensor_->mutable_cpu_data();
 }
 
-template <typename Dtype>
+template<typename Dtype>
 Dtype* Blob<Dtype>::mutable_gpu_diff() {
-  CHECK(diff_);
-  return static_cast<Dtype*>(diff_->mutable_gpu_data());
+  return diff_tensor_->mutable_gpu_data();
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::ShareData(const Blob& other) {
   CHECK_EQ(count_, other.count());
-  data_ = other.data();
+  data_tensor_ = other.data_tensor();
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::ShareDiff(const Blob& other) {
   CHECK_EQ(count_, other.count());
-  diff_ = other.diff();
+  diff_tensor_ = other.diff_tensor();
 }
 
 // The "update" method is used for parameter blobs in a Net, which are stored
 // as Blob<float> or Blob<double> -- hence we do not define it for
 // Blob<int> or Blob<unsigned int>.
-template <> void Blob<unsigned int>::Update() { NOT_IMPLEMENTED; }
-template <> void Blob<int>::Update() { NOT_IMPLEMENTED; }
+template<> void Blob<unsigned int>::Update() {
+  NOT_IMPLEMENTED;
+}
+template<> void Blob<int>::Update() {
+  NOT_IMPLEMENTED;
+}
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::Update() {
-  // We will perform update based on where the data is located.
-  switch (data_->head()) {
-  case SyncedMemory::HEAD_AT_CPU:
-    // perform computation on CPU
-    caffe_axpy<Dtype>(count_, Dtype(-1),
-        static_cast<const Dtype*>(diff_->cpu_data()),
-        static_cast<Dtype*>(data_->mutable_cpu_data()));
-    break;
-  case SyncedMemory::HEAD_AT_GPU:
-  case SyncedMemory::SYNCED:
-#ifndef CPU_ONLY
-    // perform computation on GPU
-    caffe_gpu_axpy<Dtype>(count_, Dtype(-1),
-        static_cast<const Dtype*>(diff_->gpu_data()),
-        static_cast<Dtype*>(data_->mutable_gpu_data()));
-#else
-    NO_GPU;
-#endif
-    break;
-  default:
-    LOG(FATAL) << "Syncedmem not initialized.";
-  }
+  data_tensor_->add(Dtype(-1), diff());
 }
 
-template <> unsigned int Blob<unsigned int>::asum_data() const {
+template<> unsigned int Blob<unsigned int>::asum_data() const {
   NOT_IMPLEMENTED;
   return 0;
 }
 
-template <> int Blob<int>::asum_data() const {
+template<> int Blob<int>::asum_data() const {
   NOT_IMPLEMENTED;
   return 0;
 }
 
-template <typename Dtype>
+template<typename Dtype>
 Dtype Blob<Dtype>::asum_data() const {
-  if (!data_) { return 0; }
-  switch (data_->head()) {
-  case SyncedMemory::HEAD_AT_CPU:
-    return caffe_cpu_asum(count_, cpu_data());
-  case SyncedMemory::HEAD_AT_GPU:
-  case SyncedMemory::SYNCED:
-#ifndef CPU_ONLY
-  {
-    Dtype asum;
-    caffe_gpu_asum(count_, gpu_data(), &asum);
-    return asum;
-  }
-#else
-    NO_GPU;
-#endif
-  case SyncedMemory::UNINITIALIZED:
-    return 0;
-  default:
-    LOG(FATAL) << "Unknown SyncedMemory head state: " << data_->head();
-  }
-  return 0;
+  return data_tensor_->asum();
 }
 
-template <> unsigned int Blob<unsigned int>::asum_diff() const {
+template<> unsigned int Blob<unsigned int>::asum_diff() const {
   NOT_IMPLEMENTED;
   return 0;
 }
 
-template <> int Blob<int>::asum_diff() const {
+template<> int Blob<int>::asum_diff() const {
   NOT_IMPLEMENTED;
   return 0;
 }
 
-template <typename Dtype>
+template<typename Dtype>
 Dtype Blob<Dtype>::asum_diff() const {
-  if (!diff_) { return 0; }
-  switch (diff_->head()) {
-  case SyncedMemory::HEAD_AT_CPU:
-    return caffe_cpu_asum(count_, cpu_diff());
-  case SyncedMemory::HEAD_AT_GPU:
-  case SyncedMemory::SYNCED:
-#ifndef CPU_ONLY
-  {
-    Dtype asum;
-    caffe_gpu_asum(count_, gpu_diff(), &asum);
-    return asum;
-  }
-#else
-    NO_GPU;
-#endif
-  case SyncedMemory::UNINITIALIZED:
-    return 0;
-  default:
-    LOG(FATAL) << "Unknown SyncedMemory head state: " << diff_->head();
-  }
-  return 0;
+  return diff_tensor_->asum();
 }
 
-template <> unsigned int Blob<unsigned int>::sumsq_data() const {
+template<> unsigned int Blob<unsigned int>::sumsq_data() const {
   NOT_IMPLEMENTED;
   return 0;
 }
 
-template <> int Blob<int>::sumsq_data() const {
+template<> int Blob<int>::sumsq_data() const {
   NOT_IMPLEMENTED;
   return 0;
 }
 
-template <typename Dtype>
+template<typename Dtype>
 Dtype Blob<Dtype>::sumsq_data() const {
-  Dtype sumsq;
-  const Dtype* data;
-  if (!data_) { return 0; }
-  switch (data_->head()) {
-  case SyncedMemory::HEAD_AT_CPU:
-    data = cpu_data();
-    sumsq = caffe_cpu_dot(count_, data, data);
-    break;
-  case SyncedMemory::HEAD_AT_GPU:
-  case SyncedMemory::SYNCED:
-#ifndef CPU_ONLY
-    data = gpu_data();
-    caffe_gpu_dot(count_, data, data, &sumsq);
-#else
-    NO_GPU;
-#endif
-    break;
-  case SyncedMemory::UNINITIALIZED:
-    return 0;
-  default:
-    LOG(FATAL) << "Unknown SyncedMemory head state: " << data_->head();
-  }
-  return sumsq;
+  return data_tensor_->sumsq();
 }
 
-template <> unsigned int Blob<unsigned int>::sumsq_diff() const {
+template<> unsigned int Blob<unsigned int>::sumsq_diff() const {
   NOT_IMPLEMENTED;
   return 0;
 }
 
-template <> int Blob<int>::sumsq_diff() const {
+template<> int Blob<int>::sumsq_diff() const {
   NOT_IMPLEMENTED;
   return 0;
 }
 
-template <typename Dtype>
+template<typename Dtype>
 Dtype Blob<Dtype>::sumsq_diff() const {
-  Dtype sumsq;
-  const Dtype* diff;
-  if (!diff_) { return 0; }
-  switch (diff_->head()) {
-  case SyncedMemory::HEAD_AT_CPU:
-    diff = cpu_diff();
-    sumsq = caffe_cpu_dot(count_, diff, diff);
-    break;
-  case SyncedMemory::HEAD_AT_GPU:
-  case SyncedMemory::SYNCED:
-#ifndef CPU_ONLY
-    diff = gpu_diff();
-    caffe_gpu_dot(count_, diff, diff, &sumsq);
-    break;
-#else
-    NO_GPU;
-#endif
-  case SyncedMemory::UNINITIALIZED:
-    return 0;
-  default:
-    LOG(FATAL) << "Unknown SyncedMemory head state: " << data_->head();
-  }
-  return sumsq;
+  return diff_tensor_->sumsq();
 }
 
-template <> void Blob<unsigned int>::scale_data(unsigned int scale_factor) {
+template<> void Blob<unsigned int>::scale_data(unsigned int scale_factor) {
   NOT_IMPLEMENTED;
 }
 
-template <> void Blob<int>::scale_data(int scale_factor) {
+template<> void Blob<int>::scale_data(int scale_factor) {
   NOT_IMPLEMENTED;
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::scale_data(Dtype scale_factor) {
-  Dtype* data;
-  if (!data_) { return; }
-  switch (data_->head()) {
-  case SyncedMemory::HEAD_AT_CPU:
-    data = mutable_cpu_data();
-    caffe_scal(count_, scale_factor, data);
-    return;
-  case SyncedMemory::HEAD_AT_GPU:
-  case SyncedMemory::SYNCED:
-#ifndef CPU_ONLY
-    data = mutable_gpu_data();
-    caffe_gpu_scal(count_, scale_factor, data);
-    return;
-#else
-    NO_GPU;
-#endif
-  case SyncedMemory::UNINITIALIZED:
-    return;
-  default:
-    LOG(FATAL) << "Unknown SyncedMemory head state: " << data_->head();
-  }
+  data_tensor_->scale(scale_factor);
 }
 
-template <> void Blob<unsigned int>::scale_diff(unsigned int scale_factor) {
+template<> void Blob<unsigned int>::scale_diff(unsigned int scale_factor) {
   NOT_IMPLEMENTED;
 }
 
-template <> void Blob<int>::scale_diff(int scale_factor) {
+template<> void Blob<int>::scale_diff(int scale_factor) {
   NOT_IMPLEMENTED;
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::scale_diff(Dtype scale_factor) {
-  Dtype* diff;
-  if (!diff_) { return; }
-  switch (diff_->head()) {
-  case SyncedMemory::HEAD_AT_CPU:
-    diff = mutable_cpu_diff();
-    caffe_scal(count_, scale_factor, diff);
-    return;
-  case SyncedMemory::HEAD_AT_GPU:
-  case SyncedMemory::SYNCED:
-#ifndef CPU_ONLY
-    diff = mutable_gpu_diff();
-    caffe_gpu_scal(count_, scale_factor, diff);
-    return;
-#else
-    NO_GPU;
-#endif
-  case SyncedMemory::UNINITIALIZED:
-    return;
-  default:
-    LOG(FATAL) << "Unknown SyncedMemory head state: " << diff_->head();
-  }
+  diff_tensor_->scale(scale_factor);
 }
 
-template <typename Dtype>
+template<typename Dtype>
 bool Blob<Dtype>::ShapeEquals(const BlobProto& other) {
-  if (other.has_num() || other.has_channels() ||
-      other.has_height() || other.has_width()) {
-    // Using deprecated 4D Blob dimensions --
-    // shape is (num, channels, height, width).
-    // Note: we do not use the normal Blob::num(), Blob::channels(), etc.
-    // methods as these index from the beginning of the blob shape, where legacy
-    // parameter blobs were indexed from the end of the blob shape (e.g., bias
-    // Blob shape (1 x 1 x 1 x N), IP layer weight Blob shape (1 x 1 x M x N)).
-    return shape_.size() <= 4 &&
-           LegacyShape(-4) == other.num() &&
-           LegacyShape(-3) == other.channels() &&
-           LegacyShape(-2) == other.height() &&
-           LegacyShape(-1) == other.width();
+  if (other.has_num() || other.has_channels() || other.has_height()
+      || other.has_width()) {
+// Using deprecated 4D Blob dimensions --
+// shape is (num, channels, height, width).
+// Note: we do not use the normal Blob::num(), Blob::channels(), etc.
+// methods as these index from the beginning of the blob shape, where legacy
+// parameter blobs were indexed from the end of the blob shape (e.g., bias
+// Blob shape (1 x 1 x 1 x N), IP layer weight Blob shape (1 x 1 x M x N)).
+    return shape_.size() <= 4 && LegacyShape(-4) == other.num()
+        && LegacyShape(-3) == other.channels()
+        && LegacyShape(-2) == other.height()
+        && LegacyShape(-1) == other.width();
   }
   vector<int> other_shape(other.shape().dim_size());
   for (int i = 0; i < other.shape().dim_size(); ++i) {
@@ -398,7 +257,7 @@ bool Blob<Dtype>::ShapeEquals(const BlobProto& other) {
   return shape_ == other_shape;
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::CopyFrom(const Blob& source, bool copy_diff, bool reshape) {
   if (source.count() != count_ || source.shape() != shape_) {
     if (reshape) {
@@ -407,36 +266,19 @@ void Blob<Dtype>::CopyFrom(const Blob& source, bool copy_diff, bool reshape) {
       LOG(FATAL) << "Trying to copy blobs of different sizes.";
     }
   }
-  switch (Caffe::mode()) {
-  case Caffe::GPU:
-    if (copy_diff) {
-      caffe_copy(count_, source.gpu_diff(),
-          static_cast<Dtype*>(diff_->mutable_gpu_data()));
-    } else {
-      caffe_copy(count_, source.gpu_data(),
-          static_cast<Dtype*>(data_->mutable_gpu_data()));
-    }
-    break;
-  case Caffe::CPU:
-    if (copy_diff) {
-      caffe_copy(count_, source.cpu_diff(),
-          static_cast<Dtype*>(diff_->mutable_cpu_data()));
-    } else {
-      caffe_copy(count_, source.cpu_data(),
-          static_cast<Dtype*>(data_->mutable_cpu_data()));
-    }
-    break;
-  default:
-    LOG(FATAL) << "Unknown caffe mode.";
+  if (copy_diff) {
+    diff_tensor_->CopyFrom(source.diff(), reshape);
+  } else {
+    data_tensor_->CopyFrom(source.data(), reshape);
   }
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::FromProto(const BlobProto& proto, bool reshape) {
   if (reshape) {
     vector<int> shape;
-    if (proto.has_num() || proto.has_channels() ||
-        proto.has_height() || proto.has_width()) {
+    if (proto.has_num() || proto.has_channels() || proto.has_height()
+        || proto.has_width()) {
       // Using deprecated 4D Blob dimensions --
       // shape is (num, channels, height, width).
       shape.resize(4);
@@ -454,7 +296,7 @@ void Blob<Dtype>::FromProto(const BlobProto& proto, bool reshape) {
   } else {
     CHECK(ShapeEquals(proto)) << "shape mismatch (reshape not set)";
   }
-  // copy data
+// copy data
   Dtype* data_vec = mutable_cpu_data();
   for (int i = 0; i < count_; ++i) {
     data_vec[i] = proto.data(i);
@@ -467,7 +309,7 @@ void Blob<Dtype>::FromProto(const BlobProto& proto, bool reshape) {
   }
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void Blob<Dtype>::ToProto(BlobProto* proto, bool write_diff) const {
   proto->clear_shape();
   for (int i = 0; i < shape_.size(); ++i) {

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -13,11 +13,12 @@ namespace caffe {
 template<typename Dtype>
 DataTransformer<Dtype>::DataTransformer(const TransformationParameter& param,
     Phase phase)
-    : param_(param), phase_(phase) {
+    : param_(param),
+      phase_(phase) {
   // check if we want to use mean_file
   if (param_.has_mean_file()) {
-    CHECK_EQ(param_.mean_value_size(), 0) <<
-      "Cannot specify mean_file and mean_value at the same time";
+    CHECK_EQ(param_.mean_value_size(), 0)
+        << "Cannot specify mean_file and mean_value at the same time";
     const string& mean_file = param.mean_file();
     LOG(INFO) << "Loading mean file from: " << mean_file;
     BlobProto blob_proto;
@@ -26,8 +27,8 @@ DataTransformer<Dtype>::DataTransformer(const TransformationParameter& param,
   }
   // check if we want to use mean_value
   if (param_.mean_value_size() > 0) {
-    CHECK(param_.has_mean_file() == false) <<
-      "Cannot specify mean_file and mean_value at the same time";
+    CHECK(param_.has_mean_file() == false)
+        << "Cannot specify mean_file and mean_value at the same time";
     for (int c = 0; c < param_.mean_value_size(); ++c) {
       mean_values_.push_back(param_.mean_value(c));
     }
@@ -36,7 +37,7 @@ DataTransformer<Dtype>::DataTransformer(const TransformationParameter& param,
 
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const Datum& datum,
-                                       Dtype* transformed_data) {
+    Dtype* transformed_data) {
   const string& data = datum.data();
   const int datum_channels = datum.channels();
   const int datum_height = datum.height();
@@ -61,8 +62,9 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
     mean = data_mean_.mutable_cpu_data();
   }
   if (has_mean_values) {
-    CHECK(mean_values_.size() == 1 || mean_values_.size() == datum_channels) <<
-     "Specify either 1 mean_value or as many as channels: " << datum_channels;
+    CHECK(mean_values_.size() == 1 || mean_values_.size() == datum_channels)
+        << "Specify either 1 mean_value or as many as channels: "
+        << datum_channels;
     if (datum_channels > 1 && mean_values_.size() == 1) {
       // Replicate the mean_value for simplicity
       for (int c = 1; c < datum_channels; ++c) {
@@ -102,17 +104,18 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
         }
         if (has_uint8) {
           datum_element =
-            static_cast<Dtype>(static_cast<uint8_t>(data[data_index]));
+              static_cast<Dtype>(static_cast<uint8_t>(data[data_index]));
         } else {
           datum_element = datum.float_data(data_index);
         }
+
         if (has_mean_file) {
-          transformed_data[top_index] =
-            (datum_element - mean[data_index]) * scale;
+          transformed_data[top_index] = (datum_element - mean[data_index])
+              * scale;
         } else {
           if (has_mean_values) {
-            transformed_data[top_index] =
-              (datum_element - mean_values_[c]) * scale;
+            transformed_data[top_index] = (datum_element - mean_values_[c])
+                * scale;
           } else {
             transformed_data[top_index] = datum_element * scale;
           }
@@ -124,14 +127,14 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
 
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const Datum& datum,
-                                       Blob<Dtype>* transformed_blob) {
+    Blob<Dtype>* transformed_blob) {
   // If datum is encoded, decoded and transform the cv::image.
   if (datum.encoded()) {
     CHECK(!(param_.force_color() && param_.force_gray()))
         << "cannot set both force_color and force_gray";
     cv::Mat cv_img;
     if (param_.force_color() || param_.force_gray()) {
-    // If force_color then decode in color otherwise decode in gray.
+      // If force_color then decode in color otherwise decode in gray.
       cv_img = DecodeDatumToCVMat(datum, param_.force_color());
     } else {
       cv_img = DecodeDatumToCVMatNative(datum);
@@ -158,7 +161,7 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
   CHECK_EQ(channels, datum_channels);
   CHECK_LE(height, datum_height);
   CHECK_LE(width, datum_width);
-  CHECK_GE(num, 1);
+  CHECK_EQ(num, 1);
 
   if (crop_size) {
     CHECK_EQ(crop_size, height);
@@ -174,7 +177,7 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
 
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const vector<Datum> & datum_vector,
-                                       Blob<Dtype>* transformed_blob) {
+    Blob<Dtype>* transformed_blob) {
   const int datum_num = datum_vector.size();
   const int num = transformed_blob->num();
   const int channels = transformed_blob->channels();
@@ -182,9 +185,11 @@ void DataTransformer<Dtype>::Transform(const vector<Datum> & datum_vector,
   const int width = transformed_blob->width();
 
   CHECK_GT(datum_num, 0) << "There is no datum to add";
-  CHECK_LE(datum_num, num) <<
-    "The size of datum_vector must be no greater than transformed_blob->num()";
+  CHECK_LE(datum_num, num)
+      << "The size of datum_vector must be no greater than"
+      << " transformed_blob->num()";
   Blob<Dtype> uni_blob(1, channels, height, width);
+
   for (int item_id = 0; item_id < datum_num; ++item_id) {
     int offset = transformed_blob->offset(item_id);
     uni_blob.set_cpu_data(transformed_blob->mutable_cpu_data() + offset);
@@ -194,7 +199,7 @@ void DataTransformer<Dtype>::Transform(const vector<Datum> & datum_vector,
 
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const vector<cv::Mat> & mat_vector,
-                                       Blob<Dtype>* transformed_blob) {
+    Blob<Dtype>* transformed_blob) {
   const int mat_num = mat_vector.size();
   const int num = transformed_blob->num();
   const int channels = transformed_blob->channels();
@@ -202,8 +207,8 @@ void DataTransformer<Dtype>::Transform(const vector<cv::Mat> & mat_vector,
   const int width = transformed_blob->width();
 
   CHECK_GT(mat_num, 0) << "There is no MAT to add";
-  CHECK_EQ(mat_num, num) <<
-    "The size of mat_vector must be equals to transformed_blob->num()";
+  CHECK_EQ(mat_num, num)
+      << "The size of mat_vector must be equals to transformed_blob->num()";
   Blob<Dtype> uni_blob(1, channels, height, width);
   for (int item_id = 0; item_id < mat_num; ++item_id) {
     int offset = transformed_blob->offset(item_id);
@@ -214,7 +219,7 @@ void DataTransformer<Dtype>::Transform(const vector<cv::Mat> & mat_vector,
 
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
-                                       Blob<Dtype>* transformed_blob) {
+    Blob<Dtype>* transformed_blob) {
   const int crop_size = param_.crop_size();
   const int img_channels = cv_img.channels();
   const int img_height = cv_img.rows;
@@ -250,8 +255,9 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
     mean = data_mean_.mutable_cpu_data();
   }
   if (has_mean_values) {
-    CHECK(mean_values_.size() == 1 || mean_values_.size() == img_channels) <<
-     "Specify either 1 mean_value or as many as channels: " << img_channels;
+    CHECK(mean_values_.size() == 1 || mean_values_.size() == img_channels)
+        << "Specify either 1 mean_value or as many as channels: "
+        << img_channels;
     if (img_channels > 1 && mean_values_.size() == 1) {
       // Replicate the mean_value for simplicity
       for (int c = 1; c < img_channels; ++c) {
@@ -286,7 +292,7 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
   Dtype* transformed_data = transformed_blob->mutable_cpu_data();
   int top_index;
   for (int h = 0; h < height; ++h) {
-    const uchar* ptr = cv_cropped_img.ptr<uchar>(h);
+    const uchar* ptr = cv_cropped_img.ptr < uchar > (h);
     int img_index = 0;
     for (int w = 0; w < width; ++w) {
       for (int c = 0; c < img_channels; ++c) {
@@ -299,12 +305,10 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
         Dtype pixel = static_cast<Dtype>(ptr[img_index++]);
         if (has_mean_file) {
           int mean_index = (c * img_height + h_off + h) * img_width + w_off + w;
-          transformed_data[top_index] =
-            (pixel - mean[mean_index]) * scale;
+          transformed_data[top_index] = (pixel - mean[mean_index]) * scale;
         } else {
           if (has_mean_values) {
-            transformed_data[top_index] =
-              (pixel - mean_values_[c]) * scale;
+            transformed_data[top_index] = (pixel - mean_values_[c]) * scale;
           } else {
             transformed_data[top_index] = pixel * scale;
           }
@@ -316,7 +320,7 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
 
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
-                                       Blob<Dtype>* transformed_blob) {
+    Blob<Dtype>* transformed_blob) {
   const int crop_size = param_.crop_size();
   const int input_num = input_blob->num();
   const int input_channels = input_blob->channels();
@@ -326,11 +330,11 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
   if (transformed_blob->count() == 0) {
     // Initialize transformed_blob with the right shape.
     if (crop_size) {
-      transformed_blob->Reshape(input_num, input_channels,
-                                crop_size, crop_size);
+      transformed_blob->Reshape(input_num, input_channels, crop_size,
+                                crop_size);
     } else {
-      transformed_blob->Reshape(input_num, input_channels,
-                                input_height, input_width);
+      transformed_blob->Reshape(input_num, input_channels, input_height,
+                                input_width);
     }
   }
 
@@ -344,7 +348,6 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
   CHECK_EQ(input_channels, channels);
   CHECK_GE(input_height, height);
   CHECK_GE(input_width, width);
-
 
   const Dtype scale = param_.scale();
   const bool do_mirror = param_.mirror() && Rand(2);
@@ -376,14 +379,15 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
     CHECK_EQ(input_width, data_mean_.width());
     for (int n = 0; n < input_num; ++n) {
       int offset = input_blob->offset(n);
-      caffe_sub(data_mean_.count(), input_data + offset,
-            data_mean_.cpu_data(), input_data + offset);
+      caffe_sub(data_mean_.count(), input_data + offset, data_mean_.cpu_data(),
+                input_data + offset);
     }
   }
 
   if (has_mean_values) {
-    CHECK(mean_values_.size() == 1 || mean_values_.size() == input_channels) <<
-     "Specify either 1 mean_value or as many as channels: " << input_channels;
+    CHECK(mean_values_.size() == 1 || mean_values_.size() == input_channels)
+        << "Specify either 1 mean_value or as many as channels: "
+        << input_channels;
     if (mean_values_.size() == 1) {
       caffe_add_scalar(input_blob->count(), -(mean_values_[0]), input_data);
     } else {
@@ -391,7 +395,7 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
         for (int c = 0; c < input_channels; ++c) {
           int offset = input_blob->offset(n, c);
           caffe_add_scalar(input_height * input_width, -(mean_values_[c]),
-            input_data + offset);
+                           input_data + offset);
         }
       }
     }
@@ -411,7 +415,7 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
         if (do_mirror) {
           int top_index_w = top_index_h + width - 1;
           for (int w = 0; w < width; ++w) {
-            transformed_data[top_index_w-w] = input_data[data_index_h + w];
+            transformed_data[top_index_w - w] = input_data[data_index_h + w];
           }
         } else {
           for (int w = 0; w < width; ++w) {
@@ -434,7 +438,7 @@ vector<int> DataTransformer<Dtype>::InferBlobShape(const Datum& datum) {
         << "cannot set both force_color and force_gray";
     cv::Mat cv_img;
     if (param_.force_color() || param_.force_gray()) {
-    // If force_color then decode in color otherwise decode in gray.
+      // If force_color then decode in color otherwise decode in gray.
       cv_img = DecodeDatumToCVMat(datum, param_.force_color());
     } else {
       cv_img = DecodeDatumToCVMatNative(datum);
@@ -455,8 +459,8 @@ vector<int> DataTransformer<Dtype>::InferBlobShape(const Datum& datum) {
   vector<int> shape(4);
   shape[0] = 1;
   shape[1] = datum_channels;
-  shape[2] = (crop_size)? crop_size: datum_height;
-  shape[3] = (crop_size)? crop_size: datum_width;
+  shape[2] = (crop_size) ? crop_size : datum_height;
+  shape[3] = (crop_size) ? crop_size : datum_width;
   return shape;
 }
 
@@ -486,8 +490,8 @@ vector<int> DataTransformer<Dtype>::InferBlobShape(const cv::Mat& cv_img) {
   vector<int> shape(4);
   shape[0] = 1;
   shape[1] = img_channels;
-  shape[2] = (crop_size)? crop_size: img_height;
-  shape[3] = (crop_size)? crop_size: img_width;
+  shape[2] = (crop_size) ? crop_size : img_height;
+  shape[3] = (crop_size) ? crop_size : img_width;
   return shape;
 }
 
@@ -503,10 +507,10 @@ vector<int> DataTransformer<Dtype>::InferBlobShape(
   return shape;
 }
 
-template <typename Dtype>
+template<typename Dtype>
 void DataTransformer<Dtype>::InitRand() {
-  const bool needs_rand = param_.mirror() ||
-      (phase_ == TRAIN && param_.crop_size());
+  const bool needs_rand = param_.mirror()
+      || (phase_ == TRAIN && param_.crop_size());
   if (needs_rand) {
     const unsigned int rng_seed = caffe_rng_rand();
     rng_.reset(new Caffe::RNG(rng_seed));
@@ -515,12 +519,11 @@ void DataTransformer<Dtype>::InitRand() {
   }
 }
 
-template <typename Dtype>
+template<typename Dtype>
 int DataTransformer<Dtype>::Rand(int n) {
   CHECK(rng_);
   CHECK_GT(n, 0);
-  caffe::rng_t* rng =
-      static_cast<caffe::rng_t*>(rng_->generator());
+  caffe::rng_t* rng = static_cast<caffe::rng_t*>(rng_->generator());
   return ((*rng)() % n);
 }
 

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -41,6 +41,12 @@ void MemoryDataLayer<Dtype>::AddDatumVector(const vector<Datum>& datum_vector) {
   added_data_.Reshape(num, channels_, height_, width_);
   added_label_.Reshape(num, 1, 1, 1);
   // Apply data transformations (mirror, scale, crop...)
+  LOG(ERROR) << "Apply data transformations (mirror, scale, crop...)";
+  for (int item_id = 0; item_id < datum_vector.size(); ++item_id) {
+    CHECK_EQ(4, datum_vector[item_id].channels());
+    CHECK_EQ(7, datum_vector[item_id].height());
+    CHECK_EQ(11, datum_vector[item_id].width());
+  }
   this->data_transformer_->Transform(datum_vector, &added_data_);
   // Copy Labels
   Dtype* top_label = added_label_.mutable_cpu_data();

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -25,6 +25,22 @@ message BlobProtoVector {
   repeated BlobProto blobs = 1;
 }
 
+// Specifies the shape (dimensions) of a Tensor.
+message TensorShape {
+  repeated int64 dim = 1 [packed = true];
+}
+
+message TensorProto {
+  optional TensorShape shape = 7;
+  repeated float data = 5 [packed = true];
+}
+
+// The TensorProtoVector is simply a way to pass multiple TensorProto instances
+// around.
+message TensorProtoVector {
+  repeated TensorProto tensors = 1;
+}
+
 message Datum {
   optional int32 channels = 1;
   optional int32 height = 2;

--- a/src/caffe/tensors/cpu_tensor.cpp
+++ b/src/caffe/tensors/cpu_tensor.cpp
@@ -1,0 +1,517 @@
+#include <climits>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/tensor.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template<typename Dtype>
+CPUTensor<Dtype>::CPUTensor()
+    : Tensor<Dtype>() {
+  this->type_ = CPU_TENSOR;
+}
+
+template<typename Dtype>
+CPUTensor<Dtype>::CPUTensor(const vector<int>& shape)
+    : Tensor<Dtype>(shape) {
+  this->type_ = CPU_TENSOR;
+}
+
+template<typename Dtype>
+CPUTensor<Dtype>::CPUTensor(const int dim0, const int dim1, const int dim2,
+    const int dim3)
+    : Tensor<Dtype>(dim0, dim1, dim2, dim3) {
+  this->type_ = CPU_TENSOR;
+}
+
+template<typename Dtype>
+CPUTensor<Dtype>::~CPUTensor() {
+//  free();
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::FromProto(const TensorProto& proto, bool reshape) {
+  Tensor<Dtype>::FromProto(proto, reshape);
+  //  copy data
+  Dtype* data_vec = this->mutable_data();
+  for (int i = 0; i < this->size_; ++i) {
+    data_vec[i] = proto.data(i);
+  }
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::ToProto(TensorProto* proto) {
+  Tensor<Dtype>::ToProto(proto);
+  //  copy data
+  proto->clear_data();
+  const Dtype* data_vec = this->data();
+  for (int i = 0; i < this->size_; ++i) {
+    proto->add_data(data_vec[i]);
+  }
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::malloc(const size_t num) {
+  CaffeMallocHost(&(this->ptr_), num * sizeof(Dtype));
+  Tensor<Dtype>::malloc(num);
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::free() {
+  if (this->own_data_ && this->ptr_ != NULL) {
+    CaffeFreeHost(this->ptr_);
+    Tensor<Dtype>::free();
+  }
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::set_data(Dtype* data) {
+  CHECK(data);
+  free();
+  this->ptr_ = data;
+  this->own_data_ = false;
+}
+
+/*
+ * Construction or extraction functions
+ */
+
+template<typename Dtype>
+void CPUTensor<Dtype>::mem_set(const Dtype value) {
+  if (this->ptr_ != NULL) {
+    caffe_memset(this->size_ * sizeof(Dtype), value, this->ptr_);
+  }
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::mem_copy(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    caffe_copy(this->size_, that.data(), this->mutable_data());
+  }
+}
+
+/*
+ template<>
+ Dtype CPUTensor<int>::ones(Tensor* result, const vector<int> shape) {
+ NOT_IMPLEMENTED;
+ }
+
+ template<>
+ Dtype CPUTensor<unsigned int>::ones(Tensor* result, const vector<int> shape) {
+ NOT_IMPLEMENTED;
+ }
+
+ template<typename Dtype>
+ Dtype CPUTensor<Dtype>::ones(Tensor* result, const vector<int> shape) {
+ result->Reshape(shape);
+ caffe_set(result->size(), static_cast<Dtype>(1), result->this->mutable_data());
+ }
+
+ template<typename Dtype>
+ Dtype CPUTensor<Dtype>::ones(Tensor* result, const TensorShape& shape) {
+ ones(shapeToVector(shape));
+ }
+
+ template<typename Dtype>
+ Dtype CPUTensor<Dtype>::ones(const int dim0, int dim1, int dim2, int dim3) {
+ ones(dimToShape(dim0, dim1, dim2, dim3));
+ }
+
+ template<>
+ Dtype CPUTensor<int>::zeros(const vector<int> shape) {
+ NOT_IMPLEMENTED;
+ }
+
+ template<>
+ Dtype CPUTensor<unsigned int>::zeros(const vector<int> shape) {
+ NOT_IMPLEMENTED;
+ }
+
+ template<typename Dtype>
+ Dtype CPUTensor<Dtype>::zeros(const vector<int> shape) {
+ result->Reshape(shape);
+ caffe_memset(result->size() * sizeof(Dtype), (Dtype) 0.,
+ result->this->mutable_data());
+ }
+
+ template<typename Dtype>
+ Dtype CPUTensor<Dtype>::zeros(const TensorShape& shape) {
+ zeros(shapeToVector(shape));
+ }
+
+ template<typename Dtype>
+ Dtype CPUTensor<Dtype>::zeros(const int dim0, int dim1, int dim2, int dim3) {
+ zeros(dimToShape(dim0, dim1, dim2, dim3));
+ }
+ */
+
+/*
+ * Element-wise Mathematical Operations
+ */
+
+template<>
+void CPUTensor<int>::abs(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::abs(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::abs(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, that.size());
+    caffe_abs(this->size_, that.data(), this->mutable_data());
+  }
+}
+
+template<> void CPUTensor<int>::pow(const Tensor<int>& that, const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void CPUTensor<unsigned int>::pow(const Tensor<unsigned int>& that,
+    const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::pow(const Tensor<Dtype>& that, const Dtype value) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, that.size());
+    caffe_powx(this->size_, that.data(), value, this->mutable_data());
+  }
+}
+
+template<> void CPUTensor<int>::scale(int scale_factor) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void CPUTensor<unsigned int>::scale(unsigned int scale_factor) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::scale(Dtype scale_factor) {
+  if (this->data() == NULL) {
+    return;
+  }
+  caffe_scal(this->size_, scale_factor, this->mutable_data());
+}
+
+template<> void CPUTensor<int>::add(const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::add(const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::add(const Dtype value) {
+  caffe_add_scalar(this->size_, value, this->mutable_data());
+}
+
+template<> void CPUTensor<int>::add(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::add(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::add(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, that.size());
+    caffe_add(this->size_, this->data(), that.data(), this->mutable_data());
+  }
+}
+
+template<> void CPUTensor<int>::add(const int value, const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::add(const unsigned int value,
+    const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::add(const Dtype value, const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, that.size());
+    caffe_axpy<Dtype>(this->size_, value, that.data(), this->mutable_data());
+  }
+}
+
+template<> int CPUTensor<int>::dot(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<>
+unsigned int CPUTensor<unsigned int>::dot(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<typename Dtype>
+Dtype CPUTensor<Dtype>::dot(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, that.size());
+    return caffe_cpu_dot(this->size_, this->data(), that.data());
+  }
+  return 0;
+}
+
+template<> void CPUTensor<int>::mul(const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::mul(const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::mul(const Dtype value) {
+  scale(value);
+//  caffe_axpy(this->size_, value, this->data(), this->mutable_data());
+}
+
+template<> void CPUTensor<int>::div(const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::div(const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::div(const Dtype value) {
+  CHECK_NE(0, value);
+  mul(1 / value);
+}
+
+template<> void CPUTensor<int>::cmul(const Tensor<int>& first,
+    const Tensor<int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::cmul(const Tensor<unsigned int>& first,
+    const Tensor<unsigned int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::cmul(const Tensor<Dtype>& first,
+    const Tensor<Dtype>& second) {
+  CHECK_EQ(first.type(), CPU_TENSOR);
+  CHECK_EQ(second.type(), CPU_TENSOR);
+  this->resize(first.size());
+  if (first.size() > 0) {
+    CHECK_EQ(first.size(), second.size());
+    CHECK(first.data());
+    CHECK(second.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, first.size());
+    caffe_mul(this->size_, first.data(), second.data(), this->mutable_data());
+  }
+}
+
+template<> void CPUTensor<int>::cdiv(const Tensor<int>& first,
+    const Tensor<int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::cdiv(const Tensor<unsigned int>& first,
+    const Tensor<unsigned int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::cdiv(const Tensor<Dtype>& first,
+    const Tensor<Dtype>& second) {
+  CHECK_EQ(first.type(), CPU_TENSOR);
+  CHECK_EQ(second.type(), CPU_TENSOR);
+  this->resize(first.size());
+  if (first.size() > 0) {
+    CHECK_EQ(first.size(), second.size());
+    CHECK(first.data());
+    CHECK(second.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, first.size());
+    caffe_div(this->size_, first.data(), second.data(), this->mutable_data());
+  }
+}
+
+template<> void CPUTensor<int>::mv(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::mv(const Tensor<unsigned int>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::mv(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, that.size());
+    caffe_cpu_gemv(this->get_transpose(), this->shape(0), this->shape(1),
+                   static_cast<Dtype>(1), this->data(), that.data(), (Dtype) 0.,
+                   this->mutable_data());
+  }
+}
+
+template<> void CPUTensor<int>::addmv(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::addmv(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::addmv(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, that.size());
+    caffe_cpu_gemv(this->get_transpose(), this->shape(0), this->shape(1),
+                   static_cast<Dtype>(1), this->data(), that.data(),
+                   static_cast<Dtype>(1), this->mutable_data());
+  }
+}
+
+template<> void CPUTensor<int>::mm(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void CPUTensor<unsigned int>::mm(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::mm(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, that.size());
+    caffe_cpu_gemm(this->get_transpose(), that.get_transpose(), this->shape(0),
+                   that.shape(1), this->shape(1), static_cast<Dtype>(1),
+                   this->data(), that.data(), (Dtype) 0., this->mutable_data());
+  }
+}
+
+template<> void CPUTensor<int>::addmm(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void CPUTensor<unsigned int>::addmm(
+    const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void CPUTensor<Dtype>::addmm(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), CPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    CHECK_GE(this->size_, that.size());
+    caffe_cpu_gemm(this->get_transpose(), that.get_transpose(), this->shape(0),
+                   that.shape(1), this->shape(1), static_cast<Dtype>(1),
+                   this->data(), that.data(), static_cast<Dtype>(1),
+                   this->mutable_data());
+  }
+}
+
+template<> int CPUTensor<int>::asum() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<> unsigned int CPUTensor<unsigned int>::asum() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<typename Dtype>
+Dtype CPUTensor<Dtype>::asum() {
+  if (this->data() == NULL) {
+    return 0;
+  }
+  return caffe_cpu_asum(this->size_, this->data());
+}
+
+template<> int CPUTensor<int>::sumsq() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<> unsigned int CPUTensor<unsigned int>::sumsq() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<typename Dtype>
+Dtype CPUTensor<Dtype>::sumsq() {
+  if (this->data() == NULL) {
+    return 0;
+  }
+  return caffe_cpu_dot(this->size_, this->data(), this->data());
+}
+
+INSTANTIATE_CLASS(CPUTensor);
+template class CPUTensor<int>;
+template class CPUTensor<unsigned int>;
+
+}  // namespace caffe
+

--- a/src/caffe/tensors/gpu_tensor.cu
+++ b/src/caffe/tensors/gpu_tensor.cu
@@ -1,0 +1,455 @@
+#include <climits>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/tensor.hpp"
+#include "caffe/util/math_functions.hpp"
+
+#ifndef CPU_ONLY  //  CPU-only Caffe.
+
+namespace caffe {
+
+template<typename Dtype>
+GPUTensor<Dtype>::GPUTensor()
+    : Tensor<Dtype>() {
+  this->type_ = GPU_TENSOR;
+}
+
+template<typename Dtype>
+GPUTensor<Dtype>::GPUTensor(const vector<int>& shape)
+    : Tensor<Dtype>(shape) {
+  this->type_ = GPU_TENSOR;
+}
+
+template<typename Dtype>
+GPUTensor<Dtype>::GPUTensor(const int dim0, const int dim1, const int dim2,
+    const int dim3)
+    : Tensor<Dtype>(dim0, dim1, dim2, dim3) {
+  this->type_ = GPU_TENSOR;
+}
+
+template<typename Dtype>
+GPUTensor<Dtype>::~GPUTensor() {
+//  free();
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::FromProto(const TensorProto& proto, bool reshape) {
+  Tensor<Dtype>::FromProto(proto, reshape);
+  //  copy data
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::ToProto(TensorProto* proto) {
+  Tensor<Dtype>::ToProto(proto);
+  //  copy data
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::malloc(const size_t num) {
+  CUDA_CHECK(cudaMalloc(&this->ptr_, num * sizeof(Dtype)));
+  Tensor<Dtype>::malloc(num);
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::free() {
+#ifndef CPU_ONLY
+  if (this->own_data_ && this->ptr_ != NULL) {
+    CUDA_CHECK(cudaFree(this->ptr_));
+    Tensor<Dtype>::free();
+  }
+#endif  //  CPU_ONLY
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::mem_set(const Dtype value) {
+  if (this->ptr_ != NULL) {
+    caffe_gpu_memset(this->size_ * sizeof(Dtype), value, this->mutable_data());
+  }
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::mem_copy(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  this->resize(that.size());
+  if (that.size() > 0) {
+    CHECK(that.data());
+    CHECK(this->mutable_data());
+    caffe_gpu_memcpy(this->size_ * sizeof(Dtype), that.data(),
+        this->mutable_data());
+  }
+}
+
+/*
+ * Construction or extraction functions
+ *
+
+template<>
+Dtype GPUTensor<int>::ones(Tensor* this, const vector<int> shape) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+Dtype GPUTensor<unsigned int>::ones(Tensor* this, const vector<int> shape) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+Dtype GPUTensor<Dtype>::ones(Tensor* this, const vector<int> shape) {
+  this->Reshape(shape);
+  caffe_set(this->size(), static_cast<Dtype>(1), this->mutable_data());
+}
+
+template<typename Dtype>
+Dtype GPUTensor<Dtype>::ones(Tensor* this, const TensorShape& shape) {
+  ones(shapeToVector(shape));
+}
+
+template<typename Dtype>
+Dtype GPUTensor<Dtype>::ones(const int dim0, int dim1, int dim2, int dim3) {
+  ones(dimToShape(dim0, dim1, dim2, dim3));
+}
+
+template<>
+Dtype GPUTensor<int>::zeros(const vector<int> shape) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+Dtype GPUTensor<unsigned int>::zeros(const vector<int> shape) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+Dtype GPUTensor<Dtype>::zeros(const vector<int> shape) {
+  this->Reshape(shape);
+  caffe_memset(this->size() * sizeof(Dtype), (Dtype) 0., this->mutable_data());
+}
+
+template<typename Dtype>
+Dtype GPUTensor<Dtype>::zeros(const TensorShape& shape) {
+  zeros(shapeToVector(shape));
+}
+
+template<typename Dtype>
+Dtype GPUTensor<Dtype>::zeros(const int dim0, int dim1, int dim2, int dim3) {
+  zeros(dimToShape(dim0, dim1, dim2, dim3));
+}
+*/
+
+/*
+ * Element-wise Mathematical Operations
+ */
+template<> void GPUTensor<int>::abs(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void GPUTensor<unsigned int>::abs(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::abs(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  this->resize(this->size_);
+  caffe_gpu_abs(this->size_, this->data(), this->mutable_data());
+}
+
+template<> void GPUTensor<int>::pow(const Tensor<int>& that, const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void GPUTensor<unsigned int>::pow(const Tensor<unsigned int>& that,
+    const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::pow(const Tensor<Dtype>& that, const Dtype value) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  this->resize(this->size_);
+  caffe_gpu_powx(this->size_, this->data(), value, this->mutable_data());
+}
+
+template<> void GPUTensor<int>::scale(int scale_factor) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void GPUTensor<unsigned int>::scale(unsigned int scale_factor) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::scale(Dtype scale_factor) {
+  if (this->data() == NULL) {
+    return;
+  }
+  caffe_gpu_scal(this->size_, scale_factor, this->mutable_data());
+}
+
+template<> void GPUTensor<int>::add(const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::add(const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::add(const Dtype value) {
+  caffe_gpu_add_scalar(this->size_, value, this->mutable_data());
+}
+
+template<> void GPUTensor<int>::add(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::add(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::add(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  CHECK(this->size_ <= that.size());
+  caffe_gpu_add(this->size_, this->data(), that.data(), this->mutable_data());
+}
+
+template<> void GPUTensor<int>::add(const int value, const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::add(const unsigned int value,
+    const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::add(const Dtype value, const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  caffe_gpu_axpy(this->size_, value, that.data(), this->mutable_data());
+}
+
+template<> int GPUTensor<int>::dot(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<>
+unsigned int GPUTensor<unsigned int>::dot(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<typename Dtype>
+Dtype GPUTensor<Dtype>::dot(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  CHECK(this->size_ <= that.size());
+  Dtype result = 0;
+  caffe_gpu_dot(this->size_, this->data(), that.data(), &result);
+  return result;
+}
+
+template<> void GPUTensor<int>::mul(const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::mul(const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::mul(const Dtype value) {
+  caffe_gpu_axpy(this->size_, value, this->data(), this->mutable_data());
+}
+
+template<> void GPUTensor<int>::div(const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::div(const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::div(const Dtype value) {
+  CHECK_NE(0, value);
+  mul(1 / value);
+}
+
+template<> void GPUTensor<int>::cmul(const Tensor<int>& first,
+    const Tensor<int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::cmul(const Tensor<unsigned int>& first,
+                                   const Tensor<unsigned int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::cmul(const Tensor<Dtype>& first,
+    const Tensor<Dtype>& second) {
+  CHECK_EQ(first.type(), GPU_TENSOR);
+  CHECK_EQ(second.type(), GPU_TENSOR);
+  CHECK(first.data());
+  CHECK(second.data());
+  CHECK(this->mutable_data());
+  CHECK_EQ(first.size(), second.size());
+  this->resize(first.size());
+  caffe_gpu_mul(this->size_, first.data(), second.data(), this->mutable_data());
+}
+
+template<> void GPUTensor<int>::cdiv(const Tensor<int>& first,
+    const Tensor<int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::cdiv(const Tensor<unsigned int>& first,
+                                   const Tensor<unsigned int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::cdiv(const Tensor<Dtype>& first,
+    const Tensor<Dtype>& second) {
+  CHECK_EQ(first.type(), GPU_TENSOR);
+  CHECK_EQ(second.type(), GPU_TENSOR);
+  CHECK(first.data());
+  CHECK(second.data());
+  CHECK(this->mutable_data());
+  CHECK_EQ(first.size(), second.size());
+  this->resize(first.size());
+  caffe_gpu_div(this->size_, first.data(), second.data(), this->mutable_data());
+}
+
+template<> void GPUTensor<int>::mv(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::mv(const Tensor<unsigned int>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::mv(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  CHECK(this->size_ <= that.size());
+  caffe_gpu_gemv(this->get_transpose(), this->shape(0), this->shape(1),
+                 static_cast<Dtype>(1), this->data(), that.data(), (Dtype) 0.,
+                 this->mutable_data());
+}
+
+template<> void GPUTensor<int>::addmv(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::addmv(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::addmv(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  CHECK(this->size_ <= that.size());
+  caffe_gpu_gemv(this->get_transpose(), this->shape(0), this->shape(1),
+                 static_cast<Dtype>(1), this->data(), that.data(),
+                 static_cast<Dtype>(1), this->mutable_data());
+}
+
+template<> void GPUTensor<int>::mm(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void GPUTensor<unsigned int>::mm(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::mm(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  CHECK(this->size_ <= that.size());
+  caffe_gpu_gemm(this->get_transpose(), that.get_transpose(), this->shape(0),
+                 that.shape(1), this->shape(1), static_cast<Dtype>(1),
+                 this->data(), that.data(), (Dtype) 0., this->mutable_data());
+}
+
+template<> void GPUTensor<int>::addmm(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void GPUTensor<unsigned int>::addmm(
+    const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void GPUTensor<Dtype>::addmm(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), GPU_TENSOR);
+  CHECK(this->size_ <= that.size());
+  caffe_gpu_gemm(this->get_transpose(), that.get_transpose(), this->shape(0),
+                 that.shape(1), this->shape(1), static_cast<Dtype>(1),
+                 this->data(), that.data(), static_cast<Dtype>(1),
+                 this->mutable_data());
+}
+
+template<> int GPUTensor<int>::asum() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<> unsigned int GPUTensor<unsigned int>::asum() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<typename Dtype>
+Dtype GPUTensor<Dtype>::asum() {
+  if (this->data() == NULL) {
+    return 0;
+  }
+  Dtype result = 0;
+  caffe_gpu_asum(this->size_, this->data(), &result);
+  return result;
+}
+
+template<> int GPUTensor<int>::sumsq() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<> unsigned int GPUTensor<unsigned int>::sumsq() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<typename Dtype>
+Dtype GPUTensor<Dtype>::sumsq() {
+  if (this->data() == NULL) {
+    return 0;
+  }
+  Dtype result = 0;
+  caffe_gpu_dot(this->size_, this->data(), this->data(), &result);
+  return result;
+}
+
+INSTANTIATE_CLASS(GPUTensor);
+template class GPUTensor<int>;
+template class GPUTensor<unsigned int>;
+
+}  //  namespace caffe
+
+#endif  // #ifndef CPU_ONLY

--- a/src/caffe/tensors/synced_tensor.cpp
+++ b/src/caffe/tensors/synced_tensor.cpp
@@ -1,0 +1,472 @@
+#include <climits>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/tensor.hpp"
+
+namespace caffe {
+
+template<typename Dtype>
+SyncedTensor<Dtype>::SyncedTensor()
+    : Tensor<Dtype>(),
+      cpu_tensor_(new CPUTensor<Dtype>()),
+#ifndef CPU_ONLY
+      gpu_tensor_(new GPUTensor<Dtype>()),
+#endif  // #ifndef CPU_ONLY
+      head_(UNINITIALIZED),
+      own_cpu_data_(false) {
+  this->type_ = SYNCED_TENSOR;
+}
+
+template<typename Dtype>
+SyncedTensor<Dtype>::SyncedTensor(const vector<int>& shape)
+    : Tensor<Dtype>(shape),
+      cpu_tensor_(new CPUTensor<Dtype>()),
+#ifndef CPU_ONLY
+      gpu_tensor_(new GPUTensor<Dtype>()),
+#endif  // #ifndef CPU_ONLY
+      head_(UNINITIALIZED),
+      own_cpu_data_(false) {
+  this->type_ = SYNCED_TENSOR;
+}
+
+template<typename Dtype>
+SyncedTensor<Dtype>::SyncedTensor(const int dim0, const int dim1,
+    const int dim2, const int dim3)
+    : Tensor<Dtype>(dim0, dim1, dim2, dim3),
+      cpu_tensor_(new CPUTensor<Dtype>()),
+#ifndef CPU_ONLY
+      gpu_tensor_(new GPUTensor<Dtype>()),
+#endif  // #ifndef CPU_ONLY
+      head_(UNINITIALIZED),
+      own_cpu_data_(false) {
+  this->type_ = SYNCED_TENSOR;
+}
+
+template<typename Dtype>
+SyncedTensor<Dtype>::~SyncedTensor() {
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::FromProto(const TensorProto& proto, bool reshape) {
+  CHECK(cpu_tensor_);
+  cpu_tensor_->FromProto(proto, reshape);
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::ToProto(TensorProto* proto) {
+  to_cpu();
+  if (cpu_tensor_) {
+    cpu_tensor_->ToProto(proto);
+  }
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::malloc(const size_t num) {
+  if (current_tensor_) {
+    current_tensor()->malloc(num);
+  }
+  Tensor<Dtype>::malloc(num);
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::free() {
+  if (this->own_data_) {
+    if (cpu_tensor_) {
+      cpu_tensor_->free();
+    }
+#ifndef CPU_ONLY
+    if (gpu_tensor_) {
+      gpu_tensor_->free();
+    }
+#endif  // #ifndef CPU_ONLY
+    Tensor<Dtype>::free();
+  }
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::choose_device() {
+  switch (Caffe::mode()) {
+  case Caffe::GPU:
+    to_gpu();
+    break;
+  case Caffe::CPU:
+  default:
+    to_cpu();
+    break;
+  }
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::to_cpu() {
+  switch (head_) {
+  case UNINITIALIZED:
+    cpu_tensor_->malloc(this->size_);
+    cpu_tensor_->mem_set(0);
+    head_ = HEAD_AT_CPU;
+    own_cpu_data_ = true;
+    current_tensor_ = cpu_tensor_;
+    break;
+  case HEAD_AT_GPU:
+#ifndef CPU_ONLY
+    if (cpu_tensor_->ptr() == NULL) {
+      cpu_tensor_->malloc(this->size_);
+      own_cpu_data_ = true;
+    }
+    caffe_gpu_memcpy(this->size_, gpu_tensor_->ptr(),
+                     cpu_tensor_->mutable_ptr());
+    head_ = SYNCED;
+    current_tensor_ = cpu_tensor_;
+#else
+    NO_GPU;
+#endif
+    break;
+  case HEAD_AT_CPU:
+  case SYNCED:
+    break;
+  }
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::to_gpu() {
+#ifndef CPU_ONLY
+  switch (head_) {
+  case UNINITIALIZED:
+    gpu_tensor_->malloc(this->size_);
+    gpu_tensor_->mem_set(0);
+    head_ = HEAD_AT_GPU;
+    current_tensor_ = gpu_tensor_;
+    break;
+  case HEAD_AT_CPU:
+    if (gpu_tensor_->ptr() == NULL) {
+      gpu_tensor_->malloc(this->size_);
+    }
+    caffe_gpu_memcpy(this->size_, cpu_tensor_->ptr(),
+                     gpu_tensor_->mutable_ptr());
+    head_ = SYNCED;
+    current_tensor_ = gpu_tensor_;
+    break;
+  case HEAD_AT_GPU:
+  case SYNCED:
+    break;
+  }
+#else
+  NO_GPU;
+#endif
+}
+
+template<typename Dtype>
+const Dtype* SyncedTensor<Dtype>::cpu_data() {
+  to_cpu();
+  return cpu_tensor_->data();
+}
+
+template<typename Dtype>
+Dtype* SyncedTensor<Dtype>::mutable_cpu_data() {
+  to_cpu();
+  return cpu_tensor_->mutable_data();
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::set_cpu_data(Dtype* data) {
+  CHECK(data);
+  CHECK(cpu_tensor_);
+  if (own_cpu_data_) {
+    cpu_tensor_->free();
+  }
+  cpu_tensor_->set_data(data);
+  head_ = HEAD_AT_CPU;
+  own_cpu_data_ = false;
+}
+
+template<typename Dtype>
+const Dtype* SyncedTensor<Dtype>::gpu_data() {
+#ifndef CPU_ONLY
+  to_gpu();
+  return gpu_tensor_->data();
+#endif  // #ifndef CPU_ONLY
+  return NULL;
+}
+
+template<typename Dtype>
+Dtype* SyncedTensor<Dtype>::mutable_gpu_data() {
+#ifndef CPU_ONLY
+  to_gpu();
+  return gpu_tensor_->mutable_data();
+#endif  // #ifndef CPU_ONLY
+  return NULL;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::mem_set(const Dtype value) {
+  current_tensor()->mem_set(value);
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::mem_copy(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  current_tensor()->mem_copy(const_cast<Tensor<Dtype>&>(that).tensor());
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::abs(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  current_tensor()->abs(const_cast<Tensor<Dtype>&>(that).tensor());
+}
+
+template<> void SyncedTensor<int>::pow(const Tensor<int>& that,
+    const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void SyncedTensor<unsigned int>::pow(
+    const Tensor<unsigned int>& that, const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::pow(const Tensor<Dtype>& that, const Dtype value) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  current_tensor()->pow(const_cast<Tensor<Dtype>&>(that).tensor(), value);
+}
+
+template<> void SyncedTensor<int>::scale(int scale_factor) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void SyncedTensor<unsigned int>::scale(unsigned int scale_factor) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::scale(Dtype scale_factor) {
+  current_tensor()->scale(scale_factor);
+}
+
+template<> void SyncedTensor<int>::add(const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::add(const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::add(const Dtype value) {
+  current_tensor()->add(value);
+}
+
+template<> void SyncedTensor<int>::add(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::add(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::add(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  current_tensor()->add(const_cast<Tensor<Dtype>&>(that).tensor());
+}
+
+template<> void SyncedTensor<int>::add(const int value,
+                                       const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::add(const unsigned int value,
+    const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::add(const Dtype value, const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  current_tensor()->add(value, const_cast<Tensor<Dtype>&>(that).tensor());
+}
+
+template<> int SyncedTensor<int>::dot(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<>
+unsigned int SyncedTensor<unsigned int>::dot(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<typename Dtype>
+Dtype SyncedTensor<Dtype>::dot(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  return current_tensor()->dot(const_cast<Tensor<Dtype>&>(that).tensor());
+}
+
+template<> void SyncedTensor<int>::mul(const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::mul(const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::mul(const Dtype value) {
+  current_tensor()->mul(value);
+}
+
+template<> void SyncedTensor<int>::div(const int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::div(const unsigned int value) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::div(const Dtype value) {
+  current_tensor()->div(value);
+}
+
+template<> void SyncedTensor<int>::cmul(const Tensor<int>& first,
+    const Tensor<int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::cmul(const Tensor<unsigned int>& first,
+    const Tensor<unsigned int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::cmul(const Tensor<Dtype>& first,
+    const Tensor<Dtype>& second) {
+  CHECK_EQ(first.type(), SYNCED_TENSOR);
+  CHECK_EQ(second.type(), SYNCED_TENSOR);
+  current_tensor()->cmul(const_cast<Tensor<Dtype>&>(first).tensor(),
+                         const_cast<Tensor<Dtype>&>(second).tensor());
+}
+
+template<> void SyncedTensor<int>::cdiv(const Tensor<int>& first,
+    const Tensor<int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::cdiv(const Tensor<unsigned int>& first,
+    const Tensor<unsigned int>& second) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::cdiv(const Tensor<Dtype>& first,
+    const Tensor<Dtype>& second) {
+  CHECK_EQ(first.type(), SYNCED_TENSOR);
+  CHECK_EQ(second.type(), SYNCED_TENSOR);
+  current_tensor()->cdiv(const_cast<Tensor<Dtype>&>(first).tensor(),
+                         const_cast<Tensor<Dtype>&>(second).tensor());
+}
+
+template<> void SyncedTensor<int>::mv(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::mv(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::mv(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  current_tensor()->mv(const_cast<Tensor<Dtype>&>(that).tensor());
+}
+
+template<> void SyncedTensor<int>::addmv(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::addmv(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::addmv(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  current_tensor()->addmv(const_cast<Tensor<Dtype>&>(that).tensor());
+}
+
+template<> void SyncedTensor<int>::mm(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<>
+void SyncedTensor<unsigned int>::mm(const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::mm(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  current_tensor()->mm(const_cast<Tensor<Dtype>&>(that).tensor());
+}
+
+template<> void SyncedTensor<int>::addmm(const Tensor<int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<> void SyncedTensor<unsigned int>::addmm(
+    const Tensor<unsigned int>& that) {
+  NOT_IMPLEMENTED;
+}
+
+template<typename Dtype>
+void SyncedTensor<Dtype>::addmm(const Tensor<Dtype>& that) {
+  CHECK_EQ(that.type(), SYNCED_TENSOR);
+  current_tensor()->addmm(const_cast<Tensor<Dtype>&>(that).tensor());
+}
+
+template<> int SyncedTensor<int>::asum() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<> unsigned int SyncedTensor<unsigned int>::asum() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<typename Dtype>
+Dtype SyncedTensor<Dtype>::asum() {
+  return current_tensor()->asum();
+}
+
+template<> int SyncedTensor<int>::sumsq() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<> unsigned int SyncedTensor<unsigned int>::sumsq() {
+  NOT_IMPLEMENTED;
+  return 0;
+}
+
+template<typename Dtype>
+Dtype SyncedTensor<Dtype>::sumsq() {
+  return current_tensor()->sumsq();
+}
+
+INSTANTIATE_CLASS(SyncedTensor);
+template class SyncedTensor<int>;
+template class SyncedTensor<unsigned int>;
+
+}  // namespace caffe
+

--- a/src/caffe/tensors/tensor.cpp
+++ b/src/caffe/tensors/tensor.cpp
@@ -1,0 +1,136 @@
+#include <climits>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/tensor.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template<typename Dtype>
+Tensor<Dtype>::Tensor()
+    : own_data_(false),
+      type_(UNKNOWN_TENSOR),
+      ptr_(NULL),
+      size_(0),
+// capacity_ must be initialized before calling Reshape
+      capacity_(0),
+      transpose_(CblasNoTrans) {
+}
+
+template<typename Dtype>
+Tensor<Dtype>::Tensor(const vector<int>& shape)
+    : own_data_(false),
+      type_(UNKNOWN_TENSOR),
+      ptr_(NULL),
+      size_(0),
+      // capacity_ must be initialized before calling Reshape
+      capacity_(0),
+      transpose_(CblasNoTrans) {
+  Reshape(shape);
+}
+
+template<typename Dtype>
+Tensor<Dtype>::Tensor(const int dim0, const int dim1, const int dim2,
+    const int dim3)
+    : own_data_(false),
+      type_(UNKNOWN_TENSOR),
+      ptr_(NULL),
+      size_(0),
+      // capacity_ must be initialized before calling Reshape
+      capacity_(0),
+      transpose_(CblasNoTrans) {
+  Reshape(dim0, dim1, dim2, dim3);
+}
+
+template<typename Dtype>
+void Tensor<Dtype>::Reshape(const vector<int>& shape) {
+  CHECK_LE(shape.size(), kMaxTensorAxes);
+  size_ = 1;
+  shape_.resize(shape.size());
+  for (int i = 0; i < shape.size(); ++i) {
+    CHECK_GE(shape[i], 0);
+    CHECK_LE(shape[i], INT_MAX / size_) << "Tensor size exceeds INT_MAX";
+    size_ *= shape[i];
+    shape_[i] = shape[i];
+  }
+  resize(size_);
+}
+
+template<typename Dtype>
+void Tensor<Dtype>::Reshape(const TensorShape& shape) {
+  Reshape(shapeToVector(shape));
+}
+
+template<typename Dtype>
+void Tensor<Dtype>::Reshape(const int dim0, const int dim1, const int dim2,
+    const int dim3) {
+  Reshape(dimToShape(dim0, dim1, dim2, dim3));
+}
+
+template<typename Dtype>
+void Tensor<Dtype>::ReshapeLike(const Tensor<Dtype>& that) {
+  Reshape(that.shape());
+}
+
+template<typename Dtype>
+void Tensor<Dtype>::resize(const size_t size) {
+  if (size > capacity_) {
+    capacity_ = size;
+    free();
+    malloc(capacity_);
+  }
+  size_ = size;
+}
+
+template<typename Dtype>
+void Tensor<Dtype>::CopyFrom(const Tensor<Dtype>& source, bool reshape) {
+  if (source.size() != size_ || source.shape() != shape_) {
+    if (reshape) {
+      ReshapeLike(source);
+    } else {
+      LOG(FATAL) << "Trying to copy blobs of different sizes.";
+    }
+  }
+  mem_copy(source);
+}
+
+template<typename Dtype>
+void Tensor<Dtype>::FromProto(const TensorProto& proto, bool reshape) {
+  if (reshape) {
+    vector<int> shape;
+    shape.resize(proto.shape().dim_size());
+    for (int i = 0; i < proto.shape().dim_size(); ++i) {
+      shape[i] = proto.shape().dim(i);
+    }
+    Reshape(shape);
+  } else {
+    CHECK(ShapeEquals(proto)) << "shape mismatch (reshape not set)";
+  }
+  // copy data is implemented in subclasses
+}
+
+template<typename Dtype>
+void Tensor<Dtype>::ToProto(TensorProto* proto) {
+  proto->clear_shape();
+  for (int i = 0; i < shape_.size(); ++i) {
+    proto->mutable_shape()->add_dim(shape_[i]);
+  }
+  // copy data is implemented in subclasses
+}
+
+template<typename Dtype>
+bool Tensor<Dtype>::ShapeEquals(const TensorProto& that) {
+  vector<int> shape(that.shape().dim_size());
+  for (int i = 0; i < that.shape().dim_size(); ++i) {
+    shape[i] = that.shape().dim(i);
+  }
+  return shape_ == shape;
+}
+
+INSTANTIATE_CLASS(Tensor);
+template class Tensor<int>;
+template class Tensor<unsigned int>;
+
+}  // namespace caffe
+

--- a/src/caffe/test/test_blob.cpp
+++ b/src/caffe/test/test_blob.cpp
@@ -37,10 +37,15 @@ TYPED_TEST(BlobSimpleTest, TestInitialization) {
 }
 
 TYPED_TEST(BlobSimpleTest, TestPointersCPUGPU) {
-  EXPECT_TRUE(this->blob_preshaped_->gpu_data());
   EXPECT_TRUE(this->blob_preshaped_->cpu_data());
-  EXPECT_TRUE(this->blob_preshaped_->mutable_gpu_data());
   EXPECT_TRUE(this->blob_preshaped_->mutable_cpu_data());
+#ifndef CPU_ONLY
+  EXPECT_TRUE(this->blob_preshaped_->gpu_data());
+  EXPECT_TRUE(this->blob_preshaped_->mutable_gpu_data());
+#else
+  EXPECT_FALSE(this->blob_preshaped_->gpu_data());
+  EXPECT_FALSE(this->blob_preshaped_->mutable_gpu_data());
+#endif
 }
 
 TYPED_TEST(BlobSimpleTest, TestReshape) {

--- a/src/caffe/test/test_memory_data_layer.cpp
+++ b/src/caffe/test/test_memory_data_layer.cpp
@@ -140,6 +140,10 @@ TYPED_TEST(MemoryDataLayerTest, AddDatumVectorDefaultTransform) {
       pixels[j] = pixel_index++ % 256;
     }
     datum_vector[i].set_data(&(pixels[0]), count);
+
+    CHECK_EQ(this->channels_, datum_vector[i].channels());
+    CHECK_EQ(this->height_, datum_vector[i].height());
+    CHECK_EQ(this->width_, datum_vector[i].width());
   }
   layer.AddDatumVector(datum_vector);
 

--- a/src/caffe/test/test_tensor.cpp
+++ b/src/caffe/test/test_tensor.cpp
@@ -1,0 +1,597 @@
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/tensor.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+template<typename Dtype>
+class TensorTest : public ::testing::Test {
+ protected:
+  TensorTest()
+      : tensor_(),
+        tensor_preshaped_(2, 3, 4, 5) {
+  }
+  virtual ~TensorTest() {
+  }
+  SyncedTensor<Dtype> tensor_;
+  SyncedTensor<Dtype> tensor_preshaped_;
+};
+
+TYPED_TEST_CASE(TensorTest, TestDtypes);
+
+
+TYPED_TEST(TensorTest, TestInitialization) {
+//  EXPECT_TRUE(this->tensor_);EXPECT_TRUE(this->tensor_preshaped_);
+  EXPECT_EQ(this->tensor_preshaped_.num_axes(), 4);
+  EXPECT_EQ(
+    this->tensor_preshaped_.shape(0), 2);
+  EXPECT_EQ(
+    this->tensor_preshaped_.shape(1), 3);
+  EXPECT_EQ(
+    this->tensor_preshaped_.shape(2), 4);
+  EXPECT_EQ(
+    this->tensor_preshaped_.shape(3), 5);
+  EXPECT_EQ(
+    this->tensor_preshaped_.size(), 120);
+  EXPECT_EQ(this->tensor_.num_axes(), 0);
+  EXPECT_EQ(
+    this->tensor_.size(), 0);
+}
+
+TYPED_TEST(TensorTest, TestPointersCPUGPU) {
+  EXPECT_TRUE(
+    this->tensor_preshaped_.cpu_data());
+  EXPECT_TRUE(
+    this->tensor_preshaped_.mutable_cpu_data());
+#ifndef CPU_ONLY
+  EXPECT_TRUE(this->tensor_preshaped_.gpu_data());
+  EXPECT_TRUE(
+    this->tensor_preshaped_.mutable_gpu_data());
+#else
+  EXPECT_FALSE(this->tensor_preshaped_.gpu_data());
+  EXPECT_FALSE(
+    this->tensor_preshaped_.mutable_gpu_data());
+#endif
+}
+
+TYPED_TEST(TensorTest, TestReshape) {
+  this->tensor_.Reshape(2, 3, 4, 5);
+  EXPECT_EQ(this->tensor_.shape(0), 2);
+  EXPECT_EQ(this->tensor_.shape(1), 3);
+  EXPECT_EQ(
+    this->tensor_.shape(2), 4);
+  EXPECT_EQ(this->tensor_.shape(3), 5);
+  EXPECT_EQ(
+    this->tensor_.size(), 120);}
+
+/*
+ TYPED_TEST(TensorTest, TestLegacyTensorProtoShapeEquals) {
+ TensorProto tensor_proto;
+
+ // Reshape to (3 x 2).
+ vector<int> shape(2);
+ shape[0] = 3;
+ shape[1] = 2;
+ this->tensor_.Reshape(shape);
+
+ tensor_proto.mutable_shape()->add_dim(3);
+ tensor_proto.mutable_shape()->add_dim(2);
+ EXPECT_TRUE(this->tensor_.ShapeEquals(tensor_proto));
+
+ // (3 x 2) tensor != (3 x 2 x 1) tensor
+ tensor_proto.clear_shape();
+ tensor_proto.mutable_shape()->add_dim(3);
+ tensor_proto.mutable_shape()->add_dim(2);
+ tensor_proto.mutable_shape()->add_dim(1);
+ EXPECT_FALSE(this->tensor_.ShapeEquals(tensor_proto));
+
+ // (3 x 2) tensor != (3 x 1 x 2) tensor
+ tensor_proto.clear_shape();
+ tensor_proto.mutable_shape()->add_dim(3);
+ tensor_proto.mutable_shape()->add_dim(2);
+ tensor_proto.mutable_shape()->add_dim(1);
+ EXPECT_FALSE(this->tensor_.ShapeEquals(tensor_proto));
+
+ // (3 x 2) tensor != (1 x 3 x 2) tensor
+ tensor_proto.clear_shape();
+ tensor_proto.mutable_shape()->add_dim(1);
+ tensor_proto.mutable_shape()->add_dim(3);
+ tensor_proto.mutable_shape()->add_dim(2);
+ EXPECT_FALSE(this->tensor_.ShapeEquals(tensor_proto));
+
+ // Reshape to (1 x 3 x 2).
+ shape.insert(shape.begin(), 1);
+ this->tensor_.Reshape(shape);
+
+ // (1 x 3 x 2) tensor != (1 x 3 x 2) tensor
+ tensor_proto.clear_shape();
+ tensor_proto.mutable_shape()->add_dim(1);
+ tensor_proto.mutable_shape()->add_dim(1);
+ tensor_proto.mutable_shape()->add_dim(3);
+ tensor_proto.mutable_shape()->add_dim(2);
+ EXPECT_FALSE(this->tensor_.ShapeEquals(tensor_proto));
+
+ // Reshape to (2 x 3 x 2).
+ shape[0] = 2;
+ this->tensor_.Reshape(shape);
+
+ // (2 x 3 x 2) tensor != (1 x 1 x 3 x 2) tensor
+ tensor_proto.clear_shape();
+ tensor_proto.mutable_shape()->add_dim(1);
+ tensor_proto.mutable_shape()->add_dim(1);
+ tensor_proto.mutable_shape()->add_dim(3);
+ tensor_proto.mutable_shape()->add_dim(2);
+ EXPECT_FALSE(this->tensor_.ShapeEquals(tensor_proto));}
+ }
+ */
+
+template<typename TypeParam>
+class TensorMathTest : public MultiDeviceTest<TypeParam> {
+typedef typename TypeParam::Dtype Dtype;
+ protected:
+TensorMathTest()
+    : tensor_(2, 3, 4, 5),
+      epsilon_(1e-6) {
+}
+
+virtual ~TensorMathTest() {
+}
+SyncedTensor<Dtype> tensor_;
+Dtype epsilon_;
+};
+
+TYPED_TEST_CASE(TensorMathTest, TestDtypesAndDevices);
+
+/*
+TYPED_TEST(TensorMathTest, TestOnes) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  Caffe::set_mode(TypeParam::device);Tensor<Dtype>::ones(&result, this->tensor_.shape());
+  Dtype expected_result = 1;
+  const Dtype* data = result.cpu_data();
+  for (int i = 0; i < result.size(); ++i) {
+    EXPECT_NEAR(
+  expected_result, data[i], this->epsilon_);
+}
+}
+*/
+
+TYPED_TEST(TensorMathTest, TestZeros) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  Caffe::set_mode(TypeParam::device);
+  result.zeros();
+  Dtype expected_result = 0;
+  const Dtype* data = result.cpu_data();
+  for (int i = 0; i < result.size(); ++i) {
+    EXPECT_NEAR(expected_result, data[i], this->epsilon_);
+}
+}
+
+
+TYPED_TEST(TensorMathTest, TestAbs) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> result;
+  Caffe::set_mode(TypeParam::device);
+  result.abs(this->tensor_);
+  const Dtype* data = this->tensor_.cpu_data();
+  const Dtype* result_data = result.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    EXPECT_NEAR(std::abs(data[i]), result_data[i], this->epsilon_);
+}
+}
+
+TYPED_TEST(TensorMathTest, TestPow) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+  FillerParameter filler_param;
+  filler_param.set_min(0);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> result;
+  Caffe::set_mode(TypeParam::device);
+  const Dtype value = 3.14;
+  result.pow(this->tensor_, value);
+  const Dtype* data = this->tensor_.cpu_data();
+  const Dtype* result_data = result.cpu_data();
+  Dtype expected_result;
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    expected_result = std::pow(data[i], value);
+    EXPECT_NEAR(expected_result, result_data[i],
+        this->epsilon_ * expected_result);
+  }
+}
+
+TYPED_TEST(TensorMathTest, TestAddValue) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  const Dtype* result_data = result.cpu_data();
+  vector<Dtype> old_result_data(result.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    old_result_data[i] = result_data[i];
+  }
+  const Dtype value = 3.14;
+  Caffe::set_mode(TypeParam::device);
+  result.add(value);
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    EXPECT_NEAR(old_result_data[i] + value, result_data[i],
+                                               this->epsilon_);
+}
+}
+
+TYPED_TEST(TensorMathTest, TestAddTensor) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  const Dtype* result_data = result.cpu_data();
+  vector<Dtype> old_result_data(result.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    old_result_data[i] = result_data[i];
+  }
+  Caffe::set_mode(TypeParam::device);
+  result.add(this->tensor_);
+  const Dtype* data = this->tensor_.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    EXPECT_NEAR(data[i] + old_result_data[i], result_data[i], this->epsilon_);
+}
+}
+
+TYPED_TEST(TensorMathTest, TestAddValueMultipliedTensor) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  const Dtype value = 3.14;
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  const Dtype* result_data = result.cpu_data();
+  vector<Dtype> old_result_data(result.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    old_result_data[i] = result_data[i];
+  }
+  Caffe::set_mode(TypeParam::device);
+  result.add(value, this->tensor_);
+  const Dtype* data = this->tensor_.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    EXPECT_NEAR(
+  old_result_data[i] + value * data[i], result_data[i], this->epsilon_);
+}
+}
+
+TYPED_TEST(TensorMathTest, TestDot) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  const Dtype* data = this->tensor_.cpu_data();
+  const Dtype* result_data = result.cpu_data();
+  Dtype expected_result = 0;
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    expected_result += data[i] * result_data[i];
+  }
+  Dtype epsilon = std::abs(this->epsilon_ * expected_result);
+  if (sizeof(Dtype) == sizeof(float)) {
+    epsilon *= 3;
+  }
+  Caffe::set_mode(TypeParam::device);
+  EXPECT_NEAR(expected_result, result.dot(this->tensor_), epsilon);
+}
+
+TYPED_TEST(TensorMathTest, TestMul) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  const Dtype* result_data = result.cpu_data();
+  vector<Dtype> old_result_data(result.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    old_result_data[i] = result_data[i];
+  }
+  const Dtype value = 3.14;
+  Caffe::set_mode(TypeParam::device);
+  result.mul(value);
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    EXPECT_NEAR(
+  old_result_data[i] * value, result_data[i], this->epsilon_);
+}
+}
+TYPED_TEST(TensorMathTest, TestDiv) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  vector<Dtype> old_result_data(result.size());
+  const Dtype* result_data = result.cpu_data();
+  for (size_t i = 0; i < result.size(); ++i) {
+    old_result_data[i] = result_data[i];
+  }
+  const Dtype value = 3.14;
+  Caffe::set_mode(TypeParam::device);
+  result.div(value);
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    EXPECT_NEAR(
+  old_result_data[i] / value, result_data[i], this->epsilon_);
+}
+}
+
+TYPED_TEST(TensorMathTest, TestCmul) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> that(this->tensor_.shape());
+  filler.Fill(&that);
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  Caffe::set_mode(TypeParam::device);
+result.cmul(this->tensor_, that);
+  const Dtype* data = this->tensor_.cpu_data();
+  const Dtype* that_data = that.cpu_data();
+  const Dtype* result_data = result.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    EXPECT_NEAR(
+        data[i] * that_data[i], result_data[i], this->epsilon_);
+}
+}
+
+TYPED_TEST(TensorMathTest, TestCdiv) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> that(this->tensor_.shape());
+  filler.Fill(&that);
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  Caffe::set_mode(TypeParam::device);
+result.cdiv(this->tensor_, that);
+  const Dtype* data = this->tensor_.cpu_data();
+  const Dtype* that_data = that.cpu_data();
+  const Dtype* result_data = result.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    EXPECT_NEAR(
+        data[i] / that_data[i], result_data[i], this->epsilon_);
+}
+}
+
+TYPED_TEST(TensorMathTest, TestMv) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  Caffe::set_mode(TypeParam::device);
+//  result.mv(this->tensor_);
+  const Dtype* data = this->tensor_.cpu_data();
+  const Dtype* result_data = result.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    // TODO
+    EXPECT_NEAR(
+  data[i], data[i], this->epsilon_);
+    EXPECT_NEAR(
+        result_data[i], result_data[i], this->epsilon_);
+  }
+}
+
+TYPED_TEST(TensorMathTest, TestAddmv) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  Caffe::set_mode(TypeParam::device);
+//  result.addmv(this->tensor_);
+  const Dtype* data = this->tensor_.cpu_data();
+  const Dtype* result_data = result.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    // TODO
+    EXPECT_NEAR(
+  data[i], data[i], this->epsilon_);
+    EXPECT_NEAR(
+        result_data[i], result_data[i], this->epsilon_);
+  }
+}
+
+TYPED_TEST(TensorMathTest, TestMm) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  Caffe::set_mode(TypeParam::device);
+//  result.mm(this->tensor_);
+  const Dtype* data = this->tensor_.cpu_data();
+  const Dtype* result_data = result.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    // TODO
+    EXPECT_NEAR(
+  data[i], data[i], this->epsilon_);
+    EXPECT_NEAR(
+        result_data[i], result_data[i], this->epsilon_);
+  }
+}
+
+TYPED_TEST(TensorMathTest, TestAddmm) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  SyncedTensor<Dtype> result(this->tensor_.shape());
+  filler.Fill(&result);
+  Caffe::set_mode(TypeParam::device);
+//  result.addmm(this->tensor_);
+  const Dtype* data = this->tensor_.cpu_data();
+  const Dtype* result_data = result.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    // TODO
+    EXPECT_NEAR(
+  data[i], data[i], this->epsilon_);
+    EXPECT_NEAR(
+        result_data[i], result_data[i], this->epsilon_);
+  }
+}
+
+TYPED_TEST(TensorMathTest, TestAsum) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Uninitialized Tensor should have asum == 0.
+  EXPECT_EQ(0, this->tensor_.asum());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  Dtype expected_asum = 0;
+  const Dtype* data = this->tensor_.cpu_data();
+  for (size_t i = 0; i < this->tensor_.size(); ++i) {
+    expected_asum += std::fabs(data[i]);
+  }
+  Caffe::set_mode(TypeParam::device);
+  EXPECT_NEAR(expected_asum, this->tensor_.asum(),
+      this->epsilon_ * expected_asum);
+}
+
+TYPED_TEST(TensorMathTest, TestScaleData) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  EXPECT_EQ(0, this->tensor_.asum());
+  FillerParameter filler_param;
+  filler_param.set_min(-3);
+  filler_param.set_max(3);
+  UniformFiller<Dtype> filler(filler_param);
+  filler.Fill(&(this->tensor_));
+  const Dtype asum_before_scale = this->tensor_.asum();
+  Caffe::set_mode(TypeParam::device);
+  const Dtype kDataScaleFactor = 3;
+  this->tensor_.scale(kDataScaleFactor);
+  EXPECT_NEAR(
+  asum_before_scale * kDataScaleFactor, this->tensor_.asum(),
+  this->epsilon_ * asum_before_scale * kDataScaleFactor);
+}
+
+TYPED_TEST(TensorMathTest, TestSumsq) {
+typedef typename TypeParam::Dtype Dtype;
+
+// Uninitialized Tensor should have sum of squares == 0.
+EXPECT_EQ(0, this->tensor_.sumsq());
+FillerParameter filler_param;
+filler_param.set_min(-3);
+filler_param.set_max(3);
+UniformFiller<Dtype> filler(filler_param);
+filler.Fill(&(this->tensor_));
+Dtype expected_sumsq = 0;
+const Dtype* data = this->tensor_.cpu_data();
+for (size_t i = 0; i < this->tensor_.size(); ++i) {
+  expected_sumsq += data[i] * data[i];
+}
+Caffe::set_mode(TypeParam::device);
+EXPECT_NEAR(
+    expected_sumsq, this->tensor_.sumsq(), this->epsilon_ * expected_sumsq);
+}
+
+}  // namespace caffe


### PR DESCRIPTION
Torch which is endorsed by [Facebook AI Research](https://research.facebook.com/blog/879898285375829/fair-open-sources-deep-learning-modules-for-torch/) and [Google DeepMind](https://github.com/deepmind) provides a productive API for fast research prototyping. Compared to Torch and Theano, Caffe was deemed to be [not targeted toward the research community](http://fastml.com/torch-vs-theano/). One of most followed DL researcher @karpathy [switched from Caffe and Theano to Torch recently](http://karpathy.github.io/2015/05/21/rnn-effectiveness/) because the former two didn't get right with regards to the abstraction level. At the high level, it takes Torch several times less lines of code to define a complex model. At the low level, Torch has concise [tensor](https://github.com/torch/torch7/blob/master/doc/tensor.md) and [maths](https://github.com/torch/torch7/blob/master/doc/maths.md) APIs like those of MATLAB while Caffe sticks to the raw BLAS. This PR attempts to at least partly fill the abstraction level gap between BLAS and tensor maths to improve the development productivity of advanced neural network models and speed up the turnaround time of doing research with Caffe.

Three types of API syntax for matrix-matrix multiplication:

``` C++
Tensor A = ...;
Tensor B = ...;
```
1. `Tensor C = A \* B; // Zero copy with the help of move semantics in Boost.Move
2. `Tensor C = Tensor::mm(A, B); // Zero copy too` or `Tensor C; Tensor::mm(A, B, &C);` or `Tensor C; Tensor::mm(&C, A, B);`
3. `Tensor C; C.mm(A, B); // Store the result of A * B in C`
   Seamlessly compute on GPU:

``` C++
A.cuda(); // or A.gpu();
B.cuda();
C.cuda();
C.mm(A, B);
```
