### PR TITLE
Nd conv pool

### DIFF
--- a/include/caffe/util/cudnn.hpp
+++ b/include/caffe/util/cudnn.hpp
@@ -66,7 +66,7 @@ inline void createTensor4dDesc(cudnnTensorDescriptor_t* desc) {
 }
 
 template <typename Dtype>
-inline void createTensorNdDesc(cudnnTensorDescriptor_t* desc) {
+inline void createTensorDesc(cudnnTensorDescriptor_t* desc) {
   CUDNN_CHECK(cudnnCreateTensorDescriptor(desc));
 }
 
@@ -80,11 +80,11 @@ inline void setTensor4dDesc(cudnnTensorDescriptor_t* desc,
 
 template <typename Dtype>
 inline void setTensorNdDesc(cudnnTensorDescriptor_t* desc,
-    vector<int> shape,
-    vector<int> stride) {
+    std::vector<int> shape,
+    std::vector<int> stride) {
   CHECK_EQ(shape.size(), stride.size()) << "Dimensions of shape and stride don't match !";
   CUDNN_CHECK(cudnnSetTensorNdDescriptor(*desc, dataType<Dtype>::type,
-        shape.size(), shape.data(), stride.data());
+        shape.size(), shape.data(), stride.data()));
 }
 
 template <typename Dtype>
@@ -100,8 +100,8 @@ inline void setTensor4dDesc(cudnnTensorDescriptor_t* desc,
 
 template <typename Dtype>
 inline void setTensorNdDesc(cudnnTensorDescriptor_t* desc,
-    vector<int> shape) {
-  vector<int> stride(shape.size(), 1);
+    std::vector<int> shape) {
+  std::vector<int> stride(shape.size(), 1);
   for(int i = stride.size()-2; i >= 0; --i) {
 	  stride[i] = shape[i+1] * stride[i+1];
   }
@@ -118,7 +118,7 @@ inline void createFilterDesc(cudnnFilterDescriptor_t* desc,
 
 template <typename Dtype>
 inline void createNdFilterDesc(cudnnFilterDescriptor_t* desc,
-    vector<int> shape) {
+    std::vector<int> shape) {
   CUDNN_CHECK(cudnnCreateFilterDescriptor(desc));
   CUDNN_CHECK(cudnnSetFilterNdDescriptor(*desc, dataType<Dtype>::type,
       shape.size(), shape.data()));
@@ -140,13 +140,14 @@ inline void setConvolutionDesc(cudnnConvolutionDescriptor_t* conv,
 template <typename Dtype>
 inline void setNdConvolutionDesc(cudnnConvolutionDescriptor_t* conv,
     cudnnTensorDescriptor_t bottom, cudnnFilterDescriptor_t filter,
-    vector<int> pad, vector<int> stride) {
+    std::vector<int> pad, std::vector<int> stride) {
   int nbDims;
-  vector<int> shape(pad.size()+2);
-  cudnnGetFilterNdDescriptor(filter, shape.size(), dataType<Dtype>::type, &nbDims, shape.data());
+  std::vector<int> shape(pad.size()+2);
+  cudnnDataType_t cudnn_type;
+  cudnnGetFilterNdDescriptor(filter, shape.size(), &cudnn_type, &nbDims, shape.data());
   CHECK_EQ(nbDims, pad.size()+2) << "Dimensions of filters and pad don't match !";
   CHECK_EQ(nbDims, stride.size()+2) << "Dimensions of filters and stride don't match !";
-  vector<int> upscale(pad.size(), 1);
+  std::vector<int> upscale(pad.size(), 1);
   CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(*conv,
       pad.size(), pad.data(), stride.data(), upscale.data(), CUDNN_CROSS_CORRELATION));
 }
@@ -173,7 +174,7 @@ inline void createPoolingDesc(cudnnPoolingDescriptor_t* pool_desc,
 template <typename Dtype>
 inline void createNdPoolingDesc(cudnnPoolingDescriptor_t* pool_desc,
     PoolingParameter_PoolMethod poolmethod, cudnnPoolingMode_t* mode,
-    vector<int> shape, vector<int> pad, vector<int> stride) {
+    std::vector<int> shape, std::vector<int> pad, std::vector<int> stride) {
   CHECK_EQ(shape.size(), pad.size()) << "Dimensions of shape and pad don't match !";
   CHECK_EQ(shape.size(), stride.size()) << "Dimensions of shape and stride don't match !";
   switch (poolmethod) {

--- a/include/caffe/util/cudnn.hpp
+++ b/include/caffe/util/cudnn.hpp
@@ -66,11 +66,25 @@ inline void createTensor4dDesc(cudnnTensorDescriptor_t* desc) {
 }
 
 template <typename Dtype>
+inline void createTensorNdDesc(cudnnTensorDescriptor_t* desc) {
+  CUDNN_CHECK(cudnnCreateTensorDescriptor(desc));
+}
+
+template <typename Dtype>
 inline void setTensor4dDesc(cudnnTensorDescriptor_t* desc,
     int n, int c, int h, int w,
     int stride_n, int stride_c, int stride_h, int stride_w) {
   CUDNN_CHECK(cudnnSetTensor4dDescriptorEx(*desc, dataType<Dtype>::type,
         n, c, h, w, stride_n, stride_c, stride_h, stride_w));
+}
+
+template <typename Dtype>
+inline void setTensorNdDesc(cudnnTensorDescriptor_t* desc,
+    vector<int> shape,
+    vector<int> stride) {
+  CHECK_EQ(shape.size(), stride.size()) << "Dimensions of shape and stride don't match !";
+  CUDNN_CHECK(cudnnSetTensorNdDescriptor(*desc, dataType<Dtype>::type,
+        shape.size(), shape.data(), stride.data());
 }
 
 template <typename Dtype>
@@ -85,11 +99,29 @@ inline void setTensor4dDesc(cudnnTensorDescriptor_t* desc,
 }
 
 template <typename Dtype>
+inline void setTensorNdDesc(cudnnTensorDescriptor_t* desc,
+    vector<int> shape) {
+  vector<int> stride(shape.size(), 1);
+  for(int i = stride.size()-2; i >= 0; --i) {
+	  stride[i] = shape[i+1] * stride[i+1];
+  }
+  setTensorNdDesc<Dtype>(desc, shape, stride);
+}
+
+template <typename Dtype>
 inline void createFilterDesc(cudnnFilterDescriptor_t* desc,
     int n, int c, int h, int w) {
   CUDNN_CHECK(cudnnCreateFilterDescriptor(desc));
   CUDNN_CHECK(cudnnSetFilter4dDescriptor(*desc, dataType<Dtype>::type,
       n, c, h, w));
+}
+
+template <typename Dtype>
+inline void createNdFilterDesc(cudnnFilterDescriptor_t* desc,
+    vector<int> shape) {
+  CUDNN_CHECK(cudnnCreateFilterDescriptor(desc));
+  CUDNN_CHECK(cudnnSetFilterNdDescriptor(*desc, dataType<Dtype>::type,
+      shape.size(), shape.data()));
 }
 
 template <typename Dtype>
@@ -103,6 +135,20 @@ inline void setConvolutionDesc(cudnnConvolutionDescriptor_t* conv,
     int pad_h, int pad_w, int stride_h, int stride_w) {
   CUDNN_CHECK(cudnnSetConvolution2dDescriptor(*conv,
       pad_h, pad_w, stride_h, stride_w, 1, 1, CUDNN_CROSS_CORRELATION));
+}
+
+template <typename Dtype>
+inline void setNdConvolutionDesc(cudnnConvolutionDescriptor_t* conv,
+    cudnnTensorDescriptor_t bottom, cudnnFilterDescriptor_t filter,
+    vector<int> pad, vector<int> stride) {
+  int nbDims;
+  vector<int> shape(pad.size()+2);
+  cudnnGetFilterNdDescriptor(filter, shape.size(), dataType<Dtype>::type, &nbDims, shape.data());
+  CHECK_EQ(nbDims, pad.size()+2) << "Dimensions of filters and pad don't match !";
+  CHECK_EQ(nbDims, stride.size()+2) << "Dimensions of filters and stride don't match !";
+  vector<int> upscale(pad.size(), 1);
+  CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(*conv,
+      pad.size(), pad.data(), stride.data(), upscale.data(), CUDNN_CROSS_CORRELATION));
 }
 
 template <typename Dtype>
@@ -122,6 +168,27 @@ inline void createPoolingDesc(cudnnPoolingDescriptor_t* pool_desc,
   CUDNN_CHECK(cudnnCreatePoolingDescriptor(pool_desc));
   CUDNN_CHECK(cudnnSetPooling2dDescriptor(*pool_desc, *mode, h, w,
         pad_h, pad_w, stride_h, stride_w));
+}
+
+template <typename Dtype>
+inline void createNdPoolingDesc(cudnnPoolingDescriptor_t* pool_desc,
+    PoolingParameter_PoolMethod poolmethod, cudnnPoolingMode_t* mode,
+    vector<int> shape, vector<int> pad, vector<int> stride) {
+  CHECK_EQ(shape.size(), pad.size()) << "Dimensions of shape and pad don't match !";
+  CHECK_EQ(shape.size(), stride.size()) << "Dimensions of shape and stride don't match !";
+  switch (poolmethod) {
+  case PoolingParameter_PoolMethod_MAX:
+    *mode = CUDNN_POOLING_MAX;
+    break;
+  case PoolingParameter_PoolMethod_AVE:
+    *mode = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
+    break;
+  default:
+    LOG(FATAL) << "Unknown pooling method.";
+  }
+  CUDNN_CHECK(cudnnCreatePoolingDescriptor(pool_desc));
+  CUDNN_CHECK(cudnnSetPoolingNdDescriptor(*pool_desc, *mode, shape.size(),
+        shape.data(), pad.data(), stride.data()));
 }
 
 }  // namespace cudnn

--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -523,6 +523,8 @@ class CudnnNdPoolingLayer : public Layer<Dtype> {
   virtual inline int ExactNumTopBlobs() const { return 1; }
 
  protected:
+  virtual void compute_output_shape();
+
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,

--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -269,6 +269,10 @@ class CudnnNdConvolutionLayer : public Layer<Dtype> {
   virtual inline const char* type() const { return "NdConvolution"; }
 
  protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
   virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
@@ -519,6 +523,10 @@ class CudnnNdPoolingLayer : public Layer<Dtype> {
   virtual inline int ExactNumTopBlobs() const { return 1; }
 
  protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
   virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,

--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -290,7 +290,6 @@ class CudnnNdConvolutionLayer : public Layer<Dtype> {
 
   int conv_out_spatial_dim_;
   int kernel_dim_;
-  int weight_offset_;
   int output_offset_;
 
   Blob<Dtype> bias_multiplier_;
@@ -529,7 +528,7 @@ class CudnnNdPoolingLayer : public Layer<Dtype> {
   vector<int> stride_shape_;
   vector<int> pad_shape_;
   int channels_;
-  vector<int> shape_in_;
+  vector<int> input_shape_;
   vector<int> pooled_shape_;
   bool global_pooling_;
   Blob<Dtype> rand_idx_;

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -26,7 +26,7 @@ shared_ptr<Layer<Dtype> > GetConvolutionLayer(
     return shared_ptr<Layer<Dtype> >(new ConvolutionLayer<Dtype>(param));
 #ifdef USE_CUDNN
   } else if (engine == ConvolutionParameter_Engine_CUDNN) {
-    return shared_ptr<Layer<Dtype> >(new CuDNNConvolutionLayer<Dtype>(param));
+    return shared_ptr<Layer<Dtype> >(new CUDNNConvolutionLayer<Dtype>(param));
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
@@ -34,6 +34,29 @@ shared_ptr<Layer<Dtype> > GetConvolutionLayer(
 }
 
 REGISTER_LAYER_CREATOR(Convolution, GetConvolutionLayer);
+
+template <typename Dtype>
+shared_ptr<Layer<Dtype> > GetNdConvolutionLayer(
+    const LayerParameter& param) {
+  ConvolutionParameter_Engine engine = param.convolution_param().engine();
+  if (engine == ConvolutionParameter_Engine_DEFAULT) {
+    engine = ConvolutionParameter_Engine_CAFFE;
+#ifdef USE_CUDNN
+    engine = ConvolutionParameter_Engine_CUDNN;
+#endif
+  }
+  if (engine == ConvolutionParameter_Engine_CAFFE) {
+	  NOT_IMPLEMENTED;
+#ifdef USE_CUDNN
+  } else if (engine == ConvolutionParameter_Engine_CUDNN) {
+    return shared_ptr<Layer<Dtype> >(new CudnnNdConvolutionLayer<Dtype>(param));
+#endif
+  } else {
+    LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+  }
+}
+
+REGISTER_LAYER_CREATOR(NdConvolution, GetNdConvolutionLayer);
 
 // Get pooling layer according to engine.
 template <typename Dtype>
@@ -56,7 +79,7 @@ shared_ptr<Layer<Dtype> > GetPoolingLayer(const LayerParameter& param) {
                 << "Using Caffe's own pooling layer.";
       return shared_ptr<Layer<Dtype> >(new PoolingLayer<Dtype>(param));
     }
-    return shared_ptr<Layer<Dtype> >(new CuDNNPoolingLayer<Dtype>(param));
+    return shared_ptr<Layer<Dtype> >(new CUDNNPoolingLayer<Dtype>(param));
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
@@ -64,6 +87,29 @@ shared_ptr<Layer<Dtype> > GetPoolingLayer(const LayerParameter& param) {
 }
 
 REGISTER_LAYER_CREATOR(Pooling, GetPoolingLayer);
+
+// Get pooling layer according to engine.
+template <typename Dtype>
+shared_ptr<Layer<Dtype> > GetNdPoolingLayer(const LayerParameter& param) {
+  PoolingParameter_Engine engine = param.pooling_param().engine();
+  if (engine == PoolingParameter_Engine_DEFAULT) {
+    engine = PoolingParameter_Engine_CAFFE;
+#ifdef USE_CUDNN
+    engine = PoolingParameter_Engine_CUDNN;
+#endif
+  }
+  if (engine == PoolingParameter_Engine_CAFFE) {
+	  NOT_IMPLEMENTED;
+#ifdef USE_CUDNN
+  } else if (engine == PoolingParameter_Engine_CUDNN) {
+    return shared_ptr<Layer<Dtype> >(new CudnnNdPoolingLayer<Dtype>(param));
+#endif
+  } else {
+    LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+  }
+}
+
+REGISTER_LAYER_CREATOR(NdPooling, GetNdPoolingLayer);
 
 // Get relu layer according to engine.
 template <typename Dtype>

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -26,7 +26,7 @@ shared_ptr<Layer<Dtype> > GetConvolutionLayer(
     return shared_ptr<Layer<Dtype> >(new ConvolutionLayer<Dtype>(param));
 #ifdef USE_CUDNN
   } else if (engine == ConvolutionParameter_Engine_CUDNN) {
-    return shared_ptr<Layer<Dtype> >(new CUDNNConvolutionLayer<Dtype>(param));
+    return shared_ptr<Layer<Dtype> >(new CuDNNConvolutionLayer<Dtype>(param));
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
@@ -79,7 +79,7 @@ shared_ptr<Layer<Dtype> > GetPoolingLayer(const LayerParameter& param) {
                 << "Using Caffe's own pooling layer.";
       return shared_ptr<Layer<Dtype> >(new PoolingLayer<Dtype>(param));
     }
-    return shared_ptr<Layer<Dtype> >(new CUDNNPoolingLayer<Dtype>(param));
+    return shared_ptr<Layer<Dtype> >(new CuDNNPoolingLayer<Dtype>(param));
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";

--- a/src/caffe/layers/cudnn_ndconv_layer.cpp
+++ b/src/caffe/layers/cudnn_ndconv_layer.cpp
@@ -220,6 +220,16 @@ void CudnnNdConvolutionLayer<Dtype>::compute_output_shape() {
 }
 
 template <typename Dtype>
+void CudnnNdConvolutionLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>* >& bottom, const vector<Blob<Dtype>* >& top) {
+	NOT_IMPLEMENTED;
+}
+
+template <typename Dtype>
+void CudnnNdConvolutionLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>* >& bottom, const vector<bool>& propagate_down, const vector<Blob<Dtype>* >& top) {
+	NOT_IMPLEMENTED;
+}
+
+template <typename Dtype>
 CudnnNdConvolutionLayer<Dtype>::~CudnnNdConvolutionLayer() {
   // Check that handles have been setup before destroying.
   if (!handles_setup_) { return; }

--- a/src/caffe/layers/cudnn_ndconv_layer.cpp
+++ b/src/caffe/layers/cudnn_ndconv_layer.cpp
@@ -1,0 +1,247 @@
+#ifdef USE_CUDNN
+#include <vector>
+
+#include "caffe/filler.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/util/im2col.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+// Set to three for the benefit of the backward pass, which
+// can use separate streams for calculating the gradient w.r.t.
+// bias, filter weights, and bottom data for each group independently
+#define CUDNN_STREAMS_PER_GROUP 3
+
+/**
+ * TODO(dox) explain cuDNN interface
+ */
+template <typename Dtype>
+void CudnnNdConvolutionLayer<Dtype>::LayerSetUp(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  ConvolutionParameter conv_param = this->layer_param_.convolution_param();
+  // Configure the kernel size, padding, stride, and inputs.
+  CHECK(conv_param.has_kernel_shape()
+	  && conv_param.has_pad_shape()
+	  && conv_param.has_stride_shape())
+	<< "Kernel, Pad and Stride shape are required.";
+  CHECK_EQ(conv_param.kernel_shape.dim_size(), conv_param.pad_shape.dim_size())
+	<< "Kernel and Pad shape don't match !";
+  CHECK_EQ(conv_param.kernel_shape.dim_size(), conv_param.stride_shape.dim_size())
+	<< "Kernel and Stride shape don't match !";
+  for(int i = 0; i < conv_param.kernel_shape.dim_size(); ++i) {
+  	kernel_shape_.push_back(conv_param.kernel_shape.dim(i));
+    CHECK_GT(kernel_shape_[i], 0) << "Filter dimensions cannot be zero.";
+  	pad_shape_.push_back(conv_param.pad_shape.dim(i));
+  	stride_shape_.push_back(conv_param.stride_shape.dim(i));
+  }
+
+  // Configure output channels and groups.
+  channels_ = bottom[0]->channels();
+  num_output_ = this->layer_param_.convolution_param().num_output();
+  CHECK_GT(num_output_, 0);
+  group_ = this->layer_param_.convolution_param().group();
+  CHECK_EQ(channels_ % group_, 0);
+  CHECK_EQ(num_output_ % group_, 0)
+      << "Number of output should be multiples of group.";
+
+  // Handle the parameters: weights and biases.
+  // - blobs_[0] holds the filter weights
+  // - blobs_[1] holds the biases (optional)
+  bias_term_ = this->layer_param_.convolution_param().bias_term();
+  if (this->blobs_.size() > 0) {
+    LOG(INFO) << "Skipping parameter initialization";
+  } else {
+    if (bias_term_) {
+      this->blobs_.resize(2);
+    } else {
+      this->blobs_.resize(1);
+    }
+    // Initialize and fill the weights:
+    // output channels x input channels per-group x kernel height x kernel width
+	vector<int> weight_shape(kernel_shape_);
+	weight_shape_.insert(weight_shape_.begin(), channels_ / group_);
+	weight_shape_.insert(weight_shape_.begin(), num_output_);
+    this->blobs_[0].reset(new Blob<Dtype>(weight_shape_));
+    shared_ptr<Filler<Dtype> > weight_filler(GetFiller<Dtype>(
+        this->layer_param_.convolution_param().weight_filler()));
+    weight_filler->Fill(this->blobs_[0].get());
+    // If necessary, initialize and fill the biases.
+    if (bias_term_) {
+      vector<int> bias_shape(1, num_output_);
+      this->blobs_[1].reset(new Blob<Dtype>(bias_shape));
+      shared_ptr<Filler<Dtype> > bias_filler(GetFiller<Dtype>(
+          this->layer_param_.convolution_param().bias_filler()));
+      bias_filler->Fill(this->blobs_[1].get());
+    }
+  }
+  
+  // Propagate gradients to the parameters (as directed by backward pass).
+  this->param_propagate_down_.resize(this->blobs_.size(), true);
+
+  // Initialize CUDA streams and cuDNN.
+  stream_         = new cudaStream_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
+  handle_         = new cudnnHandle_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
+  workspaceSizeInBytes = 0;
+  workspace = NULL;
+
+  for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
+    CUDA_CHECK(cudaStreamCreate(&stream_[g]));
+    CUDNN_CHECK(cudnnCreate(&handle_[g]));
+    CUDNN_CHECK(cudnnSetStream(handle_[g], stream_[g]));
+  }
+
+  // Set the indexing parameters.
+  weight_shape[0] /= group_;
+  weight_offset_ = 1;
+  for(int i = 0; i < weight_shape_.size(); ++i) {
+	weight_offset_ *= weight_shape_[i];
+  }
+  bias_offset_ = weight_shape[0];
+
+  // Create filter descriptor.
+  cudnn::createNdFilterDesc<Dtype>(&filter_desc_, weight_shape);
+
+  // Create tensor descriptor(s) for data and corresponding convolution(s).
+  for (int i = 0; i < bottom.size(); i++) {
+    cudnnTensorDescriptor_t bottom_desc;
+    cudnn::createTensorNdDesc<Dtype>(&bottom_desc);
+    bottom_descs_.push_back(bottom_desc);
+    cudnnTensorDescriptor_t top_desc;
+    cudnn::createTensorNdDesc<Dtype>(&top_desc);
+    top_descs_.push_back(top_desc);
+    cudnnConvolutionDescriptor_t conv_desc;
+    cudnn::createConvolutionDesc<Dtype>(&conv_desc);
+    conv_descs_.push_back(conv_desc);
+  }
+
+  // Tensor descriptor for bias.
+  if (this->bias_term_) {
+    cudnn::createTensorNdDesc<Dtype>(&bias_desc_);
+  }
+
+  handles_setup_ = true;
+}
+
+template <typename Dtype>
+void CudnnNdConvolutionLayer<Dtype>::Reshape(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  num_ = bottom[0]->num();
+  CHECK_EQ(bottom[0]->channels(), channels_) << "Input size incompatible with convolution kernel.";
+  input_shape_ = bottom[0]->shape();
+  // TODO: generalize to handle inputs of different shapes.
+  for (int bottom_id = 1; bottom_id < bottom.size(); ++bottom_id) {
+    CHECK_EQ(num_, bottom[bottom_id]->num())
+	  << "Inputs must have same num.";
+    CHECK_EQ(channels_, bottom[bottom_id]->channels())
+        << "Inputs must have same channels.";
+  	for(int i = 0; i < bottom[0]->num_axis(); ++i) {
+      CHECK_EQ(input_shape_[i], bottom[bottom_id]->shape(i)) << "Inputs must have same shape.";
+  	}
+  }
+  // Shape the tops.
+  compute_output_shape();
+  for (int top_id = 0; top_id < top.size(); ++top_id) {
+    top[top_id]->Reshape(output_shape_);
+  }
+
+  conv_out_spatial_dim_ = 1;
+  for(int i = 2; i < output_shape_.size(); ++i) {
+  	conv_out_spatial_dim_ *= output_shape_[i];
+  }
+
+  kernel_dim_ = channels_;
+  for(int i = 0; i < kernel_shape_.size(); ++i) {
+  	kernel_dim_ *= kernel_shape_[i];
+  }
+  weight_offset_ = num_output_ * kernel_dim_ / group_ / group_;
+  output_offset_ = num_output_ * conv_out_spatial_dim_ / group_;
+  // Set up the all ones "bias multiplier" for adding biases by BLAS
+  if (bias_term_) {
+    vector<int> bias_multiplier_shape(1, conv_out_spatial_dim_);
+    bias_multiplier_.Reshape(bias_multiplier_shape);
+    caffe_set(bias_multiplier_.count(), Dtype(1),
+        bias_multiplier_.mutable_cpu_data());
+  }
+
+  bottom_offset_ = 1;
+  for(int i = 1; i < input_shape_.size(); ++i) {
+    bottom_offset_ *= input_shape_[i];
+  }
+  bottom_offset_ /= group_;
+  top_offset_ = 1;
+  for(int i = 1; i < output_shape_.size(); ++i) {
+    top_offset_ *= output_shape_[i];
+  }
+  top_offset_ /= group_;
+
+  vector<int> bottom_tensor_shape(input_shape_);
+  bottom_tensor_shape[1] /= group_;
+  vector<int> bottom_tensor_stride(input_shape_.size(), 1);
+  for(int i = input_shape_.size()-2; i >= 0; --i) {
+	bottom_tensor_stride[i] = input_shape_[i+1] * bottom_tensor_stride[i+1];
+  }
+  vector<int> top_tensor_shape(output_shape_);
+  top_tensor_shape[1] /= group_;
+  vector<int> top_tensor_stride(output_shape_.size(), 1);
+  for(int i = output_shape_.size()-2; i >= 0; --i) {
+	top_tensor_stride[i] = output_shape_[i+1] * top_tensor_stride[i+1];
+  }
+
+  for (int i = 0; i < bottom.size(); i++) {
+    cudnn::setTensorNdDesc<Dtype>(&bottom_descs_[i],
+        bottom_tensor_shape, bottom_tensor_stride);
+    cudnn::setTensorNdDesc<Dtype>(&top_descs_[i],
+        top_tensor_shape, top_tensor_stride);
+    cudnn::setNdConvolutionDesc<Dtype>(&conv_descs_[i], bottom_descs_[i],
+        filter_desc_, pad_shape_, stride_shape_);
+  }
+
+  // Tensor descriptor for bias.
+  if (this->bias_term_) {
+    cudnn::setTensor4dDesc<Dtype>(&bias_desc_,
+        1, this->num_output_ / this->group_, 1, 1);
+  }
+}
+
+template <typename Dtype>
+void CudnnNdConvolutionLayer<Dtype>::compute_output_shape() {
+  output_shape_ = input_shape_;
+  output_shape_[1] = num_output_;
+  
+  for(int i = 2; i < output_shape_.size(); ++i) {
+	output_shape_[i] += 2*pad_shape_[i-2] - kernel_shape_[i-2];
+	output_shape_[i] /= stride_shape_[i-2];
+	++output_shape_[i];
+  }
+}
+
+template <typename Dtype>
+CudnnNdConvolutionLayer<Dtype>::~CudnnNdConvolutionLayer() {
+  // Check that handles have been setup before destroying.
+  if (!handles_setup_) { return; }
+
+  for (int i = 0; i < bottom_descs_.size(); i++) {
+    cudnnDestroyTensorDescriptor(bottom_descs_[i]);
+    cudnnDestroyTensorDescriptor(top_descs_[i]);
+    cudnnDestroyConvolutionDescriptor(conv_descs_[i]);
+  }
+  if (this->bias_term_) {
+    cudnnDestroyTensorDescriptor(bias_desc_);
+  }
+  cudnnDestroyFilterDescriptor(filter_desc_);
+
+  for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
+    cudaStreamDestroy(stream_[g]);
+    cudnnDestroy(handle_[g]);
+  }
+
+  delete [] stream_;
+  delete [] handle_;
+}
+
+INSTANTIATE_CLASS(CudnnNdConvolutionLayer);
+
+}   // namespace caffe
+#endif

--- a/src/caffe/layers/cudnn_ndconv_layer.cpp
+++ b/src/caffe/layers/cudnn_ndconv_layer.cpp
@@ -244,7 +244,6 @@ CudnnNdConvolutionLayer<Dtype>::~CudnnNdConvolutionLayer() {
 }
 
 INSTANTIATE_CLASS(CudnnNdConvolutionLayer);
-REGISTER_LAYER_CLASS(NdConvolution);
 
 }   // namespace caffe
 #endif

--- a/src/caffe/layers/cudnn_ndconv_layer.cpp
+++ b/src/caffe/layers/cudnn_ndconv_layer.cpp
@@ -244,6 +244,7 @@ CudnnNdConvolutionLayer<Dtype>::~CudnnNdConvolutionLayer() {
 }
 
 INSTANTIATE_CLASS(CudnnNdConvolutionLayer);
+REGISTER_LAYER_CLASS(NdConvolution);
 
 }   // namespace caffe
 #endif

--- a/src/caffe/layers/cudnn_ndconv_layer.cpp
+++ b/src/caffe/layers/cudnn_ndconv_layer.cpp
@@ -23,32 +23,32 @@ void CudnnNdConvolutionLayer<Dtype>::LayerSetUp(
   ConvolutionParameter conv_param = this->layer_param_.convolution_param();
   // Configure the kernel size, padding, stride, and inputs.
   CHECK(conv_param.has_kernel_shape())
-	<< "Kernel shape is required.";
+    << "Kernel shape is required.";
   if(conv_param.has_pad_shape()) {
     CHECK_EQ(conv_param.kernel_shape().dim_size(), conv_param.pad_shape().dim_size())
-	  << "Kernel and Pad shape don't match !";
+      << "Kernel and Pad shape don't match !";
   }
   if(conv_param.has_stride_shape()) {
     CHECK_EQ(conv_param.kernel_shape().dim_size(), conv_param.stride_shape().dim_size())
-	  << "Kernel and Stride shape don't match !";
+      << "Kernel and Stride shape don't match !";
   }
   for(int i = 0; i < conv_param.kernel_shape().dim_size(); ++i) {
-  	kernel_shape_.push_back(conv_param.kernel_shape().dim(i));
+    kernel_shape_.push_back(conv_param.kernel_shape().dim(i));
     CHECK_GT(kernel_shape_[i], 0) << "Filter dimensions cannot be zero.";
   }
   if(conv_param.has_pad_shape()) {
     for(int i = 0; i < conv_param.kernel_shape().dim_size(); ++i) {
-  	  pad_shape_.push_back(conv_param.pad_shape().dim(i));
-	}
+      pad_shape_.push_back(conv_param.pad_shape().dim(i));
+    }
   } else {
-	pad_shape_ = std::vector<int>(kernel_shape_.size(), 0);
+    pad_shape_ = std::vector<int>(kernel_shape_.size(), 0);
   }
   if(conv_param.has_stride_shape()) {
     for(int i = 0; i < conv_param.kernel_shape().dim_size(); ++i) {
-  	  stride_shape_.push_back(conv_param.stride_shape().dim(i));
-	}
+      stride_shape_.push_back(conv_param.stride_shape().dim(i));
+    }
   } else {
-	stride_shape_ = std::vector<int>(kernel_shape_.size(), 1);
+    stride_shape_ = std::vector<int>(kernel_shape_.size(), 1);
   }
   // Configure output channels and groups.
   channels_ = bottom[0]->shape(1);
@@ -57,7 +57,7 @@ void CudnnNdConvolutionLayer<Dtype>::LayerSetUp(
   group_ = this->layer_param_.convolution_param().group();
   CHECK_EQ(channels_ % group_, 0);
   CHECK_EQ(num_output_ % group_, 0)
-      << "Number of output should be multiples of group.";
+    << "Number of output should be multiples of group.";
 
   // Handle the parameters: weights and biases.
   // - blobs_[0] holds the filter weights
@@ -80,18 +80,18 @@ void CudnnNdConvolutionLayer<Dtype>::LayerSetUp(
     // output channels x input channels per-group x kernel height x kernel width
     this->blobs_[0].reset(new Blob<Dtype>(weight_shape));
     shared_ptr<Filler<Dtype> > weight_filler(GetFiller<Dtype>(
-        this->layer_param_.convolution_param().weight_filler()));
+          this->layer_param_.convolution_param().weight_filler()));
     weight_filler->Fill(this->blobs_[0].get());
     // If necessary, initialize and fill the biases.
     if (bias_term_) {
       vector<int> bias_shape(1, num_output_);
       this->blobs_[1].reset(new Blob<Dtype>(bias_shape));
       shared_ptr<Filler<Dtype> > bias_filler(GetFiller<Dtype>(
-          this->layer_param_.convolution_param().bias_filler()));
+            this->layer_param_.convolution_param().bias_filler()));
       bias_filler->Fill(this->blobs_[1].get());
     }
   }
-  
+
   // Propagate gradients to the parameters (as directed by backward pass).
   this->param_propagate_down_.resize(this->blobs_.size(), true);
 
@@ -111,7 +111,7 @@ void CudnnNdConvolutionLayer<Dtype>::LayerSetUp(
   weight_shape[0] /= group_;
   weight_offset_ = 1;
   for(int i = 0; i < weight_shape.size(); ++i) {
-	weight_offset_ *= weight_shape[i];
+    weight_offset_ *= weight_shape[i];
   }
   bias_offset_ = weight_shape[0];
 
@@ -148,12 +148,12 @@ void CudnnNdConvolutionLayer<Dtype>::Reshape(
   // TODO: generalize to handle inputs of different shapes.
   for (int bottom_id = 1; bottom_id < bottom.size(); ++bottom_id) {
     CHECK_EQ(num_, bottom[bottom_id]->shape(0))
-	  << "Inputs must have same num.";
+      << "Inputs must have same num.";
     CHECK_EQ(channels_, bottom[bottom_id]->shape(1))
-        << "Inputs must have same channels.";
-  	for(int i = 0; i < bottom[0]->num_axes(); ++i) {
+      << "Inputs must have same channels.";
+    for(int i = 0; i < bottom[0]->num_axes(); ++i) {
       CHECK_EQ(input_shape_[i], bottom[bottom_id]->shape(i)) << "Inputs must have same shape.";
-  	}
+    }
   }
   // Shape the tops.
   compute_output_shape();
@@ -163,12 +163,12 @@ void CudnnNdConvolutionLayer<Dtype>::Reshape(
 
   conv_out_spatial_dim_ = 1;
   for(int i = 2; i < output_shape_.size(); ++i) {
-  	conv_out_spatial_dim_ *= output_shape_[i];
+    conv_out_spatial_dim_ *= output_shape_[i];
   }
 
   kernel_dim_ = channels_;
   for(int i = 0; i < kernel_shape_.size(); ++i) {
-  	kernel_dim_ *= kernel_shape_[i];
+    kernel_dim_ *= kernel_shape_[i];
   }
   weight_offset_ = num_output_ * kernel_dim_ / group_ / group_;
   output_offset_ = num_output_ * conv_out_spatial_dim_ / group_;
@@ -195,13 +195,13 @@ void CudnnNdConvolutionLayer<Dtype>::Reshape(
   bottom_tensor_shape[1] /= group_;
   vector<int> bottom_tensor_stride(input_shape_.size(), 1);
   for(int i = input_shape_.size()-2; i >= 0; --i) {
-	bottom_tensor_stride[i] = input_shape_[i+1] * bottom_tensor_stride[i+1];
+    bottom_tensor_stride[i] = input_shape_[i+1] * bottom_tensor_stride[i+1];
   }
   vector<int> top_tensor_shape(output_shape_);
   top_tensor_shape[1] /= group_;
   vector<int> top_tensor_stride(output_shape_.size(), 1);
   for(int i = output_shape_.size()-2; i >= 0; --i) {
-	top_tensor_stride[i] = output_shape_[i+1] * top_tensor_stride[i+1];
+    top_tensor_stride[i] = output_shape_[i+1] * top_tensor_stride[i+1];
   }
 
   for (int i = 0; i < bottom.size(); i++) {
@@ -215,8 +215,9 @@ void CudnnNdConvolutionLayer<Dtype>::Reshape(
 
   // Tensor descriptor for bias.
   if (this->bias_term_) {
-    cudnn::setTensor4dDesc<Dtype>(&bias_desc_,
-        1, this->num_output_ / this->group_, 1, 1);
+    vector<int> bias_shape(input_shape_.size(), 1);
+    bias_shape[1] = this->num_output_ / this->group_;
+    cudnn::setTensorNdDesc<Dtype>(&bias_desc_, bias_shape);
   }
 }
 
@@ -225,23 +226,23 @@ void CudnnNdConvolutionLayer<Dtype>::compute_output_shape() {
   output_shape_.clear();
   output_shape_.push_back(num_);
   output_shape_.push_back(num_output_);
-  
+
   for(int i = 2; i < input_shape_.size(); ++i) {
     int dim = (input_shape_[i] + 2*pad_shape_[i-2] - kernel_shape_[i-2]) / stride_shape_[i-2] + 1;
-	if(dim > 1){
-	  output_shape_.push_back(dim);
-	}
+    if(dim > 1){
+      output_shape_.push_back(dim);
+    }
   }
 }
 
 template <typename Dtype>
 void CudnnNdConvolutionLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>* >& bottom, const vector<Blob<Dtype>* >& top) {
-	NOT_IMPLEMENTED;
+  NOT_IMPLEMENTED;
 }
 
 template <typename Dtype>
 void CudnnNdConvolutionLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>* >& bottom, const vector<bool>& propagate_down, const vector<Blob<Dtype>* >& top) {
-	NOT_IMPLEMENTED;
+  NOT_IMPLEMENTED;
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/cudnn_ndconv_layer.cpp
+++ b/src/caffe/layers/cudnn_ndconv_layer.cpp
@@ -227,7 +227,7 @@ void CudnnNdConvolutionLayer<Dtype>::compute_output_shape() {
   output_shape_.push_back(num_output_);
   
   for(int i = 2; i < input_shape_.size(); ++i) {
-    int dim = input_shape_[i] + 2*pad_shape_[i-2] - kernel_shape_[i-2] / stride_shape_[i-2] + 1;
+    int dim = (input_shape_[i] + 2*pad_shape_[i-2] - kernel_shape_[i-2]) / stride_shape_[i-2] + 1;
 	if(dim > 1){
 	  output_shape_.push_back(dim);
 	}

--- a/src/caffe/layers/cudnn_ndconv_layer.cu
+++ b/src/caffe/layers/cudnn_ndconv_layer.cu
@@ -1,0 +1,161 @@
+#ifdef USE_CUDNN
+#include <vector>
+
+#include "caffe/filler.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/util/im2col.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+__global__ void sync_conv_groups() { }
+
+template <typename Dtype>
+void CuDNNConvolutionLayer<Dtype>::Forward_gpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  for (int i = 0; i < bottom.size(); ++i) {
+    const Dtype* bottom_data = bottom[i]->gpu_data();
+    Dtype* top_data = top[i]->mutable_gpu_data();
+    const Dtype* weight = this->blobs_[0]->gpu_data();
+
+    size_t workspace_limit_bytes = this->channels_*sizeof(int);
+	for(int i = 0; i < this->kernel_shape_.size(); ++i) {
+	  workspace_limit_bytes *= kernel_shape_[i];
+	}
+	++workspace_limit_bytes;
+
+    // Forward through cuDNN in parallel over groups.
+    for (int g = 0; g < this->group_; g++) {
+      cudnnConvolutionFwdAlgo_t algo;
+
+      // pick the convolution algorithm
+      // TODO(shelhamer) this should be done during reshape
+      // TODO(shelhamer) the choice of automatic or manual algorithm picking
+      // should be exposed in proto
+      CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(handle_[g],
+        bottom_descs_[i],
+        filter_desc_,
+        conv_descs_[i],
+        top_descs_[i],
+        CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
+        workspace_limit_bytes,  // memoryLimitInBytes,
+        &algo));
+
+      // get minimum size of the workspace needed for the desired algorithm
+      size_t workspaceSizeInBytes_temp = 0;
+
+      CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(handle_[g],
+        bottom_descs_[i],
+        filter_desc_,
+        conv_descs_[i],
+        top_descs_[i],
+        algo,
+        &workspaceSizeInBytes_temp));
+
+      if (workspaceSizeInBytes_temp > workspaceSizeInBytes) {
+        workspaceSizeInBytes = workspaceSizeInBytes_temp;
+        // free the existing workspace and allocate a new (larger) one
+        cudaFree(this->workspace);
+        cudaError_t err = cudaMalloc(&(this->workspace), workspaceSizeInBytes);
+        if (err != cudaSuccess) {
+          // force zero memory path
+          algo = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
+          workspace = NULL;
+          workspaceSizeInBytes = 0;
+        }
+      }
+
+      // Filters.
+      CUDNN_CHECK(cudnnConvolutionForward(handle_[g],
+            cudnn::dataType<Dtype>::one,
+            bottom_descs_[i], bottom_data + bottom_offset_ * g,
+            filter_desc_, weight + weight_offset_ * g,
+            conv_descs_[i],
+            algo, workspace, workspaceSizeInBytes,
+            cudnn::dataType<Dtype>::zero,
+            top_descs_[i], top_data + top_offset_ * g));
+
+      // Bias.
+      if (this->bias_term_) {
+        const Dtype* bias_data = this->blobs_[1]->gpu_data();
+        CUDNN_CHECK(cudnnAddTensor(handle_[g], CUDNN_ADD_SAME_C,
+              cudnn::dataType<Dtype>::one,
+              bias_desc_, bias_data + bias_offset_ * g,
+              cudnn::dataType<Dtype>::one,
+              top_descs_[i], top_data + top_offset_ * g));
+      }
+    }
+
+    // Synchronize the work across groups, each of which went into its own
+    // stream, by launching an empty kernel into the default (null) stream.
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    sync_conv_groups<<<1, 1>>>();
+  }
+}
+
+template <typename Dtype>
+void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  const Dtype* weight = NULL;
+  Dtype* weight_diff = NULL;
+  if (this->param_propagate_down_[0]) {
+    weight = this->blobs_[0]->gpu_data();
+    weight_diff = this->blobs_[0]->mutable_gpu_diff();
+  }
+  Dtype* bias_diff = NULL;
+  if (this->bias_term_ && this->param_propagate_down_[1]) {
+    bias_diff = this->blobs_[1]->mutable_gpu_diff();
+  }
+  for (int i = 0; i < top.size(); ++i) {
+    const Dtype* top_diff = top[i]->gpu_diff();
+    // Backward through cuDNN in parallel over groups and gradients.
+    for (int g = 0; g < this->group_; g++) {
+      // Gradient w.r.t. bias.
+      if (this->bias_term_ && this->param_propagate_down_[1]) {
+        CUDNN_CHECK(cudnnConvolutionBackwardBias(handle_[0*this->group_ + g],
+              cudnn::dataType<Dtype>::one,
+              top_descs_[i],  top_diff + top_offset_ * g,
+              cudnn::dataType<Dtype>::one,
+              bias_desc_, bias_diff + bias_offset_ * g));
+      }
+
+      // Gradient w.r.t. weights.
+      if (this->param_propagate_down_[0]) {
+        const Dtype* bottom_data = bottom[i]->gpu_data();
+        CUDNN_CHECK(cudnnConvolutionBackwardFilter(handle_[1*this->group_ + g],
+              cudnn::dataType<Dtype>::one,
+              bottom_descs_[i], bottom_data + bottom_offset_ * g,
+              top_descs_[i],    top_diff + top_offset_ * g,
+              conv_descs_[i],
+              cudnn::dataType<Dtype>::one,
+              filter_desc_, weight_diff + weight_offset_ * g));
+      }
+
+      // Gradient w.r.t. bottom data.
+      if (propagate_down[i]) {
+        if (weight == NULL) {
+          weight = this->blobs_[0]->gpu_data();
+        }
+        Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
+        CUDNN_CHECK(cudnnConvolutionBackwardData(handle_[2*this->group_ + g],
+              cudnn::dataType<Dtype>::one,
+              filter_desc_, weight + weight_offset_ * g,
+              top_descs_[i], top_diff + top_offset_ * g,
+              conv_descs_[i],
+              cudnn::dataType<Dtype>::zero,
+              bottom_descs_[i], bottom_diff + bottom_offset_ * g));
+      }
+    }
+
+    // Synchronize the work across groups, each of which went into its own
+    // stream, by launching an empty kernel into the default (null) stream.
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    sync_conv_groups<<<1, 1>>>();
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(CuDNNConvolutionLayer);
+
+}  // namespace caffe
+#endif

--- a/src/caffe/layers/cudnn_ndpooling_layer.cpp
+++ b/src/caffe/layers/cudnn_ndpooling_layer.cpp
@@ -97,7 +97,6 @@ CudnnNdPoolingLayer<Dtype>::~CudnnNdPoolingLayer() {
 }
 
 INSTANTIATE_CLASS(CudnnNdPoolingLayer);
-REGISTER_LAYER_CLASS(NdPooling);
 
 }   // namespace caffe
 #endif

--- a/src/caffe/layers/cudnn_ndpooling_layer.cpp
+++ b/src/caffe/layers/cudnn_ndpooling_layer.cpp
@@ -97,6 +97,7 @@ CudnnNdPoolingLayer<Dtype>::~CudnnNdPoolingLayer() {
 }
 
 INSTANTIATE_CLASS(CudnnNdPoolingLayer);
+REGISTER_LAYER_CLASS(NdPooling);
 
 }   // namespace caffe
 #endif

--- a/src/caffe/layers/cudnn_ndpooling_layer.cpp
+++ b/src/caffe/layers/cudnn_ndpooling_layer.cpp
@@ -89,7 +89,7 @@ template <typename Dtype>
 void CudnnNdPoolingLayer<Dtype>::compute_output_shape() {
   pooled_shape_ = std::vector<int>(input_shape_.begin(), input_shape_.begin()+2);
   for(int i = 2; i < input_shape_.size(); ++i) {
-	int dim = input_shape_[i] + 2 * pad_shape_[i-2] - kernel_shape_[i-2] / stride_shape_[i-2] + 1;
+	int dim = (input_shape_[i] + 2 * pad_shape_[i-2] - kernel_shape_[i-2]) / stride_shape_[i-2] + 1;
 
 	if(pad_shape_[i-2] > 0) {
       if ((dim - 1) * stride_shape_[i-2] >= input_shape_[i] + pad_shape_[i-2]) {

--- a/src/caffe/layers/cudnn_ndpooling_layer.cpp
+++ b/src/caffe/layers/cudnn_ndpooling_layer.cpp
@@ -86,6 +86,16 @@ void CudnnNdPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
 }
 
 template <typename Dtype>
+void CudnnNdPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>* >& bottom, const vector<Blob<Dtype>* >& top) {
+	NOT_IMPLEMENTED;
+}
+
+template <typename Dtype>
+void CudnnNdPoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>* >& bottom, const vector<bool>& propagate_down, const vector<Blob<Dtype>* >& top) {
+	NOT_IMPLEMENTED;
+}
+
+template <typename Dtype>
 CudnnNdPoolingLayer<Dtype>::~CudnnNdPoolingLayer() {
   // Check that handles have been setup before destroying.
   if (!handles_setup_) { return; }

--- a/src/caffe/layers/cudnn_ndpooling_layer.cpp
+++ b/src/caffe/layers/cudnn_ndpooling_layer.cpp
@@ -1,0 +1,102 @@
+#ifdef USE_CUDNN
+#include <vector>
+
+#include "caffe/filler.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/util/im2col.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void CudnnNdPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  PoolingParameter pool_param = this->layer_param_.pooling_param();
+  CHECK(pool_param.has_kernel_shape()
+	  && pool_param.has_pad_shape()
+	  && pool_param.has_stride_shape())
+	<< "Kernel, Pad and Stride shape required."
+  CHECK_EQ(pool_param.kernel_shape.dim_size(), pool_param.pad_shape.dim_size())
+	<< "Kernel and Pad shape don't match !";
+  CHECK_EQ(pool_param.kernel_shape.dim_size(), pool_param.stride_shape.dim_size())
+	<< "Kernel and Stride shape don't match !";
+  global_pooling_ = pool_param.global_pooling();
+
+  if(global_pooling_) {
+	kernel_shape_ = vector<int>(bottom[0]->shape().begin()+2, bottom->shape().end());
+  } else {
+  	for(int i = 0; i < pool_param.kernel_shape.dim_size(); ++i) {
+  	  kernel_shape_.push_back(pool_param.kernel_shape.dim(i));
+  	  CHECK_GT(kernel_shape_[i], 0) << "Filter dimensions cannot be zero.";
+  	}
+  }
+  for(int i = 0; i < pool_param.kernel_shape.dim_size(); ++i) {
+    pad_shape_.push_back(pool_param.pad_shape.dim(i));
+    stride_shape_.push_back(pool_param.stride_shape.dim(i));
+  }
+
+  CUDNN_CHECK(cudnnCreate(&handle_));
+  cudnn::createTensorNdDesc<Dtype>(&bottom_desc_);
+  cudnn::createTensorNdDesc<Dtype>(&top_desc_);
+  cudnn::createPoolingNdDesc<Dtype>(&pooling_desc_,
+      layer_param_.pooling_param().pool(), &mode_,
+      kernel_shape_, pad_shape_, stride_shape_);
+  handles_setup_ = true;
+}
+
+template <typename Dtype>
+void CudnnNdPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+
+  channels_ = bottom[0]->channels();
+  input_shape_ = bottom[0]->shape();
+  if(global_pooling_) {
+	kernel_shape_ = vector<int>(bottom[0]->shape().begin()+2, bottom->shape().end());
+  }
+
+  pooled_shape_ = input_shape_;
+  for(int i = 2; i < pooled_shape_.size(); ++i) {
+	pooled_shape_[i] += 2 * pad_shape_[i-2] - kernel_shape_[i-2];
+	pooled_shape_[i] /= stride_shape_[i-2];
+	++pooled_shape_[i];
+
+	if(pad_shape_[i-2] > 0) {
+      if ((pooled_shape_[i] - 1) * stride_shape_[i-2] >= input_shape_[i] + pad_shape[i-2]) {
+        --pooled_shape_[i];
+      }
+      CHECK_LT((pooled_shape_[i] - 1) * stride_shape_[i-2], input_shape_[i] + pad_shape_[i-2]);
+	}
+  }
+  top[0]->Reshape(pooled_shape_);
+ 
+  // If max pooling, we will initialize the vector index part.
+  if (this->layer_param_.pooling_param().pool() ==
+      PoolingParameter_PoolMethod_MAX && top.size() == 1) {
+    max_idx_.Reshape(pooled_shape_);
+  }
+  // If stochastic pooling, we will initialize the random index part.
+  if (this->layer_param_.pooling_param().pool() ==
+      PoolingParameter_PoolMethod_STOCHASTIC) {
+    rand_idx_.Reshape(pooled_shape_);
+  }
+
+  cudnn::setTensorNdDesc<Dtype>(&bottom_desc_, input_shape_);
+  cudnn::setTensorNdDesc<Dtype>(&top_desc_, pooled_shape_);
+}
+
+template <typename Dtype>
+CudnnNdPoolingLayer<Dtype>::~CudnnNdPoolingLayer() {
+  // Check that handles have been setup before destroying.
+  if (!handles_setup_) { return; }
+
+  cudnnDestroyTensorDescriptor(bottom_desc_);
+  cudnnDestroyTensorDescriptor(top_desc_);
+  cudnnDestroyPoolingDescriptor(pooling_desc_);
+  cudnnDestroy(handle_);
+}
+
+INSTANTIATE_CLASS(CudnnNdPoolingLayer);
+
+}   // namespace caffe
+#endif

--- a/src/caffe/layers/cudnn_ndpooling_layer.cu
+++ b/src/caffe/layers/cudnn_ndpooling_layer.cu
@@ -1,0 +1,45 @@
+#ifdef USE_CUDNN
+#include <vector>
+
+#include "caffe/filler.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/util/im2col.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void CuDNNPoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  Dtype* top_data = top[0]->mutable_gpu_data();
+  CUDNN_CHECK(cudnnPoolingForward(handle_, pooling_desc_,
+        cudnn::dataType<Dtype>::one,
+        bottom_desc_, bottom_data,
+        cudnn::dataType<Dtype>::zero,
+        top_desc_, top_data));
+}
+
+template <typename Dtype>
+void CuDNNPoolingLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  if (!propagate_down[0]) {
+    return;
+  }
+  const Dtype* top_diff = top[0]->gpu_diff();
+  const Dtype* top_data = top[0]->gpu_data();
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
+  CUDNN_CHECK(cudnnPoolingBackward(handle_, pooling_desc_,
+        cudnn::dataType<Dtype>::one,
+        top_desc_, top_data, top_desc_, top_diff,
+        bottom_desc_, bottom_data,
+        cudnn::dataType<Dtype>::zero,
+        bottom_desc_, bottom_diff));
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(CuDNNPoolingLayer);
+
+}  // namespace caffe
+#endif

--- a/src/caffe/layers/cudnn_ndpooling_layer.cu
+++ b/src/caffe/layers/cudnn_ndpooling_layer.cu
@@ -10,7 +10,7 @@
 namespace caffe {
 
 template <typename Dtype>
-void CuDNNPoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+void CudnnNdPoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
@@ -22,7 +22,7 @@ void CuDNNPoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 }
 
 template <typename Dtype>
-void CuDNNPoolingLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+void CudnnNdPoolingLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
   if (!propagate_down[0]) {
     return;
@@ -39,7 +39,7 @@ void CuDNNPoolingLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
         bottom_desc_, bottom_diff));
 }
 
