### PR TITLE
DataLayer with float labels (ex: for regression)

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -237,7 +237,7 @@ class ImageDataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual void ShuffleImages();
   virtual void InternalThreadEntry();
 
-  vector<std::pair<std::string, int> > lines_;
+  vector<std::pair<std::string, double> > lines_;
   int lines_id_;
 };
 

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -36,7 +36,7 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   LOG(INFO) << "Opening file " << source;
   std::ifstream infile(source.c_str());
   string filename;
-  int label;
+  double label;
   while (infile >> filename >> label) {
     lines_.push_back(std::make_pair(filename, label));
   }


### PR DESCRIPTION
There are multiple requests for allowing floating point in the label of Data Layer. I just hacked a bit and that's what I got so far. It seems to work with EuclideanLoss but crash with SoftmaxWithLoss.

Anyway, my questions are: if this is not a good idea, why? Is there an alternative as simple as writing a text file with image and label? I don't think so, so why not extend it for floating point? The next step is to allow multiple labels of course, which seem to be addressed in other PR.

If this feature is approved then I would gladly take a hint considering the problem with softmax (valgrind says):
```
==2931== Thread 4:
==2931== Invalid read of size 16
==2931==    at 0x9360CF3: sgemm_kernel_SANDYBRIDGE (in /usr/lib/libopenblasp-r0.2.14.so)
==2931==  Address 0x2e488d1c is 6,859,996 bytes inside a block of size 6,860,000 alloc'd
==2931==    at 0x4C28C20: malloc (vg_replace_malloc.c:296)
==2931==    by 0x4F7C003: caffe::SyncedMemory::mutable_cpu_data() (in ~/caffe/.build_release/lib/libcaffe.so)
==2931==    by 0x4F7CAA1: caffe::Blob<float>::mutable_cpu_data() (in ~/caffe/.build_release/lib/libcaffe.so)
==2931==    by 0x4FF3678: caffe::ConvolutionLayer<float>::Forward_cpu(std::vector<caffe::Blob<float>*, std::allocator<caffe::Blob<float>*> > const&, std::vector<caffe::Blob<float>*, std::allocator<caffe::Blob<float>*> > const&) (in ~/caffe/.build_release/lib/libcaffe.so)
==2931==    by 0x504B719: caffe::Net<float>::ForwardFromTo(int, int) (in ~/caffe/.build_release/lib/libcaffe.so)
==2931==    by 0x504BA86: caffe::Net<float>::ForwardPrefilled(float*) (in ~/caffe/.build_release/lib/libcaffe.so)
==2931==    by 0x502D389: caffe::Solver<float>::Test(int) (in ~/caffe/.build_release/lib/libcaffe.so)
==2931==    by 0x502DAA5: caffe::Solver<float>::TestAll() (in ~/caffe/.build_release/lib/libcaffe.so)
==2931==    by 0x50375B3: caffe::Solver<float>::Step(int) (in ~/caffe/.build_release/lib/libcaffe.so)
==2931==    by 0x5037FEE: caffe::Solver<float>::Solve(char const*) (in ~/caffe/.build_release/lib/libcaffe.so)
==2931==    by 0x407D94: train() (in ~/caffe/.build_release/tools/caffe.bin)
==2931==    by 0x4056A6: main (in ~/caffe/.build_release/tools/caffe.bin)
```