### PR TITLE
NoiseLayer

### DIFF
--- a/include/caffe/neuron_layers.hpp
+++ b/include/caffe/neuron_layers.hpp
@@ -475,6 +475,85 @@ class ReLULayer : public NeuronLayer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 };
 
+/**
+ * @brief NoiseLayer for adding noise to a blob.
+ */
+template <typename Dtype>
+class NoiseLayer : public NeuronLayer<Dtype> {
+ public:
+  /**
+   * @param param provides NoiseParameter noise_param.
+   *
+   */
+  explicit NoiseLayer(const LayerParameter& param)
+      : NeuronLayer<Dtype>(param), inplace_(false) {}
+  virtual inline const char* type() const { return "Noise"; }
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+ protected:
+  /**
+   * @param bottom input Blob vector (length 1)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the inputs @f$ x @f$
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the noised output.
+   *        y = \max(0, x)
+   */
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  /**
+   * @brief Computes the error gradient w.r.t. the inputs.
+   *
+   * @param top output Blob vector (length 1), providing the error gradient with
+   *      respect to the outputs
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      containing error gradients @f$ \frac{\partial E}{\partial y} @f$
+   *      with respect to computed outputs @f$ y @f$
+   * @param propagate_down see Layer::Backward.
+   * @param bottom input Blob vector (length 1)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the inputs @f$ x @f$; Backward fills their diff with the top diff.
+   */
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  const NoiseParameter& NoiseParam() const {
+    return this->layer_param_.noise_param();
+  }
+
+  const FillerParameter& FillerParam() const {
+    return NoiseParam().filler_param();
+  }
+
+  std::string NoiseType() const {
+    const FillerParameter& filler_param = this->NoiseParam().filler_param();
+    return filler_param.type();
+  }
+
+  // Returns true if we are noising in-place. I.e. the top and bottom blob are
+  // the same.
+  bool Inplace() const {
+    return inplace_;
+  }
+
+  // Buffer for noise used when top and bottom blob are the same.
+  Blob<Dtype> inplace_noise_;
+  // True iff bottom and top blob are the same.
+  bool inplace_;
+
+  static const std::string GAUSSIAN;
+  static const std::string UNIFORM;
+};
+
 #ifdef USE_CUDNN
 /**
  * @brief CuDNN acceleration of ReLULayer.

--- a/src/caffe/layers/noise_layer.cpp
+++ b/src/caffe/layers/noise_layer.cpp
@@ -1,0 +1,91 @@
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "caffe/filler.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template<typename Dtype>
+const std::string NoiseLayer<Dtype>::GAUSSIAN = "gaussian";
+template<typename Dtype>
+const std::string NoiseLayer<Dtype>::UNIFORM = "uniform";
+
+template <typename Dtype>
+void NoiseLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype> *> &bottom,
+                              const vector<Blob<Dtype> *> &top) {
+  CHECK(this->layer_param().has_noise_param()) <<
+      "No noise parameter specified for NoiseLayer.";
+  CHECK(this->NoiseParam().has_filler_param()) <<
+      "No filler specified for NoiseLayer noise_param.";
+  NoiseParameter noise_param = this->layer_param().noise_param();
+  CHECK(NoiseType() == GAUSSIAN || NoiseType() == UNIFORM) <<
+      "NoiseLayer only supports normally- or uniformly-distributed noise.";
+}
+
+template <typename Dtype>
+void NoiseLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  this->inplace_ = bottom[0] == top[0];
+  if (Inplace()) {
+    // For in-place noising.
+    inplace_noise_.ReshapeLike(*bottom[0]);
+  } else {
+    top[0]->ReshapeLike(*bottom[0]);
+  }
+}
+
+template <typename Dtype>
+void NoiseLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  int count = top[0]->count();
+
+  CHECK(top[0]->count());
+  // If we are noising in-place, then put the generated noise in the layer's
+  // buffer. Otherwise, put it directly into the top blob.
+  Dtype* noise_buffer = Inplace() ? inplace_noise_.mutable_cpu_data() :
+                                    top_data;
+  if (NoiseType() == GAUSSIAN) {
+    caffe_rng_gaussian<Dtype>(count,
+        Dtype(FillerParam().mean()),
+        Dtype(FillerParam().std()),
+        noise_buffer);
+  } else if (NoiseType() == UNIFORM) {
+    caffe_rng_uniform(count,
+        Dtype(FillerParam().min()),
+        Dtype(FillerParam().max()),
+        noise_buffer);
+  } else {
+    LOG(FATAL) << "Unexpected noise type in NoiseLayer.";
+  }
+  // Add the noise to the bottom blob to produce the top blob.
+  caffe_add(count, bottom_data, noise_buffer, top_data);
+}
+
+template <typename Dtype>
+void NoiseLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
+  if (bottom.empty()) {
+    return;
+  }
+  // Only copy the top diffs to bottom if we are not noising in-place.
+  if (propagate_down[0] && !Inplace()) {
+    const Dtype* top_diff = top[0]->cpu_diff();
+    Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+    caffe_copy(top[0]->count(), top_diff, bottom_diff);
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(NoiseLayer);
+#endif
+
+INSTANTIATE_CLASS(NoiseLayer);
+REGISTER_LAYER_CLASS(Noise);
+
+}  // namespace caffe

--- a/src/caffe/layers/noise_layer.cu
+++ b/src/caffe/layers/noise_layer.cu
@@ -1,0 +1,55 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void NoiseLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  Dtype* top_data = top[0]->mutable_gpu_data();
+  const int count = bottom[0]->count();
+
+  CHECK(top[0]->count());
+  // If we are noising in-place, then put the generated noise in the layer's
+  // buffer. Otherwise, put it directly into the top blob.
+  Dtype* noise_buffer = Inplace() ? inplace_noise_.mutable_gpu_data() :
+                                    top_data;
+  if (NoiseType() == GAUSSIAN) {
+    caffe_gpu_rng_gaussian<Dtype>(count,
+        Dtype(FillerParam().mean()),
+        Dtype(FillerParam().std()),
+        noise_buffer);
+  } else if (NoiseType() == UNIFORM) {
+    caffe_gpu_rng_uniform(count,
+        Dtype(FillerParam().min()),
+        Dtype(FillerParam().max()),
+        noise_buffer);
+  } else {
+    LOG(FATAL) << "Unexpected noise type in NoiseLayer.";
+  }
+  caffe_gpu_add(count, bottom_data, noise_buffer, top_data);
+}
+
+template <typename Dtype>
+void NoiseLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
+  if (bottom.empty()) {
+    return;
+  }
+  // Only copy the top diffs to bottom if we are not noising in-place.
+  if (propagate_down[0] && !Inplace()) {
+    const Dtype* top_diff = top[0]->cpu_diff();
+    Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+    caffe_copy(top[0]->count(), top_diff, bottom_diff);
+    CUDA_POST_KERNEL_CHECK;
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(NoiseLayer);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -301,7 +301,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 139 (last added: tile_param)
+// LayerParameter next available layer-specific ID: 140 (last added: noise_param)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -385,6 +385,7 @@ message LayerParameter {
   optional ThresholdParameter threshold_param = 128;
   optional TileParameter tile_param = 138;
   optional WindowDataParameter window_data_param = 129;
+  optional NoiseParameter noise_param = 139;
 }
 
 // Message that stores parameters used to apply transformation
@@ -715,6 +716,12 @@ message MVNParameter {
 
   // Epsilon for not dividing by zero while normalizing variance
   optional float eps = 3 [default = 1e-9];
+}
+
+message NoiseParameter {
+  // This parameter must be set to specify the kind of noise to be generated.
+  // Gaussian and Uniform noise are the only supported types.
+  optional FillerParameter filler_param = 1;
 }
 
 message PoolingParameter {

--- a/src/caffe/test/test_noise_layer.cpp
+++ b/src/caffe/test/test_noise_layer.cpp
@@ -1,0 +1,351 @@
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/neuron_layers.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "google/protobuf/text_format.h"
+
+namespace caffe {
+
+template <typename TypeParam>
+class NoiseLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  NoiseLayerTest()
+    : blob_bottom_(new Blob<Dtype>(5, 40, 5, 6)),
+      blob_top_(new Blob<Dtype>()) {
+    // fill the values
+    FillerParameter filler_param;
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_);
+    blob_bottom_vec_.push_back(blob_bottom_);
+    blob_top_vec_.push_back(blob_top_);
+    blob_inplace_top_vec_.push_back(blob_bottom_);
+  }
+
+  virtual ~NoiseLayerTest() { delete blob_bottom_; delete blob_top_; }
+
+  // We can't use the GradientChecker since it checks by numerically computing
+  // gradient using finite differences, and the forward prop noise added by
+  // NoiseLayer should not have any effect the gradient backprop.
+  // The behavior we want is to just pass the diffs through from top to bottom.
+  void RunBackwardTest(const std::string& layer_param_string, bool in_place) {
+    typedef typename TypeParam::Dtype Dtype;
+
+    LayerParameter layer_param;
+    CHECK(google::protobuf::TextFormat::ParseFromString(layer_param_string,
+                                                        &layer_param));
+    NoiseLayer<Dtype> layer(layer_param);
+    std::vector<bool> prop_down;
+    prop_down.push_back(true);
+
+    // Put some diffs in the top blob.
+    Blob<Dtype> top_diffs;
+    top_diffs.ReshapeLike(*this->blob_bottom_);
+    for (int i = 0; i < this->blob_top_->count(); ++i) {
+      top_diffs.mutable_cpu_data()[i] = static_cast<Dtype>(i);
+    }
+    if (in_place) {
+      this->blob_inplace_top_vec_[0]->CopyFrom(top_diffs, true, true);
+      layer.Backward(this->blob_inplace_top_vec_, prop_down,
+                     this->blob_bottom_vec_);
+    } else {
+      this->blob_top_vec_[0]->CopyFrom(top_diffs, true, true);
+      layer.Backward(this->blob_top_vec_, prop_down,
+                     this->blob_bottom_vec_);
+    }
+
+    const Dtype TOLERANCE = 0.001;
+    // Bottom diffs should be the same as the diffs we created above.
+    CHECK_GT(this->blob_bottom_->count(), 0);
+    for (int i = 0; i < this->blob_bottom_->count(); ++i) {
+      EXPECT_NEAR(this->blob_bottom_->cpu_diff()[i], top_diffs.cpu_diff()[i],
+                  TOLERANCE);
+    }
+  }
+
+  void RunGaussianBackwardsTest(bool inplace) {
+    typedef typename TypeParam::Dtype Dtype;
+    const Dtype NOISE_MEAN = static_cast<Dtype>(-0.5);
+    const Dtype NOISE_STD_DEV = static_cast<Dtype>(0.7);
+
+    LayerParameter layer_param;
+    std::stringstream ss;
+    ss << "noise_param { filler_param { type: 'gaussian' mean: "
+       << NOISE_MEAN << " std:" << NOISE_STD_DEV << "} }";
+    bool in_place = false;
+    this->RunBackwardTest(ss.str(), in_place);
+  }
+
+  void RunUniformBackwardsTest(bool inplace) {
+    typedef typename TypeParam::Dtype Dtype;
+    const float NOISE_MIN = static_cast<Dtype>(-0.5);
+    const float NOISE_MAX = static_cast<Dtype>(0.2);
+    LayerParameter layer_param;
+    std::stringstream ss;
+    ss << "noise_param { filler_param { type: 'uniform' min: " << NOISE_MIN <<
+          " max:" << NOISE_MAX << "} }";
+    bool in_place = false;
+    this->RunBackwardTest(ss.str(), in_place);
+  }
+
+  Blob<Dtype>* const blob_bottom_;
+  Blob<Dtype>* const blob_top_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+  vector<Blob<Dtype>*> blob_inplace_top_vec_;
+};
+
+TYPED_TEST_CASE(NoiseLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(NoiseLayerTest, TestForwardGaussian) {
+  typedef typename TypeParam::Dtype Dtype;
+  const Dtype NOISE_MEAN = static_cast<Dtype>(-0.5);
+  const Dtype NOISE_STD_DEV = static_cast<Dtype>(0.7);
+
+  LayerParameter layer_param;
+  std::stringstream ss;
+  ss << "noise_param{ filler_param { type: 'gaussian' mean: " << NOISE_MEAN <<
+        " std:" << NOISE_STD_DEV << "} }";
+  CHECK(google::protobuf::TextFormat::ParseFromString(ss.str(), &layer_param));
+  NoiseLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+
+  // Check top shape.
+  EXPECT_EQ(this->blob_top_->num(), this->blob_bottom_->num());
+  EXPECT_EQ(this->blob_top_->channels(), this->blob_bottom_->channels());
+  EXPECT_EQ(this->blob_top_->height(), this->blob_bottom_->height());
+  EXPECT_EQ(this->blob_top_->width(), this->blob_bottom_->width());
+
+  // Compute the mean and variance of the noise that was added to the bottom
+  // blob.
+  Dtype mean = static_cast<Dtype>(0.0);
+  Dtype var = static_cast<Dtype>(0.0);
+  for (int n = 0; n < this->blob_bottom_->num(); ++n) {
+    for (int c = 0; c < this->blob_bottom_->channels(); ++c) {
+      for (int h = 0; h < this->blob_bottom_->height(); ++h) {
+        for (int w = 0; w < this->blob_bottom_->width(); ++w) {
+          int offset = this->blob_bottom_->offset(n, c, h, w);
+          Dtype delta =  this->blob_top_->cpu_data()[offset] -
+                          this->blob_bottom_->cpu_data()[offset];
+          mean += delta;
+          var += delta*delta;
+        }
+      }
+    }
+  }
+
+  mean /= this->blob_bottom_->count();
+  var /= this->blob_bottom_->count();
+  var -= mean*mean;
+  Dtype std_dev = std::sqrt(var);
+  const Dtype kErrorBound = NOISE_STD_DEV/10.0;
+  // Computed mean and variance should match what we specified as the noise
+  // layer's parameter.
+  EXPECT_NEAR(mean, NOISE_MEAN, kErrorBound);
+  EXPECT_NEAR(std_dev, NOISE_STD_DEV, kErrorBound);
+}
+
+TYPED_TEST(NoiseLayerTest, TestForwardUniform) {
+  typedef typename TypeParam::Dtype Dtype;
+  const float NOISE_MIN = static_cast<Dtype>(-0.5);
+  const float NOISE_MAX = static_cast<Dtype>(0.2);
+
+  LayerParameter layer_param;
+  std::stringstream ss;
+  ss << "noise_param{ filler_param { type: 'uniform' min: "
+     << NOISE_MIN << " max:" << NOISE_MAX << "} }";
+  CHECK(google::protobuf::TextFormat::ParseFromString(ss.str(), &layer_param));
+  NoiseLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+
+  // Check top shape.
+  EXPECT_EQ(this->blob_top_->num(), this->blob_bottom_->num());
+  EXPECT_EQ(this->blob_top_->channels(), this->blob_bottom_->channels());
+  EXPECT_EQ(this->blob_top_->height(), this->blob_bottom_->height());
+  EXPECT_EQ(this->blob_top_->width(), this->blob_bottom_->width());
+
+  int positive_noise_count = 0;
+  int negative_noise_count = 0;
+  for (int n = 0; n < this->blob_bottom_->num(); ++n) {
+    for (int c = 0; c < this->blob_bottom_->channels(); ++c) {
+      for (int h = 0; h < this->blob_bottom_->height(); ++h) {
+        for (int w = 0; w < this->blob_bottom_->width(); ++w) {
+          int offset = this->blob_bottom_->offset(n, c, h, w);
+          float noise_middle = (NOISE_MIN + NOISE_MAX) / 2.0f;
+
+          // delta is the value that we added to the bottom blob
+          // to produce the top blob.
+          Dtype delta =  this->blob_top_->cpu_data()[offset] -
+                          this->blob_bottom_->cpu_data()[offset];
+
+          if (delta < noise_middle) {
+            negative_noise_count++;
+          } else if (delta > noise_middle) {
+            positive_noise_count++;
+          }
+          // All of the noise values should be between NOISE_MIN and NOISE_MAX.
+          EXPECT_GE(delta, NOISE_MIN);
+          EXPECT_LE(delta, NOISE_MAX);
+        }
+      }
+    }
+  }
+
+  float total_noise_count = negative_noise_count + positive_noise_count;
+  float positive_noise_ratio = positive_noise_count / total_noise_count;
+  float negative_noise_ratio = negative_noise_count / total_noise_count;
+
+  // Sanity check that we didn't fall through the loops without testing
+  // anything.
+  EXPECT_GT(total_noise_count, 10.0f);
+  // Approx half the top values should be greater than the bottom val,
+  // and approx half less than the bottom val.
+  EXPECT_NEAR(negative_noise_ratio, 0.5f, 0.1f);
+  EXPECT_NEAR(positive_noise_ratio, 0.5f, 0.1f);
+}
+
+TYPED_TEST(NoiseLayerTest, TestForwardGaussianInplace) {
+  typedef typename TypeParam::Dtype Dtype;
+  const Dtype NOISE_MEAN = static_cast<Dtype>(-0.5);
+  const Dtype NOISE_STD_DEV = static_cast<Dtype>(0.7);
+
+  // We are noising inplace, so copy the original bottom blob before it gets
+  // changed.
+  Blob<Dtype> orig_bottom;
+  orig_bottom.CopyFrom(*this->blob_bottom_, false, true);
+
+  LayerParameter layer_param;
+  std::stringstream ss;
+  ss << "noise_param{ filler_param { type: 'gaussian' mean: " << NOISE_MEAN <<
+        " std:" << NOISE_STD_DEV << "} }";
+  CHECK(google::protobuf::TextFormat::ParseFromString(ss.str(), &layer_param));
+  NoiseLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_inplace_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_inplace_top_vec_);
+
+  // Compute the mean and variance of the noise that was added to the bottom
+  // blob.
+  Dtype mean = static_cast<Dtype>(0.0);
+  Dtype var = static_cast<Dtype>(0.0);
+  for (int n = 0; n < this->blob_bottom_->num(); ++n) {
+    for (int c = 0; c < this->blob_bottom_->channels(); ++c) {
+      for (int h = 0; h < this->blob_bottom_->height(); ++h) {
+        for (int w = 0; w < this->blob_bottom_->width(); ++w) {
+          int offset = this->blob_bottom_->offset(n, c, h, w);
+          // inplace, so bottom blob is also the top blob.
+          // delta is the value that we added to the bottom blob
+          // to produce the top blob.
+          Dtype delta =  this->blob_bottom_->cpu_data()[offset] -
+                          orig_bottom.cpu_data()[offset];
+          mean += delta;
+          var += delta*delta;
+        }
+      }
+    }
+  }
+
+  mean /= this->blob_bottom_->count();
+  var /= this->blob_bottom_->count();
+  var -= mean*mean;
+  Dtype std_dev = std::sqrt(var);
+  const Dtype kErrorBound = NOISE_STD_DEV/10.0;
+  // Computed mean and variance should match what we specified as the noise
+  // layer's parameter.
+  EXPECT_NEAR(mean, NOISE_MEAN, kErrorBound);
+  EXPECT_NEAR(std_dev, NOISE_STD_DEV, kErrorBound);
+}
+
+
+TYPED_TEST(NoiseLayerTest, TestForwardUniformInplace) {
+  typedef typename TypeParam::Dtype Dtype;
+  const float NOISE_MIN = static_cast<Dtype>(-0.5);
+  const float NOISE_MAX = static_cast<Dtype>(0.2);
+
+  // We are noising inplace, so copy the original bottom blob before it gets
+  // changed.
+  Blob<Dtype> orig_bottom;
+  orig_bottom.CopyFrom(*this->blob_bottom_, false, true);
+
+  LayerParameter layer_param;
+  std::stringstream ss;
+  ss << "noise_param{ filler_param { type: 'uniform' min: "
+     << NOISE_MIN << " max:" << NOISE_MAX << "} }";
+  CHECK(google::protobuf::TextFormat::ParseFromString(ss.str(), &layer_param));
+  NoiseLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_inplace_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_inplace_top_vec_);
+
+  int positive_noise_count = 0;
+  int negative_noise_count = 0;
+  for (int n = 0; n < this->blob_bottom_->num(); ++n) {
+    for (int c = 0; c < this->blob_bottom_->channels(); ++c) {
+      for (int h = 0; h < this->blob_bottom_->height(); ++h) {
+        for (int w = 0; w < this->blob_bottom_->width(); ++w) {
+          int offset = this->blob_bottom_->offset(n, c, h, w);
+          float noise_middle = (NOISE_MIN + NOISE_MAX) / 2.0f;
+
+          // inplace, so bottom blob is also the top blob.
+          // delta is the value that we added to the bottom blob
+          // to produce the top blob.
+          Dtype delta =  this->blob_bottom_->cpu_data()[offset] -
+                          orig_bottom.cpu_data()[offset];
+
+          if (delta < noise_middle) {
+            negative_noise_count++;
+          } else if (delta > noise_middle) {
+            positive_noise_count++;
+          }
+          // All of the noise values should be between NOISE_MIN and NOISE_MAX.
+          EXPECT_GE(delta, NOISE_MIN);
+          EXPECT_LE(delta, NOISE_MAX);
+        }
+      }
+    }
+  }
+
+  float total_noise_count = negative_noise_count + positive_noise_count;
+  float positive_noise_ratio = positive_noise_count / total_noise_count;
+  float negative_noise_ratio = negative_noise_count / total_noise_count;
+
+  // Sanity check that we didn't fall through the loops without testing
+  // anything.
+  EXPECT_GT(total_noise_count, 10.0f);
+  // Approx half the top values should be greater than the bottom val,
+  // and approx half less than the bottom val.
+  EXPECT_NEAR(negative_noise_ratio, 0.5f, 0.1f);
+  EXPECT_NEAR(positive_noise_ratio, 0.5f, 0.1f);
+}
+
+TYPED_TEST(NoiseLayerTest, TestGradientGaussian) {
+  bool in_place = false;
+  this->RunGaussianBackwardsTest(in_place);
+}
+
+TYPED_TEST(NoiseLayerTest, TestGradientUniform) {
+  bool in_place = false;
+  this->RunUniformBackwardsTest(in_place);
+}
+
+TYPED_TEST(NoiseLayerTest, TestGradientGaussianInPlace) {
+  bool in_place = true;
+  this->RunGaussianBackwardsTest(in_place);
+}
+
+TYPED_TEST(NoiseLayerTest, TestGradientUniformInPlace) {
+  bool in_place = true;
+  this->RunUniformBackwardsTest(in_place);
+}
+
+
+}  // namespace caffe


### PR DESCRIPTION
This PR adds a new layer type `NoiseLayer`. It can be used in a strategy that requires adding noise to a blob, e.g. de-noising autoencoders, [target prop (with corruption)](http://arxiv.org/abs/1407.7906), ["dither" as it is called here](http://arxiv.org/abs/1508.04826).

Example usage is a layer like this used to add gaussian noise to the blob `data`. Top and bottom blobs can be the same for in-place noising, or they can be different.

```
layer {
  name: "noise"
  type: "Noise"
  bottom: "data"
  top: "data"
  include {
    phase: TRAIN
  }
  noise_param {
    filler_param {
      type: "gaussian"
      mean: 0
      std: 0.5
    }
  }
}
```

I also considered having the noise layer generate a top blob, and EltWise layer to add it in, but that ends up using more memory because you end up with 3 blobs whereas 2 this way (or 1.5 with in-place noise).

