### PR TITLE
Endorse CMP0046, CMP0054

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 2.8.7)
+if(POLICY CMP0046)
+  cmake_policy(SET CMP0046 NEW)
+endif()
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
 
 # ---[ Caffe project
 project(Caffe C CXX)
@@ -66,8 +72,10 @@ add_subdirectory(docs)
 add_custom_target(lint COMMAND ${CMAKE_COMMAND} -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
 
 # ---[ pytest target
-add_custom_target(pytest COMMAND python${python_version} -m unittest discover -s caffe/test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/python )
-add_dependencies(pytest pycaffe)
+if(BUILD_python)
+  add_custom_target(pytest COMMAND python${python_version} -m unittest discover -s caffe/test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/python )
+  add_dependencies(pytest pycaffe)
+endif()
 
 # ---[ Configuration summary
 caffe_print_configuration_summary()


### PR DESCRIPTION
Set policies to silence warnings in CMake 3.02 and later.
Later versions of CMake require the user to specify whether they wish to reject or endorse the referred policies.
CMP0046 requires that we explicitly disable adding pycaffe as a dependency when it is not present.
https://cmake.org/cmake/help/v3.0/policy/CMP0046.html
CMP0054 does not require changes.
https://cmake.org/cmake/help/v3.1/policy/CMP0054.html
This improves forward compatibility with newer versions of CMake.
