### PR TITLE
need -lopencv_imgcodecs for opencv 3.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ ifeq ($(USE_LMDB), 1)
 	LIBRARIES += lmdb
 endif
 ifeq ($(USE_OPENCV), 1)
-	LIBRARIES += opencv_core opencv_highgui opencv_imgproc
+	LIBRARIES += opencv_core opencv_highgui opencv_imgproc opencv_imgcodecs
 endif
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare


### PR DESCRIPTION
Add `opencv_imgcodecs` for opencv 3.0.0