### PR TITLE
List protobuf-compiler dependency in the correct place (it is in the …

### DIFF
--- a/docs/install_apt.md
+++ b/docs/install_apt.md
@@ -6,7 +6,7 @@ title: Installation: Ubuntu
 
 **General dependencies**
 
-    sudo apt-get install libprotobuf-dev libleveldb-dev libsnappy-dev libopencv-dev libhdf5-serial-dev
+    sudo apt-get install libprotobuf-dev libleveldb-dev libsnappy-dev libopencv-dev libhdf5-serial-dev protobuf-compiler
     sudo apt-get install --no-install-recommends libboost-all-dev
 
 **CUDA**: Install via the NVIDIA package instead of `apt-get` to be certain of the library and driver versions.
@@ -21,7 +21,7 @@ This can be skipped for CPU-only installation.
 
 Everything is packaged in 14.04.
 
-    sudo apt-get install libgflags-dev libgoogle-glog-dev liblmdb-dev protobuf-compiler
+    sudo apt-get install libgflags-dev libgoogle-glog-dev liblmdb-dev
 
 **Remaining dependencies, 12.04**
 


### PR DESCRIPTION
…package managers for both 14.04 and 12.04)