### PR TITLE
Compute backward for negative lr_mult

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -182,7 +182,7 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
     for (int param_id = 0; param_id < num_param_blobs; ++param_id) {
       const ParamSpec* param_spec = (param_id < param_size) ?
           &layer_param.param(param_id) : &default_param_spec;
-      const bool param_need_backward = param_spec->lr_mult() > 0;
+      const bool param_need_backward = param_spec->lr_mult() != 0;
       need_backward |= param_need_backward;
       layers_[layer_id]->set_param_propagate_down(param_id,
                                                   param_need_backward);


### PR DESCRIPTION
Caffe currently does not update parameters for layers with negative lr_mult. This PR changes this behavior to update parameters for all layers with non-zero lr_mult.
I belief this is a bug after a conversation with @jeffdonahue .