### PR TITLE
improve matcaffe to support  input data of arbitrary size

### DIFF
--- a/matlab/+caffe/Blob.m
+++ b/matlab/+caffe/Blob.m
@@ -41,38 +41,11 @@ classdef Blob < handle
         'shape must be a integer row vector');
       shape = double(shape);
     end
-    function data = check_and_preprocess_data(self, data)
+    function data = check_and_preprocess_data(~, data)
       CHECK(isnumeric(data), 'data or diff must be numeric types');
-      self.check_data_size_matches(data);
       if ~isa(data, 'single')
         data = single(data);
       end
-    end
-    function check_data_size_matches(self, data)
-      % check whether size of data matches shape of this blob
-      % note: matlab arrays always have at least 2 dimensions. To compare
-      % shape between size of data and shape of this blob, extend shape of
-      % this blob to have at least 2 dimensions
-      self_shape_extended = self.shape;
-      if isempty(self_shape_extended)
-        % target blob is a scalar (0 dim)
-        self_shape_extended = [1, 1];
-      elseif isscalar(self_shape_extended)
-        % target blob is a vector (1 dim)
-        self_shape_extended = [self_shape_extended, 1];
-      end
-      % Also, matlab cannot have tailing dimension 1 for ndim > 2, so you
-      % cannot create 20 x 10 x 1 x 1 array in matlab as it becomes 20 x 10
-      % Extend matlab arrays to have tailing dimension 1 during shape match
-      data_size_extended = ...
-        [size(data), ones(1, length(self_shape_extended) - ndims(data))];
-      is_matched = ...
-        (length(self_shape_extended) == length(data_size_extended)) ...
-        && all(self_shape_extended == data_size_extended);
-      CHECK(is_matched, ...
-        sprintf('%s, input data/diff size: [ %s] vs target blob shape: [ %s]', ...
-        'input data/diff size does not match target blob shape', ...
-        sprintf('%d ', data_size_extended), sprintf('%d ', self_shape_extended)));
     end
   end
 end


### PR DESCRIPTION
This PR brings the arbitrary input size support back.
In the previous matcaffe, the input image can be of arbitrary size, while the current version does not support that. When dealing with fully convolutional networks forward for response map, arbitrary image size support is kind of necessary. Besides, the data size match check is not necessary in matcaffe because Caffe itself will do. 