### PR TITLE
[pycaffe,build] include Python first in caffe tool

### DIFF
--- a/python/caffe/test/test_python_layer.py
+++ b/python/caffe/test/test_python_layer.py
@@ -43,7 +43,7 @@ def python_net_file():
 
 
 def exception_net_file():
-    with tempfile.NamedTemporaryFile(delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
         f.write("""name: 'pythonnet' force_backward: true
         input: 'data' input_shape { dim: 10 dim: 9 dim: 8 }
         layer { type: 'Python' name: 'layer' bottom: 'data' top: 'top'

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -1,3 +1,8 @@
+#ifdef WITH_PYTHON_LAYER
+#include "boost/python.hpp"
+namespace bp = boost::python;
+#endif
+
 #include <glog/logging.h>
 
 #include <cstring>
@@ -7,11 +12,6 @@
 
 #include "boost/algorithm/string.hpp"
 #include "caffe/caffe.hpp"
-
-#ifdef WITH_PYTHON_LAYER
-#include "boost/python.hpp"
-namespace bp = boost::python;
-#endif
 
 using caffe::Blob;
 using caffe::Caffe;


### PR DESCRIPTION
#2462 introduced the `Python.hpp` include into the caffe tool which somehow resulted in warnings not picked up by the branch CI at the time. This fixes the order of includes to avoid the `"_POSIX_C_SOURCE" redefined` warning.