### PR TITLE
SolverPool for MultiGPU in Python

### DIFF
--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -39,6 +39,7 @@ class Solver {
     return test_nets_;
   }
   int iter() { return iter_; }
+  void set_device_id(int device) { param_.set_device_id(device); }
 
   // Invoked at specific points during an iteration
   class Callback {

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -273,6 +273,14 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("step", &Solver<Dtype>::Step)
     .def("restore", &Solver<Dtype>::Restore);
 
+  bp::class_<SolverPool<Dtype>,
+             shared_ptr<SolverPool<Dtype> >,
+             boost::noncopyable> (
+    "SolverPool", bp::init<string, vector<int> >())
+    .add_property("solvers", bp::make_function(&SolverPool<Dtype>::solvers,
+          bp::return_value_policy<bp::return_by_value>()))
+    .def("step", &SolverPool<Dtype>::Step);
+
   bp::class_<SGDSolver<Dtype>, bp::bases<Solver<Dtype> >,
     shared_ptr<SGDSolver<Dtype> >, boost::noncopyable>(
         "SGDSolver", bp::init<string>());
@@ -303,6 +311,9 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def(bp::vector_indexing_suite<vector<shared_ptr<Net<Dtype> > >, true>());
   bp::class_<vector<bool> >("BoolVec")
     .def(bp::vector_indexing_suite<vector<bool> >());
+  bp::class_<vector<shared_ptr<Solver<Dtype> > > >("SolverVec")
+    .def(bp::vector_indexing_suite<vector<shared_ptr<Solver<Dtype> > >
+                                   , true>());
 
   // boost python expects a void (missing) return value, while import_array
   // returns NULL for python3. import_array1() forces a void return value.

--- a/python/caffe/pycaffe.py
+++ b/python/caffe/pycaffe.py
@@ -10,8 +10,9 @@ except:
     from itertools import zip_longest as izip_longest
 import numpy as np
 
-from ._caffe import Net, SGDSolver
+from ._caffe import Net, SGDSolver, IntVec, SolverPool
 import caffe.io
+
 
 # We directly update methods from Net here (rather than using composition or
 # inheritance) so that nets created by caffe (e.g., by SGDSolver) will
@@ -289,3 +290,10 @@ Net.set_input_arrays = _Net_set_input_arrays
 Net._batch = _Net_batch
 Net.inputs = _Net_inputs
 Net.outputs = _Net_outputs
+
+def get_solver_pool(solver_definition, gpus):
+  vec=caffe.IntVec()
+  vec.extend(gpus)
+  pool=caffe.SolverPool(solver_definition, gpus)
+  return pool
+  


### PR DESCRIPTION
A simple interface which allows you to use the new MultiGPU functionality from inside python.  Begin by calling `pool=get_solver_pool(solver_file,gpu_list)`, where solver_file is a string for the file name of the solver definition prototxt, and gpu_list is a python list of ints specifying the gpus to use.  pool will then have the methods `pool.step(int)`, which lets you step all solvers in the pool in parallel for the specified number of iterations, and `pool.solvers` which is a list of python solver objects.  

There is currently no documentation or tests.  This has been well tested on an older version of the MultiGPU version of caffe.  There have been several boilerplate changes since that version (most notably, `P2Psync::run` is no longer static, which changed how `SolverPool` interacts with it).  I have updated this PR such that it compiles and the tests pass, but it is still possible that I made some mistake while updating the boilerplate.  Feedback is appreciated.

@cypof parallel.cpp line 396 now calls `SetDevice`, since I couldn't find another good place to do this.  This means that `SetDevice` gets called twice when you run tools/caffe, which is maybe a bit confusing.  Let me know if I can get rid of the `SetDevice` call in tools/caffe.  
