### PR TITLE
Fix broken conv/deconv reshaping

### DIFF
--- a/include/caffe/vision_layers.hpp
+++ b/include/caffe/vision_layers.hpp
@@ -58,6 +58,10 @@ class BaseConvolutionLayer : public Layer<Dtype> {
   void backward_gpu_bias(Dtype* bias, const Dtype* input);
 #endif
 
+  /// @brief The spatial dimensions of the input.
+  inline int input_shape(int i) {
+    return (*bottom_shape_)[channel_axis_ + i];
+  }
   // reverse_dimensions should return true iff we are implementing deconv, so
   // that conv helpers know which dimensions are which.
   virtual bool reverse_dimensions() = 0;
@@ -72,12 +76,11 @@ class BaseConvolutionLayer : public Layer<Dtype> {
   Blob<int> pad_;
   /// @brief The spatial dimensions of the convolution input.
   Blob<int> conv_input_shape_;
-  /// @brief The spatial dimensions of the input.
-  Blob<int> input_shape_;
   /// @brief The spatial dimensions of the col_buffer.
   vector<int> col_buffer_shape_;
   /// @brief The spatial dimensions of the output.
   vector<int> output_shape_;
+  const vector<int>* bottom_shape_;
 
   int num_spatial_axes_;
   int bottom_dim_;

--- a/src/caffe/layers/conv_layer.cpp
+++ b/src/caffe/layers/conv_layer.cpp
@@ -10,14 +10,13 @@ namespace caffe {
 
 template <typename Dtype>
 void ConvolutionLayer<Dtype>::compute_output_shape() {
-  // input_shape_ + 1 to skip channel axis
-  const int* input_shape_data = this->input_shape_.cpu_data() + 1;
   const int* kernel_shape_data = this->kernel_shape_.cpu_data();
   const int* stride_data = this->stride_.cpu_data();
   const int* pad_data = this->pad_.cpu_data();
   this->output_shape_.clear();
   for (int i = 0; i < this->num_spatial_axes_; ++i) {
-    const int input_dim = input_shape_data[i];
+    // i + 1 to skip channel axis
+    const int input_dim = this->input_shape(i + 1);
     const int output_dim = (input_dim + 2 * pad_data[i] - kernel_shape_data[i])
         / stride_data[i] + 1;
     this->output_shape_.push_back(output_dim);

--- a/src/caffe/layers/deconv_layer.cpp
+++ b/src/caffe/layers/deconv_layer.cpp
@@ -10,14 +10,13 @@ namespace caffe {
 
 template <typename Dtype>
 void DeconvolutionLayer<Dtype>::compute_output_shape() {
-  // input_shape_ + 1 to skip channel axis
-  const int* input_shape_data = this->input_shape_.cpu_data() + 1;
   const int* kernel_shape_data = this->kernel_shape_.cpu_data();
   const int* stride_data = this->stride_.cpu_data();
   const int* pad_data = this->pad_.cpu_data();
   this->output_shape_.clear();
   for (int i = 0; i < this->num_spatial_axes_; ++i) {
-    const int input_dim = input_shape_data[i];
+    // i + 1 to skip channel axis
+    const int input_dim = this->input_shape(i + 1);
     const int output_dim = stride_data[i] * (input_dim - 1)
         + kernel_shape_data[i] - 2 * pad_data[i];
     this->output_shape_.push_back(output_dim);


### PR DESCRIPTION
#2049 moved reading and storing of `bottom` shapes to `LayerSetUp`, which (silently) breaks reshaping to different input shapes.

This PR fixes that issue. I'm also not sure why another blob was introduced to store the input shape; this PR uses an inline function that wraps `bottom[0]->shape` instead. (Note that that's now somewhat awkwardly stored as `bottom_shape_` in order to get around the fact that `bottom` is neither a member variable nor argument to functions to such as `compute_output_shape`.)

Again, this should definitely be tested, but this PR is just the fix...