### PR TITLE
Add opencv_imgcodecs to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ ifneq ($(CPU_ONLY), 1)
 endif
 LIBRARIES += glog gflags protobuf leveldb snappy \
 	lmdb boost_system hdf5_hl hdf5 m \
-	opencv_core opencv_highgui opencv_imgproc
+	opencv_core opencv_highgui opencv_imgproc opencv_imgcodecs
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare
 


### PR DESCRIPTION
opencv_imgcodecs needed for compilation (at least with OpenCV 3.0)