### PR TITLE
Fix opencv 3.0 linking issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ ifneq ($(CPU_ONLY), 1)
 endif
 LIBRARIES += glog gflags protobuf leveldb snappy \
 	lmdb boost_system hdf5_hl hdf5 m \
-	opencv_core opencv_highgui opencv_imgproc
+	opencv_core opencv_highgui opencv_imgproc opencv_imgcodecs
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare
 


### PR DESCRIPTION
There is a opencv 3.0 linking issue when building `cpp_classification` example, as shown below

```
ld: .build_release/examples/cpp_classification/classification.o: undefined reference to symbol '_ZN2cv6imreadERKNS_6StringEi'
/usr/lib64/libopencv_imgcodecs.so.3.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [.build_release/examples/cpp_classification/classification.bin] Error 1
```

Please check http://answers.opencv.org/question/46755/first-example-code-error/?answer=49952#post-id-49952 for details.

But it may not work for opencv 2.x.