### PR TITLE
Sample implementation for memory pool by CNMeM support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,12 @@ ifeq ($(USE_CUDNN), 1)
 	COMMON_FLAGS += -DUSE_CUDNN
 endif
 
+# CNMeM configuration
+ifeq ($(USE_CNMEM), 1)
+	LIBRARIES += cnmem
+	COMMON_FLAGS += -DUSE_CNMEM
+endif
+
 # CPU-only configuration
 ifeq ($(CPU_ONLY), 1)
 	OBJS := $(PROTO_OBJS) $(CXX_OBJS)

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -4,6 +4,11 @@
 # cuDNN acceleration switch (uncomment to build with cuDNN).
 # USE_CUDNN := 1
 
+# CNMeM memory pool switch (uncomment to build with CNMeM)
+# CNMeM is a basic memory pool designed to accelerate Machine
+# Learning applications (github.com/NVIDIA/cnmem)
+# USE_CNMEM := 1
+
 # CPU-only switch (uncomment to build without GPU support).
 # CPU_ONLY := 1
 

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -18,6 +18,10 @@
 
 #include "caffe/util/device_alternate.hpp"
 
+#ifdef USE_CNMEM
+#include <cnmem.h>
+#endif
+
 // gflags 2.1 issue: namespace google was changed to gflags without warning.
 // Luckily we will be able to use GFLAGS_GFLAGS_H_ to detect if it is version
 // 2.1. If yes, we will add a temporary solution to redirect the namespace.
@@ -165,6 +169,62 @@ class Caffe {
   Caffe();
 
   DISABLE_COPY_AND_ASSIGN(Caffe);
+};
+
+class MemoryHandler {
+ public:
+  static MemoryHandler& Get();
+#ifndef CPU_ONLY
+  static void mallocGPU(void **ptr, size_t size,
+                        cudaStream_t stream = cudaStreamDefault);
+  static void freeGPU(void *ptr, cudaStream_t = cudaStreamDefault);
+  static void registerStream(cudaStream_t stream);
+#endif
+  static void setGPUs(const std::vector<int>& gpus) { Get().gpus_ = gpus; }
+  static void usePool() { Get().using_pool_ = true; }
+  static bool usingPool() {
+#ifdef USE_CNMEM
+    return Get().using_pool_;
+#else
+    return false;
+#endif
+  }
+  static void getInfo(size_t *free_mem, size_t *total_mem);
+  static void destroy();
+  ~MemoryHandler() { }
+
+ private:
+  MemoryHandler() : using_pool_(false), initialized_(false) {}
+  static void Init();
+  // static void Destroy();
+#ifndef CPU_ONLY
+  void allocate_memory(void **ptr, size_t size, cudaStream_t stream);
+  void free_memory(void *ptr, cudaStream_t stream);
+#endif
+  DISABLE_COPY_AND_ASSIGN(MemoryHandler);
+
+  bool using_pool_;
+  bool initialized_;
+  std::vector<int> gpus_;
+};
+
+class MemoryHandlerActivator {
+ public:
+  explicit MemoryHandlerActivator(const std::vector<int>& gpus)
+            : using_pool_(false) {
+    if (gpus.size() > 0) {
+      using_pool_ = true;
+      MemoryHandler::usePool();
+      MemoryHandler::setGPUs(gpus);
+    }
+  }
+  ~MemoryHandlerActivator() {
+    if (using_pool_) {
+      MemoryHandler::destroy();
+    }
+  }
+ private:
+  int using_pool_;
 };
 
 }  // namespace caffe

