### PR TITLE
Get back 'USE CPU' print for caffe train

### DIFF
--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -174,6 +174,7 @@ int train() {
   vector<int> gpus;
   get_gpus(&gpus);
   if (gpus.size() == 0) {
+    LOG(INFO) << "Use CPU.";
     Caffe::set_mode(Caffe::CPU);
   } else {
     ostringstream s;


### PR DESCRIPTION
Get back the "Use CPU." output during caffe train (this was accidentally removed in #2903).