### PR TITLE
improve net config and shape mismatch error messages

### DIFF
--- a/src/caffe/util/insert_splits.cpp
+++ b/src/caffe/util/insert_splits.cpp
@@ -32,7 +32,8 @@ void InsertSplits(const NetParameter& param, NetParameter* param_split) {
       const string& blob_name = layer_param.bottom(j);
       if (blob_name_to_last_top_idx.find(blob_name) ==
           blob_name_to_last_top_idx.end()) {
-        LOG(FATAL) << "Unknown blob input " << blob_name << " to layer " << j;
+        LOG(FATAL) << "Unknown bottom blob '" << blob_name << "' (layer '"
+                   << layer_param.name() << "', bottom index " << j << ")";
       }
       const pair<int, int>& bottom_idx = make_pair(i, j);
       const pair<int, int>& top_idx = blob_name_to_last_top_idx[blob_name];


### PR DESCRIPTION
This PR tries to improve a few unclear error messages that can be triggered from `Net::Init` (many of which were my fault to begin with, sorry about that).  In particular many questions on caffe-users are about the error message `Check failed: ShapeEquals(proto) shape mismatch (reshape not set)` which occurs in the call to `FromProto` in `CopyTrainedLayersFrom`; this new message which displays the layer name and the shape of both blobs (and suggests renaming the layer if you didn't want to finetune) will hopefully help clear up some of that confusion.