### PR TITLE
fixed two compatibility bugs for prototext format

### DIFF
--- a/src/caffe/test/test_net.cpp
+++ b/src/caffe/test/test_net.cpp
@@ -288,6 +288,7 @@ class NetTest : public MultiDeviceTest<TypeParam> {
       const bool force_backward = false, const bool bias_term = false,
       const Dtype blobs_lr_w1 = 1, const Dtype blobs_lr_b1 = 2,
       const Dtype blobs_lr_w2 = 1, const Dtype blobs_lr_b2 = 2) {
+    string bias_str = bias_term ? "true ":"false ";
     ostringstream proto;
     proto << "name: 'UnsharedWeightsNetwork' ";
     if (force_backward) {
@@ -314,7 +315,7 @@ class NetTest : public MultiDeviceTest<TypeParam> {
         "  type: 'InnerProduct' "
         "  inner_product_param { "
         "    num_output: 10 "
-        "    bias_term: " << bias_term <<
+        "    bias_term: " << bias_str <<
         "    weight_filler { "
         "      type: 'gaussian' "
         "      std: 10 "
@@ -340,7 +341,7 @@ class NetTest : public MultiDeviceTest<TypeParam> {
         "  type: 'InnerProduct' "
         "  inner_product_param { "
         "    num_output: 10 "
-        "    bias_term: " << bias_term <<
+        "    bias_term: " << bias_str <<
         "    weight_filler { "
         "      type: 'gaussian' "
         "      std: 10 "
@@ -699,9 +700,11 @@ class NetTest : public MultiDeviceTest<TypeParam> {
       "  bottom: 'innerproduct' "
       "  bottom: 'label_argmax' ";
     if (test_skip_true)
-      proto += "  propagate_down: [true, false] ";
+      proto += "  propagate_down: true "
+               "  propagate_down: false ";
     else
-      proto += "  propagate_down: [true, true] ";
+      proto += "  propagate_down: true "
+               "  propagate_down: true ";
     proto +=
       "  top: 'cross_entropy_loss' "
       "  type: 'SigmoidCrossEntropyLoss' "


### PR DESCRIPTION
The first bug was in InitUnsharedWeightsNet. The bias_term var
was passed as an int and was breaking earlier versions of protobuffer.
I wrote an inline conditional to convert the term into a string.
This allows backwards compatibility with earlier protobuf
versions (e.g. version 2.3.0 on Redhat was failing without this).

The second bug was in the syntax for repeated bool parameters,
assigned to the propagate_down parameter. The style used for e.g.
propagate_down: [true,true] does not work with earlier prototext
versions (failed with version 2.3.0 on Redhat). New syntax works
for all versions.