### PR TITLE
Add opencv_imgcodecs to library path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,12 @@ ifeq ($(USE_LMDB), 1)
 	LIBRARIES += lmdb
 endif
 ifeq ($(USE_OPENCV), 1)
-	LIBRARIES += opencv_core opencv_highgui opencv_imgproc
+	LIBRARIES += opencv_core opencv_highgui opencv_imgproc 
+
+	ifeq ($(OPENCV_VERSION), 3)
+		LIBRARIES += opencv_imgcodecs
+	endif
+		
 endif
 PYTHON_LIBRARIES := boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -12,6 +12,9 @@
 # USE_LMDB := 0
 # USE_OPENCV := 0
 
+# Uncomment if you're using OpenCV 3
+# OPENCV_VERSION := 3
+
 # To customize your choice of compiler, uncomment and set the following.
 # N.B. the default for Linux is g++ and the default for OSX is clang++
 # CUSTOM_CXX := g++


### PR DESCRIPTION
Running 'make all' on my OSX with OpenCV 3.0.0 failed due to a reference to imread which is in imgcodecs and not included in the Makefile.

'make all' failed with the following error before this fix:

```
file: .build_release/lib/libcaffe.a(cudnn.o) has no symbols
LD -o .build_release/lib/libcaffe.so
clang: warning: argument unused during compilation: '-pthread'
Undefined symbols for architecture x86_64:
  "cv::imread(cv::String const&, int)", referenced from:
      caffe::WindowDataLayer<float>::load_batch(caffe::Batch<float>*) in window_data_layer.o
      caffe::WindowDataLayer<double>::load_batch(caffe::Batch<double>*) in window_data_layer.o
      caffe::ReadImageToCVMat(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, bool) in io.o
  "cv::imdecode(cv::_InputArray const&, int)", referenced from:
      caffe::DecodeDatumToCVMatNative(caffe::Datum const&) in io.o
      caffe::DecodeDatumToCVMat(caffe::Datum const&, bool) in io.o
  "cv::imencode(cv::String const&, cv::_InputArray const&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >&, std::__1::vector<int, std::__1::allocator<int> > const&)", referenced from:
      caffe::ReadImageToDatum(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, int, int, int, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, caffe::Datum*) in io.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [.build_release/lib/libcaffe.so] Error 1
```

This fixes it.