--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -136,6 +136,9 @@ class Caffe {
   inline static curandGenerator_t curand_generator() {
     return Get().curand_generator_;
   }
+#ifdef USE_CUDNN
+  inline static cudnnHandle_t cudnn_handle() { return Get().cudnn_handle_; }
+#endif
 #endif
 
   // Returns the mode: running on CPU or GPU.
@@ -158,6 +161,9 @@ class Caffe {
 #ifndef CPU_ONLY
   cublasHandle_t cublas_handle_;
   curandGenerator_t curand_generator_;
+#ifdef USE_CUDNN
+  cudnnHandle_t cudnn_handle_;
+#endif
 #endif
   shared_ptr<RNG> random_generator_;
 

--- a/include/caffe/common_layers.hpp
+++ b/include/caffe/common_layers.hpp
@@ -532,7 +532,6 @@ class CuDNNSoftmaxLayer : public SoftmaxLayer<Dtype> {
      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
   bool handles_setup_;
-  cudnnHandle_t             handle_;
   cudnnTensorDescriptor_t bottom_desc_;
   cudnnTensorDescriptor_t top_desc_;
 };

--- a/include/caffe/neuron_layers.hpp
+++ b/include/caffe/neuron_layers.hpp
@@ -497,7 +497,6 @@ class CuDNNReLULayer : public ReLULayer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
   bool handles_setup_;
-  cudnnHandle_t             handle_;
   cudnnTensorDescriptor_t bottom_desc_;
   cudnnTensorDescriptor_t top_desc_;
 };
@@ -580,7 +579,6 @@ class CuDNNSigmoidLayer : public SigmoidLayer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
   bool handles_setup_;
-  cudnnHandle_t             handle_;
   cudnnTensorDescriptor_t bottom_desc_;
   cudnnTensorDescriptor_t top_desc_;
 };
@@ -665,7 +663,6 @@ class CuDNNTanHLayer : public TanHLayer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
   bool handles_setup_;
-  cudnnHandle_t             handle_;
   cudnnTensorDescriptor_t bottom_desc_;
   cudnnTensorDescriptor_t top_desc_;
 };

--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -66,6 +66,14 @@ void classname<Dtype>::funcname##_##gpu(const vector<Blob<Dtype>*>& top, \
       << caffe::curandGetErrorString(status); \
   } while (0)
 
+#define CNMEM_CHECK(condition) \
+  /* Code block avoids redefinition of cudaError_t error */ \
+  do { \
+    cnmemStatus_t error = condition; \
+    CHECK_EQ(error, CNMEM_STATUS_SUCCESS) << " " \
+      << cnmemGetErrorString(error); \
+  } while (0)
+
 // CUDA: grid stride looping
 #define CUDA_KERNEL_LOOP(i, n) \
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; \

--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -244,8 +244,6 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
   bool handles_setup_;
-  cudnnHandle_t* handle_;
-  cudaStream_t*  stream_;
   vector<cudnnTensorDescriptor_t> bottom_descs_, top_descs_;
   cudnnTensorDescriptor_t    bias_desc_;
   cudnnFilterDescriptor_t      filter_desc_;
@@ -446,7 +444,6 @@ class CuDNNPoolingLayer : public PoolingLayer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
   bool handles_setup_;
