### PR TITLE
Allow WindowDataLayer to load grayscale images.

### DIFF
--- a/include/caffe/data_layers.hpp
+++ b/include/caffe/data_layers.hpp
@@ -327,7 +327,7 @@ class WindowDataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual void load_batch(Batch<Dtype>* batch);
 
   shared_ptr<Caffe::RNG> prefetch_rng_;
-  vector<std::pair<std::string, vector<int> > > image_database_;
+  vector<std::string> image_database_;
   enum WindowField { IMAGE_INDEX, LABEL, OVERLAP, X1, Y1, X2, Y2, NUM };
   vector<vector<float> > fg_windows_;
   vector<vector<float> > bg_windows_;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -989,6 +989,8 @@ message WindowDataParameter {
   optional bool cache_images = 12 [default = false];
   // append root_folder to locate images
   optional string root_folder = 13 [default = ""];
+  // Specify if the images are color or gray
+  optional bool is_color = 14 [default = true];
 }
 
 message SPPParameter {


### PR DESCRIPTION
This PR is to improve WindowDataLayer by allowing it to load grayscale images and reducing memory usage. 

The current implementation always loads data as 3-channel color images and causes a memory corruption error when the number of channels specified in the loaded window data file is not 3. 
I fixed this by adding 'is_color' as a new window data parameter and using it to find correct channels.
Additionally I modified image_databes_ in WindowDataLayer to not save unused vectors of image sizes (channels, height, width).
The unused image size related elements in window file format can be deleted, but did not modify it for backward compatibility.
