### PR TITLE
Test Layer Type Upgrade

### DIFF
--- a/src/caffe/test/test_upgrade_proto.cpp
+++ b/src/caffe/test/test_upgrade_proto.cpp
@@ -2892,7 +2892,6 @@ TEST_F(NetUpgradeTest, TestImageNet) {
   this->RunV1UpgradeTest(expected_v1_proto, expected_v2_proto);
 }  // NOLINT(readability/fn_size)
 
-#ifdef USE_OPENCV
 TEST_F(NetUpgradeTest, TestUpgradeV1LayerType) {
   LayerParameter layer_param;
   shared_ptr<Layer<float> > layer;
@@ -2927,7 +2926,6 @@ TEST_F(NetUpgradeTest, TestUpgradeV1LayerType) {
     EXPECT_EQ(v2_layer_type, layer->type());
   }
 }
-#endif  // USE_OPENCV
 
 class SolverTypeUpgradeTest : public ::testing::Test {
  protected:


### PR DESCRIPTION
The V1 layer type test should always be run regardless of the IO dependencies.

@eelstork can you explain your thinking in f3a933a6? Let me know if this is somehow needed.