### PR TITLE
Confusion Matrix

### DIFF
--- a/README_confusion_matrix.md
+++ b/README_confusion_matrix.md
@@ -1,0 +1,19 @@
+# Confusion Matrix Layer
+Written by *Boris Ginsburg*
+
+Loss layer, which  produces [Confusion Matrix](https://en.wikipedia.org/wiki/Confusion_matrix).
+ - input : the same as all loss layers
+ - output: 2D Matrix (*Blob*)
+
+Sources:
+ - include/caffe/loss_layers.hpp: added ConfusionMatrix Layer
+ - src/caffe/layers/confusion_matrix_layer.cpp
+ - src/caffe/test/test_confusion_matrix_layer.cpp: tests
+ - src/caffe/proto/caffe.proto:  added proto parameters
+ - src/caffe/solver.cpp: modifed *Solver::Test(.)* to support layers with 2D output
+ - plot_conf_matrix.py: visualization
+
+Example:
+ - examples/cifar10/cifar10_cm_solver.prototxt
+ - examples/cifar10/cifar10_cm_train_test.prototxt
+ - examples/cifar10/train_cm.sh

--- a/examples/cifar10/cifar10_cm_solver.prototxt
+++ b/examples/cifar10/cifar10_cm_solver.prototxt
@@ -1,0 +1,26 @@
+# The train/test net protocol buffer definition
+net: "examples/cifar10/cifar10_cm_train_test.prototxt"
+# test_iter specifies how many forward passes the test should carry out.
+# In the case of MNIST, we have test batch size 100 and 100 test iterations,
+# covering the full 10,000 testing images.
+test_iter: 100
+# Carry out testing every 500 training iterations.
+test_interval: 500
+# The base learning rate, momentum and the weight decay of the network.
+base_lr: 0.001
+momentum: 0.9
+weight_decay: 0.004
+# The learning rate policy: reduce lr after 5000 iters(10 epochs) by 5x
+lr_policy: "multistep"
+stepvalue: 5000
+stepvalue: 10000
+gamma: 0.2
+# Display every 100 iterations
+display: 100
+# The maximum number of iterations
+max_iter: 15000
+# snapshot intermediate results
+#sapshot: 10000
+#snapshot_prefix: "examples/cifar10/cifar10_quick"
+# solver mode: CPU or GPU
+solver_mode: GPU

--- a/examples/cifar10/cifar10_cm_train_test.prototxt
+++ b/examples/cifar10/cifar10_cm_train_test.prototxt
@@ -1,0 +1,232 @@
+name: "CIFAR10_quick"
+layer {
+  name: "cifar"
+  type: "Data"
+  top: "data"
+  top: "label"
+  include {
+    phase: TRAIN
+  }
+  transform_param {
+    mean_file: "examples/cifar10/mean.binaryproto"
+  }
+  data_param {
+    source: "examples/cifar10/cifar10_train_lmdb"
+    batch_size: 100
+    backend: LMDB
+  }
+}
+layer {
+  name: "cifar"
+  type: "Data"
+  top: "data"
+  top: "label"
+  include {
+    phase: TEST
+  }
+  transform_param {
+    mean_file: "examples/cifar10/mean.binaryproto"
+  }
+  data_param {
+    source: "examples/cifar10/cifar10_test_lmdb"
+    batch_size: 100
+    backend: LMDB
+  }
+}
+layer {
+  name: "conv1"
+  type: "Convolution"
+  bottom: "data"
+  top: "conv1"
+  param {
+    lr_mult: 1
+  }
+  param {
+    lr_mult: 2
+  }
+  convolution_param {
+    num_output: 32
+    pad: 2
+    kernel_size: 5
+    stride: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.0001
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "pool1"
+  type: "Pooling"
+  bottom: "conv1"
+  top: "pool1"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layer {
+  name: "relu1"
+  type: "ReLU"
+  bottom: "pool1"
+  top: "pool1"
+}
+layer {
+  name: "conv2"
+  type: "Convolution"
+  bottom: "pool1"
+  top: "conv2"
+  param {
+    lr_mult: 1
+  }
+  param {
+    lr_mult: 2
+  }
+  convolution_param {
+    num_output: 32
+    pad: 2
+    kernel_size: 5
+    stride: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "relu2"
+  type: "ReLU"
+  bottom: "conv2"
+  top: "conv2"
+}
+layer {
+  name: "pool2"
+  type: "Pooling"
+  bottom: "conv2"
+  top: "pool2"
+  pooling_param {
+    pool: AVE
+    kernel_size: 3
+    stride: 2
+  }
+}
+layer {
+  name: "conv3"
+  type: "Convolution"
+  bottom: "pool2"
+  top: "conv3"
+  param {
+    lr_mult: 1
+  }
+  param {
+    lr_mult: 2
+  }
+  convolution_param {
+    num_output: 64
+    pad: 2
+    kernel_size: 5
+    stride: 1
+    weight_filler {
+      type: "gaussian"
+      std: 0.01
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "relu3"
+  type: "ReLU"
+  bottom: "conv3"
+  top: "conv3"
+}
+layer {
+  name: "pool3"
+  type: "Pooling"
+  bottom: "conv3"
+  top: "pool3"
+  pooling_param {
+    pool: AVE
+    kernel_size: 3
+    stride: 2
+  }
+}
+layer {
+  name: "ip1"
+  type: "InnerProduct"
+  bottom: "pool3"
+  top: "ip1"
+  param {
+    lr_mult: 1
+  }
+  param {
+    lr_mult: 2
+  }
+  inner_product_param {
+    num_output: 64
+    weight_filler {
+      type: "gaussian"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "ip2"
+  type: "InnerProduct"
+  bottom: "ip1"
+  top: "ip2"
+  param {
+    lr_mult: 1
+  }
+  param {
+    lr_mult: 2
+  }
+  inner_product_param {
+    num_output: 10
+    weight_filler {
+      type: "gaussian"
+      std: 0.1
+    }
+    bias_filler {
+      type: "constant"
+    }
+  }
+}
+layer {
+  name: "accuracy"
+  type: "Accuracy"
+  bottom: "ip2"
+  bottom: "label"
+  top: "accuracy"
+  include {
+    phase: TEST
+  }
+}
+layer {
+  name: "loss"
+  type: "SoftmaxWithLoss"
+  bottom: "ip2"
+  bottom: "label"
+  top: "loss"
+}
+layer {
+  name: "confusion_matrix"
+  type: "ConfusionMatrix"
+  bottom: "ip2"
+  bottom: "label"
+  top: "confusion_matrix"
+  include {
+    phase: TEST
+  }
+}

--- a/examples/cifar10/train_cm.sh
+++ b/examples/cifar10/train_cm.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+./build/tools/caffe train \
+  --solver=examples/cifar10/cifar10_cm_solver.prototxt --gpu=all 2>&1 | tee examples/cifar10/cifar10_cm_log.txt
+

--- a/include/caffe/loss_layers.hpp
+++ b/include/caffe/loss_layers.hpp
@@ -768,6 +768,59 @@ class SoftmaxWithLossLayer : public LossLayer<Dtype> {
   int softmax_axis_, outer_num_, inner_num_;
 };
 
+/**
+ * @brief Computes the confusion matrix for a one-of-many classification task.
+ */
+template <typename Dtype>
+class ConfusionMatrixLayer : public Layer<Dtype> {
+ public:
+  /**
+   * @param param provides ConfusionMatrixParameter confusion_matrix_param
+   */
+  explicit ConfusionMatrixLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "ConfusionMatrix"; }
+  virtual inline int ExactNumBottomBlobs() const { return 2; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  /**
+   * @param bottom input Blob vector (length 2)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the predictions @f$ x @f$, a Blob with values in
+   *      @f$ [-\infty, +\infty] @f$ indicating the predicted score for each of
+   *      the @f$ K = CHW @f$ classes. Each @f$ x_n @f$ is mapped to a predicted
+   *      label @f$ \hat{l}_n @f$ given by its maximal index:
+   *      @f$ \hat{l}_n = \arg\max\limits_k x_{nk} @f$
+   *   -# @f$ (N \times 1 \times 1 \times 1) @f$
+   *      the labels @f$ l @f$, an integer-valued Blob with values
+   *      @f$ l_n \in [0, 1, 2, ..., K - 1] @f$
+   *      indicating the correct class label among the @f$ K @f$ classes
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (K \times K \) @f$
+   *      
+   */
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  /// @brief Not implemented -- ConfusionMatrixLayer cannot be used as a loss.
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    for (int i = 0; i < propagate_down.size(); ++i) {
+      if (propagate_down[i]) { NOT_IMPLEMENTED; }
+    }
+  }
+
+  int label_axis_, outer_num_, inner_num_;
+  int num_classes_;
+  Blob<Dtype> confusion_matrix_;
+};
+
 }  // namespace caffe
 
 #endif  // CAFFE_LOSS_LAYERS_HPP_

--- a/plot_conf_matrix.py
+++ b/plot_conf_matrix.py
@@ -1,0 +1,65 @@
+#!/home/bginsburg/anaconda/bin/python
+
+"""Extract confusion matrix from log file
+   usage: file.log
+   
+"""
+
+import sys
+import re
+import os
+import math
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+import numpy as np
+
+#--------------------------------------------------------------------
+def extract_confusion_matrix(filename):
+  f=open(filename,'r')
+  openFile = f.read()
+  iteration = re.findall(r'Iteration (\d*), Testing net \(#0\)', openFile)
+  print iteration
+  numLabels = re.findall(r'Test net output #\d*: confusion_matrix \[(\d*)', openFile) 
+  numClasses=int(numLabels[0])
+  #print numClasses
+  class_prob = re.findall(r'       confusion_matrix    \d*: ([d*.\d*  ]*)', openFile)
+  print class_prob
+  temp=[]
+  for i in range(len(class_prob)) :
+    temp.append(map(float, class_prob[i].split()))
+  temp2=np.array(temp)
+
+  dim=temp2.shape
+  temp3= temp2.reshape(dim[0]/ dim[1], dim[1], dim[1])
+  print temp3.shape
+  print temp3[-1]
+  return temp3 
+
+#----------------------------------------------------------------------
+def main():
+  # command-line parsing
+  filename = sys.argv[1]
+  if not filename:
+    print 'usage: file.log '
+    sys.exit(1)
+ 
+  cm = extract_confusion_matrix(filename)
+  
+  fig = plt.figure()
+  num_steps = cm.shape[0]
+  print num_steps
+  cmap=plt.cm.brg
+  ims = []
+  for i in range(num_steps):
+    plt.title('Num of steps: ' + str(i))
+    ims.append((plt.imshow(cm[i],interpolation='nearest', cmap=cmap ),))
+   
+  im_ani = animation.ArtistAnimation(fig, ims, interval=1000, repeat_delay=100000, blit=True)   
+  plt.colorbar()
+  plt.ylabel('True label')
+  plt.xlabel('Predicted label')
+  plt.show()
+  
+  
+if __name__ == '__main__':
+  main()

--- a/src/caffe/layers/confusion_matrix_layer.cpp
+++ b/src/caffe/layers/confusion_matrix_layer.cpp
@@ -1,0 +1,91 @@
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/vision_layers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void ConfusionMatrixLayer<Dtype>::LayerSetUp(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+}
+
+template <typename Dtype>
+void ConfusionMatrixLayer<Dtype>::Reshape(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  label_axis_ = bottom[0]->CanonicalAxisIndex(
+                  this->layer_param_.confusion_matrix_param().axis());
+  outer_num_ = bottom[0]->count(0, label_axis_);
+  inner_num_ = bottom[0]->count(label_axis_ + 1);
+  num_classes_ = bottom[0]->shape(label_axis_);
+  CHECK_EQ(outer_num_ * inner_num_, bottom[1]->count())
+      << "Number of labels must match number of channels in bottom[0]";
+  vector<int> confusion_dim(2, num_classes_);
+  top[0]->Reshape(confusion_dim);
+  confusion_matrix_.Reshape(confusion_dim);
+}
+
+template <typename Dtype>
+void ConfusionMatrixLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  const Dtype* bottom_label = bottom[1]->cpu_data();
+  const int dim = bottom[0]->count() / outer_num_;
+
+  caffe_set(confusion_matrix_.count(), Dtype(0),
+            confusion_matrix_.mutable_cpu_data());
+  caffe_set(top[0]->count(), Dtype(0), top[0]->mutable_cpu_data());
+
+  Dtype max_val = -1.;
+  int max_id = 0;
+  int count = 0;
+  for (int i = 0; i < outer_num_; ++i) {
+    for (int j = 0; j < inner_num_; ++j) {
+      const int label_value =
+          static_cast<int>(bottom_label[i * inner_num_ + j]);
+      DCHECK_GE(label_value, 0);
+      DCHECK_LT(label_value, num_classes_);
+
+      max_id = 0;
+      max_val = -1.;
+      for (int k = 0; k < num_classes_; ++k) {
+        if (bottom_data[i * dim + k * inner_num_ + j] > max_val) {
+          max_val = bottom_data[i * dim + k * inner_num_ + j];
+          max_id = k;
+        }
+      }
+      int predicted_class = max_id;
+      DCHECK_GE(predicted_class, 0);
+      DCHECK_LT(predicted_class, num_classes_);
+      confusion_matrix_.mutable_cpu_data()[label_value * num_classes_
+                                           + predicted_class] += 1;
+      ++count;
+    }
+  }
+
+  int num_image_per_class = 0;
+  for (int i = 0; i < num_classes_; ++i) {
+    num_image_per_class = 0;
+    int base= i * num_classes_;
+    for (int j = 0; j < num_classes_; ++j) {
+      num_image_per_class = num_image_per_class
+                            + confusion_matrix_.cpu_data()[base +j];
+    }
+    for (int j = 0; j < num_classes_; ++j) {
+      Dtype value = confusion_matrix_.cpu_data()[base + j]
+                    / ((Dtype) num_image_per_class);
+      top[0]->mutable_cpu_data()[base + j] = value;
+    }
+  }
+}
+
+INSTANTIATE_CLASS(ConfusionMatrixLayer);
+REGISTER_LAYER_CLASS(ConfusionMatrix);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -351,6 +351,7 @@ message LayerParameter {
   optional AccuracyParameter accuracy_param = 102;
   optional ArgMaxParameter argmax_param = 103;
   optional ConcatParameter concat_param = 104;
+  optional ConfusionMatrixParameter confusion_matrix_param = 140;
   optional ContrastiveLossParameter contrastive_loss_param = 105;
   optional ConvolutionParameter convolution_param = 106;
   optional DataParameter data_param = 107;
@@ -385,6 +386,7 @@ message LayerParameter {
   optional ThresholdParameter threshold_param = 128;
   optional TileParameter tile_param = 138;
   optional WindowDataParameter window_data_param = 129;
+
 }
 
 // Message that stores parameters used to apply transformation
@@ -454,6 +456,15 @@ message ConcatParameter {
 
   // DEPRECATED: alias for "axis" -- does not support negative indexing.
   optional uint32 concat_dim = 1 [default = 1];
+}
+
+message ConfusionMatrixParameter {
+  // The "label" axis of the prediction blob, whose argmax corresponds to the
+  // predicted label -- may be negative to index from the end (e.g., -1 for the
+  // last axis).  For example, if axis == 1 and the predictions are
+  // (N x C x H x W), the label blob is expected to contain N*H*W ground truth
+  // labels with integer values in {0, 1, ..., C-1}.
+  optional int32 axis = 1 [default = 1];
 }
 
 message ContrastiveLossParameter {

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -347,6 +347,144 @@ void Solver<Dtype>::Test(const int test_net_id) {
             << ", Testing net (#" << test_net_id << ")";
   CHECK_NOTNULL(test_nets_[test_net_id].get())->
       ShareTrainedLayersWith(net_.get());
+//   vector<Dtype> test_score;
+  vector<Blob<Dtype>* > test_score;
+  vector<int> test_score_output_id;
+  vector<Blob<Dtype>*> bottom_vec;
+  const shared_ptr<Net<Dtype> >& test_net = test_nets_[test_net_id];
+  Dtype loss = 0;
+  for (int i = 0; i < param_.test_iter(test_net_id); ++i) {
+    SolverAction::Enum request = GetRequestedAction();
+    // Check to see if stoppage of testing/training has been requested.
+    while (request != SolverAction::NONE) {
+        if (SolverAction::SNAPSHOT == request) {
+          Snapshot();
+        } else if (SolverAction::STOP == request) {
+          requested_early_exit_ = true;
+        }
+        request = GetRequestedAction();
+    }
+    if (requested_early_exit_) {
+      // break out of test loop.
+      break;
+    }
+
+    Dtype iter_loss;
+    const vector<Blob<Dtype>*>& result =
+        test_net->Forward(bottom_vec, &iter_loss);
+    if (param_.test_compute_loss()) {
+      loss += iter_loss;
+    }
+    int num_results = result.size();
+    test_score.resize(num_results);
+    if (i == 0) {
+      for (int j = 0; j < result.size(); ++j) {
+        const Dtype* result_vec = result[j]->cpu_data();
+        test_score[j] = new Blob<Dtype>;
+        test_score[j]->Reshape(result[j]->shape());
+        const int output_blob_index = test_net->output_blob_indices()[j];
+        const string& output_name = test_net->blob_names()[output_blob_index];
+        DLOG(INFO) << "Test net " << test_net_id
+                  << " output: " << j << " " << output_name
+                  << " dim=" << result[j]-> shape().size()
+                  << " size="<< result[j]-> count();
+        for (int k = 0; k < result[j]->count(); ++k) {
+          test_score[j]->mutable_cpu_data()[k]=result_vec[k];
+        }
+        test_score_output_id.push_back(j);
+        // for (int k = 0; k < result[j]->count(); ++k) {
+        //   test_score.push_back(result_vec[k]);
+        //   test_score_output_id.push_back(j);
+        // }
+      }
+    } else {
+      // int idx = 0;
+      for (int j = 0; j < result.size(); ++j) {
+        const Dtype* result_vec = result[j]->cpu_data();
+        for (int k = 0; k < result[j]->count(); ++k) {
+        // test_score[idx++] += result_vec[k];
+          test_score[j]->mutable_cpu_data()[k] += result_vec[k];
+        }
+      }
+    }
+  }
+  if (requested_early_exit_) {
+    LOG(INFO)     << "Test interrupted.";
+    return;
+  }
+  // --- print to log test results --------------------------------------------
+  if (param_.test_compute_loss()) {
+    loss /= param_.test_iter(test_net_id);
+    LOG(INFO) << "Test loss: " << loss;
+  }
+  for (int i = 0; i < test_score.size(); ++i) {
+    const int output_blob_index =
+        test_net->output_blob_indices()[test_score_output_id[i]];
+    const string& output_name = test_net->blob_names()[output_blob_index];
+    const Dtype loss_weight = test_net->blob_loss_weights()[output_blob_index];
+    ostringstream loss_msg_stream;
+    if (test_score[i]->count() == 1) {
+      const Dtype mean_score =
+                  test_score[i]->cpu_data()[0] / param_.test_iter(test_net_id);
+      if (loss_weight) {
+        loss_msg_stream << " (* " << loss_weight
+                        << " = " << loss_weight * mean_score << " loss)";
+      }
+      LOG(INFO) << "    Test net output #" << i << ": " << output_name << " = "
+                << mean_score << loss_msg_stream.str();
+    } else if (test_score[i]->shape().size() == 1) {    //  0- or 1-D-vector
+      for (int j = 0; j < test_score[i]->count(); ++j) {
+        Dtype mean_score =
+              test_score[i]->cpu_data()[j] / param_.test_iter(test_net_id);
+        if (loss_weight)
+           mean_score = mean_score * loss_weight;
+        loss_msg_stream <<  mean_score << " ";
+      }
+      LOG(INFO) << "    Test net output #" << i << ": "
+                << output_name << " = " << loss_msg_stream.str();
+    } else if (test_score[i]->shape().size() == 2) {    // 2D - array
+      LOG(INFO) << "    Test net output #" << i << ": " << output_name
+                << " [" << test_score[i]->shape()[0] << "x"
+                << test_score[i]->shape()[1] << "]";
+      int num_rows = test_score[i]->shape()[0];
+      int num_columns = test_score[i]->shape()[1];
+      for (int j = 0; j < num_rows; ++j) {
+        ostringstream line_msg_stream;
+        line_msg_stream << "      " << output_name << " ";
+        line_msg_stream.width(4);
+        line_msg_stream << j << ": ";
+        for (int k = 0; k < num_columns; ++k) {
+          line_msg_stream.width(6);
+          line_msg_stream.precision(4);
+          line_msg_stream.setf(ostringstream::fixed);
+          line_msg_stream.setf(ostringstream::showpoint);
+          Dtype prob = test_score[i]->cpu_data()[j*num_columns + k] /
+                          param_.test_iter(test_net_id);
+          line_msg_stream << prob << "  ";
+        }
+        LOG(INFO) << line_msg_stream.str();
+      }
+    } else {
+      LOG(INFO) << "    Test net output #" << i << ": " << output_name
+                << test_score[i]->shape().size()
+                << "-d shape is not supported ";
+    }
+  }
+  // ------ free test_score ---------------------------------------------------
+  for (int i = 0; i < test_score.size(); ++i) {
+    delete test_score[i];
+  }
+  test_score.resize(0);
+}
+
+/*
+template <typename Dtype>
+void Solver<Dtype>::Test(const int test_net_id) {
+  CHECK(Caffe::root_solver());
+  LOG(INFO) << "Iteration " << iter_
+            << ", Testing net (#" << test_net_id << ")";
+  CHECK_NOTNULL(test_nets_[test_net_id].get())->
+      ShareTrainedLayersWith(net_.get());
   vector<Dtype> test_score;
   vector<int> test_score_output_id;
   vector<Blob<Dtype>*> bottom_vec;
@@ -415,6 +553,8 @@ void Solver<Dtype>::Test(const int test_net_id) {
               << mean_score << loss_msg_stream.str();
   }
 }
+
+*/
 
 template <typename Dtype>
 void Solver<Dtype>::Snapshot() {

--- a/src/caffe/test/test_confusion_matrix_layer.cpp
+++ b/src/caffe/test/test_confusion_matrix_layer.cpp
@@ -1,0 +1,123 @@
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/util/rng.hpp"
+#include "caffe/vision_layers.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+
+namespace caffe {
+
+template <typename Dtype>
+class ConfusionMatrixLayerTest : public CPUDeviceTest<Dtype> {
+ protected:
+  ConfusionMatrixLayerTest()
+      : blob_bottom_data_(new Blob<Dtype>()),
+        blob_bottom_label_(new Blob<Dtype>()),
+        blob_top_(new Blob<Dtype>()) {
+    vector<int> shape(2);
+    shape[0] = 100;
+    shape[1] = 10;
+    blob_bottom_data_->Reshape(shape);
+    shape.resize(1);
+    blob_bottom_label_->Reshape(shape);
+    FillBottoms();
+
+    blob_bottom_vec_.push_back(blob_bottom_data_);
+    blob_bottom_vec_.push_back(blob_bottom_label_);
+    blob_top_vec_.push_back(blob_top_);
+  }
+
+  virtual void FillBottoms() {
+    // fill the probability values
+    FillerParameter filler_param;
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_data_);
+
+    const unsigned int prefetch_rng_seed = caffe_rng_rand();
+    shared_ptr<Caffe::RNG> rng(new Caffe::RNG(prefetch_rng_seed));
+    caffe::rng_t* prefetch_rng =
+          static_cast<caffe::rng_t*>(rng->generator());
+    Dtype* label_data = blob_bottom_label_->mutable_cpu_data();
+    for (int i = 0; i < blob_bottom_label_->count(); ++i) {
+      label_data[i] = (*prefetch_rng)() % 10;
+    }
+  }
+
+  virtual ~ConfusionMatrixLayerTest() {
+    delete blob_bottom_data_;
+    delete blob_bottom_label_;
+    delete blob_top_;
+  }
+
+  Blob<Dtype>* const blob_bottom_data_;
+  Blob<Dtype>* const blob_bottom_label_;
+  Blob<Dtype>* const blob_top_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(ConfusionMatrixLayerTest, TestDtypes);
+
+TYPED_TEST(ConfusionMatrixLayerTest, TestSetup) {
+  LayerParameter layer_param;
+  ConfusionMatrixLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  int label_axis = 1;
+  int num_classes = this->blob_bottom_vec_[0]->shape(label_axis);
+  EXPECT_EQ(num_classes, 10);
+  EXPECT_EQ(this->blob_top_->shape().size(), 2);
+  EXPECT_EQ(this->blob_top_->shape(0), num_classes);
+  EXPECT_EQ(this->blob_top_->shape(1), num_classes);
+}
+
+
+TYPED_TEST(ConfusionMatrixLayerTest, TestForwardCPU) {
+  LayerParameter layer_param;
+  ConfusionMatrixLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+
+  int num_classes = 10;
+  vector<int> shape(2, num_classes);
+  vector<float> confusion_matrix(num_classes*num_classes, 0.);
+  vector<int> num_tests_per_class(num_classes, 0);
+
+  TypeParam max_value;
+  int max_id;
+  for (int i = 0; i < 100; ++i) {
+    max_value = -FLT_MAX;
+    max_id = 0;
+    for (int j = 0; j < num_classes; ++j) {
+      if (this->blob_bottom_data_->data_at(i, j, 0, 0) > max_value) {
+        max_value = this->blob_bottom_data_->data_at(i, j, 0, 0);
+        max_id = j;
+      }
+    }
+    int label = this->blob_bottom_label_->data_at(i, 0, 0, 0);
+    num_tests_per_class[label]++;
+    confusion_matrix[label*num_classes + max_id] += 1.0;
+  }
+  for (int j = 0; j < num_classes; ++j)
+    if (num_tests_per_class[j] > 0) {
+      for (int k = 0; k < num_classes; ++k)
+        confusion_matrix[j*num_classes + k] =
+           confusion_matrix[j*num_classes + k] /
+           static_cast<float>(num_tests_per_class[j]);
+  }
+  // test output
+  for (int j = 0; j < num_classes; ++j)
+    for (int k = 0; k < num_classes; ++k) {
+      EXPECT_NEAR(this->blob_top_vec_[0]->cpu_data()[j*num_classes + k],
+        confusion_matrix[j*num_classes + k], 1e-4);
+    }
+}
+}  // namespace caffe


### PR DESCRIPTION
New layer, which produces Confusion Matrix (https://en.wikipedia.org/wiki/Confusion_matrix ):
- input: the same as for accuracy layer
- output: 2D matrix ( Blob) [CxC], where C is number of classes

I also modified Solver::Test()  to print 2D outputs of test net into log file.

The example of using new layer:  
- examples/cifar10/cifar_cm_train_test.prototxt

The example of Visualization of confusion matrix:
- plot_conf_matrrix.py
