### PR TITLE
[pycaffe] add Blob shape accessor

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -230,6 +230,11 @@ BOOST_PYTHON_MODULE(_caffe) {
 
   bp::class_<Blob<Dtype>, shared_ptr<Blob<Dtype> >, boost::noncopyable>(
     "Blob", bp::no_init)
+    .add_property("shape",
+        bp::make_function(
+            static_cast<const vector<int>& (Blob<Dtype>::*)() const>(
+                &Blob<Dtype>::shape),
+            bp::return_value_policy<bp::copy_const_reference>()))
     .add_property("num",      &Blob<Dtype>::num)
     .add_property("channels", &Blob<Dtype>::channels)
     .add_property("height",   &Blob<Dtype>::height)


### PR DESCRIPTION
This adds a direct `shape` accessor for PyCaffe Blobs.  Currently to get the shape one has to do `myblob.data.shape` or `myblob.diff.shape` which can cause a (possibly unnecessary) allocation+copy to host memory.