-INSTANTIATE_LAYER_GPU_FUNCS(CuDNNPoolingLayer);
+INSTANTIATE_LAYER_GPU_FUNCS(CudnnNdPoolingLayer);
 
 }  // namespace caffe
 #endif

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -442,13 +442,16 @@ message ConvolutionParameter {
   optional uint32 pad = 3 [default = 0]; // The padding size (equal in Y, X)
   optional uint32 pad_h = 9 [default = 0]; // The padding height
   optional uint32 pad_w = 10 [default = 0]; // The padding width
+  optional BlobShape pad_shape = 15;
   optional uint32 kernel_size = 4; // The kernel size (square)
   optional uint32 kernel_h = 11; // The kernel height
   optional uint32 kernel_w = 12; // The kernel width
+  optional BlobShape kernel_shape = 16;
   optional uint32 group = 5 [default = 1]; // The group size for group conv
   optional uint32 stride = 6 [default = 1]; // The stride (equal in Y, X)
   optional uint32 stride_h = 13; // The stride height
   optional uint32 stride_w = 14; // The stride width
+  optional BlobShape stride_shape = 17;
   optional FillerParameter weight_filler = 7; // The filler for the weight
   optional FillerParameter bias_filler = 8; // The filler for the bias
   enum Engine {
@@ -456,7 +459,7 @@ message ConvolutionParameter {
     CAFFE = 1;
     CUDNN = 2;
   }
-  optional Engine engine = 15 [default = DEFAULT];
+  optional Engine engine = 18 [default = DEFAULT];
 }
 
 message DataParameter {
@@ -676,21 +679,24 @@ message PoolingParameter {
   optional uint32 pad = 4 [default = 0]; // The padding size (equal in Y, X)
   optional uint32 pad_h = 9 [default = 0]; // The padding height
   optional uint32 pad_w = 10 [default = 0]; // The padding width
+  optional BlobShape pad_shape = 13;
   optional uint32 kernel_size = 2; // The kernel size (square)
   optional uint32 kernel_h = 5; // The kernel height
   optional uint32 kernel_w = 6; // The kernel width
+  optional BlobShape kernel_shape = 11;
   optional uint32 stride = 3 [default = 1]; // The stride (equal in Y, X)
   optional uint32 stride_h = 7; // The stride height
   optional uint32 stride_w = 8; // The stride width
+  optional BlobShape stride_shape = 12;
   enum Engine {
     DEFAULT = 0;
     CAFFE = 1;
     CUDNN = 2;
   }
-  optional Engine engine = 11 [default = DEFAULT];
+  optional Engine engine = 14 [default = DEFAULT];
   // If global_pooling then it will pool over the size of the bottom by doing
   // kernel_h = bottom->height and kernel_w = bottom->width
-  optional bool global_pooling = 12 [default = false];
+  optional bool global_pooling = 15 [default = false];
 }
 
 message PowerParameter {


### PR DESCRIPTION
Hi !

Following my issue ticket #2671, here is my pull request for nD convolution and pooling using CuDNN primitives.

The nD convolution by itself seems to work, but the biases addition using cudnnAddTensor() returns NOT_SUPPORTED status.

The nD pooling doesn't work, and returns NOT_SUPPORTED.
Apparently the nD pooling descriptor might only be a place-holder in this version, so this might work with future version of cuDNN...

I inherits my layers directly from the Layer class and not the BaseConvolutionLayer and BasePoolingLayer to avoid modifying any existing (and working..) features.
The major drawback of this approach is that it won't be able to rely on other engines if CuDNN is not supported by the user configuration. But as I declared a LayerFactory for NdConvolution and NdPooling, it might be relatively easy to solve this behaviour.

Don't hesitate to give me feedbacks on this two new layers,
and share any new insight about why it doesn't work.

I'm already aware of the #2049 PR for nD convolution, but I'm still missing nD pooling (actually I only need 3D pooling in my application).

Cheers,