### PR TITLE
Add makefile config option for linking Python 3 libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ endif
 LIBRARIES += glog gflags protobuf leveldb snappy \
 	lmdb boost_system hdf5_hl hdf5 m \
 	opencv_core opencv_highgui opencv_imgproc
-PYTHON_LIBRARIES := boost_python python2.7
+PYTHON_LIBRARIES ?= boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare
 
 ##############################

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -68,6 +68,10 @@ PYTHON_LIB := /usr/lib
 # Uncomment to support layers written in Python (will link against Python libs)
 # WITH_PYTHON_LAYER := 1
 
+# Uncomment to use Python 3 (default is Python 2)
+# PYTHON_LIBRARIES := boost_python3 python3.4m
+# Also, you'll need to edit PYTHON_INCLUDE above.
+
 # Whatever else you find you need goes here.
 INCLUDE_DIRS := $(PYTHON_INCLUDE) /usr/local/include
 LIBRARY_DIRS := $(PYTHON_LIB) /usr/local/lib /usr/lib

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -57,6 +57,11 @@ PYTHON_INCLUDE := /usr/include/python2.7 \
 		# $(ANACONDA_HOME)/include/python2.7 \
 		# $(ANACONDA_HOME)/lib/python2.7/site-packages/numpy/core/include \
 
+# Uncomment to use Python 3 (default is Python 2):
+# PYTHON_LIBRARIES := boost_python3 python3.4m
+# PYTHON_INCLUDE := /usr/include/python3.4m \
+		# /usr/lib/python3.4/dist-packages/numpy/core/include
+
 # We need to be able to find libpythonX.X.so or .dylib.
 PYTHON_LIB := /usr/lib
 # PYTHON_LIB := $(ANACONDA_HOME)/lib
@@ -67,10 +72,6 @@ PYTHON_LIB := /usr/lib
 
 # Uncomment to support layers written in Python (will link against Python libs)
 # WITH_PYTHON_LAYER := 1
-
-# Uncomment to use Python 3 (default is Python 2)
-# PYTHON_LIBRARIES := boost_python3 python3.4m
-# Also, you'll need to edit PYTHON_INCLUDE above.
 
 # Whatever else you find you need goes here.
 INCLUDE_DIRS := $(PYTHON_INCLUDE) /usr/local/include

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -58,9 +58,9 @@ PYTHON_INCLUDE := /usr/include/python2.7 \
 		# $(ANACONDA_HOME)/lib/python2.7/site-packages/numpy/core/include \
 
 # Uncomment to use Python 3 (default is Python 2):
-# PYTHON_LIBRARIES := boost_python3 python3.4m
-# PYTHON_INCLUDE := /usr/include/python3.4m \
-		# /usr/lib/python3.4/dist-packages/numpy/core/include
+# PYTHON_LIBRARIES := boost_python3 python3.5m
+# PYTHON_INCLUDE := /usr/include/python3.5m \
+		# /usr/lib/python3.5/dist-packages/numpy/core/include
 
 # We need to be able to find libpythonX.X.so or .dylib.
 PYTHON_LIB := /usr/lib


### PR DESCRIPTION
Existing makefile always links to boost_python and python2.7, but this breaks Python 3 support which needs boost_python3 and python3.4m instead.

This PR enables overriding the default via Makefile.config and adds a commented suggestion in Makefile.config.example.

Fixed my `import caffe` issue:
`ImportError: /usr/lib/python3.4/site-packages/caffe/_caffe.so: undefined symbol: _ZN5boost6python6detail11init_moduleER11PyModuleDefPFvvE`

Looks like this happened because the Python/C API is different in Python 3, and the linked boost library was compiled for Python 2.

Might be related to #2478, #2429, #1098 (except with gflags instead of boost), #938. 

I'm using Arch Linux where python3 is default.
