### PR TITLE
draw_net.py gives an error on drawing any network

### DIFF
--- a/python/caffe/draw.py
+++ b/python/caffe/draw.py
@@ -72,7 +72,7 @@ def get_layer_label(layer, rankdir):
     else:
         # If graph orientation is horizontal, vertical space is free and
         # horizontal space is not; separate words with newlines
-        separator = '\n'
+        separator = r'\n'
 
     if layer.type == 'Convolution':
         # Outer double quotes needed or else colon characters don't parse


### PR DESCRIPTION
On using `draw_net.py`, I was getting the following error:
```text
$ python python/draw_net.py models/bvlc_reference_caffenet/train_val.prototxt out.png                                                 
Drawing net to out.png
Traceback (most recent call last):
  File "python/draw_net.py", line 45, in <module>
    main()
  File "python/draw_net.py", line 41, in main
    caffe.draw.draw_net_to_file(net, args.output_image_file, args.rankdir)
  File "/home/rgirdhar/caffe-testing/python/caffe/draw.py", line 213, in draw_net_to_file
    fid.write(draw_net(caffe_net, rankdir, ext))
  File "/home/rgirdhar/caffe-testing/python/caffe/draw.py", line 195, in draw_net
    return get_pydot_graph(caffe_net, rankdir).create(format=ext)
  File "/home/rgirdhar/anaconda/lib/python2.7/site-packages/pydot.py", line 2023, in create
    status, stderr_output) )
pydot.InvocationException: Program terminated with status: 1. stderr follows: Warning: /tmp/tmpWrxTLf:6: string ran past end of line
Error: /tmp/tmpWrxTLf:7: syntax error near line 7
context:  >>> ( <<< ReLU)" [shape=record, style=filled, fillcolor="#90EE90"];
Warning: /tmp/tmpWrxTLf:7: ambiguous "90EE" splits into two names: "90" and "EE"
Warning: /tmp/tmpWrxTLf:7: string ran past end of line
Warning: /tmp/tmpWrxTLf:8: string ran past end of line
Warning: /tmp/tmpWrxTLf:12: string ran past end of line
Warning: /tmp/tmpWrxTLf:13: string ran past end of line
Warning: /tmp/tmpWrxTLf:14: ambiguous "90EE" splits into two names: "90" and "EE"
Warning: /tmp/tmpWrxTLf:14: string ran past end of line
Warning: /tmp/tmpWrxTLf:16: string ran past end of line
Warning: /tmp/tmpWrxTLf:20: string ran past end of line
Warning: /tmp/tmpWrxTLf:21: string ran past end of line
Warning: /tmp/tmpWrxTLf:25: string ran past end of line
Warning: /tmp/tmpWrxTLf:26: string ran past end of line
Warning: /tmp/tmpWrxTLf:30: string ran past end of line
Warning: /tmp/tmpWrxTLf:32: string ran past end of line
Warning: /tmp/tmpWrxTLf:33: ambiguous "6495ED" splits into two names: "6495" and "ED"
Warning: /tmp/tmpWrxTLf:33: string ran past end of line
Warning: /tmp/tmpWrxTLf:34: string ran past end of line
Warning: /tmp/tmpWrxTLf:35: ambiguous "90EE" splits into two names: "90" and "EE"
Warning: /tmp/tmpWrxTLf:35: string ran past end of line
Warning: /tmp/tmpWrxTLf:37: string ran past end of line
Warning: /tmp/tmpWrxTLf:38: string ran past end of line
Warning: /tmp/tmpWrxTLf:39: string ran past end of line
Warning: /tmp/tmpWrxTLf:40: ambiguous "6495ED" splits into two names: "6495" and "ED"
Warning: /tmp/tmpWrxTLf:40: string ran past end of line
Warning: /tmp/tmpWrxTLf:42: string ran past end of line
Warning: /tmp/tmpWrxTLf:43: ambiguous "90EE" splits into two names: "90" and "EE"
Warning: /tmp/tmpWrxTLf:43: string ran past end of line
Warning: /tmp/tmpWrxTLf:45: string ran past end of line
Warning: /tmp/tmpWrxTLf:46: string ran past end of line
Warning: /tmp/tmpWrxTLf:48: string ran past end of line
Warning: /tmp/tmpWrxTLf:49: ambiguous "90EE" splits into two names: "90" and "EE"
Warning: /tmp/tmpWrxTLf:49: string ran past end of line
Warning: /tmp/tmpWrxTLf:52: string ran past end of line
Warning: /tmp/tmpWrxTLf:53: ambiguous "90EE" splits into two names: "90" and "EE"
Warning: /tmp/tmpWrxTLf:53: string ran past end of line
Warning: /tmp/tmpWrxTLf:57: string ran past end of line
Warning: /tmp/tmpWrxTLf:58: ambiguous "6495ED" splits into two names: "6495" and "ED"
Warning: /tmp/tmpWrxTLf:58: string ran past end of line
Warning: /tmp/tmpWrxTLf:59: string ran past end of line
Warning: /tmp/tmpWrxTLf:60: string ran past end of line
Warning: /tmp/tmpWrxTLf:61: string ran past end of line
Warning: /tmp/tmpWrxTLf:62: ambiguous "90EE" splits into two names: "90" and "EE"
Warning: /tmp/tmpWrxTLf:62: string ran past end of line
Warning: /tmp/tmpWrxTLf:63: string ran past end of line
Warning: /tmp/tmpWrxTLf:64: ambiguous "6495ED" splits into two names: "6495" and "ED"
Warning: /tmp/tmpWrxTLf:64: string ran past end of line
Warning: /tmp/tmpWrxTLf:65: string ran past end of line
Warning: /tmp/tmpWrxTLf:66: ambiguous "6495ED" splits into two names: "6495" and "ED"
```

I encountered this error with multiple versions of caffe, on Linux 64bit, with Anaconda. This PR seems to fix it. Original idea for the fix from http://stackoverflow.com/a/29173396/1492614