### PR TITLE
Update installation docs for boost - close #2454

### DIFF
--- a/docs/install_apt.md
+++ b/docs/install_apt.md
@@ -6,7 +6,8 @@ title: Installation: Ubuntu
 
 **General dependencies**
 
-    sudo apt-get install libprotobuf-dev libleveldb-dev libsnappy-dev libopencv-dev libboost-all-dev libhdf5-serial-dev
+    sudo apt-get install libprotobuf-dev libleveldb-dev libsnappy-dev libopencv-dev libhdf5-serial-dev
+    sudo apt-get install --no-install-recommends libboost-all-dev
 
 **CUDA**: Install via the NVIDIA package instead of `apt-get` to be certain of the library and driver versions.
 Install the library and latest driver separately; the driver bundled with the library is usually out-of-date.


### PR DESCRIPTION
See discussion at #2454.

This avoids whacking a previous CUDA install.