### PR TITLE
Fix python net.forward crash when top layer and top blob names mismatch

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -142,12 +142,18 @@ class Net {
   inline const vector<vector<Blob<Dtype>*> >& bottom_vecs() const {
     return bottom_vecs_;
   }
+  inline const vector<vector<int> >& bottom_id_vecs() const {
+    return bottom_id_vecs_;
+  }
   /**
    * @brief returns the top vecs for each layer -- usually you won't
    *        need this unless you do per-layer checks such as gradients.
    */
   inline const vector<vector<Blob<Dtype>*> >& top_vecs() const {
     return top_vecs_;
+  }
+  inline const vector<vector<int> >& top_id_vecs() const {
+    return top_id_vecs_;
   }
   inline const vector<vector<bool> >& bottom_need_backward() const {
     return bottom_need_backward_;

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -131,6 +131,16 @@ void Net_SetInputArrays(Net<Dtype>* net, bp::object data_obj,
       PyArray_DIMS(data_arr)[0]);
 }
 
+const vector<int>& Net_BottomsForLayer(const Net<Dtype>& net,
+                                                int layer_idx) {
+  return net.bottom_id_vecs()[layer_idx];
+}
+
+const vector<int>& Net_TopsForLayer(const Net<Dtype>& net,
+                                             int layer_idx) {
+  return net.top_id_vecs()[layer_idx];
+}
+
 Solver<Dtype>* GetSolverFromFile(const string& filename) {
   SolverParameter param;
   ReadProtoFromTextFileOrDie(filename, &param);
@@ -230,7 +240,11 @@ BOOST_PYTHON_MODULE(_caffe) {
         bp::return_value_policy<bp::copy_const_reference>()))
     .def("_set_input_arrays", &Net_SetInputArrays,
         bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >())
-    .def("save", &Net_Save);
+    .def("save", &Net_Save)
+    .def("_bottoms_for_layer", &Net_BottomsForLayer,
+        bp::return_value_policy<bp::copy_const_reference>())
+    .def("_tops_for_layer", &Net_TopsForLayer,
+        bp::return_value_policy<bp::copy_const_reference>());
 
   bp::class_<Blob<Dtype>, shared_ptr<Blob<Dtype> >, boost::noncopyable>(
     "Blob", bp::no_init)

--- a/python/caffe/pycaffe.py
+++ b/python/caffe/pycaffe.py
@@ -86,7 +86,9 @@ def _Net_forward(self, blobs=None, start=None, end=None, **kwargs):
 
     if end is not None:
         end_ind = list(self._layer_names).index(end)
-        outputs = set([end] + blobs)
+        outputs = set(blobs)
+        outputs.update([self._blob_names[idx]
+                        for idx in self._tops_for_layer(end_ind)])
     else:
         end_ind = len(self.layers) - 1
         outputs = set(self.outputs + blobs)
@@ -134,7 +136,9 @@ def _Net_backward(self, diffs=None, start=None, end=None, **kwargs):
 
     if end is not None:
         end_ind = list(self._layer_names).index(end)
-        outputs = set([end] + diffs)
+        outputs = set(diffs)
+        outputs.update([self._blob_names[idx]
+                        for idx in self._bottoms_for_layer(end_ind)])
     else:
         end_ind = 0
         outputs = set(self.inputs + diffs)
@@ -277,6 +281,18 @@ def _Net_batch(self, blobs):
                                                  padding])
         yield padded_batch
 
+def _Net_bottoms_for_layer(self, layer_name):
+    layer_idx = list(self._layer_names).index(layer_name);
+    blob_idx = self._bottoms_for_layer(layer_idx);
+    return OrderedDict([(self._blob_names[idx], self._blobs[idx])
+                        for idx in blob_idx]);
+
+def _Net_tops_for_layer(self, layer_name):
+    layer_idx = list(self._layer_names).index(layer_name);
+    blob_idx = self._tops_for_layer(layer_idx);
+    return OrderedDict([(self._blob_names[idx], self._blobs[idx])
+                        for idx in blob_idx]);
+
 # Attach methods to Net.
 Net.blobs = _Net_blobs
 Net.blob_loss_weights = _Net_blob_loss_weights
