### PR TITLE
Update classify.py to force sorting on the input folder

### DIFF
--- a/python/classify.py
+++ b/python/classify.py
@@ -117,7 +117,7 @@ def main(argv):
     elif os.path.isdir(args.input_file):
         print("Loading folder: %s" % args.input_file)
         inputs =[caffe.io.load_image(im_f)
-                 for im_f in glob.glob(args.input_file + '/*.' + args.ext)]
+                 for im_f in sorted(glob.glob(args.input_file + '/*.' + args.ext))]
     else:
         print("Loading file: %s" % args.input_file)
         inputs = [caffe.io.load_image(args.input_file)]


### PR DESCRIPTION
glob.glob does not guarantee that the list of files in the folder is returned in sorted order (depends on the OS).
Therefore force the files to be ordered (adding "sorted"), so you know the predictions are in sorted order.
