### PR TITLE
Reword help message of python training log plotting script for clarity.

### DIFF
--- a/tools/extra/plot_training_log.py.example
+++ b/tools/extra/plot_training_log.py.example
@@ -150,7 +150,7 @@ Be warned that the fields in the training log may change in the future.
 You had better check the data files and change the mapping from field name to
  field index in create_field_index before designing your own plots.
 Usage:
-    ./plot_log.sh chart_type[0-%s] /where/to/save.png /path/to/first.log ...
+    ./plot_training_log.py.example chart_type[0-%s] /where/to/save.png /path/to/first.log ...
 Notes:
     1. Supporting multiple logs.
     2. Log file name must end with the lower-cased "%s".


### PR DESCRIPTION
Seems that original author just copy the help message from shell script version of plotting script. The minor rename makes it easier to learn to use this script.