### PR TITLE
Fix broken DeconvolutionLayer GPU backward caused by ND conv typo

### DIFF
--- a/src/caffe/layers/deconv_layer.cu
+++ b/src/caffe/layers/deconv_layer.cu
@@ -51,7 +51,7 @@ void DeconvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
         }
         // gradient w.r.t. bottom data, if necessary.
         if (propagate_down[i]) {
-          this->forward_gpu_gemm(top_diff + this->top_dim_, weight,
+          this->forward_gpu_gemm(top_diff + n * this->top_dim_, weight,
               bottom_diff + n * this->bottom_dim_,
               this->param_propagate_down_[0]);
         }


### PR DESCRIPTION
#2049 broke deconvolution GPU backward with a typo (https://github.com/BVLC/caffe/pull/2049/files#diff-5911f1d28796ada5f80449e8bd05d270R54 omits the `n *` coefficient). This PR fixes.

This should really really be covered by the tests, but this PR is just the fix for master.