### PR TITLE
Bugfix for #2017 broken across_channels computation in MVNLayer

### DIFF
--- a/src/caffe/layers/mvn_layer.cpp
+++ b/src/caffe/layers/mvn_layer.cpp
@@ -18,8 +18,13 @@ void MVNLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       1, 1);
   temp_.Reshape(bottom[0]->num(), bottom[0]->channels(),
       bottom[0]->height(), bottom[0]->width());
-  sum_multiplier_.Reshape(1, 1,
-      bottom[0]->height(), bottom[0]->width());
+  if (this->layer_param_.mvn_param().across_channels()) {
+    sum_multiplier_.Reshape(1, bottom[0]->channels(),
+        bottom[0]->height(), bottom[0]->width());
+  } else {
+    sum_multiplier_.Reshape(1, 1,
+          bottom[0]->height(), bottom[0]->width());
+  }
   Dtype* multiplier_data = sum_multiplier_.mutable_cpu_data();
   caffe_set(sum_multiplier_.count(), Dtype(1), multiplier_data);
   eps_ = this->layer_param_.mvn_param().eps();


### PR DESCRIPTION
The current implementation of `MVNLayer` requires multiplying the data matrix by a vector of 1's to perform sums for the mean and variance.  This vector, sum_multiplier, gets created with the incorrect size when across_channels is true (it needs to be `channels*width*height`).  See #2017. This PR checks for the across_channels flag and creates the sum_multiplier with the correct size.  

Note that this is fixed in #1979 but it's looking less and less likely that this PR will be merged. 

@seanbell can you confirm that this fixes all the bugs you're aware of in mvnlayer?  