### PR TITLE
bug in caffe.io.resize_image when applied to images with 2 or >3 channels

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -329,7 +329,7 @@ def resize_image(im, new_dims, interp_order=1):
             return ret
     else:
         # ndimage interpolates anything but more slowly.
-        scale = tuple(np.array(new_dims) / np.array(im.shape[:2]))
+        scale = tuple(np.array(new_dims, dtype=float) / np.array(im.shape[:2]))
         resized_im = zoom(im, scale + (1,), order=interp_order)
     return resized_im.astype(np.float32)
 


### PR DESCRIPTION
When applying caffe.io.resize_image to an image that has neither 1 nor 3 channels, the scaling factor is incorrectly computed due to the use of integer division. 

Code for reproducing the bug:
```
import sys
caffe_root = #<CAFFE_ROOT>
sys.path.insert(0, caffe_root + 'python')
import caffe
im = caffe.io.load_image(caffe_root + 'examples/images/cat.jpg')
print "original RGB image shape:", im.shape                                          # (360, 480, 3)
print "resized RGB image shape:", caffe.io.resize_image(im, [100,100]).shape         # (100, 100, 3)
print "original RG image shape:", im[:,:,:2].shape                                   # (360, 480, 2)
print "resized RG image shape:", caffe.io.resize_image(im[:,:,:2], (100,100)).shape  # (0, 0, 2)
```