### PR TITLE
Caffemodel protobuf snapshots with shared weights shouldn't save multiple copies

### DIFF
--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -228,7 +228,8 @@ class Blob {
   Dtype* mutable_gpu_diff();
   void Update();
   void FromProto(const BlobProto& proto, bool reshape = true);
-  void ToProto(BlobProto* proto, bool write_diff = false) const;
+  void ToProto(BlobProto* proto, bool write_diff = false,
+          bool write_data = true) const;
 
   /// @brief Compute the sum of absolute values (L1 norm) of the data.
   Dtype asum_data() const;

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -194,6 +194,12 @@ class Layer {
   virtual void ToProto(LayerParameter* param, bool write_diff = false);
 
   /**
+   * @brief Writes the layer parameter to a protocol buffer
+   */
+  virtual void ToProto(LayerParameter* param, bool write_diff,
+          vector<bool>& is_owner);
+
+  /**
    * @brief Returns the scalar loss associated with a top blob at a given index.
    */
   inline Dtype loss(const int top_index) const {
@@ -499,6 +505,18 @@ inline void Layer<Dtype>::Backward(const vector<Blob<Dtype>*>& top,
     break;
   default:
     LOG(FATAL) << "Unknown caffe mode.";
+  }
+}
+
+// Serialize LayerParameter to protocol buffer
+template <typename Dtype>
+void Layer<Dtype>::ToProto(LayerParameter* param, bool write_diff,
+        vector<bool>& is_owner) {
+  param->Clear();
+  param->CopyFrom(layer_param_);
+  param->clear_blobs();
+  for (int i = 0; i < blobs_.size(); ++i) {
+    blobs_[i]->ToProto(param->add_blobs(), write_diff, is_owner[i]);
   }
 }
 

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -462,9 +462,12 @@ void Blob<Dtype>::FromProto(const BlobProto& proto, bool reshape) {
       data_vec[i] = proto.double_data(i);
     }
   } else {
-    CHECK_EQ(count_, proto.data_size());
-    for (int i = 0; i < count_; ++i) {
-      data_vec[i] = proto.data(i);
+    // If the data_size is 0, it was not the owner.
+    if (proto.data_size() != 0) {
+      CHECK_EQ(count_, proto.data_size());
+      for (int i = 0; i < count_; ++i) {
+        data_vec[i] = proto.data(i);
+      }
     }
   }
   if (proto.double_diff_size() > 0) {
@@ -483,16 +486,19 @@ void Blob<Dtype>::FromProto(const BlobProto& proto, bool reshape) {
 }
 
 template <>
-void Blob<double>::ToProto(BlobProto* proto, bool write_diff) const {
+void Blob<double>::ToProto(
+        BlobProto* proto, bool write_diff, bool write_data) const {
   proto->clear_shape();
   for (int i = 0; i < shape_.size(); ++i) {
     proto->mutable_shape()->add_dim(shape_[i]);
   }
   proto->clear_double_data();
   proto->clear_double_diff();
-  const double* data_vec = cpu_data();
-  for (int i = 0; i < count_; ++i) {
-    proto->add_double_data(data_vec[i]);
+  if (write_data) {
+    const double* data_vec = cpu_data();
+    for (int i = 0; i < count_; ++i) {
+      proto->add_double_data(data_vec[i]);
+    }
   }
   if (write_diff) {
     const double* diff_vec = cpu_diff();
@@ -503,16 +509,19 @@ void Blob<double>::ToProto(BlobProto* proto, bool write_diff) const {
 }
 
 template <>
-void Blob<float>::ToProto(BlobProto* proto, bool write_diff) const {
+void Blob<float>::ToProto(
+        BlobProto* proto, bool write_diff, bool write_data) const {
   proto->clear_shape();
   for (int i = 0; i < shape_.size(); ++i) {
     proto->mutable_shape()->add_dim(shape_[i]);
   }
   proto->clear_data();
   proto->clear_diff();
-  const float* data_vec = cpu_data();
-  for (int i = 0; i < count_; ++i) {
-    proto->add_data(data_vec[i]);
+  if (write_data) {
+    const float* data_vec = cpu_data();
+    for (int i = 0; i < count_; ++i) {
+      proto->add_data(data_vec[i]);
+    }
   }
   if (write_diff) {
     const float* diff_vec = cpu_diff();

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -930,7 +930,13 @@ void Net<Dtype>::ToProto(NetParameter* param, bool write_diff) const {
     for (int j = 0; j < top_id_vecs_[i].size(); ++j) {
       layer_param->add_top(blob_names_[top_id_vecs_[i][j]]);
     }
-    layers_[i]->ToProto(layer_param, write_diff);
+    vector<bool> is_owner;
+    int num_params = layers_[i]->blobs().size();
+    for (int param_id = 0; param_id < num_params; ++param_id) {
+      const int net_param_id = param_id_vecs_[i][param_id];
+      is_owner.push_back(param_owners_[net_param_id] == -1);
+    }
+    layers_[i]->ToProto(layer_param, write_diff, is_owner);
   }
 }
 


### PR DESCRIPTION
Sorry, I had to delete the other branch [#2946](https://github.com/BVLC/caffe/pull/2946) because of the squashing. Continue discussion here.

It does seem feasible to me to write separate diffs for each shared param but not need to write the data. The data among shared parameters will always be the same, but based on the path through those parameters, the diffse could be different on different layers. Looking at the HDF5 writer, a similar precaution is taken. The comment in ToHDF5 on line 977 appears to support this argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bvlc/caffe/2955)
<!-- Reviewable:end -->
