### PR TITLE
Detect division by zero

### DIFF
--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -29,7 +29,7 @@ void Blob<Dtype>::Reshape(const vector<int>& shape) {
   }
   int* shape_data = static_cast<int*>(shape_data_->mutable_cpu_data());
   for (int i = 0; i < shape.size(); ++i) {
-    CHECK_GE(shape[i], 0);
+    CHECK_GT(shape[i], 0);
     CHECK_LE(shape[i], INT_MAX / count_) << "blob size exceeds INT_MAX";
     count_ *= shape[i];
     shape_[i] = shape[i];

--- a/src/caffe/solvers/sgd_solver.cpp
+++ b/src/caffe/solvers/sgd_solver.cpp
@@ -30,6 +30,8 @@ Dtype SGDSolver<Dtype>::GetLearningRate() {
   if (lr_policy == "fixed") {
     rate = this->param_.base_lr();
   } else if (lr_policy == "step") {
+    CHECK_GT(this->param_.stepsize())
+        << "stepsize is invalid or not specified";
     this->current_step_ = this->iter_ / this->param_.stepsize();
     rate = this->param_.base_lr() *
         pow(this->param_.gamma(), this->current_step_);


### PR DESCRIPTION
There happens division by zero if the setting is inappropriate.

- When creating the layer such as convolution or pooling layer, the shape can be 0.
- When `stepsize` is not specified, it can be 0.

I added checks for these cases.