### PR TITLE
Fix SPPLayer top blob num and address `pyramid_height_ == 1`

### DIFF
--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -471,13 +471,7 @@ class SPPLayer : public Layer<Dtype> {
 
   virtual inline const char* type() const { return "SPP"; }
   virtual inline int ExactNumBottomBlobs() const { return 1; }
-  virtual inline int MinTopBlobs() const { return 1; }
-  // MAX POOL layers can output an extra top blob for the mask;
-  // others can only output the pooled inputs.
-  virtual inline int MaxTopBlobs() const {
-    return (this->layer_param_.pooling_param().pool() ==
-            PoolingParameter_PoolMethod_MAX) ? 2 : 1;
-  }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
 
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -491,9 +485,11 @@ class SPPLayer : public Layer<Dtype> {
 
   int pyramid_height_;
   int bottom_h_, bottom_w_;
+  int num_;
   int channels_;
   int kernel_h_, kernel_w_;
   int pad_h_, pad_w_;
+  bool reshaped_first_time_;
 
   /// the internal Split layer that feeds the pooling layers
   shared_ptr<SplitLayer<Dtype> > split_layer_;


### PR DESCRIPTION
This PR
* fixes previous mistake in SPPLayer, restricting top blob num to be exact 1. (Perviously top blob num can be 2 for outputting max index, but that's never implemented at all).
* addresses for the case that `pyramid_height_ == 1`. This is equivalent to max-pooling over the entire bottom, similar to what ReductionLayer does but with a MAX operation. Previously `pyramid_height_ == 1` case crashes.
* reshape only when bottom shape is changed, since it involve destroying and re-constructing inner layers.