### PR TITLE
Separate LIB addition to Makefile.config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ ifneq ($(CPU_ONLY), 1)
 	LIBRARIES := cudart cublas curand
 endif
 
-LIBRARIES += glog gflags protobuf boost_system m hdf5_hl hdf5
+LIBRARIES += glog gflags protobuf boost_system m hdf5_hl hdf5 $(ADDTIONAL_LIBS)
 
 # handle IO dependencies
 USE_LEVELDB ?= 1

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -77,6 +77,9 @@ PYTHON_LIB := /usr/lib
 INCLUDE_DIRS := $(PYTHON_INCLUDE) /usr/local/include
 LIBRARY_DIRS := $(PYTHON_LIB) /usr/local/lib /usr/lib
 
+# Add additional libraries you need here.
+# ADDTIONAL_LIBS :=
+
 # If Homebrew is installed at a non standard location (for example your home directory) and you use it for general dependencies
 # INCLUDE_DIRS += $(shell brew --prefix)/include
 # LIBRARY_DIRS += $(shell brew --prefix)/lib


### PR DESCRIPTION
I guess avoiding directly changing `Makefile` might be a good idea. I added variable `ADDITIONAL_LIBS` so those who want to add layers for themselves only don't have to modify `Makefile`.
