### PR TITLE
Fix truncation of value warning

### DIFF
--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -1,4 +1,5 @@
 #include <glog/logging.h>
+#include <cmath>
 #include <cstdio>
 #include <ctime>
 
@@ -25,7 +26,7 @@ int64_t cluster_seedgen(void) {
 
   pid = getpid();
   s = time(NULL);
-  seed = abs(((s * 181) * ((pid - 83) * 359)) % 104729);
+  seed = std::abs(((s * 181) * ((pid - 83) * 359)) % 104729);
   return seed;
 }
 


### PR DESCRIPTION
Compilation of Caffe on Yosemite with Clang raises the following warning:
```
CXX src/caffe/common.cpp
src/caffe/common.cpp:28:10: warning: absolute value function 'abs' given an argument of type 'long long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
  seed = abs(((s * 181) * ((pid - 83) * 359)) % 104729);
         ^
src/caffe/common.cpp:28:10: note: use function 'std::abs' instead
  seed = abs(((s * 181) * ((pid - 83) * 359)) % 104729);
         ^~~
         std::abs
1 warning generated.
```

This warning is obviously a false positive, since the argument is within the range of int due to the modulo operation. However, for peace of mind, I fixed the warning by replacing abs with std::abs.