### PR TITLE
Expose tops and bottoms associated with layers in python, fix #2829

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -124,12 +124,18 @@ class Net {
   inline const vector<vector<Blob<Dtype>*> >& bottom_vecs() const {
     return bottom_vecs_;
   }
+  inline const vector<vector<int> >& bottom_id_vecs() const {
+    return bottom_id_vecs_;
+  }
   /**
    * @brief returns the top vecs for each layer -- usually you won't
    *        need this unless you do per-layer checks such as gradients.
    */
   inline const vector<vector<Blob<Dtype>*> >& top_vecs() const {
     return top_vecs_;
+  }
+  inline const vector<vector<int> >& top_id_vecs() const {
+    return top_id_vecs_;
   }
   inline const vector<vector<bool> >& bottom_need_backward() const {
     return bottom_need_backward_;

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -131,6 +131,16 @@ void Net_SetInputArrays(Net<Dtype>* net, bp::object data_obj,
       PyArray_DIMS(data_arr)[0]);
 }
 
+const vector<int>& Net_BottomsForLayer(const Net<Dtype>& net,
+                                                int layer_idx) {
+  return net.bottom_id_vecs()[layer_idx];
+}
+
+const vector<int>& Net_TopsForLayer(const Net<Dtype>& net,
+                                             int layer_idx) {
+  return net.top_id_vecs()[layer_idx];
+}
+
 Solver<Dtype>* GetSolverFromFile(const string& filename) {
   SolverParameter param;
   ReadProtoFromTextFileOrDie(filename, &param);
@@ -226,7 +236,11 @@ BOOST_PYTHON_MODULE(_caffe) {
         bp::return_value_policy<bp::copy_const_reference>()))
     .def("_set_input_arrays", &Net_SetInputArrays,
         bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >())
-    .def("save", &Net_Save);
+    .def("save", &Net_Save)
+    .def("_bottoms_for_layer", &Net_BottomsForLayer,
+        bp::return_value_policy<bp::copy_const_reference>())
+    .def("_tops_for_layer", &Net_TopsForLayer,
+        bp::return_value_policy<bp::copy_const_reference>());
 
   bp::class_<Blob<Dtype>, shared_ptr<Blob<Dtype> >, boost::noncopyable>(
     "Blob", bp::no_init)


### PR DESCRIPTION
The main goal is to fix issue #2829, in which `forward()` in the python interface attempts to return the top blobs of the last layer in `forward()`, but instead uses the layer names as if they were blob names. Turns out there's not currently a way for python code to figure out which blobs are connected to which layers, so this PR exposes that functionality and fixes the bug.