### PR TITLE
tiny fix in Layer::Backward documentation

### DIFF
--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -139,7 +139,7 @@ class Layer {
    * (Backward_cpu or Backward_gpu) to compute the bottom blob diffs given the
    * top blob diffs.
    *
-   * Your layer should implement Forward_cpu and (optionally) Forward_gpu.
+   * Your layer should implement Backward_cpu and (optionally) Backward_gpu.
    */
   inline void Backward(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down,


### PR DESCRIPTION
I realize this edit is not very significant, but thought it might as well get corrected. I suspect it came from copy-pasting the documentation of the Forward method.