### PR TITLE
DeconvolutionLayer Backward_gpu fix: don't redo im2col

### DIFF
--- a/src/caffe/layers/deconv_layer.cu
+++ b/src/caffe/layers/deconv_layer.cu
@@ -52,7 +52,8 @@ void DeconvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
         // gradient w.r.t. bottom data, if necessary.
         if (propagate_down[i]) {
           this->forward_gpu_gemm(top_diff + top[i]->offset(n), weight,
-              bottom_diff + bottom[i]->offset(n));
+              bottom_diff + bottom[i]->offset(n),
+              this->param_propagate_down_[0]);
         }
       }
     }


### PR DESCRIPTION
This tells `forward_gpu_gemm` not to redo im2col when it's already been done by the above `weight_gpu_gemm` call.  I think this was the intended behavior -- this makes it work the same way as `DeconvolutionLayer::Backward_cpu`.  (Currently the `bool skip_im2col` argument to `forward_gpu_gemm` is never used anywhere in the codebase.)