### PR TITLE
Fix compilation error when absolute path contains spaces: ln: .build_release/tools/caffe: No such file or directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ $(TEST_CXX_BINS): $(TEST_BIN_DIR)/%.testbin: $(TEST_CXX_BUILD_DIR)/%.o \
 # Target for extension-less symlinks to tool binaries with extension '*.bin'.
 $(TOOL_BUILD_DIR)/%: $(TOOL_BUILD_DIR)/%.bin | $(TOOL_BUILD_DIR)
 	@ $(RM) $@
-	@ ln -s $(abspath $<) $@
+	@ ln -s "$(abspath $<)" $@
 
 $(TOOL_BINS): %.bin : %.o | $(DYNAMIC_NAME)
 	@ echo CXX/LD -o $@


### PR DESCRIPTION
Resolve compilation error `ln: .build_release/tools/caffe: No such file or directory` when absolute path contains spaces.