### PR TITLE
Fix HTML display for docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -62,28 +62,25 @@ The following is a poetic presentation of the protocol in code form.
 #### [Shelhamer's](https://github.com/shelhamer) “life of a branch in four acts”
 
 Make the `feature` branch off of the latest `bvlc/master`
-```
-git checkout master
-git pull upstream master
-git checkout -b feature
-# do your work, make commits
-```
+
+    git checkout master
+    git pull upstream master
+    git checkout -b feature
+    # do your work, make commits
 
 Prepare to merge by rebasing your branch on the latest `bvlc/master`
-```
-# make sure master is fresh
-git checkout master
-git pull upstream master
-# rebase your branch on the tip of master
-git checkout feature
-git rebase master
-```
+
+    # make sure master is fresh
+    git checkout master
+    git pull upstream master
+    # rebase your branch on the tip of master
+    git checkout feature
+    git rebase master
 
 Push your branch to pull request it into `BVLC/caffe:master`
-```
-git push origin feature
-# ...make pull request to master...
-```
+
+    git push origin feature
+    # ...make pull request to master...
 
 Now make a pull request! You can do this from the command line (`git pull-request -b master`) if you install [hub](https://github.com/github/hub). Hub has many other magical uses.
 


### PR DESCRIPTION
See the section "Shelhamer’s life of a branch in four acts” on this page:
http://caffe.berkeleyvision.org/development.html#shelhamershttpsgithubcomshelhamer-life-of-a-branch-in-four-acts
The git commands are not separated from each other.

Then, see the formatting of that section when rendered with Markdown (intended behavior):
https://github.com/BVLC/caffe/blob/0d7c6cb4b2286980c3d5b47cfddb2457202c93cf/docs/development.md#shelhamers-life-of-a-branch-in-four-acts

This little fix ought to fix the HTML generation without breaking the Markdown generation. I think it'll work based on the fact that [this section](https://github.com/BVLC/caffe/blob/0d7c6cb4b2286980c3d5b47cfddb2457202c93cf/docs/development.md#testing) displays correctly, but I don't actually know how the HTML generation works. 