### PR TITLE
Check that the snapshot directory is writeable before starting training

### DIFF
--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -82,6 +82,8 @@ class Solver {
     callbacks_.push_back(value);
   }
 
+  void CheckSnapshotWritePermissions();
+
  protected:
   // Make and apply the update value for the current iteration.
   virtual void ApplyUpdate() = 0;


### PR DESCRIPTION
When training, if a snapshot cannot be written (directory does not exist, or insufficient permissions, or invalid snapshot prefix), a lot of time can potentially be lost waiting for the error.  This tries to open an empty test file (and delete it) before training starts, so that failure happens as soon as possible.

This does not check for disk space, but usually that's a problem for later in training.