@@ -289,3 +305,5 @@ Net.set_input_arrays = _Net_set_input_arrays
 Net._batch = _Net_batch
 Net.inputs = _Net_inputs
 Net.outputs = _Net_outputs
+Net.bottoms_for_layer = _Net_bottoms_for_layer
+Net.tops_for_layer = _Net_tops_for_layer

--- a/python/caffe/test/test_net.py
+++ b/python/caffe/test/test_net.py
@@ -24,11 +24,11 @@ def simple_net_file(num_output):
         bias_filler { type: 'constant' value: 2 } }
         param { decay_mult: 1 } param { decay_mult: 0 }
         }
-    layer { type: 'InnerProduct' name: 'ip' bottom: 'conv' top: 'ip'
+    layer { type: 'InnerProduct' name: 'ip' bottom: 'conv' top: 'ip_blob'
       inner_product_param { num_output: """ + str(num_output) + """
         weight_filler { type: 'gaussian' std: 2.5 }
         bias_filler { type: 'constant' value: -3 } } }
-    layer { type: 'SoftmaxWithLoss' name: 'loss' bottom: 'ip' bottom: 'label'
+    layer { type: 'SoftmaxWithLoss' name: 'loss' bottom: 'ip_blob' bottom: 'label'
       top: 'loss' }""")
     f.close()
     return f.name
@@ -62,6 +62,43 @@ class TestNet(unittest.TestCase):
     def test_forward_backward(self):
         self.net.forward()
         self.net.backward()
+    
+    def test_forward_start_end(self):
+        conv_blob=self.net.blobs['conv'];
+        ip_blob=self.net.blobs['ip_blob'];
+        sample_data=np.random.uniform(size=conv_blob.data.shape);
+        sample_data=sample_data.astype(np.float32);
+        conv_blob.data[:]=sample_data;
+        forward_blob=self.net.forward(start='ip',end='ip');
+        self.assertIn('ip_blob',forward_blob);
+
+        manual_forward=[];
+        for i in range(0,conv_blob.data.shape[0]):
+          dot=np.dot(self.net.params['ip'][0].data,
+                     conv_blob.data[i].reshape(-1));
+          manual_forward.append(dot+self.net.params['ip'][1].data);
+        manual_forward=np.array(manual_forward);
+
+        np.testing.assert_allclose(ip_blob.data,manual_forward,rtol=1e-3);
+
+    def test_backward_start_end(self):
+        conv_blob=self.net.blobs['conv'];
+        ip_blob=self.net.blobs['ip_blob'];
+        sample_data=np.random.uniform(size=ip_blob.data.shape)
+        sample_data=sample_data.astype(np.float32);
+        ip_blob.diff[:]=sample_data;
+        backward_blob=self.net.backward(start='ip',end='ip');
+        self.assertIn('conv',backward_blob);
+
+        manual_backward=[];
+        for i in range(0,conv_blob.data.shape[0]):
+          dot=np.dot(self.net.params['ip'][0].data.transpose(),
+                     sample_data[i].reshape(-1));
+          manual_backward.append(dot);
+        manual_backward=np.array(manual_backward);
+        manual_backward=manual_backward.reshape(conv_blob.data.shape);
+
+        np.testing.assert_allclose(conv_blob.diff,manual_backward,rtol=1e-3);
 
     def test_inputs_outputs(self):
         self.assertEqual(self.net.inputs, [])


### PR DESCRIPTION
The main goal is to fix issue #2829, in which forward() in the python interface attempts to return the top blobs of the last layer in forward(), but instead uses the layer names as if they were blob names. Turns out there's not currently a way for python code to figure out which blobs are connected to which layers, so this PR exposes that functionality and fixes the bug.

This is a redone version of #2831, this time including a test to show the broken functionality.
