### PR TITLE
Fix class label index error in tutorial 00.

### DIFF
--- a/examples/00-classification.ipynb
+++ b/examples/00-classification.ipynb
@@ -119,7 +119,7 @@
    "source": [
     "net.blobs['data'].data[...] = transformer.preprocess('data', caffe.io.load_image(caffe_root + 'examples/images/cat.jpg'))\n",
     "out = net.forward()\n",
-    "print(\"Predicted class is #{}.\".format(out['prob'].argmax()))"
+    "print(\"Predicted class is #{}.\".format(out['prob'][0].argmax()))"
    ]
   },
   {


### PR DESCRIPTION
`print("Predicted class is #{}.".format(out['prob'].argmax()))`
should be:
`print("Predicted class is #{}.".format(out['prob'][0].argmax()))`

in https://github.com/BVLC/caffe/blob/master/examples/00-classification.ipynb