-  cudnnHandle_t             handle_;
   cudnnTensorDescriptor_t bottom_desc_, top_desc_;
   cudnnPoolingDescriptor_t  pooling_desc_;
   cudnnPoolingMode_t        mode_;

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -8,6 +8,7 @@
 namespace caffe {
 
 shared_ptr<Caffe> Caffe::singleton_;
+shared_ptr<MemoryHandler> mem_handler;
 
 // random seeding
 int64_t cluster_seedgen(void) {
@@ -180,8 +181,6 @@ void Caffe::DeviceQuery() {
       << (prop.kernelExecTimeoutEnabled ? "Yes" : "No");
   return;
 }
-
-
 class Caffe::RNG::Generator {
  public:
   Generator() : rng_(new caffe::rng_t(cluster_seedgen())) {}
@@ -202,6 +201,111 @@ Caffe::RNG& Caffe::RNG::operator=(const RNG& other) {
 
 void* Caffe::RNG::generator() {
   return static_cast<void*>(generator_->rng());
+}
+
+MemoryHandler& MemoryHandler::Get() {
+  if (!mem_handler.get()) {
+    mem_handler.reset(new MemoryHandler());
+  }
+  return *(mem_handler.get());
+}
+
+void MemoryHandler::mallocGPU(void **ptr, size_t size, cudaStream_t stream) {
+  if (!Get().initialized_) {
+    Init();
+  }
+  Get().allocate_memory(ptr, size, stream);
+}
+
+void MemoryHandler::freeGPU(void *ptr, cudaStream_t stream) {
+  Get().free_memory(ptr, stream);
+}
+
+void MemoryHandler::allocate_memory(void **ptr, size_t size,
+                                    cudaStream_t stream) {
+  int initial_device;
+  cudaGetDevice(&initial_device);
+  if (size == 0) return;
+  if (using_pool_) {
+#ifdef USE_CNMEM
+    CNMEM_CHECK(cnmemMalloc(ptr, size, stream));
+#endif
+  } else {
+    CUDA_CHECK(cudaMalloc(ptr, size));
+  }
+  cudaSetDevice(initial_device);
+}
+
+void MemoryHandler::free_memory(void *ptr, cudaStream_t stream) {
+  int initial_device;
+  cudaGetDevice(&initial_device);
+  if (using_pool_) {
+#ifdef USE_CNMEM
+    CNMEM_CHECK(cnmemFree(ptr, stream));
+#endif
+  } else {
+    CUDA_CHECK(cudaFree(ptr));
+  }
+  ptr = NULL;
+  cudaSetDevice(initial_device);
+}
+
+void MemoryHandler::registerStream(cudaStream_t stream) {
+  if (!Get().initialized_) {
+    Init();
+  }
+  if (Get().using_pool_) {
+#ifdef USE_CNMEM
+    CNMEM_CHECK(cnmemRegisterStream(stream));
+#endif
+  }
+}
+
+void MemoryHandler::destroy() {
+#ifdef USE_CNMEM
+  CNMEM_CHECK(cnmemFinalize());
+#endif
+}
+
+void MemoryHandler::Init() {
+  if (Get().using_pool_) {
+#ifdef USE_CNMEM
+    cnmemDevice_t *devs = new cnmemDevice_t[Get().gpus_.size()];
+
+    int initial_device;
+    CUDA_CHECK(cudaGetDevice(&initial_device));
+
+    for (int i = 0; i < Get().gpus_.size(); i++) {
+      CUDA_CHECK(cudaSetDevice(Get().gpus_[i]));
+
+      devs[i].device = Get().gpus_[i];
+
+      size_t free_mem, used_mem;
+      CUDA_CHECK(cudaMemGetInfo(&free_mem, &used_mem));
+
+      devs[i].size = size_t(0.8*free_mem);
+      devs[i].numStreams = 0;
+      devs[i].streams = NULL;
+    }
+    CNMEM_CHECK(cnmemInit(Get().gpus_.size(), devs, CNMEM_FLAGS_DEFAULT));
+    Get().initialized_ = true;
+
+    CUDA_CHECK(cudaSetDevice(initial_device));
+
+    delete [] devs;
+#endif
+  }
+  Get().initialized_ = true;
+}
+
+void MemoryHandler::getInfo(size_t *free_mem, size_t *total_mem) {
+  if (Get().using_pool_) {
+#ifdef USE_CNMEM
+    CNMEM_CHECK(cnmemMemGetInfo(free_mem, total_mem, cudaStreamDefault));
+#endif
+  } else {
+    CUDA_CHECK(cudaMemGetInfo(free_mem, total_mem));
+  }
 }
 
 const char* cublasGetErrorString(cublasStatus_t error) {

--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -22,16 +22,8 @@ void CuDNNConvolutionLayer<Dtype>::LayerSetUp(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   ConvolutionLayer<Dtype>::LayerSetUp(bottom, top);
   // Initialize CUDA streams and cuDNN.
-  stream_         = new cudaStream_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
-  handle_         = new cudnnHandle_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
   workspaceSizeInBytes = 0;
   workspace = NULL;
-
-  for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
-    CUDA_CHECK(cudaStreamCreate(&stream_[g]));
-    CUDNN_CHECK(cudnnCreate(&handle_[g]));
-    CUDNN_CHECK(cudnnSetStream(handle_[g], stream_[g]));
-  }
 
   // Set the indexing parameters.
   weight_offset_ = (this->num_output_ / this->group_)
@@ -114,14 +106,6 @@ CuDNNConvolutionLayer<Dtype>::~CuDNNConvolutionLayer() {
     cudnnDestroyTensorDescriptor(bias_desc_);
   }
   cudnnDestroyFilterDescriptor(filter_desc_);
-
-  for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
-    cudaStreamDestroy(stream_[g]);
-    cudnnDestroy(handle_[g]);
-  }
-
-  delete [] stream_;
-  delete [] handle_;
 }
 
 INSTANTIATE_CLASS(CuDNNConvolutionLayer);

--- a/src/caffe/layers/cudnn_pooling_layer.cpp
+++ b/src/caffe/layers/cudnn_pooling_layer.cpp
@@ -13,7 +13,6 @@ template <typename Dtype>
 void CuDNNPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   PoolingLayer<Dtype>::LayerSetUp(bottom, top);
-  CUDNN_CHECK(cudnnCreate(&handle_));
   cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
   cudnn::createTensor4dDesc<Dtype>(&top_desc_);
   cudnn::createPoolingDesc<Dtype>(&pooling_desc_,
@@ -41,7 +40,6 @@ CuDNNPoolingLayer<Dtype>::~CuDNNPoolingLayer() {
   cudnnDestroyTensorDescriptor(bottom_desc_);
   cudnnDestroyTensorDescriptor(top_desc_);
   cudnnDestroyPoolingDescriptor(pooling_desc_);
-  cudnnDestroy(handle_);
 }
 
 INSTANTIATE_CLASS(CuDNNPoolingLayer);

--- a/src/caffe/layers/cudnn_pooling_layer.cu
+++ b/src/caffe/layers/cudnn_pooling_layer.cu
@@ -14,7 +14,7 @@ void CuDNNPoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
-  CUDNN_CHECK(cudnnPoolingForward(handle_, pooling_desc_,
+  CUDNN_CHECK(cudnnPoolingForward(Caffe::cudnn_handle(), pooling_desc_,
         cudnn::dataType<Dtype>::one,
         bottom_desc_, bottom_data,
         cudnn::dataType<Dtype>::zero,
@@ -31,7 +31,7 @@ void CuDNNPoolingLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   const Dtype* top_data = top[0]->gpu_data();
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
-  CUDNN_CHECK(cudnnPoolingBackward(handle_, pooling_desc_,
+  CUDNN_CHECK(cudnnPoolingBackward(Caffe::cudnn_handle(), pooling_desc_,
         cudnn::dataType<Dtype>::one,
         top_desc_, top_data, top_desc_, top_diff,
         bottom_desc_, bottom_data,

--- a/src/caffe/layers/cudnn_relu_layer.cpp
+++ b/src/caffe/layers/cudnn_relu_layer.cpp
@@ -12,7 +12,6 @@ void CuDNNReLULayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   ReLULayer<Dtype>::LayerSetUp(bottom, top);
   // initialize cuDNN
-  CUDNN_CHECK(cudnnCreate(&handle_));
   cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
   cudnn::createTensor4dDesc<Dtype>(&top_desc_);
   handles_setup_ = true;
@@ -37,7 +36,6 @@ CuDNNReLULayer<Dtype>::~CuDNNReLULayer() {
 
   cudnnDestroyTensorDescriptor(this->bottom_desc_);
   cudnnDestroyTensorDescriptor(this->top_desc_);
-  cudnnDestroy(this->handle_);
 }
 
 INSTANTIATE_CLASS(CuDNNReLULayer);

--- a/src/caffe/layers/cudnn_relu_layer.cu
+++ b/src/caffe/layers/cudnn_relu_layer.cu
@@ -17,7 +17,7 @@ void CuDNNReLULayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
-  CUDNN_CHECK(cudnnActivationForward(this->handle_,
+  CUDNN_CHECK(cudnnActivationForward(Caffe::cudnn_handle(),
         CUDNN_ACTIVATION_RELU,
         cudnn::dataType<Dtype>::one,
         this->bottom_desc_, bottom_data,
@@ -42,7 +42,7 @@ void CuDNNReLULayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   const Dtype* top_diff = top[0]->gpu_diff();
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
-  CUDNN_CHECK(cudnnActivationBackward(this->handle_,
+  CUDNN_CHECK(cudnnActivationBackward(Caffe::cudnn_handle(),
         CUDNN_ACTIVATION_RELU,
         cudnn::dataType<Dtype>::one,
         this->top_desc_, top_data, this->top_desc_, top_diff,

--- a/src/caffe/layers/cudnn_sigmoid_layer.cpp
+++ b/src/caffe/layers/cudnn_sigmoid_layer.cpp
@@ -12,7 +12,6 @@ void CuDNNSigmoidLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   SigmoidLayer<Dtype>::LayerSetUp(bottom, top);
   // initialize cuDNN
-  CUDNN_CHECK(cudnnCreate(&handle_));
   cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
   cudnn::createTensor4dDesc<Dtype>(&top_desc_);
   handles_setup_ = true;
@@ -37,7 +36,6 @@ CuDNNSigmoidLayer<Dtype>::~CuDNNSigmoidLayer() {
 
   cudnnDestroyTensorDescriptor(this->bottom_desc_);
   cudnnDestroyTensorDescriptor(this->top_desc_);
-  cudnnDestroy(this->handle_);
 }
 
 INSTANTIATE_CLASS(CuDNNSigmoidLayer);

--- a/src/caffe/layers/cudnn_sigmoid_layer.cu
+++ b/src/caffe/layers/cudnn_sigmoid_layer.cu
@@ -12,7 +12,7 @@ void CuDNNSigmoidLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
-  CUDNN_CHECK(cudnnActivationForward(this->handle_,
+  CUDNN_CHECK(cudnnActivationForward(Caffe::cudnn_handle(),
         CUDNN_ACTIVATION_SIGMOID,
         cudnn::dataType<Dtype>::one,
         this->bottom_desc_, bottom_data,
@@ -32,7 +32,7 @@ void CuDNNSigmoidLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   const Dtype* top_diff = top[0]->gpu_diff();
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
-  CUDNN_CHECK(cudnnActivationBackward(this->handle_,
+  CUDNN_CHECK(cudnnActivationBackward(Caffe::cudnn_handle(),
         CUDNN_ACTIVATION_SIGMOID,
         cudnn::dataType<Dtype>::one,
         this->top_desc_, top_data, this->top_desc_, top_diff,

--- a/src/caffe/layers/cudnn_softmax_layer.cpp
+++ b/src/caffe/layers/cudnn_softmax_layer.cpp
@@ -16,7 +16,6 @@ void CuDNNSoftmaxLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   SoftmaxLayer<Dtype>::LayerSetUp(bottom, top);
   // Initialize CUDNN.
-  CUDNN_CHECK(cudnnCreate(&handle_));
   cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
   cudnn::createTensor4dDesc<Dtype>(&top_desc_);
   handles_setup_ = true;
@@ -41,7 +40,6 @@ CuDNNSoftmaxLayer<Dtype>::~CuDNNSoftmaxLayer() {
 
   cudnnDestroyTensorDescriptor(bottom_desc_);
   cudnnDestroyTensorDescriptor(top_desc_);
-  cudnnDestroy(handle_);
 }
 
 INSTANTIATE_CLASS(CuDNNSoftmaxLayer);

--- a/src/caffe/layers/cudnn_softmax_layer.cu
+++ b/src/caffe/layers/cudnn_softmax_layer.cu
@@ -16,7 +16,8 @@ void CuDNNSoftmaxLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
-  CUDNN_CHECK(cudnnSoftmaxForward(handle_, CUDNN_SOFTMAX_ACCURATE,
+  CUDNN_CHECK(cudnnSoftmaxForward(Caffe::cudnn_handle(),
+        CUDNN_SOFTMAX_ACCURATE,
         CUDNN_SOFTMAX_MODE_CHANNEL,
         cudnn::dataType<Dtype>::one,
         bottom_desc_, bottom_data,
@@ -33,7 +34,8 @@ void CuDNNSoftmaxLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     const Dtype* bottom_data = bottom[0]->gpu_data();
     Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
 
-    CUDNN_CHECK(cudnnSoftmaxBackward(handle_, CUDNN_SOFTMAX_ACCURATE,
+    CUDNN_CHECK(cudnnSoftmaxBackward(Caffe::cudnn_handle(),
+          CUDNN_SOFTMAX_ACCURATE,
           CUDNN_SOFTMAX_MODE_CHANNEL,
           cudnn::dataType<Dtype>::one,
           top_desc_, top_data, top_desc_, top_diff,

--- a/src/caffe/layers/cudnn_tanh_layer.cpp
+++ b/src/caffe/layers/cudnn_tanh_layer.cpp
@@ -12,7 +12,6 @@ void CuDNNTanHLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   TanHLayer<Dtype>::LayerSetUp(bottom, top);
   // initialize cuDNN
-  CUDNN_CHECK(cudnnCreate(&handle_));
   cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
   cudnn::createTensor4dDesc<Dtype>(&top_desc_);
   handles_setup_ = true;
@@ -37,7 +36,6 @@ CuDNNTanHLayer<Dtype>::~CuDNNTanHLayer() {
 
   cudnnDestroyTensorDescriptor(this->bottom_desc_);
   cudnnDestroyTensorDescriptor(this->top_desc_);
-  cudnnDestroy(this->handle_);
 }
 
 INSTANTIATE_CLASS(CuDNNTanHLayer);

--- a/src/caffe/layers/cudnn_tanh_layer.cu
+++ b/src/caffe/layers/cudnn_tanh_layer.cu
@@ -12,7 +12,7 @@ void CuDNNTanHLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
-  CUDNN_CHECK(cudnnActivationForward(this->handle_,
+  CUDNN_CHECK(cudnnActivationForward(Caffe::cudnn_handle(),
         CUDNN_ACTIVATION_TANH,
         cudnn::dataType<Dtype>::one,
         this->bottom_desc_, bottom_data,
@@ -33,7 +33,7 @@ void CuDNNTanHLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
 
-  CUDNN_CHECK(cudnnActivationBackward(this->handle_,
+  CUDNN_CHECK(cudnnActivationBackward(Caffe::cudnn_handle(),
         CUDNN_ACTIVATION_TANH,
         cudnn::dataType<Dtype>::one,
         this->top_desc_, top_data, this->top_desc_, top_diff,

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -13,7 +13,7 @@ SyncedMemory::~SyncedMemory() {
 
 #ifndef CPU_ONLY
   if (gpu_ptr_) {
-    CUDA_CHECK(cudaFree(gpu_ptr_));
+    MemoryHandler::freeGPU(gpu_ptr_);
   }
 #endif  // CPU_ONLY
 }
@@ -48,13 +48,13 @@ inline void SyncedMemory::to_gpu() {
 #ifndef CPU_ONLY
   switch (head_) {
   case UNINITIALIZED:
-    CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
+    MemoryHandler::mallocGPU(&gpu_ptr_, size_);
     caffe_gpu_memset(size_, 0, gpu_ptr_);
     head_ = HEAD_AT_GPU;
     break;
   case HEAD_AT_CPU:
     if (gpu_ptr_ == NULL) {
-      CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
+      MemoryHandler::mallocGPU(&gpu_ptr_, size_);
     }
     caffe_gpu_memcpy(size_, cpu_ptr_, gpu_ptr_);
     head_ = SYNCED;

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -15,6 +15,7 @@ using caffe::Layer;
 using caffe::shared_ptr;
 using caffe::Timer;
 using caffe::vector;
+using caffe::MemoryHandlerActivator;
 
 
 DEFINE_int32(gpu, -1,
@@ -117,6 +118,12 @@ int train() {
     LOG(INFO) << "Use CPU.";
     Caffe::set_mode(Caffe::CPU);
   }
+
+#ifdef USE_CNMEM
+  std::vector<int> gpus;
+  gpus.push_back(FLAGS_gpu);
+  MemoryHandlerActivator activator(gpus);
+#endif
 
   LOG(INFO) << "Starting Optimization";
   shared_ptr<caffe::Solver<float> >


### PR DESCRIPTION
Example implementation of a memory pool (in this case CNMeM, github.com/NVIDIA/cnmem) to Caffe through the singleton.

Implements all GPU allocations and frees through static methods in the singleton -- these resolve to either a call to CNMeM or straight to cudaMalloc / cudaFree depending on the USE_CNMEM flag in Makefile.config.
