### PR TITLE
cifar10: Fix examples by setting snapshot_format.

### DIFF
--- a/examples/cifar10/cifar10_full_solver.prototxt
+++ b/examples/cifar10/cifar10_full_solver.prototxt
@@ -21,6 +21,7 @@ display: 200
 max_iter: 60000
 # snapshot intermediate results
 snapshot: 10000
+snapshot_format: HDF5
 snapshot_prefix: "examples/cifar10/cifar10_full"
 # solver mode: CPU or GPU
 solver_mode: GPU

--- a/examples/cifar10/cifar10_full_solver_lr1.prototxt
+++ b/examples/cifar10/cifar10_full_solver_lr1.prototxt
@@ -21,6 +21,7 @@ display: 200
 max_iter: 65000
 # snapshot intermediate results
 snapshot: 5000
+snapshot_format: HDF5
 snapshot_prefix: "examples/cifar10/cifar10_full"
 # solver mode: CPU or GPU
 solver_mode: GPU

--- a/examples/cifar10/cifar10_full_solver_lr2.prototxt
+++ b/examples/cifar10/cifar10_full_solver_lr2.prototxt
@@ -21,6 +21,7 @@ display: 200
 max_iter: 70000
 # snapshot intermediate results
 snapshot: 5000
+snapshot_format: HDF5
 snapshot_prefix: "examples/cifar10/cifar10_full"
 # solver mode: CPU or GPU
 solver_mode: GPU

--- a/examples/cifar10/cifar10_quick_solver.prototxt
+++ b/examples/cifar10/cifar10_quick_solver.prototxt
@@ -20,6 +20,7 @@ display: 100
 max_iter: 4000
 # snapshot intermediate results
 snapshot: 4000
+snapshot_format: HDF5
 snapshot_prefix: "examples/cifar10/cifar10_quick"
 # solver mode: CPU or GPU
 solver_mode: GPU

--- a/examples/cifar10/cifar10_quick_solver_lr1.prototxt
+++ b/examples/cifar10/cifar10_quick_solver_lr1.prototxt
@@ -20,6 +20,7 @@ display: 100
 max_iter: 5000
 # snapshot intermediate results
 snapshot: 5000
+snapshot_format: HDF5
 snapshot_prefix: "examples/cifar10/cifar10_quick"
 # solver mode: CPU or GPU
 solver_mode: GPU


### PR DESCRIPTION
Commit 4227828a set the default binary format from HDF5 to BINARYPROTO to
fix #2885. This broke the cifar10 examples which relied on this default.

This commit specifies the snapshot_format explicitly since the rest of the
example relies on this being HDF5.