### PR TITLE
Show output from convert_imageset tool

### DIFF
--- a/tools/convert_imageset.cpp
+++ b/tools/convert_imageset.cpp
@@ -44,6 +44,8 @@ DEFINE_string(encode_type, "",
 
 int main(int argc, char** argv) {
   ::google::InitGoogleLogging(argv[0]);
+  // Print output to stderr (while still logging)
+  FLAGS_alsologtostderr = 1;
 
 #ifndef GFLAGS_GFLAGS_H_
   namespace gflags = google;
@@ -140,13 +142,13 @@ int main(int argc, char** argv) {
       // Commit db
       txn->Commit();
       txn.reset(db->NewTransaction());
-      LOG(ERROR) << "Processed " << count << " files.";
+      LOG(INFO) << "Processed " << count << " files.";
     }
   }
   // write the last batch
   if (count % 1000 != 0) {
     txn->Commit();
-    LOG(ERROR) << "Processed " << count << " files.";
+    LOG(INFO) << "Processed " << count << " files.";
   }
   return 0;
 }


### PR DESCRIPTION
1. Output log messages to stderr (like fa084945d43eed3d2942f4c28def2e87bbe1c92d)
2. Cleanup log message levels (like #2583)