### PR TITLE
Serialize python execution in Multi-GPU

### DIFF
--- a/include/caffe/python_layer.hpp
+++ b/include/caffe/python_layer.hpp
@@ -10,6 +10,10 @@ namespace bp = boost::python;
 
 namespace caffe {
 
+// A function to initialze Python environment that can be called multiple times
+// but ensured that Python environment is initialized exactly once
+void init_python_environment();
+
 template <typename Dtype>
 class PythonLayer : public Layer<Dtype> {
  public:
@@ -17,21 +21,9 @@ class PythonLayer : public Layer<Dtype> {
       : Layer<Dtype>(param), self_(bp::handle<>(bp::borrowed(self))) { }
 
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top) {
-    // Disallow PythonLayer in MultiGPU training stage, due to GIL issues
-    // Details: https://github.com/BVLC/caffe/issues/2936
-    if (this->phase_ == TRAIN && Caffe::solver_count() > 1
-        && !ShareInParallel()) {
-      LOG(FATAL) << "PythonLayer is not implemented in Multi-GPU training";
-    }
-    self_.attr("param_str") = bp::str(
-        this->layer_param_.python_param().param_str());
-    self_.attr("setup")(bottom, top);
-  }
+      const vector<Blob<Dtype>*>& top);
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top) {
-    self_.attr("reshape")(bottom, top);
-  }
+      const vector<Blob<Dtype>*>& top);
 
   virtual inline bool ShareInParallel() const {
     return this->layer_param_.python_param().share_in_parallel();
@@ -41,13 +33,9 @@ class PythonLayer : public Layer<Dtype> {
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top) {
-    self_.attr("forward")(bottom, top);
-  }
+      const vector<Blob<Dtype>*>& top);
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
-      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-    self_.attr("backward")(top, propagate_down, bottom);
-  }
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
  private:
   bp::object self_;

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -165,7 +165,7 @@ REGISTER_LAYER_CREATOR(TanH, GetTanHLayer);
 #ifdef WITH_PYTHON_LAYER
 template <typename Dtype>
 shared_ptr<Layer<Dtype> > GetPythonLayer(const LayerParameter& param) {
-  Py_Initialize();
+  init_python_environment();
   try {
     bp::object module = bp::import(param.python_param().module().c_str());
     bp::object layer = module.attr(param.python_param().layer().c_str())(param);

--- a/src/caffe/layers/python_layer.cpp
+++ b/src/caffe/layers/python_layer.cpp
@@ -1,0 +1,71 @@
+#ifdef WITH_PYTHON_LAYER
+
+#include "caffe/python_layer.hpp"
+
+#include <boost/thread.hpp>
+#include <vector>
+
+namespace caffe {
+
+// A class to initialize Python environment, called by init_python_environment()
+class PyInitializer {
+ private:
+  PyInitializer() {
+    Py_Initialize();
+    PyEval_InitThreads();
+    PyEval_ReleaseLock();
+  }
+  friend void init_python_environment();
+};
+
+void init_python_environment() {
+  static PyInitializer py_initializer;
+}
+
+class AcquirePyGIL {
+ public:
+  AcquirePyGIL() {
+    state = PyGILState_Ensure();
+  }
+  ~AcquirePyGIL() {
+    PyGILState_Release(state);
+  }
+ private:
+  PyGILState_STATE state;
+};
+
+template <typename Dtype>
+void PythonLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  AcquirePyGIL lock;
+  self_.attr("param_str") = bp::str(
+      this->layer_param_.python_param().param_str());
+  self_.attr("setup")(bottom, top);
+}
+
+template <typename Dtype>
+void PythonLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  AcquirePyGIL lock;
+  self_.attr("reshape")(bottom, top);
+}
+
+template <typename Dtype>
+void PythonLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  AcquirePyGIL lock;
+  self_.attr("forward")(bottom, top);
+}
+
+template <typename Dtype>
+void PythonLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  AcquirePyGIL lock;
+  self_.attr("backward")(top, propagate_down, bottom);
+}
+
+INSTANTIATE_CLASS(PythonLayer);
+
+}  // namespace caffe
+
+#endif  // #ifdef WITH_PYTHON_LAYER


### PR DESCRIPTION
This PR should fix #2936 (#2923).

PythonLayer cannot be parallelized in MultiGPU, otherwise crash because Python Global Interpreter Lock (GIL) only allows one thread at a time to run in the python interpreter. This PR serialize all calls to any Python code via a ~~global python mutex~~ GIL to allow having only one PythonLayer execution at a time to behave like before, and fix the crash in #2923. The root problem is that Python doesn't support parallelization in a reasonable way.
- This PR shouldn't affect CPU or single GPU training, where all Python calls are naturally serialized.
- Serializing python execution in Multi-GPU shouldn't lead to overhead for CPU Bound PythonLayer since Python interpretation is always serialized and never actually run in parallel (even with multi-thread).
- For IO Bound PythonLayer without backward (using PythonLayer as a data layer without performing backward), one should set `share_in_parallel: true` in Multi-GPU to share it among workers to load data sequentially (avoiding loading all the same data for each solver).
- ~~Even for the rare case of IO Bound PythonLayer with backward, serialization in Multi-GPU is still better than a GIL crash anyway.~~ IO Bound PythonLayer has its chance to release GIL when stalled waiting for IO.
