### PR TITLE
learnable_param_ids_ fix

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -485,6 +485,7 @@ void Net<Dtype>::AppendParam(const NetParameter& param, const int layer_id,
       CHECK(this_blob->shape() == owner_blob->shape());
     }
     const int learnable_param_id = learnable_param_ids_[owner_net_param_id];
+    learnable_param_ids_.push_back(learnable_param_id);
     if (param_spec->has_lr_mult()) {
       if (has_params_lr_[learnable_param_id]) {
         CHECK_EQ(param_spec->lr_mult(), params_lr_[learnable_param_id])


### PR DESCRIPTION
In #2866 I added `vector<int> learnable_param_ids_`, which was supposed to be a mapping from `params_` indices to `learnable_params_` indices used to check that `lr_mult` and `decay_mult`s matched up.  I screwed this up by only appending IDs of owner params, and forgetting to add IDs for sharing (non-owning) params. I think the only resulting problem (given that `learnable_param_ids_` is only read in one place) is that you could run into false positives or false negatives with the check that `{lr,decay}_mult`s of shared parameters are equal.  Very sorry for the trouble if this happened to you.

Thanks to @Otkrist for reporting this issue! (He was using shared params and ran into a the `lr_mult mismatch` check failure when using the same `lr_mult` for all params. He verified that this patch fixes the issue for him.)