### PR TITLE
Added per layer mode selection (CPU/GPU)

### DIFF
--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -336,6 +336,15 @@ message LayerParameter {
   repeated NetStateRule include = 8;
   repeated NetStateRule exclude = 9;
 
+  // use CPU, GPU or the solver default for this layer,
+  // this will override solver_mode
+  enum LayerMode {
+    SOLVER = 0;
+    CPU = 1;
+    GPU = 2;
+  }
+  optional LayerMode layer_mode = 12 [default = SOLVER];
+
   // Parameters for data pre-processing.
   optional TransformationParameter transform_param = 100;
 


### PR DESCRIPTION
Added a new layer parameter (layer_mode) that can override the global solver mode. This will allow running any layer in CPU/GPU mode irrespective of the solver mode.