### PR TITLE
Check for invalid cursor in data_layer

### DIFF
--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -70,6 +70,7 @@ void DataLayer<Dtype>::InternalThreadEntry() {
   CPUTimer timer;
   CHECK(this->prefetch_data_.count());
   CHECK(this->transformed_data_.count());
+  CHECK(cursor_->valid());
 
   // Reshape according to the first datum of each batch
   // on single input batches allows for inputs of varying dimension.
@@ -91,6 +92,7 @@ void DataLayer<Dtype>::InternalThreadEntry() {
   }
   timer.Start();
   for (int item_id = 0; item_id < batch_size; ++item_id) {
+    CHECK(cursor_->valid());
     // get a datum
     Datum datum;
     datum.ParseFromString(cursor_->value());


### PR DESCRIPTION
If your solver has more iterations than you have data, training will silently fail. Added checks to verify that the cursor is valid in data_layer. This would have saved a lot of time.