### PR TITLE
[examples] fix link to feature visualization notebook

### DIFF
--- a/examples/feature_extraction/readme.md
+++ b/examples/feature_extraction/readme.md
@@ -64,7 +64,7 @@ If you meet with the error "Check failed: status.ok() Failed to open leveldb exa
 
     rm -rf examples/_temp/features/
 
-If you'd like to use the Python wrapper for extracting features, check out the [layer visualization notebook](http://nbviewer.ipython.org/github/BVLC/caffe/blob/master/examples/filter_visualization.ipynb).
+If you'd like to use the Python wrapper for extracting features, check out the [filter visualization notebook](http://nbviewer.ipython.org/github/BVLC/caffe/blob/master/examples/00-classification.ipynb).
 
 Clean Up
 --------


### PR DESCRIPTION
``examples/feature_extraction/readme.md`` still had a link to the old name for the feature visualization notebook (now called ``00-classification.ipynb``).