### PR TITLE
data fast forward for frequent training restarts

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -87,6 +87,8 @@ class DataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
 
+  void FastForward(const int ffstep);  // ywc // fast forward for frequent training restarts
+
   virtual inline const char* type() const { return "Data"; }
   virtual inline int ExactNumBottomBlobs() const { return 0; }
   virtual inline int MinTopBlobs() const { return 1; }

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -285,6 +285,7 @@ class Layer {
     param_propagate_down_[param_id] = value;
   }
 
+  virtual void FastForward(const int ffstep) {}  // ywc // fast forward for frequent training restarts
 
  protected:
   /** The protobuf that stores the layer parameters */

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -186,6 +186,8 @@ class Net {
   static bool StateMeetsRule(const NetState& state, const NetStateRule& rule,
       const string& layer_name);
 
+  void FastForward(const int ffstep);  // ywc // fast forward for frequent training restarts
+
  protected:
   // Helpers for Init.
   /// @brief Append a new input or top blob to the net.

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -60,6 +60,25 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   }
 }
 
+// ywc // fast forward for frequent training restarts
+template <typename Dtype>
+void DataLayer<Dtype>::FastForward(const int ffstep) {
+   const int batch_size = this->layer_param_.data_param().batch_size();
+
+   for (int i = 0; i < ffstep; ++i) {
+       // LOG(INFO) << "ff " << i;
+       for (int item_id = 0; item_id < batch_size; ++item_id) {
+           // go to the next iter
+           // LOG(INFO) << "  item id " << item_id;
+           cursor_->Next();
+           if (!cursor_->valid()) {
+             DLOG(INFO) << "Restarting data prefetching from start.";
+             cursor_->SeekToFirst();
+           }
+       }
+   }
+}
+
 // This function is used to create a thread that prefetches the data.
 template <typename Dtype>
 void DataLayer<Dtype>::InternalThreadEntry() {

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -493,6 +493,26 @@ void Net<Dtype>::GetLearningRateAndWeightDecay() {
   }
 }
 
+// ywc // fast forward for frequent training restarts
+template <typename Dtype>
+void Net<Dtype>::FastForward(const int ffstep) {
+    int start = 0;
+    int end   = layers_.size() - 1;
+
+    // We do fast forward by ffstep-1 steps and one forward in the last step.
+    // This is because the current caffe pre-fetches the data that will be
+    // used in the next step. This is done in a forward pass.
+    LOG(INFO) << "fast forward for ffstep-1=" << ffstep-1 << " steps";
+    for (int i = start; i <= end; ++i) {
+        layers_[i]->FastForward(ffstep-1);
+    }
+    LOG(INFO) << "forward for the last step";
+    for (int i = start; i <= end; ++i) {
+        layers_[i]->Forward(bottom_vecs_[i], top_vecs_[i]);
+    }
+    LOG(INFO) << "fast forward done";
+}
+
 template <typename Dtype>
 Dtype Net<Dtype>::ForwardFromTo(int start, int end) {
   CHECK_GE(start, 0);

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -255,6 +255,12 @@ void Solver<Dtype>::Solve(const char* resume_file) {
     Restore(resume_file);
   }
 
+  // data cursor fast forward for frequent training restarts
+  int ffstep = iter_;
+  if (ffstep >= 1) {
+    net_->FastForward(ffstep);
+  }
+
   // For a network that is trained by the solver, no bottom or top vecs
   // should be given, and we will just provide dummy vecs.
   Step(param_.max_iter() - iter_);


### PR DESCRIPTION
Current data cursor starts from the head of db when the training is resumed. This becomes a bug when frequent training restarts is required, since the training will only be using a small portion of the data. This PR fixes this bug by fast-forwarding the data cursor whenever the training is resumed.