### PR TITLE
Add parameter for MemoryDataLayer to support multiple channel label

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -262,7 +262,7 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   virtual void AddMatVector(const vector<cv::Mat>& mat_vector,
       const vector<int>& labels);
   virtual void AddMatVector(const vector<cv::Mat>& mat_vector,
-      const vector<vector<int>>& labels);
+      const vector<vector<int> >& labels);
 
   // Reset should accept const pointers, but can't, because the memory
   //  will be given to Blob, which is mutable

--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -261,6 +261,8 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   virtual void AddDatumVector(const vector<Datum>& datum_vector);
   virtual void AddMatVector(const vector<cv::Mat>& mat_vector,
       const vector<int>& labels);
+  virtual void AddMatVector(const vector<cv::Mat>& mat_vector,
+      const vector<vector<int>>& labels);
 
   // Reset should accept const pointers, but can't, because the memory
   //  will be given to Blob, which is mutable
@@ -271,12 +273,13 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   int channels() { return channels_; }
   int height() { return height_; }
   int width() { return width_; }
+  int label_channels() { return label_channels_; }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
 
-  int batch_size_, channels_, height_, width_, size_;
+  int batch_size_, channels_, height_, width_, size_, label_channels_;
   Dtype* data_;
   Dtype* labels_;
   int n_;

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -100,7 +100,8 @@ void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
   Dtype* top_label = added_label_.mutable_cpu_data();
   for (int item_id = 0; item_id < num; ++item_id) {
     for (int label_id = 0; label_id < label_channels_; label_id++) {
-      top_label[item_id * label_channels_ + label_id] = labels[item_id][label_id];
+      top_label[item_id * label_channels_ + label_id] = 
+        labels[item_id][label_id];
     }
   }
   // num_images == batch_size_

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -81,7 +81,7 @@ void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
 
 template <typename Dtype>
 void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
