### PR TITLE
Add pyyaml as a requirement

### DIFF
--- a/examples/web_demo/requirements.txt
+++ b/examples/web_demo/requirements.txt
@@ -4,3 +4,4 @@ tornado
 numpy
 pandas
 pillow
+pyyaml


### PR DESCRIPTION
In getting the [web demo](http://caffe.berkeleyvision.org/gathered/examples/web_demo.html) started I get an `ImportError: No module named yaml` error when running `./scripts/download_model_binary.py models/bvlc_reference_caffenet`.