### PR TITLE
Install libs as non-executable files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -652,7 +652,7 @@ $(DISTRIBUTE_DIR): all py | $(DISTRIBUTE_SUBDIRS)
 	cp $(EXAMPLE_BINS) $(DISTRIBUTE_DIR)/bin
 	# add libraries
 	cp $(STATIC_NAME) $(DISTRIBUTE_DIR)/lib
-	cp $(DYNAMIC_NAME) $(DISTRIBUTE_DIR)/lib
+	install -m 644 $(DYNAMIC_NAME) $(DISTRIBUTE_DIR)/lib
 	# add python - it's not the standard way, indeed...
 	cp -r python $(DISTRIBUTE_DIR)/python
 


### PR DESCRIPTION
According to the Debian policy manual:

>Shared libraries should not be installed executable, since the dynamic linker does not require this and trying to execute a shared library usually results in a core dump."

https://www.debian.org/doc/debian-policy/ch-sharedlibs.html#s-sharedlibs-runtime