### PR TITLE
register a dummy reducer to prevent mincepie runtime error

### DIFF
--- a/tools/extra/resize_and_crop_images.py
+++ b/tools/extra/resize_and_crop_images.py
@@ -101,7 +101,7 @@ class ResizeCropImagesMapper(mapreducer.BasicMapper):
         yield value, FLAGS.output_folder
 
 mapreducer.REGISTER_DEFAULT_MAPPER(ResizeCropImagesMapper)
-
+mapreducer.REGISTER_DEFAULT_REDUCER(mapreducer.NoPassReducer)
 mapreducer.REGISTER_DEFAULT_READER(mapreducer.FileReader)
 mapreducer.REGISTER_DEFAULT_WRITER(mapreducer.FileWriter)
  


### PR DESCRIPTION
mincepie need a default reducer, otherwise error would occur during runtime. In this script, a dummy `NoPassReducer` is sufficient.
