### PR TITLE
  Add extra check to forward function

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -627,6 +627,7 @@ template <typename Dtype>
 const vector<Blob<Dtype>*>& Net<Dtype>::Forward(
     const vector<Blob<Dtype>*> & bottom, Dtype* loss) {
   // Copy bottom to internal bottom
+  CHECK_LE(bottom.size(), net_input_blobs_.size());
   for (int i = 0; i < bottom.size(); ++i) {
     net_input_blobs_[i]->CopyFrom(*bottom[i]);
   }


### PR DESCRIPTION
Add extra safety check to the forward function of the net class, such that a more descriptive error is written out (as opposed to a segfault) when attempting to input too many blobs for the network, or using a mis-configured net.