### PR TITLE
Python net spec cleanups and top-less layers 

### DIFF
--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -108,7 +108,15 @@ class Function(object):
             del self.params['in_place']
         self.tops = tuple(Top(self, n) for n in range(self.ntop))
 
-    def _get_name(self, top, names, autonames):
+    def _get_name(self, names, autonames):
+        if self not in names and self.ntop > 0:
+            names[self] = self._get_top_name(self.tops[0], names, autonames)
+        elif self not in names:
+            autonames[self.type_name] += 1
+            names[self] = self.type_name + str(autonames[self.type_name])
+        return names[self]
+
+    def _get_top_name(self, top, names, autonames):
         if top not in names:
             autonames[top.fn.type_name] += 1
             names[top] = top.fn.type_name + str(autonames[top.fn.type_name])
@@ -129,8 +137,8 @@ class Function(object):
             layer.top.extend(layer.bottom)
         else:
             for top in self.tops:
-                layer.top.append(self._get_name(top, names, autonames))
-        layer.name = self._get_name(self.tops[0], names, autonames)
+                layer.top.append(self._get_top_name(top, names, autonames))
+        layer.name = self._get_name(names, autonames)
 
         for k, v in six.iteritems(self.params):
             # special case to handle generic *params

--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -188,7 +188,9 @@ class Layers(object):
     def __getattr__(self, name):
         def layer_fn(*args, **kwargs):
             fn = Function(name, args, kwargs)
-            if fn.ntop == 1:
+            if fn.ntop == 0:
+                return fn
+            elif fn.ntop == 1:
                 return fn.tops[0]
             else:
                 return fn.tops

--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -18,7 +18,7 @@ for specifying nets. In particular, the automatically generated layer names
 are not guaranteed to be forward-compatible.
 """
 
-from collections import OrderedDict
+from collections import OrderedDict, Counter
 
 from .proto import caffe_pb2
 from google import protobuf
@@ -45,7 +45,7 @@ def to_proto(*tops):
     all arguments."""
 
     layers = OrderedDict()
-    autonames = {}
+    autonames = Counter()
     for top in tops:
         top.fn._to_proto(layers, {}, autonames)
     net = caffe_pb2.NetParameter()
@@ -107,9 +107,8 @@ class Function(object):
 
     def _get_name(self, top, names, autonames):
         if top not in names:
-            n = autonames.setdefault(top.fn.type_name, 1)
             autonames[top.fn.type_name] += 1
-            names[top] = top.fn.type_name + str(n)
+            names[top] = top.fn.type_name + str(autonames[top.fn.type_name])
         return names[top]
 
     def _to_proto(self, layers, names, autonames):
@@ -161,7 +160,7 @@ class NetSpec(object):
 
     def to_proto(self):
         names = {v: k for k, v in six.iteritems(self.tops)}
-        autonames = {}
+        autonames = Counter()
         layers = OrderedDict()
         for name, top in six.iteritems(self.tops):
             top.fn._to_proto(layers, names, autonames)

--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -44,8 +44,6 @@ def to_proto(*tops):
     """Generate a NetParameter that contains all layers needed to compute
     all arguments."""
 
-    if not isinstance(tops, tuple):
-        tops = (tops,)
     layers = OrderedDict()
     autonames = {}
     for top in tops:

--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -87,6 +87,9 @@ class Top(object):
 
         return to_proto(self)
 
+    def _to_proto(self, layers, names, autonames):
+        return self.fn._to_proto(layers, names, autonames)
+
 
 class Function(object):
     """A Function specifies a layer, its parameters, and its inputs (which
@@ -116,7 +119,7 @@ class Function(object):
             return
         bottom_names = []
         for inp in self.inputs:
-            inp.fn._to_proto(layers, names, autonames)
+            inp._to_proto(layers, names, autonames)
             bottom_names.append(layers[inp.fn].top[inp.n])
         layer = caffe_pb2.LayerParameter()
         layer.type = self.type_name
@@ -163,7 +166,7 @@ class NetSpec(object):
         autonames = Counter()
         layers = OrderedDict()
         for name, top in six.iteritems(self.tops):
-            top.fn._to_proto(layers, names, autonames)
+            top._to_proto(layers, names, autonames)
         net = caffe_pb2.NetParameter()
         net.layer.extend(layers.values())
         return net

--- a/python/caffe/test/test_net_spec.py
+++ b/python/caffe/test/test_net_spec.py
@@ -41,6 +41,14 @@ def anon_lenet(batch_size):
     loss = L.SoftmaxWithLoss(ip2, label)
     return loss.to_proto()
 
+def silent_net():
+    n = caffe.NetSpec()
+    n.data, n.data2 = L.DummyData(shape=[dict(dim=[3]), dict(dim=[4, 2])],
+                                  ntop=2)
+    n.silence_data = L.Silence(n.data, ntop=0)
+    n.silence_data2 = L.Silence(n.data2, ntop=0)
+    return n.to_proto()
+
 class TestNetSpec(unittest.TestCase):
     def load_net(self, net_proto):
         f = tempfile.NamedTemporaryFile(delete=False)
@@ -65,3 +73,10 @@ class TestNetSpec(unittest.TestCase):
                 net_proto.layer[6].top)
         net = self.load_net(net_proto)
         self.assertEqual(len(net.layers), 9)
+
+    def test_zero_tops(self):
+        """Test net construction for top-less layers."""
+
+        net_proto = silent_net()
+        net = self.load_net(net_proto)
+        self.assertEqual(len(net.forward()), 0)


### PR DESCRIPTION
This PR makes small stylistic improvements to the net spec code and includes an alternative implementation of the functionality provided by #2741.

While #2741 generates top-less layers, it breaks the meaningfulness of `fn.tops` (for `fn` a `Function`); in particular, it need no longer be true that `fn.ntop == len(fn.tops)`, and iterating through `fn.tops` is no longer the same as iterating through `fn`'s tops, which now requires a special case (https://github.com/BVLC/caffe/pull/2741/files#diff-57d5ca5bbea564c189da52386291f6d8R145), which, while mild in the current code, would need to propagate to future code that operates on the (Python-level) graph of `Function`s and `Top`s.

The fake top doesn't really need to be added to `fn.tops`, and could just be generated around https://github.com/BVLC/caffe/pull/2741/files#diff-57d5ca5bbea564c189da52386291f6d8R198, except that this would prohibit the top-less `Function` from discovering a name assigned to this fake top.

We could simply forgo naming of top-less layers, but a more complete solution is to allow naming of `Function`s (layers) separately from `Top`s (the fourth commit here), and have top-less layers return their _`Function`s_ rather than any (fictitious) `Top`s (the fifth). It might be argued that this solution ungraciously overloads the semantics of net spec layer creation, since layers sometimes return `Top`s and sometimes `Function`s, but this is surely no worse than any solution in which top-less layers return something, since something cannot be a top that isn't. It's probably best to view this as an abbreviation of a syntax in which all layers return _both_ their `Function` and all their `Top`s (an option which could actually be added in the future if it becomes desirable to create layers with distinct layer and first-top names).

A simple test for top-less layers is included.

Thanks @philkr for getting the ball rolling on toplessness, and let me know how you feel about this solution.

