### PR TITLE
added the chance to open an existing DB in tools/convert_imageset.cpp

### DIFF
--- a/tools/convert_imageset.cpp
+++ b/tools/convert_imageset.cpp
@@ -89,9 +89,12 @@ int main(int argc, char** argv) {
   int resize_height = std::max<int>(0, FLAGS_resize_height);
   int resize_width = std::max<int>(0, FLAGS_resize_width);
 
-  // Create new DB
+  // Create new DB or open an existing one
   scoped_ptr<db::DB> db(db::GetDB(FLAGS_backend));
-  db->Open(argv[3], db::NEW);
+  if (std::ifstream(argv[3]))
+    db->Open(argv[3], db::WRITE);
+  else
+    db->Open(argv[3], db::NEW);
   scoped_ptr<db::Transaction> txn(db->NewTransaction());
 
   // Storing to db


### PR DESCRIPTION
I added the chance to open an existing DB in tools/convert_imaset.cpp. This allow to run the program for different batches of the same dataset, and in different moments. 

Before my change,  if the DB name that you pass like parameter doesn't exist, the program created the DB. But if the DB already existed, the program complain and did nothing.

Now, if the DB already exist, the program open that DB and add the image set to that, without destroy anything. That help me a lot, and i think that might be useful for others.