### PR TITLE
Cmake add version and soversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 2.8.7)
 # ---[ Caffe project
 project(Caffe C CXX)
 
+# ---[ Caffe version
+set(CAFFE_TARGET_VERSION "0")
+set(CAFFE_TARGET_SOVERSION "0")
+
 # ---[ Using cmake scripts and modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -109,7 +109,11 @@ function(caffe_default_properties target)
     DEBUG_POSTFIX ${Caffe_DEBUG_POSTFIX}
     ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
     LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin"
+    VERSION   ${CAFFE_TARGET_VERSION}
+    SOVERSION ${CAFFE_TARGET_SOVERSION}
+  )
+
   # make sure we build all external depepdencies first
   if (DEFINED external_project_dependencies)
     add_dependencies(${target} ${external_project_dependencies})


### PR DESCRIPTION
Changed CMake files in order to add SONAME for libcaffe.so.
  
Adding SONAME would be convenient for Distribution maintainers to maintain a package.
  
This patch is derived from debian packaging repo of caffe.
  
Please have a look at it, thanks.