### PR TITLE
Disallow PythonLayer in Multi-GPU training

### DIFF
--- a/include/caffe/python_layer.hpp
+++ b/include/caffe/python_layer.hpp
@@ -18,6 +18,12 @@ class PythonLayer : public Layer<Dtype> {
 
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+    // Disallow PythonLayer in MultiGPU training stage, due to GIL issues
+    // Details: https://github.com/BVLC/caffe/issues/2936
+    if (this->phase_ == TRAIN && Caffe::solver_count() > 1
+        && !ShareInParallel()) {
+      LOG(FATAL) << "PythonLayer is not implemented in Multi-GPU training";
+    }
     self_.attr("param_str") = bp::str(
         this->layer_param_.python_param().param_str());
     self_.attr("setup")(bottom, top);


### PR DESCRIPTION
This PR disallow PythonLayer during Multi-GPU training phase. Otherwise it crash due to GIL issues #2936.

@jeffdonahue @longjon @shelhamer We should merge either this PR or #2939, to fix PythonLayer crash in Multi-GPU.