### PR TITLE
add badge for travis build and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Caffe
 
+[![Build Status](https://travis-ci.org/BVLC/caffe.svg?branch=master)](https://travis-ci.org/BVLC/caffe)
+[![License](https://img.shields.io/badge/license-BSD-blue.svg)](LICENSE)
+
 Caffe is a deep learning framework made with expression, speed, and modularity in mind.
 It is developed by the Berkeley Vision and Learning Center ([BVLC](http://bvlc.eecs.berkeley.edu)) and community contributors.
 


### PR DESCRIPTION
Markdown let's you add badges to your README that display status of things like continuous integration or static images like short license info.

It's a visual display of current info about the project, pretty common for open source projects.

Once available we can add a badge for coverage statistics or other CI platforms.

The CI badge displays the build status of the caffe's master branch.