### PR TITLE
Making the net_spec python3 compatible

### DIFF
--- a/examples/pycaffe/caffenet.py
+++ b/examples/pycaffe/caffenet.py
@@ -1,5 +1,6 @@
 from caffe import layers as L, params as P, to_proto
 from caffe.proto import caffe_pb2
+from __future__ import print_function
 
 # helper function for common structures
 
@@ -45,10 +46,10 @@ def caffenet(lmdb, batch_size=256, include_acc=False):
 
 def make_net():
     with open('train.prototxt', 'w') as f:
-        print >>f, caffenet('/path/to/caffe-train-lmdb')
+        print(caffenet('/path/to/caffe-train-lmdb'), file=f)
 
     with open('test.prototxt', 'w') as f:
-        print >>f, caffenet('/path/to/caffe-val-lmdb', batch_size=50, include_acc=True)
+        print(caffenet('/path/to/caffe-val-lmdb', batch_size=50, include_acc=True), file=f)
 
 if __name__ == '__main__':
     make_net()

--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -22,6 +22,7 @@ from collections import OrderedDict
 
 from .proto import caffe_pb2
 from google import protobuf
+import six
 
 
 def param_name_dict():
@@ -63,12 +64,12 @@ def assign_proto(proto, name, val):
         if isinstance(val[0], dict):
             for item in val:
                 proto_item = getattr(proto, name).add()
-                for k, v in item.iteritems():
+                for k, v in six.iteritems(item):
                     assign_proto(proto_item, k, v)
         else:
             getattr(proto, name).extend(val)
     elif isinstance(val, dict):
-        for k, v in val.iteritems():
+        for k, v in six.iteritems(val):
             assign_proto(getattr(proto, name), k, v)
     else:
         setattr(proto, name, val)
@@ -131,7 +132,7 @@ class Function(object):
                 layer.top.append(self._get_name(top, names, autonames))
         layer.name = self._get_name(self.tops[0], names, autonames)
 
-        for k, v in self.params.iteritems():
+        for k, v in six.iteritems(self.params):
             # special case to handle generic *params
             if k.endswith('param'):
                 assign_proto(layer, k, v)
@@ -161,10 +162,10 @@ class NetSpec(object):
         return self.tops[name]
 
     def to_proto(self):
-        names = {v: k for k, v in self.tops.iteritems()}
+        names = {v: k for k, v in six.iteritems(self.tops)}
         autonames = {}
         layers = OrderedDict()
-        for name, top in self.tops.iteritems():
+        for name, top in six.iteritems(self.tops):
             top.fn._to_proto(layers, names, autonames)
         net = caffe_pb2.NetParameter()
         net.layer.extend(layers.values())

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,3 +14,4 @@ protobuf>=2.5.0
 python-gflags>=2.0
 pyyaml>=3.10
 Pillow>=2.3.0
+six>=1.1.0


### PR DESCRIPTION
Fixes a few python3 bugs caused by iteritem and input redirection.