### PR TITLE
include IO dependencies by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,11 @@ endif
 
 LIBRARIES += glog gflags protobuf boost_system m hdf5_hl hdf5
 
+# handle IO dependencies
+USE_LEVELDB ?= 1
+USE_LMDB ?= 1
+USE_OPENCV ?= 1
+
 ifeq ($(USE_LEVELDB), 1)
 	LIBRARIES += leveldb snappy
 endif
@@ -299,7 +304,7 @@ ifeq ($(USE_CUDNN), 1)
 	COMMON_FLAGS += -DUSE_CUDNN
 endif
 
-# i/o libraries configuration
+# configure IO libraries
 ifeq ($(USE_OPENCV), 1)
 	COMMON_FLAGS += -DUSE_OPENCV
 endif

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -7,10 +7,10 @@
 # CPU-only switch (uncomment to build without GPU support).
 # CPU_ONLY := 1
 
-# comment out to disable IO dependencies
-USE_LEVELDB := 1
-USE_LMDB := 1
-USE_OPENCV := 1
+# uncomment to disable IO dependencies and corresponding data layers
+# USE_LEVELDB := 0
+# USE_LMDB := 0
+# USE_OPENCV := 0
 
 # To customize your choice of compiler, uncomment and set the following.
 # N.B. the default for Linux is g++ and the default for OSX is clang++


### PR DESCRIPTION
Follow-up to #2523: keep old behavior by including leveldb, lmdb, and opencv by
default.