### PR TITLE
New make target to only build the library.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,11 +386,13 @@ endif
 ##############################
 # Define build targets
 ##############################
-.PHONY: all test clean docs linecount lint lintclean tools examples $(DIST_ALIASES) \
+.PHONY: all lib test clean docs linecount lint lintclean tools examples $(DIST_ALIASES) \
 	py mat py$(PROJECT) mat$(PROJECT) proto runtest \
 	superclean supercleanlist supercleanfiles warn everything
 
-all: $(STATIC_NAME) $(DYNAMIC_NAME) tools examples
+all: lib tools examples
+
+lib: $(STATIC_NAME) $(DYNAMIC_NAME)
 
 everything: $(EVERYTHING_TARGETS)
 


### PR DESCRIPTION
The JavaCPP wrapper has a case where it can't compile the examples. It's not easy to fix, so it would be great to be able to skip them. https://github.com/bytedeco/javacpp-presets/pull/77