### PR TITLE
Add extra OpenBLAS include search path

### DIFF
--- a/cmake/Modules/FindOpenBLAS.cmake
+++ b/cmake/Modules/FindOpenBLAS.cmake
@@ -2,8 +2,10 @@
 
 SET(Open_BLAS_INCLUDE_SEARCH_PATHS
   /usr/include
+  /usr/include/openblas
   /usr/include/openblas-base
   /usr/local/include
+  /usr/local/include/openblas
   /usr/local/include/openblas-base
   /opt/OpenBLAS/include
   $ENV{OpenBLAS_HOME}


### PR DESCRIPTION
My default package manager on CentOS 5 put OpenBLAS includes in the /usr/include/openblas folder.