### PR TITLE
Add extra check to net forward function

### DIFF
--- a/cmake/Modules/FindOpenBLAS.cmake
+++ b/cmake/Modules/FindOpenBLAS.cmake
@@ -2,8 +2,10 @@
 
 SET(Open_BLAS_INCLUDE_SEARCH_PATHS
   /usr/include
+  /usr/include/openblas
   /usr/include/openblas-base
   /usr/local/include
+  /usr/local/include/openblas
   /usr/local/include/openblas-base
   /opt/OpenBLAS/include
   $ENV{OpenBLAS_HOME}

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -627,6 +627,7 @@ template <typename Dtype>
 const vector<Blob<Dtype>*>& Net<Dtype>::Forward(
     const vector<Blob<Dtype>*> & bottom, Dtype* loss) {
   // Copy bottom to internal bottom
+  CHECK_LE(bottom.size(), net_input_blobs_.size());
   for (int i = 0; i < bottom.size(); ++i) {
     net_input_blobs_[i]->CopyFrom(*bottom[i]);
   }


### PR DESCRIPTION
Add extra safety check to the forward function of the net class, such that a more descriptive error is written out (as opposed to a segfault) when attempting to input too many blobs for the network, or using a mis-configured net.