### PR TITLE
temporarily switch the snapshot_format default back to BINARYPROTO

### DIFF
--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -179,7 +179,7 @@ message SolverParameter {
     HDF5 = 0;
     BINARYPROTO = 1;
   }
-  optional SnapshotFormat snapshot_format = 37 [default = HDF5];
+  optional SnapshotFormat snapshot_format = 37 [default = BINARYPROTO];
   // the mode solver will use: 0 for CPU and 1 for GPU. Use GPU in default.
   enum SolverMode {
     CPU = 0;

--- a/src/caffe/test/test_gradient_based_solver.cpp
+++ b/src/caffe/test/test_gradient_based_solver.cpp
@@ -192,7 +192,7 @@ class GradientBasedSolverTest : public MultiDeviceTest<TypeParam> {
     if (snapshot) {
       ostringstream resume_file;
       resume_file << snapshot_prefix_ << "/_iter_" << num_iters
-                  << ".solverstate.h5";
+                  << ".solverstate";
       string resume_filename = resume_file.str();
       return resume_filename;
     }


### PR DESCRIPTION
See #2885 -- Caffe will crash when trying to snapshot nets with duplicate layer names (including nets with multiple unnamed layers).  This is probably going to surprise a lot of users and doesn't have a good error message, so I'm suggesting as a quick patch that we switch the default back until these issues are discussed.