### PR TITLE
Add arguments for PythonLayer

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -190,6 +190,10 @@ bp::object Blob_Reshape(bp::tuple args, bp::dict kwargs) {
   return bp::object();
 }
 
+string Layer_arguments(const Layer<Dtype>& layer) {
+  return layer.layer_param().python_param().arguments();
+}
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SolveOverloads, Solve, 0, 1);
 
 BOOST_PYTHON_MODULE(_caffe) {
@@ -248,6 +252,7 @@ BOOST_PYTHON_MODULE(_caffe) {
           bp::return_internal_reference<>()))
     .def("setup", &Layer<Dtype>::LayerSetUp)
     .def("reshape", &Layer<Dtype>::Reshape)
+    .add_property("arguments", &Layer_arguments)
     .add_property("type", bp::make_function(&Layer<Dtype>::type));
   bp::register_ptr_to_python<shared_ptr<Layer<Dtype> > >();
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -703,6 +703,7 @@ message PowerParameter {
 message PythonParameter {
   optional string module = 1;
   optional string layer = 2;
+  optional string arguments = 3;
 }
 
 // Message that stores parameters used by ReductionLayer


### PR DESCRIPTION
This pull request adds a way for PythonLayers (#1703) to accept arguments through prototxt files.

Instead of loading files or other processing in `setup()`, this allows one to pass parameters through the 'arguments' string in PythonParameter. The receiver can then process the string however they choose: load through `json.loads()`, comma separated values, etc.

This pull request is a simpler alternative to #2001, without exception handling changes.

Example class:

```python
class MultLayer(caffe.Layer):
    def setup(self, bottom, top):
        self.mult_factor = int(self.arguments)

    def reshape(self, bottom, top):
        top[0].reshape(bottom[0].num, bottom[0].channels, bottom[0].height,
            bottom[0].width)

    def forward(self, bottom, top):
        top[0].data[...] = self.mult_factor * bottom[0].data

    def backward(self, top, propagate_down, bottom):
        if propagate_down[0]:
            bottom[0].diff[...] = self.mult_factor * top[0].diff
```

Example addition to prototxt:
```protobuf
layer {
  name: "python1"
  type: "Python"
  bottom: "prev1"
  top: "curr1"
  python_param {
    module: "multlayer"
    layer: "MultLayer"
    arguments: "10"
  }
}
```