### PR TITLE
Add a new script to extract data for the ImageNet

### DIFF
--- a/data/ilsvrc12/extract_ilsvrc.sh
+++ b/data/ilsvrc12/extract_ilsvrc.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env sh
+#
+# This script is used to extract the ILSVRC training and validation set of
+# images from the available .tar files that can be downloaded from
+# http://www.image-net.org/index (after registration).
+
+# Create the training and validation data from the ILSVRC2012 training and
+# validation tar archives.
+
+# Specify the correct PATH to the folder that contains the ILSVRC .tar files; 
+# this is an example!
+DATAPATH=~/path/to/imagenet/ILSVRC2012/archived/files
+
+# Prameters that, probably, do not need to change
+ValidationSetName=ILSVRC2012_img_val.tar
+ValidationFolderName=val
+ValidationSet=$DATAPATH/$ValidationSetName
+ValidationFolder=$DATAPATH/$ValidationFolderName
+echo "$ValidationSet";
+echo "$ValidationFolder";
+
+TrainingSetName=ILSVRC2012_img_train.tar
+TrainingFolderName=train
+TrainingSet=$DATAPATH/$TrainingSetName
+TrainingFolder=$DATAPATH/$TrainingFolderName
+echo "$TrainingSet";
+echo "$TrainingFolder";
+
+
+echo "***********************************************************************";
+echo "* This script extracts the training and validation set from the .tar  *";
+echo "* archives that are available from the ImageNet website. Keep in mind *";
+echo "* that it will take time to extract all the images. Be patient!       *";
+echo "***********************************************************************";
+
+# Create a folder for the validation set and extract images
+echo "Create a folder for the validation set."
+rm -rf $ValidationFolder
+mkdir $ValidationFolder
+
+echo "Extracting validation set...";
+
+tar -xf $ValidationSet --directory $ValidationFolder
+
+echo "Validation set extracted successfully!";
+
+
+# Create a folder for the training set and extract the image archives
+echo "Create a folder for the training set.";
+rm -rf $TrainingFolder
+mkdir $TrainingFolder
+
+echo "Extracting training set... (this process will take time)";
+
+tar -xf $TrainingSet --directory $TrainingFolder
+
+# For every (image) archive that was into the training set .tar file,
+# create a folder (for that synset) and extract images
+for synset_tar in $TrainingFolder/*.tar;
+do
+
+  # remove the path from the synset name
+  synset_tar_name=$(basename "$synset_tar")
+  
+  # keep the extension (.tar) of the synset name
+  extension="${synset_tar_name##*.}"
+  
+  # remove the extension (.tar) of the synset name
+  folder_name="${synset_tar_name%.*}"
+  
+  # Create the synset folder and extract synset's images
+  echo -ne "Extract $synset_tar_name into the $TrainingFolder/$folder_name";
+  echo " folder...";
+
+  rm -rf $TrainingFolder/$folder_name
+  mkdir $TrainingFolder/$folder_name
+  
+  tar -xf $TrainingFolder/$synset_tar_name \
+      --directory $TrainingFolder/$folder_name
+
+  # delete the extracted synset to save space
+  rm -rf $TrainingFolder/$synset_tar_name
+done
+
+echo "Training set extracted successfully!"

--- a/examples/imagenet/readme.md
+++ b/examples/imagenet/readme.md
@@ -19,14 +19,18 @@ Data Preparation
 
 *By "ImageNet" we here mean the ILSVRC12 challenge, but you can easily train on the whole of ImageNet as well, just with more disk space, and a little longer training time.*
 
-We assume that you already have downloaded the ImageNet training data and validation data, and they are stored on your disk like:
+After you download the proper [ImageNet](http://www.image-net.org/index) archived files (the service needs registration) you will need to extract the images from the `.tar` files. You can use the `data/ilsvrc12/extract_ilsvrc.sh` script by specifing the path of the `.tar` files on the system at the `DATAPATH` variable and then executing:
+
+    ./data/ilsvrc12/extract_ilsvrc.sh
+
+We assume that you already have downloaded the ImageNet training data and validation data, and they are stored on your disk like (they should be if you used the `/data/ilsvrc12/extract_ilsvrc.sh` script):
 
     /path/to/imagenet/train/n01440764/n01440764_10026.JPEG
     /path/to/imagenet/val/ILSVRC2012_val_00000001.JPEG
 
 You will first need to prepare some auxiliary data for training. This data can be downloaded by:
 
-    ./data/ilsvrc12/get_ilsvrc_aux.sh
+    ./data/get_ilsvrc_aux.sh
 
 The training and validation input are described in `train.txt` and `val.txt` as text listing all the files and their labels. Note that we use a different indexing for labels than the ILSVRC devkit: we sort the synset names in their ASCII order, and then label them from 0 to 999. See `synset_words.txt` for the synset/name mapping.
 
@@ -91,9 +95,9 @@ Resume Training?
 
 We all experience times when the power goes out, or we feel like rewarding ourself a little by playing Battlefield (does anyone still remember Quake?). Since we are snapshotting intermediate results during training, we will be able to resume from snapshots. This can be done as easy as:
 
-    ./build/tools/caffe train --solver=models/bvlc_reference_caffenet/solver.prototxt --snapshot=models/bvlc_reference_caffenet/caffenet_train_iter_10000.solverstate
+    ./build/tools/caffe train --solver=models/bvlc_reference_caffenet/solver.prototxt --snapshot=models/bvlc_reference_caffenet/caffenet_train_10000.solverstate
 
-where in the script `caffenet_train_iter_10000.solverstate` is the solver state snapshot that stores all necessary information to recover the exact solver state (including the parameters, momentum history, etc).
+where in the script `caffenet_train_10000.solverstate` is the solver state snapshot that stores all necessary information to recover the exact solver state (including the parameters, momentum history, etc).
 
 Parting Words
 -------------
@@ -102,4 +106,4 @@ Hope you liked this recipe!
 Many researchers have gone further since the ILSVRC 2012 challenge, changing the network architecture and/or fine-tuning the various parameters in the network to address new data and tasks.
 **Caffe lets you explore different network choices more easily by simply writing different prototxt files** - isn't that exciting?
 
-And since now you have a trained network, check out how to use it with the Python interface for [classifying ImageNet](http://nbviewer.ipython.org/github/BVLC/caffe/blob/master/examples/00-classification.ipynb).
+And since now you have a trained network, check out how to use it with the Python interface for [classifying ImageNet](http://nbviewer.ipython.org/github/BVLC/caffe/blob/master/examples/classification.ipynb).


### PR DESCRIPTION
Provide a script that automates and simplifies the process of extracting the `.tar` files which contain the ILSVRC2012 images (train and val). The script provides comments on the stage of the process. This script might be useful for other purposes as well (extracting other `.tar` files of images) with minor changes. Also updated the `readme.md` file with information for the usage of the new script.