### PR TITLE
Add opencv_imgcodecs in LIBRARIES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ ifneq ($(CPU_ONLY), 1)
 endif
 LIBRARIES += glog gflags protobuf leveldb snappy \
 	lmdb boost_system hdf5_hl hdf5 m \
-	opencv_core opencv_highgui opencv_imgproc
+	opencv_core opencv_highgui opencv_imgproc opencv_imgcodecs
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare
 


### PR DESCRIPTION
This fixes the build issue with opencv3.

Ref: https://github.com/BVLC/caffe/issues/2288#issuecomment-102613560