### PR TITLE
Fix a recently introduced race condition in DataLayer

### DIFF
--- a/src/caffe/layers/base_data_layer.cu
+++ b/src/caffe/layers/base_data_layer.cu
@@ -20,7 +20,9 @@ void BasePrefetchingDataLayer<Dtype>::Forward_gpu(
     caffe_copy(batch->label_.count(), batch->label_.gpu_data(),
         top[1]->mutable_gpu_data());
   }
-
+  // Ensure the copy is synchronous wrt the host, so that the next batch isn't
+  // copied in meanwhile.
+  CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
   prefetch_free_.push(batch);
 }
 


### PR DESCRIPTION
This PR fixes a race condition introduced to `DataLayer` by #2903, which can cause incorrect data to appear on `top` after a GPU forward. This affects single or multiple GPU usage with any data source.

`DataLayer`'s forward copies prefetch GPU data -> top GPU data using `caffe_copy`. Meanwhile, the prefetch thread copies prefetch CPU data -> prefetch GPU data using a non-blocking CUDA stream.

`caffe_copy` is asynchronous wrt the host (when device -> device). That means these two copies can happen in any order, giving you either this batch's data or the next's (or some combination?). If you have two synchronized data sources (e.g., separate images and labels), this can be catastrophic.

Note that the queue pair is no help here; the `batch` is reinserted into the free queue immediately after the copy is issued, before it's completed.

To reproduce this issue easily, set `PREFETCH_COUNT` to `1`, and put the copy https://github.com/BVLC/caffe/blob/master/src/caffe/layers/base_data_layer.cu#L14 in a loop that executes, e.g., 1000 times. That shouldn't affect correctness, but gives the race enough time to occur reliably (on my system, at least).

The fix here explicitly synchronizes the null stream used by `caffe_copy`. However, I think it requires CUDA 7. @thatguymike or others, what's the right way to do this without switching right away to CUDA 7?

It would be nice if there were some way to test that this doesn't happen again, but that seems difficult...

_Please note:_ Caffe as such, with few exceptions, uses the default stream with no explicit synchronization. Layer calls are _asynchronous wrt the host_. (That's why there's, e.g., #2077.) `caffe_copy` (as `cudaMemcpy`) is _asynchronous wrt the host_ when device -> device. If you create a non-blocking stream, don't expect it to be synchronous wrt any existing Caffe GPU code.