### PR TITLE
Test reading and writing mean proto in matlab

### DIFF
--- a/matlab/+caffe/+test/test_io.m
+++ b/matlab/+caffe/+test/test_io.m
@@ -1,0 +1,18 @@
+classdef test_io < matlab.unittest.TestCase
+  methods (Test)
+    function test_read_write_mean(self)
+      % randomly generate mean data
+      width = 200;
+      height = 300;
+      channels = 3;
+      mean_data_write = 255 * rand(width, height, channels, 'single');
+      % write mean data to binary proto
+      mean_proto_file = tempname();
+      caffe.io.write_mean(mean_data_write, mean_proto_file);
+      % read mean data from saved binary proto and test whether they are equal
+      mean_data_read = caffe.io.read_mean(mean_proto_file);
+      self.verifyEqual(mean_data_write, mean_data_read)
+      delete(mean_proto_file);
+    end
+  end
+end

--- a/matlab/+caffe/run_tests.m
+++ b/matlab/+caffe/run_tests.m
@@ -11,7 +11,8 @@ caffe.reset_all();
 % put all test cases here
 results = [...
   run(caffe.test.test_net) ...
-  run(caffe.test.test_solver) ];
+  run(caffe.test.test_solver) ...
+  run(caffe.test.test_io) ];
 
 % reset caffe after testing
 caffe.reset_all();


### PR DESCRIPTION
After #3058, add a test case for reading and writing mean proto in Matcaffe.