### PR TITLE
Fix predict(..oversample=False) to use integer slices.

### DIFF
--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -75,10 +75,10 @@ class Classifier(caffe.Net):
         else:
             # Take center crop.
             center = np.array(self.image_dims) / 2.0
-            crop = np.tile(center, (1, 2))[0] + np.concatenate([
+            crop = (np.tile(center, (1, 2))[0] + np.concatenate([
                 -self.crop_dims / 2.0,
                 self.crop_dims / 2.0
-            ])
+            ])).astype(int)
             input_ = input_[:, crop[0]:crop[2], crop[1]:crop[3], :]
 
         # Classify


### PR DESCRIPTION
net.predict(... oversample=False) fails to work due to the fact that when it does a single center crop, the numbers crop[0] etc are not ints on the affected lines.  This change converts these numbers to ints before using them as slice indices.