### PR TITLE
fixed a problem of wasted memory.

### DIFF
--- a/src/caffe/layers/softmax_layer.cpp
+++ b/src/caffe/layers/softmax_layer.cpp
@@ -19,7 +19,7 @@ void SoftmaxLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   caffe_set(sum_multiplier_.count(), Dtype(1), multiplier_data);
   outer_num_ = bottom[0]->count(0, softmax_axis_);
   inner_num_ = bottom[0]->count(softmax_axis_ + 1);
-  vector<int> scale_dims(bottom[0]->shape().begin() + softmax_axis_ + 1, 
+  vector<int> scale_dims(bottom[0]->shape().begin() + softmax_axis_ + 1,
       bottom[0]->shape().end());
   scale_.Reshape(scale_dims);
 }

--- a/src/caffe/layers/softmax_layer.cpp
+++ b/src/caffe/layers/softmax_layer.cpp
@@ -19,8 +19,8 @@ void SoftmaxLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   caffe_set(sum_multiplier_.count(), Dtype(1), multiplier_data);
   outer_num_ = bottom[0]->count(0, softmax_axis_);
   inner_num_ = bottom[0]->count(softmax_axis_ + 1);
-  vector<int> scale_dims = bottom[0]->shape();
-  scale_dims[softmax_axis_] = 1;
+  vector<int> scale_dims(bottom[0]->shape().begin() + softmax_axis_ + 1, 
+      bottom[0]->shape().end());
   scale_.Reshape(scale_dims);
 }
 


### PR DESCRIPTION
Actually, we don't need a so large buffer. I think we only need a  buffer of `inner_num_*sizeof(Dtype) ` bytes to save intermediate results.
