### PR TITLE
add a way to construct a Blob with externally allocated GPU memory

### DIFF
--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -32,6 +32,8 @@ class Blob {
       const int width);
   explicit Blob(const vector<int>& shape);
 
+  Blob(const vector<int>& shape, void * pre_allocated_gpu_ptr, int gpu_device);
+
   /// @brief Deprecated; use <code>Reshape(const vector<int>& shape)</code>.
   void Reshape(const int num, const int channels, const int height,
       const int width);

--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -53,6 +53,14 @@ class SyncedMemory {
       : cpu_ptr_(NULL), gpu_ptr_(NULL), size_(size), head_(UNINITIALIZED),
         own_cpu_data_(false), cpu_malloc_use_cuda_(false), own_gpu_data_(false),
         gpu_device_(-1) {}
+  SyncedMemory(void * pre_allocated_gpu_ptr, size_t size, int gpu_device)
+      : cpu_ptr_(NULL), gpu_ptr_(pre_allocated_gpu_ptr), size_(size), head_(HEAD_AT_GPU),
+        own_cpu_data_(false), cpu_malloc_use_cuda_(false), own_gpu_data_(false),
+        gpu_device_(gpu_device) {
+#ifdef CPU_ONLY
+      NO_GPU;
+#endif
+  }
   ~SyncedMemory();
   const void* cpu_data();
   void set_cpu_data(void* data);

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -73,6 +73,20 @@ Blob<Dtype>::Blob(const vector<int>& shape)
 }
 
 template <typename Dtype>
+Blob<Dtype>::Blob(const vector<int>& shape, void * pre_allocated_gpu_ptr, int gpu_device)
+  // capacity_ must be initialized before calling Reshape
+  : capacity_(0) {
+#ifdef CPU_ONLY
+    NO_GPU;
+#endif
+  capacity_ = INT_MAX; // temporarily set capacity to INT_MAX to prevent Reshape from allocating data_ and diff_
+  Reshape(shape);
+  capacity_ = count_;
+  data_.reset(new SyncedMemory(pre_allocated_gpu_ptr, count_, gpu_device));
+  diff_.reset(new SyncedMemory(capacity_ * sizeof(Dtype)));
+}
+
+template <typename Dtype>
 const int* Blob<Dtype>::gpu_shape() const {
   CHECK(shape_data_);
   return (const int*)shape_data_->gpu_data();


### PR DESCRIPTION
When caffe is used with other libraries that manage their own GPU memory (e.g. ArrayFire), it would be useful to be able to create a `Blob` by passing the GPU memory pointer that was allocated in the 3rd party library directly to it. Otherwise we would have to do an extra copy to the host then back to the device.
This pull request adds the special constructors for `SyncedMemory` and `Blob` to handle this scenario.
An example of the usage would be
```
af::array my_array = af::randu(3, 4, 5);
std::vector<int> shape = {{3, 4, 5}};
Blob<float> blob = new Blob<float>(shape, my_array.device(), 0);
```
