### PR TITLE
fix examples/pycaffe/caffenet.py import

### DIFF
--- a/examples/pycaffe/caffenet.py
+++ b/examples/pycaffe/caffenet.py
@@ -1,6 +1,6 @@
+from __future__ import print_function
 from caffe import layers as L, params as P, to_proto
 from caffe.proto import caffe_pb2
-from __future__ import print_function
 
 # helper function for common structures
 


### PR DESCRIPTION
\_\_future\_\_ imports needs to occur at the beginning of the file in python2