### PR TITLE
Fix memory leak in convert_mnist_siamese_data.

### DIFF
--- a/examples/siamese/convert_mnist_siamese_data.cpp
+++ b/examples/siamese/convert_mnist_siamese_data.cpp
@@ -102,7 +102,7 @@ void convert_dataset(const char* image_filename, const char* label_filename,
   }
 
   delete db;
-  delete pixels;
+  delete [] pixels;
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This fixes a memory leak by using delete[] rather than plain delete.