### PR TITLE
add transformation to memory data layer

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -301,6 +301,8 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
   Blob<Dtype> added_data_;
   Blob<Dtype> added_label_;
   bool has_new_data_;
+  Blob<Dtype> transform_data_;
+  bool is_transformation_applied_;
 };
 
 /**

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -118,7 +118,7 @@ void MemoryDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   CHECK(data_) << "MemoryDataLayer needs to be initalized by calling Reset";
 
   if ( this->layer_param_.has_transform_param()
-      && ! is_transformation_applied_ ) {
+      && !is_transformation_applied_ ) {
     transform_data_.Reshape(batch_size_, channels_, height_, width_);
     transform_data_.set_cpu_data(data_ + pos_ * size_);
     this->data_transformer_->Transform(&transform_data_, top[0]);

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -24,10 +24,10 @@ void MemoryDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   vector<int> label_shape(1, batch_size_);
 
   if (this->layer_param_.has_transform_param()) {
-	transform_data_.Reshape(batch_size_, channels_, height_, width_);
+    transform_data_.Reshape(batch_size_, channels_, height_, width_);
     this->data_transformer_->Transform(&transform_data_, top[0]);
   } else {
-	top[0]->Reshape(batch_size_, channels_, height_, width_);
+    top[0]->Reshape(batch_size_, channels_, height_, width_);
   }
 
   top[1]->Reshape(label_shape);
@@ -117,13 +117,14 @@ void MemoryDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   CHECK(data_) << "MemoryDataLayer needs to be initalized by calling Reset";
 
-  if ( this->layer_param_.has_transform_param() && ! is_transformation_applied_ ) {
-	  transform_data_.Reshape(batch_size_, channels_, height_, width_);
-	  transform_data_.set_cpu_data(data_ + pos_ * size_);
-	  this->data_transformer_->Transform(&transform_data_, top[0]);
+  if ( this->layer_param_.has_transform_param()
+      && ! is_transformation_applied_ ) {
+    transform_data_.Reshape(batch_size_, channels_, height_, width_);
+    transform_data_.set_cpu_data(data_ + pos_ * size_);
+    this->data_transformer_->Transform(&transform_data_, top[0]);
   } else {
-	  top[0]->Reshape(batch_size_, channels_, height_, width_);
-	  top[0]->set_cpu_data(data_ + pos_ * size_);
+    top[0]->Reshape(batch_size_, channels_, height_, width_);
+    top[0]->set_cpu_data(data_ + pos_ * size_);
   }
 
   top[1]->Reshape(batch_size_, 1, 1, 1);

--- a/src/caffe/layers/memory_data_layer.cpp
+++ b/src/caffe/layers/memory_data_layer.cpp
@@ -22,7 +22,14 @@ void MemoryDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       "batch_size, channels, height, and width must be specified and"
       " positive in memory_data_param";
   vector<int> label_shape(1, batch_size_);
-  top[0]->Reshape(batch_size_, channels_, height_, width_);
+
+  if (this->layer_param_.has_transform_param()) {
+	transform_data_.Reshape(batch_size_, channels_, height_, width_);
+    this->data_transformer_->Transform(&transform_data_, top[0]);
+  } else {
+	top[0]->Reshape(batch_size_, channels_, height_, width_);
+  }
+
   top[1]->Reshape(label_shape);
   added_data_.Reshape(batch_size_, channels_, height_, width_);
   added_label_.Reshape(label_shape);
@@ -30,6 +37,7 @@ void MemoryDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   labels_ = NULL;
   added_data_.cpu_data();
   added_label_.cpu_data();
+  is_transformation_applied_ = false;
 }
 
 template <typename Dtype>
@@ -53,6 +61,7 @@ void MemoryDataLayer<Dtype>::AddDatumVector(const vector<Datum>& datum_vector) {
   Dtype* top_data = added_data_.mutable_cpu_data();
   Reset(top_data, top_label, num);
   has_new_data_ = true;
+  is_transformation_applied_ = true;
 }
 
 #ifdef USE_OPENCV
@@ -78,6 +87,7 @@ void MemoryDataLayer<Dtype>::AddMatVector(const vector<cv::Mat>& mat_vector,
   Dtype* top_data = added_data_.mutable_cpu_data();
   Reset(top_data, top_label, num);
   has_new_data_ = true;
+  is_transformation_applied_ = true;
 }
 #endif  // USE_OPENCV
 
@@ -86,11 +96,7 @@ void MemoryDataLayer<Dtype>::Reset(Dtype* data, Dtype* labels, int n) {
   CHECK(data);
   CHECK(labels);
   CHECK_EQ(n % batch_size_, 0) << "n must be a multiple of batch size";
-  // Warn with transformation parameters since a memory array is meant to
-  // be generic and no transformations are done with Reset().
-  if (this->layer_param_.has_transform_param()) {
-    LOG(WARNING) << this->type() << " does not transform array data on Reset()";
-  }
+
   data_ = data;
   labels_ = labels;
   n_ = n;
@@ -110,10 +116,19 @@ template <typename Dtype>
 void MemoryDataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   CHECK(data_) << "MemoryDataLayer needs to be initalized by calling Reset";
-  top[0]->Reshape(batch_size_, channels_, height_, width_);
+
+  if ( this->layer_param_.has_transform_param() && ! is_transformation_applied_ ) {
+	  transform_data_.Reshape(batch_size_, channels_, height_, width_);
+	  transform_data_.set_cpu_data(data_ + pos_ * size_);
+	  this->data_transformer_->Transform(&transform_data_, top[0]);
+  } else {
+	  top[0]->Reshape(batch_size_, channels_, height_, width_);
+	  top[0]->set_cpu_data(data_ + pos_ * size_);
+  }
+
   top[1]->Reshape(batch_size_, 1, 1, 1);
-  top[0]->set_cpu_data(data_ + pos_ * size_);
   top[1]->set_cpu_data(labels_ + pos_);
+
   pos_ = (pos_ + batch_size_) % n_;
   if (pos_ == 0)
     has_new_data_ = false;

--- a/src/caffe/test/test_memory_data_layer.cpp
+++ b/src/caffe/test/test_memory_data_layer.cpp
@@ -115,7 +115,7 @@ TYPED_TEST(MemoryDataLayerTest, TestForward) {
   }
 }
 
-TYPED_TEST(MemoryDataLayerTest, TestForwardTransform) {
+TYPED_TEST(MemoryDataLayerTest, TestForwardTransform){
   typedef typename TypeParam::Dtype Dtype;
 
   LayerParameter layer_param;
@@ -134,7 +134,8 @@ TYPED_TEST(MemoryDataLayerTest, TestForwardTransform) {
       this->labels_->mutable_cpu_data(), this->data_->num());
   for (int i = 0; i < this->batches_ * 6; ++i) {
     layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
-    EXPECT_EQ(this->batch_size_*this->channels_, this->blob_top_vec_[0]->count());
+    EXPECT_EQ(this->batch_size_*this->channels_,
+        this->blob_top_vec_[0]->count());
   }
 }
 

--- a/src/caffe/test/test_memory_data_layer.cpp
+++ b/src/caffe/test/test_memory_data_layer.cpp
@@ -115,6 +115,29 @@ TYPED_TEST(MemoryDataLayerTest, TestForward) {
   }
 }
 
+TYPED_TEST(MemoryDataLayerTest, TestForwardTransform) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  LayerParameter layer_param;
+  MemoryDataParameter* md_param = layer_param.mutable_memory_data_param();
+  md_param->set_batch_size(this->batch_size_);
+  md_param->set_channels(this->channels_);
+  md_param->set_height(this->height_);
+  md_param->set_width(this->width_);
+  TransformationParameter* tr_param = layer_param.mutable_transform_param();
+  tr_param->set_crop_size(1);
+  shared_ptr<MemoryDataLayer<Dtype> > layer(
+      new MemoryDataLayer<Dtype>(layer_param));
+  layer->SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  EXPECT_EQ(this->batch_size_*this->channels_, this->blob_top_vec_[0]->count());
+  layer->Reset(this->data_->mutable_cpu_data(),
+      this->labels_->mutable_cpu_data(), this->data_->num());
+  for (int i = 0; i < this->batches_ * 6; ++i) {
+    layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+    EXPECT_EQ(this->batch_size_*this->channels_, this->blob_top_vec_[0]->count());
+  }
+}
+
 #ifdef USE_OPENCV
 TYPED_TEST(MemoryDataLayerTest, AddDatumVectorDefaultTransform) {
   typedef typename TypeParam::Dtype Dtype;

--- a/src/caffe/test/test_memory_data_layer.cpp
+++ b/src/caffe/test/test_memory_data_layer.cpp
@@ -115,7 +115,7 @@ TYPED_TEST(MemoryDataLayerTest, TestForward) {
   }
 }
 
-TYPED_TEST(MemoryDataLayerTest, TestForwardTransform){
+TYPED_TEST(MemoryDataLayerTest, TestForwardTransform) {
   typedef typename TypeParam::Dtype Dtype;
 
   LayerParameter layer_param;


### PR DESCRIPTION
This PR adds transformations according to TransformParam to the MemoryDataLayer for the case that data is directly set by a pointer via reset. The transformations (on the blobs) are done on-the-fly during Forward. Including test cases.
