### PR TITLE
Net: expose param_display_names_

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -179,6 +179,9 @@ class Net {
     return param_names_index_;
   }
   inline const vector<int>& param_owners() const { return param_owners_; }
+  inline const vector<string>& param_display_names() const {
+    return param_display_names_;
+  }
   /// @brief Input and output blob numbers
   inline int num_inputs() const { return net_input_blobs_.size(); }
   inline int num_outputs() const { return net_output_blobs_.size(); }


### PR DESCRIPTION
This exposes `param_display_names_` from Net.  Pulled out of #2033, where I use this to log the param names of the internal unrolled net.