-    const vector<vector<int>>& labels) {
+    const vector<vector<int> >& labels) {
   size_t num = mat_vector.size();
   CHECK(!has_new_data_) <<
       "Can't add mat until current data has been consumed.";

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -100,7 +100,7 @@ void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
   Dtype* top_label = added_label_.mutable_cpu_data();
   for (int item_id = 0; item_id < num; ++item_id) {
     for (int label_id = 0; label_id < label_channels_; label_id++) {
-      top_label[item_id * label_channels_ + label_id] = 
+      top_label[item_id * label_channels_ + label_id] =
         labels[item_id][label_id];
     }
   }

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -16,14 +16,14 @@ void MemoryDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   height_ = this->layer_param_.memory_data_param().height();
   width_ = this->layer_param_.memory_data_param().width();
   size_ = channels_ * height_ * width_;
+  label_channels_ = this->layer_param_.memory_data_param().label_channels();
   CHECK_GT(batch_size_ * size_, 0) <<
       "batch_size, channels, height, and width must be specified and"
       " positive in memory_data_param";
-  vector<int> label_shape(1, batch_size_);
   top[0]->Reshape(batch_size_, channels_, height_, width_);
-  top[1]->Reshape(label_shape);
+  top[1]->Reshape(batch_size_, label_channels_, 1, 1);
   added_data_.Reshape(batch_size_, channels_, height_, width_);
-  added_label_.Reshape(label_shape);
+  added_label_.Reshape(batch_size_, label_channels_, 1, 1);
   data_ = NULL;
   labels_ = NULL;
   added_data_.cpu_data();
@@ -62,6 +62,8 @@ void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
   CHECK_GT(num, 0) << "There is no mat to add";
   CHECK_EQ(num % batch_size_, 0) <<
       "The added data must be a multiple of the batch size.";
+  CHECK_EQ(mat_vector.size(), labels.size()) <<
+      "The number of data and label should be the same.";
   added_data_.Reshape(num, channels_, height_, width_);
   added_label_.Reshape(num, 1, 1, 1);
   // Apply data transformations (mirror, scale, crop...)
@@ -70,6 +72,36 @@ void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
   Dtype* top_label = added_label_.mutable_cpu_data();
   for (int item_id = 0; item_id < num; ++item_id) {
     top_label[item_id] = labels[item_id];
+  }
+  // num_images == batch_size_
+  Dtype* top_data = added_data_.mutable_cpu_data();
+  Reset(top_data, top_label, num);
+  has_new_data_ = true;
+}
+
+template <typename Dtype>
+void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
+    const vector<vector<int>>& labels) {
+  size_t num = mat_vector.size();
+  CHECK(!has_new_data_) <<
+      "Can't add mat until current data has been consumed.";
+  CHECK_GT(num, 0) << "There is no mat to add";
+  CHECK_EQ(num % batch_size_, 0) <<
+      "The added data must be a multiple of the batch size.";
+  CHECK_EQ(mat_vector.size(), labels.size()) <<
+      "The number of data and label should be the same.";
+  CHECK_EQ(labels[0].size(), label_channels_) <<
+      "The input label must have the specified number of channels.";
+  added_data_.Reshape(num, channels_, height_, width_);
+  added_label_.Reshape(num, label_channels_, 1, 1);
+  // Apply data transformations (mirror, scale, crop...)
+  this->data_transformer_->Transform(mat_vector, &added_data_);
+  // Copy Labels
+  Dtype* top_label = added_label_.mutable_cpu_data();
+  for (int item_id = 0; item_id < num; ++item_id) {
+    for (int label_id = 0; label_id < label_channels_; label_id++) {
+      top_label[item_id * label_channels_ + label_id] = labels[item_id][label_id];
+    }
   }
   // num_images == batch_size_
   Dtype* top_data = added_data_.mutable_cpu_data();
@@ -107,9 +139,9 @@ void MemoryDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   CHECK(data_) << "MemoryDataLayer needs to be initalized by calling Reset";
   top[0]->Reshape(batch_size_, channels_, height_, width_);
-  top[1]->Reshape(batch_size_, 1, 1, 1);
+  top[1]->Reshape(batch_size_, label_channels_, 1, 1);
   top[0]->set_cpu_data(data_ + pos_ * size_);
-  top[1]->set_cpu_data(labels_ + pos_);
+  top[1]->set_cpu_data(labels_ + pos_ * label_channels_);
   pos_ = (pos_ + batch_size_) % n_;
   if (pos_ == 0)
     has_new_data_ = false;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -651,6 +651,7 @@ message MemoryDataParameter {
   optional uint32 channels = 2;
   optional uint32 height = 3;
   optional uint32 width = 4;
+  optional uint32 label_channels = 5 [default = 1];
 }
 
 message MVNParameter {


### PR DESCRIPTION
## Change:
- add `label_channels` in `message MemoryDataParameter`
- modify the number of channels in MemoryDataParameter's
  `DataLayerSetUp`
- modify the number of channels in MemoryDataParameter's `Forward_cpu`
- accept `vector<vector<int>>& labels` as input for `AddMatVector()`
## Usage:
- memory_data_layer can have multiple channels of label and be sliced afterwards, e.g.:

```
layer {
  name: "data"
  type: "MEMORY_DATA"
  top: "data"
  top: "label"
  memory_data_param 
  {
    batch_size: 100
    channels: 6
    height: 64
    width: 64
    label_channels: 3
  }
  transform_param 
  {
    crop_size: 64
    mirror: true
  }
  include: { phase: TRAIN }
}

layer {
  name: "slicer_label"
  type: "Slice"
  bottom: "label"
  ## Example of label with a shape N x 3 x 1 x 1
  top: "label1"
  top: "label2"
  top: "label3"
  slice_param {
    axis: 1
    slice_point: 1
    slice_point: 2
  }
}
```
- together with OpenCV, training data can be prepared as blow:

```
// every Mat is a image with 1 or more channels
vector<Mat> patches_train, patches_test;

// if one input has one label, use: vector<int> labels_train, labels_test;
// if one input has multiple labels, use below
vector<vector<int> > labels_train, labels_test;
...
```
- training can start after pushing the prepared data into memory_data_layers:

```
// caffe training
int train(vector<Mat> & patches_train, vector<vector<int> > & labels_train, 
    vector<Mat> & patches_test, vector<vector<int> > & labels_test) 
{
    // parse solver parameters
    string solver_prototxt = "prototxt/solver_lenet_memory.prototxt";
    caffe::SolverParameter solver_param;
    caffe::ReadProtoFromTextFileOrDie(solver_prototxt, &solver_param);

    // set device id and mode
    Caffe::SetDevice(0);
    Caffe::set_mode(Caffe::GPU);

    // solver handler
    caffe::shared_ptr<caffe::Solver<float> > solver(caffe::GetSolver<float>(solver_param));

    // net handler
    caffe::shared_ptr<Net<float> > net;
    boost::shared_ptr<MemoryDataLayer<float> > memory_data_layer;

    // push data and label to training net
    net = solver->net();
    memory_data_layer = boost::static_pointer_cast<MemoryDataLayer<float> >(
        net->layer_by_name("data"));
    memory_data_layer->AddMatVector(patches_train, labels_train);

    // push data and label to testing net
    net = solver->test_nets()[0];
    memory_data_layer = boost::static_pointer_cast<MemoryDataLayer<float> >(
        net->layer_by_name("data"));
    memory_data_layer->AddMatVector(patches_test, labels_test);

    //// resume training
    //string snapshot_status = "lenet_iter_10000.solverstate";
    //solver->Solve(snapshot_status);

    //// finetune
    //string weights_model = "lenet_iter_10000.caffemodel";
    //solver->net()->CopyTrainedLayersFrom(weights_model);
    //solver->Solve();

    // start solver
    solver->Solve();
    LOG(INFO) << "Optimization Done.";

    return 0;
}
```
