### PR TITLE
Give the python layer parameter/weight blobs.

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -189,18 +189,22 @@ bp::object Blob_Reshape(bp::tuple args, bp::dict kwargs) {
   // We need to explicitly return None to use bp::raw_function.
   return bp::object();
 }
+
 bp::object BlobVec_add_blob(bp::tuple args, bp::dict kwargs) {
-  if (bp::len(kwargs) > 0)
+  if (bp::len(kwargs) > 0) {
     throw std::runtime_error("BlobVec.add_blob takes no kwargs");
+  }
   typedef vector<shared_ptr<Blob<Dtype> > > BlobVec;
   BlobVec* self = bp::extract<BlobVec*>(args[0]);
   vector<int> shape(bp::len(args) - 1);
-  for (int i = 1; i < bp::len(args); ++i)
+  for (int i = 1; i < bp::len(args); ++i) {
     shape[i - 1] = bp::extract<int>(args[i]);
+  }
   self->push_back(shared_ptr<Blob<Dtype> >(new Blob<Dtype>(shape)));
   // We need to explicitly return None to use bp::raw_function.
   return bp::object();
 }
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SolveOverloads, Solve, 0, 1);
 
 BOOST_PYTHON_MODULE(_caffe) {

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -189,7 +189,18 @@ bp::object Blob_Reshape(bp::tuple args, bp::dict kwargs) {
   // We need to explicitly return None to use bp::raw_function.
   return bp::object();
 }
-
+bp::object BlobVec_add_blob(bp::tuple args, bp::dict kwargs) {
+  if (bp::len(kwargs) > 0)
+    throw std::runtime_error("BlobVec.add_blob takes no kwargs");
+  typedef vector<shared_ptr<Blob<Dtype> > > BlobVec;
+  BlobVec* self = bp::extract<BlobVec*>(args[0]);
+  vector<int> shape(bp::len(args) - 1);
+  for (int i = 1; i < bp::len(args); ++i)
+    shape[i - 1] = bp::extract<int>(args[i]);
+  self->push_back(shared_ptr<Blob<Dtype> >(new Blob<Dtype>(shape)));
+  // We need to explicitly return None to use bp::raw_function.
+  return bp::object();
+}
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SolveOverloads, Solve, 0, 1);
 
 BOOST_PYTHON_MODULE(_caffe) {
@@ -288,7 +299,8 @@ BOOST_PYTHON_MODULE(_caffe) {
 
   // vector wrappers for all the vector types we use
   bp::class_<vector<shared_ptr<Blob<Dtype> > > >("BlobVec")
-    .def(bp::vector_indexing_suite<vector<shared_ptr<Blob<Dtype> > >, true>());
+    .def(bp::vector_indexing_suite<vector<shared_ptr<Blob<Dtype> > >, true>())
+    .def("add_blob", bp::raw_function(&BlobVec_add_blob));
   bp::class_<vector<Blob<Dtype>*> >("RawBlobVec")
     .def(bp::vector_indexing_suite<vector<Blob<Dtype>*>, true>());
   bp::class_<vector<shared_ptr<Layer<Dtype> > > >("LayerVec")

--- a/python/caffe/test/test_python_layer.py
+++ b/python/caffe/test/test_python_layer.py
@@ -28,6 +28,21 @@ class ExceptionLayer(caffe.Layer):
     def setup(self, bottom, top):
         raise RuntimeError
 
+class ParameterLayer(caffe.Layer):
+    """A layer that just multiplies by ten"""
+
+    def setup(self, bottom, top):
+        self.blobs.add_blob(1)
+        self.blobs[0].data[0] = 0
+
+    def reshape(self, bottom, top):
+        top[0].reshape(*bottom[0].data.shape)
+
+    def forward(self, bottom, top):
+        pass
+
+    def backward(self, top, propagate_down, bottom):
+        self.blobs[0].diff[0] = 1
 
 def python_net_file():
     with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
@@ -48,6 +63,16 @@ def exception_net_file():
         input: 'data' input_shape { dim: 10 dim: 9 dim: 8 }
         layer { type: 'Python' name: 'layer' bottom: 'data' top: 'top'
           python_param { module: 'test_python_layer' layer: 'ExceptionLayer' } }
+          """)
+        return f.name
+
+
+def parameter_net_file():
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
+        f.write("""name: 'pythonnet' force_backward: true
+        input: 'data' input_shape { dim: 10 dim: 9 dim: 8 }
+        layer { type: 'Python' name: 'layer' bottom: 'data' top: 'top'
+          python_param { module: 'test_python_layer' layer: 'ParameterLayer' } }
           """)
         return f.name
 
@@ -83,4 +108,33 @@ class TestPythonLayer(unittest.TestCase):
     def test_exception(self):
         net_file = exception_net_file()
         self.assertRaises(RuntimeError, caffe.Net, net_file, caffe.TEST)
+        os.remove(net_file)
+
+    def test_parameter(self):
+        net_file = parameter_net_file()
+        net = caffe.Net(net_file, caffe.TRAIN)
+        # Test forward and backward
+        net.forward()
+        net.backward()
+        layer = net.layers[list(net._layer_names).index('layer')]
+        self.assertEqual(layer.blobs[0].data[0], 0)
+        self.assertEqual(layer.blobs[0].diff[0], 1)
+        layer.blobs[0].data[0] += layer.blobs[0].diff[0]
+        self.assertEqual(layer.blobs[0].data[0], 1)
+
+        # Test saving and loading
+        h, caffemodel_file = tempfile.mkstemp()
+        net.save(caffemodel_file)
+        layer.blobs[0].data[0] = -1
+        self.assertEqual(layer.blobs[0].data[0], -1)
+        net.copy_from(caffemodel_file)
+        self.assertEqual(layer.blobs[0].data[0], 1)
+        os.remove(caffemodel_file)
+        
+        # Test weight sharing
+        net2 = caffe.Net(net_file, caffe.TRAIN)
+        net2.share_with(net)
+        layer = net.layers[list(net2._layer_names).index('layer')]
+        self.assertEqual(layer.blobs[0].data[0], 1)
+
         os.remove(net_file)


### PR DESCRIPTION
This PR allows the python layer to have its own parameter/weight blobs.
As any python layer inherits form caffe.Layer it already has a self.blobs variable that gets saved and loaded properly, however it wasn't possible to add a new blob to that BlobVec. This PR adds a function ```add_blob``` to the BlobVec which allows a python layer to extend the vector with a new blob. The arguments of the ```add_blob``` function are the dimensions of the blob to be added.

Here is a simple layer that demonstrates the use.
```python
import caffe

class Param(caffe.Layer):
	def setup(self, bottom, top):
		self.blobs.add_blob(1,2,3)
		self.blobs[0].data[...] = 0

	def reshape(self, bottom, top):
		top[0].reshape(10)

	def forward(self, bottom, top):
		print(self.blobs[0].data)
		self.blobs[0].data[...] += 1

	def backward(self, top, propagate_down, bottom):
		pass


def main():
	from caffe import NetSpec, layers as L, params as P, to_proto
	from os import path
	ns = NetSpec()

	A = L.Python(module='test_phase', layer='Param', ntop=1, name='foo')
	open('/tmp/test.prototxt', 'w').write(str(to_proto(A)))
	net = caffe.Net('/tmp/test.prototxt', caffe.TRAIN )
	if path.exists('/tmp/test.caffemodel'):
		net.copy_from('/tmp/test.caffemodel')
	print( "Loaded" )
	net.forward()
	net.forward()
	net.save('/tmp/test.caffemodel')

if __name__ == "__main__":
	main()
```