### PR TITLE
Remove superfluous code in Net::ToProto

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -763,12 +763,6 @@ void Net<Dtype>::ToProto(NetParameter* param, bool write_diff) const {
   DLOG(INFO) << "Serializing " << layers_.size() << " layers";
   for (int i = 0; i < layers_.size(); ++i) {
     LayerParameter* layer_param = param->add_layer();
-    for (int j = 0; j < bottom_id_vecs_[i].size(); ++j) {
-      layer_param->add_bottom(blob_names_[bottom_id_vecs_[i][j]]);
-    }
-    for (int j = 0; j < top_id_vecs_[i].size(); ++j) {
-      layer_param->add_top(blob_names_[top_id_vecs_[i][j]]);
-    }
     layers_[i]->ToProto(layer_param, write_diff);
   }
 }


### PR DESCRIPTION
Since `Layer::ToProto` calls `layer_param->Clear` (https://github.com/BVLC/caffe/blob/master/include/caffe/layer.hpp#L508), I think filling in fields beforehand has no effect. This appears to be leftover from an ancient protobuf format.