### PR TITLE
Use input_shape instead of input_dim in examples

### DIFF
--- a/examples/cifar10/cifar10_full.prototxt
+++ b/examples/cifar10/cifar10_full.prototxt
@@ -2,10 +2,12 @@ name: "CIFAR10_full_deploy"
 # N.B. input image must be in CIFAR-10 format
 # as described at http://www.cs.toronto.edu/~kriz/cifar.html
 input: "data"
-input_dim: 1
-input_dim: 3
-input_dim: 32
-input_dim: 32
+input_shape {
+  dim: 1
+  dim: 3
+  dim: 32
+  dim: 32
+}
 layer {
   name: "conv1"
   type: "Convolution"

--- a/examples/cifar10/cifar10_quick.prototxt
+++ b/examples/cifar10/cifar10_quick.prototxt
@@ -1,9 +1,11 @@
 name: "CIFAR10_quick_test"
 input: "data"
-input_dim: 1
-input_dim: 3
-input_dim: 32
-input_dim: 32
+input_shape {
+  dim: 1
+  dim: 3
+  dim: 32
+  dim: 32
+}
 layer {
   name: "conv1"
   type: "Convolution"

--- a/examples/mnist/lenet.prototxt
+++ b/examples/mnist/lenet.prototxt
@@ -1,9 +1,11 @@
 name: "LeNet"
 input: "data"
-input_dim: 64
-input_dim: 1
-input_dim: 28
-input_dim: 28
+input_shape {
+  dim: 64
+  dim: 1
+  dim: 28
+  dim: 28
+}
 layer {
   name: "conv1"
   type: "Convolution"

--- a/examples/net_surgery/bvlc_caffenet_full_conv.prototxt
+++ b/examples/net_surgery/bvlc_caffenet_full_conv.prototxt
@@ -1,10 +1,12 @@
 # Fully convolutional network version of CaffeNet.
 name: "CaffeNetConv"
 input: "data"
-input_dim: 1
-input_dim: 3
-input_dim: 451
-input_dim: 451
+input_shape {
+  dim: 1
+  dim: 3
+  dim: 451
+  dim: 451
+}
 layer {
   name: "conv1"
   type: "Convolution"

--- a/examples/net_surgery/conv.prototxt
+++ b/examples/net_surgery/conv.prototxt
@@ -1,10 +1,12 @@
 # Simple single-layer network to showcase editing model parameters.
 name: "convolution"
 input: "data"
-input_dim: 1
-input_dim: 1
-input_dim: 100
-input_dim: 100
+input_shape {
+  dim: 1
+  dim: 1
+  dim: 100
+  dim: 100
+}
 layer {
   name: "conv"
   type: "Convolution"

--- a/examples/siamese/mnist_siamese.prototxt
+++ b/examples/siamese/mnist_siamese.prototxt
@@ -1,9 +1,11 @@
 name: "mnist_siamese"
 input: "data"
-input_dim: 10000
-input_dim: 1
-input_dim: 28
-input_dim: 28
+input_shape {
+  dim: 10000
+  dim: 1
+  dim: 28
+  dim: 28
+}
 layer {
   name: "conv1"
   type: "Convolution"

--- a/models/bvlc_alexnet/deploy.prototxt
+++ b/models/bvlc_alexnet/deploy.prototxt
@@ -1,9 +1,11 @@
 name: "AlexNet"
 input: "data"
-input_dim: 10
-input_dim: 3
-input_dim: 227
-input_dim: 227
+input_shape {
+  dim: 10
+  dim: 3
+  dim: 227
+  dim: 227
+}
 layer {
   name: "conv1"
   type: "Convolution"

--- a/models/bvlc_googlenet/deploy.prototxt
+++ b/models/bvlc_googlenet/deploy.prototxt
@@ -1,9 +1,11 @@
 name: "GoogleNet"
 input: "data"
-input_dim: 10
-input_dim: 3
-input_dim: 224
-input_dim: 224
+input_shape {
+  dim: 10
+  dim: 3
+  dim: 224
+  dim: 224
+}
 layer {
   name: "conv1/7x7_s2"
   type: "Convolution"

--- a/models/bvlc_reference_caffenet/deploy.prototxt
+++ b/models/bvlc_reference_caffenet/deploy.prototxt
@@ -1,9 +1,11 @@
 name: "CaffeNet"
 input: "data"
-input_dim: 10
-input_dim: 3
-input_dim: 227
-input_dim: 227
+input_shape {
+  dim: 10
+  dim: 3
+  dim: 227
+  dim: 227
+}
 layer {
   name: "conv1"
   type: "Convolution"

--- a/models/bvlc_reference_rcnn_ilsvrc13/deploy.prototxt
+++ b/models/bvlc_reference_rcnn_ilsvrc13/deploy.prototxt
@@ -1,9 +1,11 @@
 name: "R-CNN-ilsvrc13"
 input: "data"
-input_dim: 10
-input_dim: 3
-input_dim: 227
-input_dim: 227
+input_shape {
+  dim: 10
+  dim: 3
+  dim: 227
+  dim: 227
+}
 layer {
   name: "conv1"
   type: "Convolution"

--- a/models/finetune_flickr_style/deploy.prototxt
+++ b/models/finetune_flickr_style/deploy.prototxt
@@ -1,9 +1,11 @@
 name: "FlickrStyleCaffeNet"
 input: "data"
-input_dim: 10
-input_dim: 3
-input_dim: 227
-input_dim: 227
+input_shape {
+  dim: 10
+  dim: 3
+  dim: 227
+  dim: 227
+}
 layer {
   name: "conv1"
   type: "Convolution"


### PR DESCRIPTION
Since #1970, `input_dim` is deprecated.

>  4D input dimensions -- deprecated.  Use "shape" instead.
https://github.com/BVLC/caffe/blob/833b334b53/src/caffe/proto/caffe.proto#L71