### PR TITLE
typo: "a fixed steps" to "at fixed steps"

### DIFF
--- a/gathered/examples/mnist.html
+++ b/gathered/examples/mnist.html
@@ -347,7 +347,7 @@ solver_mode: CPU
 
 <p>MNIST is a small dataset, so training with GPU does not really introduce too much benefit due to communication overheads. On larger datasets with more complex models, such as ImageNet, the computation speed difference will be more significant.</p>
 
-<h3 id="how-to-reduce-the-learning-rate-a-fixed-steps">How to reduce the learning rate a fixed steps?</h3>
+<h3 id="how-to-reduce-the-learning-rate-a-fixed-steps">How to reduce the learning rate at fixed steps?</h3>
 <p>Look at lenet_multistep_solver.prototxt</p>
 
 


### PR DESCRIPTION
I'm not sure if these are generated from some other source; just noticed the typo and found this first.