### PR TITLE
Multi-node caffe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,7 @@ LINKFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
 USE_PKG_CONFIG ?= 0
 ifeq ($(USE_PKG_CONFIG), 1)
 	PKG_CONFIG := $(shell pkg-config opencv --libs)
+  PKG_CONFIG += $(shell pkg-config libzmq --libs)
 else
 	PKG_CONFIG :=
 endif

--- a/examples/cifar10/conv.prototxt
+++ b/examples/cifar10/conv.prototxt
@@ -1,0 +1,14 @@
+
+# conv clients
+
+start_layer : "cifar"
+end_layer : "pool3"
+num_splits : 1
+
+node_info {
+    router_port : 1000
+    pub_port : 1001
+    position : 0
+}
+
+

--- a/examples/cifar10/fc.prototxt
+++ b/examples/cifar10/fc.prototxt
@@ -1,0 +1,14 @@
+
+# fcnode
+
+start_layer : "ip1"
+end_layer : "loss"
+num_splits : 1
+
+node_info {
+    router_port : 1002
+    pub_port : 1003
+    position : 0
+}
+
+

--- a/examples/cpp_classification/classification.cpp
+++ b/examples/cpp_classification/classification.cpp
@@ -3,6 +3,7 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/imgproc/types_c.h>
 #endif  // USE_OPENCV
 #include <algorithm>
 #include <iosfwd>

--- a/include/caffe/multi_node/async_data.hpp
+++ b/include/caffe/multi_node/async_data.hpp
@@ -1,0 +1,57 @@
+
+
+#ifndef MULTI_NODE_ASYNC_DATA_H
+#define MULTI_NODE_ASYNC_DATA_H
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/data_transformer.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/internal_thread.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/net.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/data_layers.hpp"
+
+#include "caffe/multi_node/async_reader.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+class AsyncDataLayer : public BasePrefetchingDataLayer<Dtype> {
+
+public:
+  explicit AsyncDataLayer(const LayerParameter& param)
+    : BasePrefetchingDataLayer<Dtype>(param) {
+      queue_index_ = AsyncReader::Instance()->RegisterLayer(param);
+      full_ = AsyncReader::Instance()->GetFull(queue_index_);
+      free_ = AsyncReader::Instance()->GetFree(queue_index_);
+    }
+
+  virtual ~AsyncDataLayer();
+
+  virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "AsyncData"; }
+  virtual inline int ExactNumBottomBlobs() const { return 0; }
+  virtual inline int MinTopBlobs() const { return 1; }
+  virtual inline int MaxTopBlobs() const { return 2; }
+
+
+protected:
+  virtual void load_batch(Batch<Dtype>* batch);
+
+protected:
+  int queue_index_; 
+  BlockingQueue<Datum*> *full_;
+  BlockingQueue<Datum*> *free_;
+};
+
+
+} // end caffe
+
+
+#endif
+
+

--- a/include/caffe/multi_node/async_reader.hpp
+++ b/include/caffe/multi_node/async_reader.hpp
@@ -1,0 +1,123 @@
+
+
+#ifndef MULTI_NODE_ASYNC_READER_H_
+#define MULTI_NODE_ASYNC_READER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/internal_thread.hpp"
+#include "caffe/util/blocking_queue.hpp"
+#include "caffe/util/db.hpp"
+
+#include "boost/thread/once.hpp"
+#include "boost/thread/thread.hpp"
+#include "boost/thread/mutex.hpp"
+
+
+namespace caffe {
+
+class ReaderThread : public InternalThread 
+{
+public:
+  explicit ReaderThread(const LayerParameter& param, BlockingQueue<Datum*> *free, BlockingQueue<Datum*> * full) 
+    : param_(param)
+  {
+    free_ = free;
+    full_ = full;
+
+    StartInternalThread();
+  }
+
+  virtual ~ReaderThread() {
+    StopInternalThread();
+  }
+
+protected:
+  void InternalThreadEntry();
+  
+protected:
+  LayerParameter param_;
+  BlockingQueue<Datum*> *free_;
+  BlockingQueue<Datum*> * full_;
+
+DISABLE_COPY_AND_ASSIGN(ReaderThread);
+};
+
+class AsyncReader {
+
+public:
+  virtual ~AsyncReader() {
+    Datum* datum = NULL;
+    
+    for (int i = 0; i < free_queue_.size(); i++) {
+      while (free_queue_[i]->try_pop(&datum)) {
+        delete datum;
+      }
+    }
+
+    for (int i = 0; i < full_queue_.size(); i++) {
+      while (full_queue_[i]->try_pop(&datum)) {
+        delete datum;
+      }
+    }
+  }
+
+  static AsyncReader* Instance()
+  {
+    boost::call_once(flag_once_, InitReader);
+    
+    return instance_;
+  }
+
+
+public:
+  int RegisterLayer(const LayerParameter& param);
+  BlockingQueue<Datum*> *GetFree(int i) { return free_queue_[i]; }
+  BlockingQueue<Datum*> *GetFull(int i) { return full_queue_[i]; }
+
+protected:
+  int AddBlockQueue(const LayerParameter& param);
+
+protected:
+  static void InitReader()
+  {
+    instance_ = new AsyncReader();
+  }
+  
+  static inline string source_key(const LayerParameter& param) 
+  {
+    return param.name() + ":" + param.data_param().source();
+  }
+
+protected:
+  vector<BlockingQueue<Datum*> *> free_queue_;
+  vector<BlockingQueue<Datum*> *> full_queue_;
+  
+  //for the reader threads
+  vector<shared_ptr<ReaderThread> > thread_arr_;
+
+  map<const string, int> index_map_;
+  boost::mutex register_mutex_;
+
+protected:
+  static AsyncReader *instance_;
+  static boost::once_flag flag_once_;
+
+
+private:
+  AsyncReader() {}
+
+DISABLE_COPY_AND_ASSIGN(AsyncReader);
+
+};
+
+
+} //namespace caffe
+
+
+#endif
+
+

--- a/include/caffe/multi_node/conv_node.hpp
+++ b/include/caffe/multi_node/conv_node.hpp
@@ -1,0 +1,76 @@
+
+
+#ifndef MULTI_NODE_CONV_NODE_H_
+#define MULTI_NODE_CONV_NODE_H_
+
+#include "caffe/multi_node/msg_hub.hpp"
+
+namespace caffe {
+
+/*
+ * Nodes responsible for convolution
+ * Several work threads are forked to do convolution
+ * The main thread is used to route messages
+ */
+template <typename Dtype>
+class ConvClient : public MsgHub<Dtype>
+{
+
+public:
+  ConvClient(int nthreads, const string& fc_gateway_addr, const string& ps_addr)
+    : MsgHub<Dtype>(nthreads, nthreads - 1)
+  {
+    fc_client_.reset(new SkSock(ZMQ_DEALER));
+    
+    int client_id = NodeEnv::Instance()->ID();
+    fc_client_->SetId(client_id);
+
+    ps_client_.reset(new SkSock(ZMQ_DEALER));
+    ps_client_->SetId(client_id);
+
+    fc_gateway_addr_ = fc_gateway_addr;
+    ps_addr_ = ps_addr;
+
+    fc_sock_index_ = nthreads;
+    ps_sock_index_ = nthreads + 1;
+    ps_thread_index_ = nthreads - 1;
+  }
+
+
+  virtual ~ConvClient() { }
+
+public:
+  virtual int Init();
+
+  virtual int RouteMsg();
+
+protected:
+  virtual int SetUpPoll();
+  
+
+protected:
+  /// socket used to communicate Fully Connected layers
+  shared_ptr<SkSock> fc_client_;
+  /// socket used to communicate parameter server
+  shared_ptr<SkSock> ps_client_;
+  /// zmq addr of Fully Connected Layers gateway
+  string fc_gateway_addr_;
+  /// zmq addr of Parameter Server
+  string ps_addr_;
+  
+  /// the location of fc socket in zmq polling table
+  int fc_sock_index_;
+  /// the location of parameter server socket in zmq polling table
+  int ps_sock_index_;
+  /// A thread is dedicated to communicate parameter server
+  /// this index stores its location in the polling table
+  int ps_thread_index_;
+
+DISABLE_COPY_AND_ASSIGN(ConvClient);
+};
+
+} //end caffe
+
+#endif
+
+

--- a/include/caffe/multi_node/conv_thread.hpp
+++ b/include/caffe/multi_node/conv_thread.hpp
@@ -1,0 +1,89 @@
+
+
+#ifndef MULTI_NODE_CONV_THREAD_H_
+#define MULTI_NODE_CONV_THREAD_H_
+
+#include "caffe/multi_node/worker_thread.hpp"
+#include "caffe/sgd_solvers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+class ConvThread : public WorkerThread<Dtype>
+{
+
+public:
+  ConvThread() { 
+  
+  }
+
+  virtual ~ConvThread() {
+
+  }
+
+  virtual void Run();
+
+protected:
+  shared_ptr<Msg> ConvForward();
+  int ConvBackward(shared_ptr<Msg> m);
+  
+  virtual Solver<Dtype> *CreateSolver() {
+    Caffe::set_root_solver(false);
+    SGDSolver<Dtype> *conv_root = (SGDSolver<Dtype> *)NodeEnv::Instance()->GetRootSolver();
+    const SolverParameter& param = NodeEnv::Instance()->SolverParam();
+
+    return new WorkerSolver<Dtype>(param, conv_root);
+  }
+
+  int64_t NewConvId() {
+    boost::mutex::scoped_lock lock(conv_id_mutex_);
+     
+    int64_t orig_id = conv_id_;
+    conv_id_++;
+
+    return orig_id;
+  }
+
+protected:
+  static int64_t conv_id_;
+  static boost::mutex conv_id_mutex_;
+
+DISABLE_COPY_AND_ASSIGN(ConvThread);
+};
+
+
+//for collect and update parameters in conv threads
+template <typename Dtype>
+class ConvParamThread : public WorkerThread<Dtype>
+{
+
+public:
+  ConvParamThread() { 
+  
+  }
+  
+  virtual ~ConvParamThread() {
+
+  }
+
+  virtual void Run();
+
+protected:
+  virtual Solver<Dtype> *CreateSolver() {
+    return NULL;
+  }
+
+protected:
+  //update gradient
+  int PutGradient(shared_ptr<Msg> m);
+  //update parameter got from parameter server
+  int UpdateParam(shared_ptr<Msg> m);
+
+DISABLE_COPY_AND_ASSIGN(ConvParamThread);
+};
+
+} //end caffe
+
+#endif
+
+

--- a/include/caffe/multi_node/fc_node.hpp
+++ b/include/caffe/multi_node/fc_node.hpp
@@ -1,0 +1,146 @@
+
+#ifndef MULTI_NODE_FC_NODE_H_
+#define MULTI_NODE_FC_NODE_H_
+
+#include "caffe/multi_node/msg_hub.hpp"
+#include "caffe/multi_node/fc_thread.hpp"
+#include "caffe/sgd_solvers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+class FcNode : public MsgHub<Dtype>
+{
+
+public:
+  FcNode (int nthreads, int nworkers) 
+      : MsgHub<Dtype>(nthreads, nworkers)
+  {
+    node_id_ = NodeEnv::Instance()->ID();
+
+    string pub_addr = NodeEnv::Instance()->PubAddr();
+    string back_addr = NodeEnv::Instance()->RouterAddr();
+
+    sock_pub_.reset(new SkSock(ZMQ_PUB));
+    sock_pub_->Bind(pub_addr);
+
+    LOG(INFO) << "Bind PUB to: " << pub_addr;
+
+    sock_back_.reset(new SkServer());
+    sock_back_->Bind(back_addr);
+    
+    LOG(INFO) << "Bind Router to " << back_addr;
+
+    num_next_hops_ = 0;
+    param_thread_index_ = nthreads - 1;
+    back_sock_index_ = nthreads;
+  }
+
+
+public:
+  virtual int Init();
+
+  virtual int RouteMsg();
+
+
+protected:
+  virtual int SetUpPoll();
+  
+  //send out the msg processed by threads
+  virtual int SendOutMsg(shared_ptr<Msg> m);
+  
+  //Set up the connections and init the routing table 
+  int InitRoute();
+  
+protected:
+  shared_ptr<SkSock> sock_pub_;
+
+  //a REP socket to received the packets from downstream nodes
+  shared_ptr<SkSock> sock_back_;
+  //back sock index in the poll table
+  int back_sock_index_;
+  int num_next_hops_;
+  
+  //use hash map as a routing table
+  //map from node id to the sock index
+  unordered_map<int, shared_ptr<SkSock> > node_to_sock_;
+  
+  //the dealer sock
+  vector<shared_ptr<SkSock> > vec_dealer_;
+  
+  //NodeID, fetched from ID server
+  int node_id_;
+
+  //
+  int param_thread_index_;
+};
+
+
+//Interface to the conv. clients
+template <typename Dtype>
+class FcGateway : public FcNode<Dtype>
+{
+public:
+  FcGateway(int nthreads, string server_addr)
+      : FcNode<Dtype>(nthreads, nthreads - 1)
+  {
+    sock_server_.reset(new SkServer());
+    sock_server_->Bind(server_addr);
+
+    msg_id_ = 0;
+    server_sock_index_ = nthreads + 1;
+  }
+
+public:
+  virtual int Init();
+
+  virtual int RouteMsg();
+
+  virtual int SendOutMsg(shared_ptr<Msg> m);
+
+protected:
+  virtual int SetUpPoll();
+
+protected:
+  shared_ptr<SkServer> sock_server_;
+  
+  //position of server sock
+  int server_sock_index_;
+
+  //increasing message id by 1 at a time
+  int64_t msg_id_;
+  
+  //connect to the nodes in bottom layer
+  vector<shared_ptr<SkSock> > bottom_socks_;
+};
+
+template <typename Dtype>
+class FcClient : public FcNode<Dtype>
+{
+public:
+  FcClient(int nthreads)
+      : FcNode<Dtype>(nthreads, nthreads - 1)
+  {
+    sub_sock_index_ = nthreads + 1;
+  }
+
+public:
+  virtual int Init();
+  virtual int RouteMsg();
+
+protected:
+  virtual int SetUpPoll();
+
+protected:
+  //receive broadcast message from upstream nodes
+  vector<shared_ptr<SkSock> > vec_sub_sock_;
+  
+  //
+  int sub_sock_index_;
+};
+
+} //end caffe
+
+#endif
+
+

--- a/include/caffe/multi_node/fc_thread.hpp
+++ b/include/caffe/multi_node/fc_thread.hpp
@@ -1,0 +1,76 @@
+
+#ifndef MULTI_NODE_FC_THREAD_H_
+#define MULTI_NODE_FC_THREAD_H_
+
+#include "caffe/multi_node/worker_thread.hpp"
+#include "caffe/sgd_solvers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+class FcThread : public WorkerThread<Dtype>
+{
+public:
+  FcThread() { }
+  virtual ~FcThread() { }
+
+  virtual void Run();
+
+protected:
+  virtual Solver<Dtype> *CreateSolver() {
+    Caffe::set_root_solver(false);
+    SGDSolver<Dtype> *fc_root = (SGDSolver<Dtype> *)NodeEnv::Instance()->GetRootSolver();
+    const SolverParameter& param = NodeEnv::Instance()->SolverParam();
+
+    return new SGDSolver<Dtype>(param, fc_root);
+  }
+
+
+protected:
+  shared_ptr<Msg> FcForward(shared_ptr<Msg> m);
+  void FcBackward(shared_ptr<Msg> m, vector<shared_ptr<Msg> >& replies);
+
+DISABLE_COPY_AND_ASSIGN(FcThread);
+};
+
+
+//the last part of FC layers
+template <typename Dtype>
+class FcEndThread : public FcThread<Dtype>
+{
+public:
+  FcEndThread() { }
+  virtual ~FcEndThread() { }
+  virtual void Run();
+
+protected:
+  static boost::atomic_int iter_;
+
+DISABLE_COPY_AND_ASSIGN(FcEndThread);
+};
+
+
+//for updating the FC parameters
+template <typename Dtype>
+class FcParamThread : public WorkerThread<Dtype>
+{
+public:
+  FcParamThread() { }
+
+  virtual void Run();
+
+protected:
+  void UpdateParam(shared_ptr<Msg> m);
+  
+  virtual Solver<Dtype> *CreateSolver() {
+    return NULL;
+  }
+
+DISABLE_COPY_AND_ASSIGN(FcParamThread);
+};
+
+} //end caffe
+
+#endif
+
+

--- a/include/caffe/multi_node/model_map.hpp
+++ b/include/caffe/multi_node/model_map.hpp
@@ -1,0 +1,198 @@
+
+
+#ifndef MULTI_NODE_MODEL_MAP_H_
+#define MULTI_NODE_MODEL_MAP_H_
+
+#include "caffe/multi_node/msg.hpp"
+#include "caffe/caffe.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/upgrade_proto.hpp"
+#include "caffe/util/insert_splits.hpp"
+
+#include "caffe/proto/multi_node.pb.h"
+
+
+namespace caffe {
+
+template <typename Dtype>
+class ModelMap
+{
+
+public:
+  ModelMap(const string full_solver) {
+    ReadProtoFromTextFileOrDie(full_solver, &solver_param_);
+    
+    orig_solver_param_.CopyFrom(solver_param_);
+
+    //clear test net in the solver param
+    solver_param_.clear_test_net();
+    solver_param_.clear_test_net_param();
+    solver_param_.clear_test_iter();
+    solver_param_.clear_test_interval();
+    
+    Caffe::set_root_solver(true);
+    psolver_ = SolverRegistry<Dtype>::CreateSolver(solver_param_);
+    
+    //we only deal with the net parameter is specified by a txt path
+    CHECK(solver_param_.has_net());
+
+    //init the net parameter
+    NetParameter in_param;
+    ReadNetParamsFromTextFileOrDie(solver_param_.net(), &in_param);
+
+    //add the parameter to the original solver param
+    orig_solver_param_.clear_net();
+    orig_solver_param_.mutable_net_param()->CopyFrom(in_param);
+
+    //init net parameter
+    net_ = psolver_->net();
+
+    InitTrainNetParam(in_param);
+
+    LOG(INFO) << "Model map inited";
+  }
+
+  ~ModelMap() {
+    delete psolver_;
+  }
+
+  int GetModel(shared_ptr<Msg> m);
+  
+  //return full model and all the nodes in FC layer
+  int GetFullModel(shared_ptr<Msg> m);
+
+  const vector<shared_ptr<Msg> > &Replies() { return replies_; }
+
+  void ClearMsg() { replies_.clear(); }
+
+protected:
+  void InitTrainNetParam(NetParameter &in_param) 
+  {
+    NetState net_state;
+    net_state.set_phase(TRAIN);
+    net_state.MergeFrom(in_param.state());
+    net_state.MergeFrom(solver_param_.train_state());
+    in_param.mutable_state()->CopyFrom(net_state);
+
+    NetParameter filtered_param;
+    net_->FilterNet(in_param, &filtered_param);
+    
+    //we only deal with train net in this class
+    InsertSplits(filtered_param, &net_param_);
+    
+    //check we have the same number of layers
+    CHECK(net_param_.layer_size() == net_->layers().size());
+
+    const LayerParameter& first_layer = net_param_.layer(0);
+
+    //the first layer should be Data layer and should has the data param
+    CHECK(first_layer.type() == string("Data"));
+    CHECK(first_layer.has_data_param());
+    
+    train_batch_size_ = first_layer.data_param().batch_size();
+    
+    const vector<shared_ptr<Layer<Dtype> > > &layers = net_->layers();
+    
+    //init the size of the request table
+    requests_.resize(layers.size());
+
+    //find the first FC layer
+    first_fc_ = -1;
+    for (int i = 0; i < layers.size(); i++) {
+      shared_ptr<Layer<Dtype> > l = layers[i];
+
+      LOG(INFO) << "layer index: " << i << " name: " << net_->layer_names()[i] << " type: " << l->type();
+      if ( 0 == strcmp(l->type(), "InnerProduct") ) {
+        first_fc_ = i;
+        break;
+      }
+    }
+
+    CHECK( first_fc_ >= 0 );
+    
+    //generate a clean solver(without any net)
+    clear_solver_.CopyFrom(solver_param_);
+
+    //delete all the existing nets...
+    clear_solver_.release_train_net_param();
+    clear_solver_.clear_train_net();
+    clear_solver_.clear_net_param();
+    clear_solver_.clear_net();
+
+    //generate clean net without any layers
+    clear_net_.CopyFrom(net_param_);
+    clear_net_.clear_layer();
+
+    fc_filled_ = false;
+  }
+
+
+protected:
+  int FindLayer(string name);
+
+  //generate a virtual net from first to end
+  int GenerateSolver(SolverParameter &sparam, shared_ptr<ModelRequest> r);
+  
+  //Generating Rout infomation for a layer
+  //note that all the sublayers in a layer have the same route infor
+  int GenerateRoute(RouteInfo &rt, vector<shared_ptr<ModelRequest> > *pre, vector<shared_ptr<ModelRequest> > *next);
+
+  //check the integrity of the FC layers
+  bool CheckIntegrity();
+
+  //prepare messages containing models and routing infomation
+  int PrepareMessages();
+
+  int PrepareFullModel();
+
+  int ProcessConv(shared_ptr<Msg> m);
+
+protected:
+  //we use the full solver to generate layers
+  //ParaSolver *psolver_;
+  Solver<Dtype> *psolver_;
+  SolverParameter solver_param_;
+  //with test nets
+  SolverParameter orig_solver_param_;
+
+  //clear solver parameter without net param, only have solver param
+  SolverParameter clear_solver_;
+  
+  shared_ptr<Net<Dtype> > net_;
+  NetParameter net_param_;
+  
+  //clear net parameter without layers, only have net params
+  NetParameter clear_net_;
+
+  int first_fc_;
+
+  //store the model requests in a 2D vector
+  vector<vector<shared_ptr<ModelRequest> > > requests_;
+  
+  //all the nodes in FC layers
+  vector<shared_ptr<ModelRequest> > fc_requests_;
+
+  //the full request message
+  shared_ptr<Msg> full_request_msg_;
+
+  //the generated message for FC layers
+  vector<shared_ptr<Msg> > replies_;
+
+  //whether the FC layers are fully occupied.
+  bool fc_filled_;
+
+  //node in the bottom: usually loss nodes and need labels
+  vector<NodeInfo> bottom_nodes_;
+
+  //
+  int train_batch_size_;
+
+DISABLE_COPY_AND_ASSIGN(ModelMap);
+};
+
+} // end namespace caffe
+
+#endif
+
+
+

--- a/include/caffe/multi_node/msg.hpp
+++ b/include/caffe/multi_node/msg.hpp
@@ -1,0 +1,222 @@
+
+#ifndef MULTI_NODE_MSG_H_
+#define MULTI_NODE_MSG_H_
+
+#include <vector>
+#include <string>
+#include <glog/logging.h>
+#include <stdlib.h>
+#include <boost/shared_ptr.hpp>
+#include <gflags/gflags.h>
+
+#include <zmq.h>
+
+#include "caffe/proto/multi_node.pb.h"
+
+using std::vector;
+using std::string;
+using std::map;
+
+const int REQ_SERVER_ID = 3;
+const int PS_ID = 2;
+const int ROOT_THREAD_ID = 1;
+const int INVALID_ID = -1;
+
+using boost::shared_ptr;
+
+namespace caffe {
+
+class Msg {
+
+public:
+  Msg() {
+  }
+  
+  Msg(shared_ptr<Msg> m) {
+    set_src(m->src());
+    set_dst(m->dst());
+    set_msg_id(m->msg_id());
+    set_type(m->type());
+    set_conv_id(m->conv_id());
+  }
+
+  Msg(Msg *p) {        
+    set_src(p->src());
+    set_dst(p->dst());
+    set_msg_id(p->msg_id());
+    set_type(p->type());
+    set_conv_id(p->conv_id());
+  }
+
+
+  virtual ~Msg() {
+    for (int i = 0; i < zmsg_vec_.size(); i++) {
+      zmq_msg_close(zmsg_vec_[i]);
+      delete zmsg_vec_[i];
+    }
+  }
+
+  void set_src(int src) {
+    header_.set_src(src);
+  }
+
+  void set_dst(int dst) {
+    header_.set_dst(dst);
+  }
+
+  int src() const {
+    return header_.src();
+  }
+
+  int dst() const {
+    return header_.dst();
+  }
+  
+  int64_t msg_id() {
+    return header_.msg_id();
+  }
+
+  void set_msg_id(int64_t id) {
+    header_.set_msg_id(id);
+  }
+
+  void set_type(MsgType type) {
+    header_.set_type(type);
+  }
+
+  MsgType type() const {
+    return header_.type();
+  }
+
+  int num_blobs() {
+    return header_.blobs_size();
+  }
+
+  inline const BlobInfo& blob_info(int index) {
+    return header_.blobs(index);
+  }
+
+  void add_blob_info(const BlobInfo& b) {
+    CHECK( !has_blob(b.blob_name()) );
+    blob_name_index_[b.blob_name()] = header_.blobs_size();
+    header_.add_blobs()->CopyFrom(b);
+  }
+
+  int AppendZmsg(zmq_msg_t *zmsg)
+  {
+    zmsg_vec_.push_back(zmsg);
+
+    return zmsg_vec_.size() - 1;
+  }
+  
+  int64_t conv_id() {
+    return header_.conv_id();
+  }
+
+  void set_conv_id(int64_t id) {
+    header_.set_conv_id(id);
+  }
+
+  //return the data index
+  int AppendData(const void *p, int len)
+  {
+    zmq_msg_t *m = new zmq_msg_t;
+    zmq_msg_init_size(m, len);
+
+    memcpy(zmq_msg_data (m), p, len);
+    zmsg_vec_.push_back(m);
+
+    return zmsg_vec_.size() - 1;
+  }
+  
+  int MergeMsg(shared_ptr<Msg> m);
+  shared_ptr<Msg> ExtractMsg(const string blob_name);
+
+  //clear messages without releasing the content
+  void ClearMsg()
+  {
+    header_.Clear();
+    zmsg_vec_.clear();
+  }
+  
+  void PrintHeader()
+  {
+    LOG(INFO) << "message header: " << std::endl << header_.DebugString();
+  }
+
+
+  void SerializeHeader(string& str)
+  {
+    header_.SerializeToString(&str);
+  }
+
+
+  void ParseHeader(string& str)
+  {
+    header_.ParseFromString(str);
+
+    //init the blob name map
+    for (int i = 0; i < header_.blobs_size(); i++) {
+      const string& blob_name = header_.blobs(i).blob_name();
+      
+      CHECK(blob_name_index_.find(blob_name) == blob_name_index_.end());
+      blob_name_index_[blob_name] = i;
+    }
+  }
+  
+  bool has_blob(const string& blob_name) {
+    return (blob_name_index_.find(blob_name) == blob_name_index_.end()) ? false : true;
+  }
+  
+  //return -1 if didn't find the blob
+  int blob_index_by_name(const string& blob_name) {
+    if (!has_blob(blob_name)) {
+      return -1;
+    }
+
+    return blob_name_index_[blob_name];
+  }
+
+  void *ZmsgData(int i)
+  {
+    CHECK_LT(i, zmsg_vec_.size()) << "ERROR: vector size is " << zmsg_vec_.size() << " index is " << i;
+    return zmq_msg_data(zmsg_vec_[i]);
+  }
+
+  void AddNewBlob(const string& blob_name, const void *data, int sz);
+  void CopyBlob(const string& blob_name, void *data, int sz);
+
+  int ZmsgSize(int i) 
+  {
+    CHECK_LT(i, zmsg_vec_.size()) << "ERROR: vector size is " << zmsg_vec_.size() << " index is " << i;
+    return zmq_msg_size(zmsg_vec_[i]);
+  }
+  
+
+  zmq_msg_t *GetZmsg(int i)
+  {
+    CHECK(i < zmsg_vec_.size()) << "Getting index " << i << " from a vector with size of: " << zmsg_vec_.size();
+    
+    return zmsg_vec_[i];
+  }
+
+  int ZmsgCnt()
+  {
+    return zmsg_vec_.size();
+  }
+
+
+protected:
+  MsgHeader header_;
+
+  vector<zmq_msg_t *> zmsg_vec_;
+  
+  //map blob name to the blob info index where it is stored.
+  map<string, int> blob_name_index_;
+};
+
+}
+
+#endif // MULTI_NODE_MSG_H_
+
+

--- a/include/caffe/multi_node/msg_hub.hpp
+++ b/include/caffe/multi_node/msg_hub.hpp
@@ -1,0 +1,103 @@
+
+#ifndef MULTI_NODE_MSG_HUB_H_
+#define MULTI_NODE_MSG_HUB_H_
+
+#include "caffe/multi_node/msg.hpp"
+#include "caffe/multi_node/sk_server.hpp"
+#include "caffe/multi_node/worker_thread.hpp"
+#include "caffe/caffe.hpp"
+
+#include "caffe/multi_node/node_env.hpp"
+
+#define SERVER_SK_STR "inproc://workers"
+
+#include "boost/unordered_map.hpp"
+
+using boost::unordered_map;
+
+namespace caffe {
+/**
+* Virtual base class of convolution, FC and parameter server nodes
+* It launches worker threads and set up in-process sockets for communication
+*/
+template <typename Dtype>
+class MsgHub
+{
+
+public:
+  MsgHub(int nthreads, int nworkers) {
+    nthreads_ = nthreads;
+    nworkers_ = nworkers;
+    
+    CHECK_GT(nthreads_, 0);
+    CHECK_GT(nworkers_, 0);
+
+    threads_.resize(nthreads);
+
+    for (int i = 0; i < nthreads; i++) {
+      sockp_arr_.push_back(shared_ptr<SkSock>(new SkSock(ZMQ_PAIR)));
+    }
+
+    //no poll items in the begining
+    poll_items_ = NULL;
+    num_poll_items_ = 0;
+    
+    //get ip address from machine (use the first interface by default)
+    node_ip_ = NodeEnv::Instance()->IP();
+  }
+  
+  virtual ~MsgHub() {
+    //deleting poll items if any
+    if ( NULL != poll_items_ ) {
+      delete [] poll_items_;
+    }
+  }
+  
+  /// monitor the incoming and outgoing messages
+  int Poll();
+  
+  //initing the contex for each thread, e.g. create caffe solver etc.
+  //and connect the nodes together.
+  virtual int Init() = 0;
+
+  //scheduling incoming & out-going message
+  virtual int RouteMsg() = 0;
+  
+  //use the internal threads to process message
+  int ProcessMsg(shared_ptr<Msg> m);
+
+protected:
+  virtual int SetUpPoll();
+  int StartThreads();
+
+protected:
+  //total number of threads
+  int nthreads_;
+  //number of threads used as workers
+  int nworkers_;
+  vector<shared_ptr<WorkerThread<Dtype> > > threads_;
+
+  //pair sockets to communicate with the work threads
+  vector<shared_ptr<SkSock> > sockp_arr_;
+
+  //for message polling
+  zmq_pollitem_t *poll_items_;
+  int num_poll_items_;
+
+  string node_ip_;
+  
+  //use hash map to store message
+  unordered_map<int64_t, shared_ptr<Msg> > id_to_msg_;
+
+private:
+  MsgHub() {  }
+
+DISABLE_COPY_AND_ASSIGN(MsgHub);
+};
+
+} // end caffe
+
+
+#endif
+
+

--- a/include/caffe/multi_node/node_env.hpp
+++ b/include/caffe/multi_node/node_env.hpp
@@ -1,0 +1,318 @@
+
+
+#ifndef MULTI_NODE_NODE_ENV_H_
+#define MULTI_NODE_NODE_ENV_H_
+
+#include <string>
+
+#include "caffe/multi_node/msg.hpp"
+#include "caffe/caffe.hpp"
+#include "caffe/multi_node/sk_sock.hpp"
+
+#include "boost/lexical_cast.hpp"
+
+#include "boost/unordered_map.hpp"
+using boost::unordered_map;
+
+#include "boost/thread/once.hpp"
+#include "boost/thread/mutex.hpp"
+#include "boost/thread.hpp"
+
+#include <sys/types.h>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <net/if.h>
+
+
+namespace caffe {
+
+class NodeEnv {
+
+////NOTE: all the public funcations are constants
+
+public:
+  const string& IP() { return node_ip_; }
+  const string& Interface() { return interface_; }
+  
+  //ID is used by ZMQ to identify socket
+  int ID() { return node_id_; }
+
+  ///
+  const SolverParameter& SolverParam() { return solver_param_; }
+
+
+  static NodeEnv *Instance();
+
+  ////
+  const vector<string>& SubAddrs() { return sub_addrs_; }
+  const vector<string>& DealerAddrs() { return dealer_addrs_; }
+  const vector<string>& ClientAddrs() { return client_addrs_; }
+  const vector<int>& DealerIDs() { return dealer_ids_; }
+  const vector<string>& BottomAddrs() { return bottom_addrs_; }
+  const vector<int>& BottomIDs() { return bottom_ids_; }
+
+  int NumInputBlobs() { return num_input_blobs_; }
+
+  string PubAddr() {
+    string addr = "tcp://*:";
+    addr += boost::lexical_cast<string>(pub_port_);
+    
+    return addr;
+  }
+
+
+  string RouterAddr() {
+    string addr = "tcp://*:";
+    addr += boost::lexical_cast<string>(router_port_);
+
+    return addr;
+  }
+
+
+  void *FindSolver(int64_t msg_id) {
+    boost::mutex::scoped_lock lock(id_map_mutex_);
+    unordered_map<int64_t, void *>::iterator iter = id_to_solver_.find(msg_id);
+
+    if (iter == id_to_solver_.end()) {
+      return NULL;
+    } else {
+      return iter->second;
+    }
+  }
+
+
+  void PutSolver(int64_t msg_id, void *solver) {
+    boost::mutex::scoped_lock lock(id_map_mutex_);
+    unordered_map<int64_t, void *>::iterator iter = id_to_solver_.find(msg_id);
+
+    CHECK (iter == id_to_solver_.end());
+    id_to_solver_[msg_id] = solver;
+
+    return;
+  }
+
+
+  void *DeleteSolver(int64_t msg_id) {
+    boost::mutex::scoped_lock lock(id_map_mutex_);
+    unordered_map<int64_t, void *>::iterator iter = id_to_solver_.find(msg_id);
+
+    CHECK (iter != id_to_solver_.end());
+    
+    void *p = iter->second;
+    id_to_solver_.erase(iter);
+
+    return p;
+  }
+
+
+  void PushFreeSolver(void *solver) {
+    boost::mutex::scoped_lock lock(id_map_mutex_);
+    free_solver_.push_back(solver);
+  }
+
+
+  void *PopFreeSolver() {
+    boost::mutex::scoped_lock lock(id_map_mutex_);
+    
+    //the 0th solver is root solver
+    if (free_solver_.size() <= 1) {
+      return NULL;
+    }
+
+    void *p = free_solver_.back();
+    free_solver_.pop_back();
+
+    return p;
+  }
+
+
+  int NumFreeSolver() {
+    boost::mutex::scoped_lock lock(id_map_mutex_);
+    return free_solver_.size();
+  }
+  
+  void *GetRootSolver() {
+    if (free_solver_.size() <= 0) {
+      return NULL;
+    } else {
+      return free_solver_[0];
+    }
+  }
+  
+  int GetTrainBatchSize() {
+    return rt_info_.train_batch_size();
+  }
+  
+
+public:
+  static inline void set_id_server(const string& addr) {
+    id_server_addr_ = addr;
+  }
+
+  static inline void set_model_server(const string& addr) {
+    model_server_addr_ = addr;
+  }
+
+  static inline void set_request_file(const string& addr) {
+    request_file_addr_ = addr;
+  }
+
+  static inline void set_node_role(const NodeRole role) {
+    node_role_ = role;
+  }
+
+  static inline const string& id_server_addr() {
+    return id_server_addr_;
+  }
+
+  static inline const string& model_server_addr() {
+    return model_server_addr_;
+  }
+
+  static inline const string& request_file_addr() {
+    return request_file_addr_;
+  }
+
+  static inline NodeRole node_role() {
+    return node_role_;
+  }
+
+protected:
+  static std::string IP(const std::string& interface) {
+    struct ifaddrs * ifAddrStruct = NULL;
+    struct ifaddrs * ifa = NULL;
+    void * tmpAddrPtr = NULL;
+    std::string ret_ip;
+
+    getifaddrs(&ifAddrStruct);
+    for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next) {
+      if (ifa->ifa_addr == NULL) continue;
+      if (ifa->ifa_addr->sa_family==AF_INET) {
+        // is a valid IP4 Address
+        tmpAddrPtr=&((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+        char addressBuffer[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, tmpAddrPtr, addressBuffer, INET_ADDRSTRLEN);
+        if (strncmp(ifa->ifa_name,
+                    interface.c_str(),
+                    interface.size()) == 0) {
+          ret_ip = addressBuffer;
+          break;
+        }
+      }
+    }
+    if (ifAddrStruct != NULL) freeifaddrs(ifAddrStruct);
+    return ret_ip;
+  }
+
+  static void GetInterfaceAndIP(std::string& interface, std::string& ip) {
+    struct ifaddrs * ifAddrStruct = NULL;
+    struct ifaddrs * ifa = NULL;
+
+    interface.clear();
+    ip.clear();
+    getifaddrs(&ifAddrStruct);
+    for (ifa = ifAddrStruct; ifa != NULL; ifa = ifa->ifa_next) {
+      if (NULL == ifa->ifa_addr) continue;
+
+      if (AF_INET == ifa->ifa_addr->sa_family &&
+        0 == (ifa->ifa_flags & IFF_LOOPBACK)) {
+
+        char address_buffer[INET_ADDRSTRLEN];
+        void* sin_addr_ptr = &((struct sockaddr_in*)ifa->ifa_addr)->sin_addr;
+        inet_ntop(AF_INET, sin_addr_ptr, address_buffer, INET_ADDRSTRLEN);
+
+        ip = address_buffer;
+        interface = ifa->ifa_name;
+
+        break;
+      }
+    }
+
+    if (NULL != ifAddrStruct) freeifaddrs(ifAddrStruct);
+    return;
+  }
+
+
+protected: 
+  static void InitNode(void);
+  int InitNodeID();
+  int InitModel();
+  int InitIP();
+
+
+private:
+  NodeEnv() {
+    node_id_ = INVALID_ID;
+  }
+
+
+protected:
+  int node_id_;
+  string node_ip_;
+  string interface_;
+
+  int router_port_;
+  int pub_port_;
+
+  int server_port_;
+  
+  //parameters from server
+  SolverParameter solver_param_;
+  RouteInfo rt_info_;
+
+  //routing addresses
+
+  //addresses of the SUB sockets to receive broadcasting messages
+  vector<string> sub_addrs_;
+
+  //address of the dealer sockets to send message to upstream node
+  vector<string> dealer_addrs_;
+  
+  //ID of the dealers
+  vector<int> dealer_ids_;
+
+  //address of the clients
+  vector<string> client_addrs_;
+
+  //listen address in the loss layer
+  vector<string> bottom_addrs_;
+  
+  //node ID in the bottom nodes, used for routing
+  vector<int> bottom_ids_;
+
+  //number of input blobs
+  int num_input_blobs_;
+  
+  //mapping message id to solver
+  unordered_map<int64_t, void *> id_to_solver_;
+  boost::mutex  id_map_mutex_;
+  
+  //available solvers
+  vector<void *> free_solver_;
+
+private:
+  //For Singleton pattern
+  static NodeEnv *instance_;
+  static boost::once_flag once_;
+
+  // get unique integer id from id server
+  static string id_server_addr_;
+
+  static string model_server_addr_;
+  
+  // request file is sent to model server for model splitting
+  static string request_file_addr_;
+
+  static NodeRole node_role_;
+
+DISABLE_COPY_AND_ASSIGN(NodeEnv);
+};
+
+} //namespace caffe
+
+#endif
+
+

--- a/include/caffe/multi_node/ps_node.hpp
+++ b/include/caffe/multi_node/ps_node.hpp
@@ -1,0 +1,40 @@
+
+#ifndef MULTI_NODE_PS_NODE_H_
+#define MULTI_NODE_PS_NODE_H_
+
+#include "caffe/multi_node/msg_hub.hpp"
+#include "caffe/multi_node/ps_thread.hpp"
+#include "caffe/sgd_solvers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+class ParamServer : public MsgHub<Dtype>
+{
+
+public:
+  ParamServer(int nthreads, const string& ps_bind_addr);
+  virtual ~ParamServer() { }
+
+public:
+  virtual int Init();
+
+  virtual int RouteMsg();
+
+public:
+  virtual int SetUpPoll();
+
+protected:
+  shared_ptr<SkSock> ps_router_;
+
+  string ps_bind_addr_;
+  int ps_sock_index_;
+
+DISABLE_COPY_AND_ASSIGN(ParamServer);
+};
+
+} //end caffe
+
+#endif
+
+

--- a/include/caffe/multi_node/ps_thread.hpp
+++ b/include/caffe/multi_node/ps_thread.hpp
@@ -1,0 +1,46 @@
+
+
+#ifndef MULTI_NODE_PS_THREAD_H_
+#define MULTI_NODE_PS_THREAD_H_
+
+#include "caffe/multi_node/worker_thread.hpp"
+#include "caffe/sgd_solvers.hpp"
+
+
+namespace caffe {
+/**
+*Threads work in parameter server nodes
+*Get param gradients from convolution nodes
+* and update parameters using SGD solver
+*/
+template <typename Dtype>
+class PSThread : public WorkerThread<Dtype>
+{
+public:
+  PSThread() {
+    ps_solver_ = NULL;
+  }
+
+  virtual void Run();
+
+protected:
+  void UpdateParam(shared_ptr<Msg> m);
+  void SendParam(shared_ptr<Msg> m);
+
+  virtual Solver<Dtype> *CreateSolver() {
+    Caffe::set_root_solver(false);
+    SGDSolver<Dtype> *ps_root = (SGDSolver<Dtype> *)NodeEnv::Instance()->GetRootSolver();
+    const SolverParameter& param = NodeEnv::Instance()->SolverParam();
+
+    return new SGDSolver<Dtype>(param, ps_root);
+  }
+
+protected:
+  SGDSolver<Dtype> *ps_solver_;
+};
+
+} //end caffe
+
+#endif
+
+

--- a/include/caffe/multi_node/sk_server.hpp
+++ b/include/caffe/multi_node/sk_server.hpp
@@ -1,0 +1,36 @@
+
+
+#ifndef MULTI_NODE_SK_SERVER_H
+#define MULTI_NODE_SK_SERVER_H
+
+#include "caffe/multi_node/msg.hpp"
+#include "caffe/multi_node/sk_sock.hpp"
+
+namespace caffe {
+/*
+*SkServer wrapps ZMQ router socket
+*ZMQ attaches an ID in a message sent by a dealer socket
+* to router socket, we intentionally remove the header
+* and hide the details to high lever classes
+*/
+class SkServer : public SkSock {
+
+public:
+  SkServer(); 
+
+  virtual ~SkServer();
+
+  virtual int Connect(string addr);
+  
+  /// removes the ID message added by ZMQ layer
+  virtual shared_ptr<Msg> RecvMsg(bool blocked);
+  
+  /// attaches an ID message for ZMQ
+  virtual int SendMsg(shared_ptr<Msg> msg);
+};
+
+} //end caffe
+
+#endif
+
+

--- a/include/caffe/multi_node/sk_sock.hpp
+++ b/include/caffe/multi_node/sk_sock.hpp
@@ -1,0 +1,99 @@
+
+
+#ifndef MULTI_NODE_SK_SOCK_H
+#define MULTI_NODE_SK_SOCK_H
+
+#include "caffe/multi_node/msg.hpp"
+#include <boost/thread.hpp>
+
+namespace caffe {
+
+class SkSock {
+
+public:
+  SkSock() {
+    id_ = INVALID_ID;
+  }
+
+  SkSock(int type, int id) {
+    InitZmq(); 
+    sock_ = zmq_socket (zmq_ctx_, type);
+    id_ = id;
+    sk_type_ = type;
+  }
+  
+  SkSock(int type) {
+    InitZmq(); 
+    sk_type_ = type;
+    sock_ = zmq_socket (zmq_ctx_, type);
+  }
+
+  virtual ~SkSock() {
+    if (NULL != sock_) {
+        zmq_close(sock_);
+    }
+    
+    boost::mutex::scoped_lock lock(zmq_init_mutex_);
+    LOG(INFO) << "deinitialize zmq ctx cnt: " << inited_cnt_;
+    
+    inited_cnt_--;
+    if (0 == inited_cnt_) {
+        LOG(INFO) << "destroying zmq context";
+        zmq_ctx_destroy(zmq_ctx_);
+    }
+
+  }
+  
+  virtual int Bind(const string& addr);
+
+  virtual int Connect(const string& addr);
+  
+  virtual shared_ptr<Msg> RecvMsg(bool blocked);
+
+  virtual int SendMsg(shared_ptr<Msg> msg);
+
+  int GetId() { return id_; }
+
+  int SetId(int id) {
+    id_ = id;
+    zmq_setsockopt (sock_, ZMQ_IDENTITY, &id, sizeof(id));
+
+    return 0;
+  }
+  
+  /// return the native zmq socket
+  void *GetSock() {
+    return sock_;
+  }
+
+protected:
+  int SendHeader(shared_ptr<Msg> msg);
+
+protected:
+  // the native zmq socket
+  void *sock_;
+  // the zmq address of this socket
+  string addr_;
+
+  void InitZmq(void);
+  static void *zmq_ctx_;
+
+protected:
+  // an unique id allocated by an global id server
+  int id_;
+  // zmq socket type
+  int sk_type_;
+
+private:
+  // a zmq context should be inited only once
+  static boost::mutex zmq_init_mutex_;
+  static int inited_cnt_;
+};
+
+} //end caffe
+
+#endif
+
+
+
+

--- a/include/caffe/multi_node/worker_thread.hpp
+++ b/include/caffe/multi_node/worker_thread.hpp
@@ -1,0 +1,143 @@
+
+#ifndef MULTI_NODE_WORKER_THREAD_H_
+#define MULTI_NODE_WORKER_THREAD_H_
+
+
+#include "caffe/multi_node/msg.hpp"
+#include "caffe/multi_node/sk_server.hpp"
+#include "caffe/multi_node/node_env.hpp"
+
+#include <boost/thread.hpp>
+
+namespace caffe {
+/**
+* Base class of the convolution, FC, PS threads
+* Set up the communication enviroment with routing thread
+*/
+template <typename Dtype>
+class WorkerThread : public InternalThread
+{
+public:
+  WorkerThread() {
+    worker_id_ = -1;
+  }
+
+  virtual ~WorkerThread() {
+    StopInternalThread();
+  }
+
+  void SetWorkerId(int id) { worker_id_ = id; }
+  int GetWorkerId() { return worker_id_; }
+
+  void SetAddr(const string& addr) { addr_ = addr; }
+  
+  int SendMsg(shared_ptr<Msg> msg) {
+    return sk_client_->SendMsg(msg);
+  }
+
+  shared_ptr<Msg> RecvMsg(bool blocked) {
+    return sk_client_->RecvMsg(blocked);
+  }
+
+  virtual void InternalThreadEntry() {
+    sk_client_.reset(new SkSock(ZMQ_PAIR));
+    sk_client_->Connect(addr_);
+
+    Run();
+  }
+  
+  /// should be reimplented in the working threads
+  virtual void Run() = 0;
+
+protected:
+  Solver<Dtype> *NewSolver() {
+    boost::mutex::scoped_lock lock(new_solver_mutex_);
+    Solver<Dtype> *root_solver = (Solver<Dtype> *)NodeEnv::Instance()->GetRootSolver();
+    const vector<Blob<Dtype>*>& root_params = root_solver->net()->learnable_params();
+
+    Solver<Dtype> *new_solver = CreateSolver();
+    if (new_solver == NULL) {
+      return new_solver;
+    }
+
+    const vector<Blob<Dtype>*>& new_params = new_solver->net()->learnable_params();
+    
+    /// share parameters with root solver
+    for (int i = 0; i < new_params.size(); i++) {
+      CHECK_EQ(new_params[i]->count(), root_params[i]->count());
+      new_params[i]->ShareData(*root_params[i]);
+    }
+
+    return new_solver;
+  }
+
+  virtual Solver<Dtype> *CreateSolver() = 0;
+  
+  ///move these functions to caffe::Net?
+
+  /// net get input blob data from message
+  static void GetInputData(shared_ptr<Net<Dtype> > net, shared_ptr<Msg> m) {
+    for (int i = 0; i < net->num_inputs(); i++) {
+      int blob_index = net->input_blob_indices()[i];
+      const string& blob_name = net->blob_names()[blob_index];
+      Blob<Dtype>* pblob = net->input_blobs()[i];
+
+      m->CopyBlob(blob_name, pblob->mutable_cpu_data(), pblob->count() * sizeof(Dtype));
+    }
+  }
+
+  /// net get output blob diffs from message
+  static void GetOutputDiff(shared_ptr<Net<Dtype> > net, shared_ptr<Msg> m) {
+    for (int i = 0; i < net->num_outputs(); i++) {
+      int blob_index = net->output_blob_indices()[i];
+      const string& blob_name = net->blob_names()[blob_index];
+      Blob<Dtype>* pblob = net->output_blobs()[i];
+
+      m->CopyBlob(blob_name, pblob->mutable_cpu_diff(), pblob->count() * sizeof(Dtype));
+    }
+  }
+  
+  /// net copy input blob diffs to message
+  static void CopyInputDiff(shared_ptr<Net<Dtype> > net, shared_ptr<Msg> m) {
+    for (int i = 0; i < net->num_inputs(); i++) {
+      int blob_index = net->input_blob_indices()[i];
+      const string& blob_name = net->blob_names()[blob_index];
+      Blob<Dtype>* pblob = net->input_blobs()[i];
+
+      m->AddNewBlob(blob_name, pblob->cpu_diff(), pblob->count() * sizeof(Dtype));
+    }
+  }
+  
+  /// net copy output blob data to a message
+  static void CopyOutputData(shared_ptr<Net<Dtype> > net, shared_ptr<Msg> m) {
+    for (int i = 0; i < net->num_outputs(); i++) {
+      int blob_index = net->output_blob_indices()[i];
+      const string& blob_name = net->blob_names()[blob_index];
+      Blob<Dtype>* pblob = net->output_blobs()[i];
+
+      m->AddNewBlob(blob_name, pblob->cpu_data(), pblob->count() * sizeof(Dtype));
+    }
+  }
+  
+
+protected:
+  int worker_id_;
+  /// in-process communication addr with routing thread
+  string addr_;
+  shared_ptr<SkSock> sk_client_;
+
+protected:
+  //serialize creating new solver within a process
+  static boost::mutex  new_solver_mutex_;
+
+DISABLE_COPY_AND_ASSIGN(WorkerThread);
+};
+
+
+} // end caffe
+
+
+#endif
+
+
+

--- a/include/caffe/sgd_solvers.hpp
+++ b/include/caffe/sgd_solvers.hpp
@@ -15,13 +15,18 @@ namespace caffe {
 template <typename Dtype>
 class SGDSolver : public Solver<Dtype> {
  public:
-  explicit SGDSolver(const SolverParameter& param)
-      : Solver<Dtype>(param) { PreSolve(); }
-  explicit SGDSolver(const string& param_file)
-      : Solver<Dtype>(param_file) { PreSolve(); }
+  explicit SGDSolver(const SolverParameter& param, const Solver<Dtype>* root_solver = NULL)
+      : Solver<Dtype>(param, root_solver) { PreSolve(); }
+  explicit SGDSolver(const string& param_file, const Solver<Dtype>* root_solver = NULL)
+      : Solver<Dtype>(param_file, root_solver) { PreSolve(); }
   virtual inline const char* type() const { return "SGD"; }
 
   const vector<shared_ptr<Blob<Dtype> > >& history() { return history_; }
+  
+  void CommitGradient() {
+    ApplyUpdate();
+    ++this->iter_;
+  }
 
  protected:
   void PreSolve();

--- a/src/caffe/multi_node/async_data.cpp
+++ b/src/caffe/multi_node/async_data.cpp
@@ -1,0 +1,121 @@
+
+
+#include <opencv2/core/core.hpp>
+
+#include <stdint.h>
+
+#include <string>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/data_layers.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/benchmark.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/util/rng.hpp"
+
+#include "caffe/multi_node/async_data.hpp"
+
+
+namespace caffe {
+
+template <typename Dtype>
+AsyncDataLayer<Dtype>::~AsyncDataLayer<Dtype>() {
+
+}
+
+
+template <typename Dtype>
+void AsyncDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+
+  const int batch_size = this->layer_param_.data_param().batch_size();
+  // Read a data point, and use it to initialize the top blob.
+  Datum& datum = *(full_->peek());
+
+  // Use data_transformer to infer the expected blob shape from datum.
+  vector<int> top_shape = this->data_transformer_->InferBlobShape(datum);
+  this->transformed_data_.Reshape(top_shape);
+  // Reshape top[0] and prefetch_data according to the batch_size.
+  top_shape[0] = batch_size;
+  top[0]->Reshape(top_shape);
+  for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
+    this->prefetch_[i].data_.Reshape(top_shape);
+  }
+  LOG(INFO) << "output data size: " << top[0]->num() << ","
+    << top[0]->channels() << "," << top[0]->height() << ","
+    << top[0]->width();
+  
+  // label
+  if (this->output_labels_) {
+    vector<int> label_shape(1, batch_size);
+    top[1]->Reshape(label_shape);
+    for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
+      this->prefetch_[i].label_.Reshape(label_shape);
+    }
+  }
+
+}
+
+
+template<typename Dtype>
+void AsyncDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
+  CPUTimer batch_timer;
+  batch_timer.Start();
+  double read_time = 0;
+  double trans_time = 0;
+  CPUTimer timer;
+  CHECK(batch->data_.count());
+  CHECK(this->transformed_data_.count());
+
+  // Reshape according to the first datum of each batch
+  // on single input batches allows for inputs of varying dimension.
+  const int batch_size = this->layer_param_.data_param().batch_size();
+  Datum& datum = *(full_->peek());
+  // Use data_transformer to infer the expected blob shape from datum.
+  vector<int> top_shape = this->data_transformer_->InferBlobShape(datum);
+  this->transformed_data_.Reshape(top_shape);
+  // Reshape batch according to the batch_size.
+  top_shape[0] = batch_size;
+  batch->data_.Reshape(top_shape);
+
+  Dtype* top_data = batch->data_.mutable_cpu_data();
+  Dtype* top_label = NULL;  // suppress warnings about uninitialized variables
+
+  if (this->output_labels_) {
+    top_label = batch->label_.mutable_cpu_data();
+  }
+  for (int item_id = 0; item_id < batch_size; ++item_id) {
+    timer.Start();
+    // get a datum
+    Datum& datum = *(full_->pop("Waiting for data"));
+    read_time += timer.MicroSeconds();
+    timer.Start();
+    // Apply data transformations (mirror, scale, crop...)
+    int offset = batch->data_.offset(item_id);
+    this->transformed_data_.set_cpu_data(top_data + offset);
+    this->data_transformer_->Transform(datum, &(this->transformed_data_));
+    // Copy label.
+    if (this->output_labels_) {
+      top_label[item_id] = datum.label();
+    }
+    trans_time += timer.MicroSeconds();
+
+    free_->push(const_cast<Datum*>(&datum));
+  }
+  timer.Stop();
+  batch_timer.Stop();
+  //LOG(INFO) << "Prefetch batch: " << batch_timer.MilliSeconds() << " ms.";
+  //LOG(INFO) << "     Read time: " << read_time / 1000 << " ms.";
+  //LOG(INFO) << "Transform time: " << trans_time / 1000 << " ms.";
+
+}
+
+INSTANTIATE_CLASS(AsyncDataLayer);
+REGISTER_LAYER_CLASS(AsyncData);
+
+}  // namespace caffe
+
+

--- a/src/caffe/multi_node/async_reader.cpp
+++ b/src/caffe/multi_node/async_reader.cpp
@@ -1,0 +1,79 @@
+
+
+#include "caffe/multi_node/async_reader.hpp"
+
+namespace caffe {
+
+boost::once_flag AsyncReader::flag_once_;
+
+AsyncReader *AsyncReader::instance_ = NULL;
+
+int AsyncReader::RegisterLayer(const LayerParameter& param)
+{
+  boost::mutex::scoped_lock lock(register_mutex_);
+  
+  string key = source_key(param);
+  map<const string, int>::iterator iter = index_map_.find(key);
+  
+  int index = -1;
+
+  if (iter == index_map_.end()) {
+    index = AddBlockQueue(param);
+  } else {
+    index = iter->second;
+  }
+  
+  BlockingQueue<Datum*> *p = free_queue_[index];
+  int sz = param.data_param().prefetch() * param.data_param().batch_size();
+
+  //increase the buffer queue
+  for (int i = 0; i < sz; i++) {
+    p->push(new Datum());
+  }
+
+  return index;
+}
+
+
+int AsyncReader::AddBlockQueue(const LayerParameter& param)
+{
+  BlockingQueue<Datum*> *p = new BlockingQueue<Datum*>();
+
+  free_queue_.push_back(p);
+  full_queue_.push_back(new BlockingQueue<Datum*>());
+
+  CHECK_EQ(free_queue_.size(), full_queue_.size());
+  
+  int index = free_queue_.size() - 1;
+
+  //start a new reader thread
+  thread_arr_.push_back(shared_ptr<ReaderThread>(new ReaderThread( param,
+                                      free_queue_[index], full_queue_[index] )));
+
+  return index;
+}
+
+
+void ReaderThread::InternalThreadEntry()
+{
+  shared_ptr<db::DB> db(db::GetDB(param_.data_param().backend()));
+  db->Open(param_.data_param().source(), db::READ);
+  shared_ptr<db::Cursor> cursor(db->NewCursor());
+
+  while (!must_stop()) {
+    Datum* datum = free_->pop();
+
+    datum->ParseFromString(cursor->value());
+    full_->push(datum);
+
+    cursor->Next();
+    if (!cursor->valid()) {
+      LOG(INFO) << "Restarting data prefetching from start.";
+      cursor->SeekToFirst();
+    }
+  }
+}
+
+}
+
+

--- a/src/caffe/multi_node/conv_node.cpp
+++ b/src/caffe/multi_node/conv_node.cpp
@@ -1,0 +1,121 @@
+
+
+#include "caffe/multi_node/conv_node.hpp"
+#include "caffe/multi_node/conv_thread.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+int ConvClient<Dtype>::Init()
+{
+  //at leaset two threads
+  CHECK_GE(this->nthreads_, 2);
+
+  //connecting to the gateway of fully connected layer
+  fc_client_->Connect(fc_gateway_addr_);
+  ps_client_->Connect(ps_addr_);
+  
+  //using a solver to share weights among threads
+  Caffe::set_root_solver(true);
+  SGDSolver<Dtype> *root_solver = new SGDSolver<Dtype>( NodeEnv::Instance()->SolverParam() );
+  
+  //init parameters from parameter server
+  shared_ptr<Msg> ps_msg(new Msg());
+  ps_msg->set_type(GET_PARAM);
+  ps_msg->set_dst(PS_ID);
+  ps_msg->set_src(NodeEnv::Instance()->ID());
+
+  const vector<Blob<Dtype>*>& net_params = root_solver->net()->learnable_params();
+  for (int i = 0; i < net_params.size(); i++) {
+    ps_msg->AppendData(net_params[i]->cpu_diff(), net_params[i]->count() * sizeof(Dtype));
+  }
+  ps_client_->SendMsg(ps_msg);
+  
+  shared_ptr<Msg> r = ps_client_->RecvMsg(true);
+  for (int i = 0; i < net_params.size(); i++) {
+    CHECK_EQ(net_params[i]->count() * sizeof(Dtype), r->ZmsgSize(i));
+
+    memcpy(net_params[i]->mutable_cpu_data(), r->ZmsgData(i), r->ZmsgSize(i));
+  }
+
+  //push as root solver
+  NodeEnv::Instance()->PushFreeSolver(root_solver);
+  
+  CHECK_GE(this->threads_.size(), this->nthreads_);
+  for (int i = 0; i < this->nworkers_; i++) {
+    this->threads_[i].reset(new ConvThread<Dtype>());
+  }
+
+  this->threads_[ps_thread_index_].reset(new ConvParamThread<Dtype>());
+
+  return this->StartThreads();
+}
+
+template <typename Dtype>
+int ConvClient<Dtype>::SetUpPoll()
+{
+  this->num_poll_items_ = this->nthreads_ + 2;
+  this->poll_items_ = new zmq_pollitem_t[this->num_poll_items_];
+  
+  //1 socket to communicate fc_gateway
+  this->poll_items_[fc_sock_index_].socket = fc_client_->GetSock();
+  this->poll_items_[fc_sock_index_].events = ZMQ_POLLIN;
+  this->poll_items_[fc_sock_index_].fd = 0;
+  this->poll_items_[fc_sock_index_].revents = 0;
+
+  //1 socket to communicate parameter server
+  this->poll_items_[ps_sock_index_].socket = ps_client_->GetSock();
+  this->poll_items_[ps_sock_index_].events = ZMQ_POLLIN;
+  this->poll_items_[ps_sock_index_].fd = 0;
+  this->poll_items_[ps_sock_index_].revents = 0;
+
+  return MsgHub<Dtype>::SetUpPoll();
+}
+
+template <typename Dtype>
+int ConvClient<Dtype>::RouteMsg()
+{
+  for (int i = 0; i < this->nworkers_; i++) {
+    if (this->poll_items_[i].revents & ZMQ_POLLIN) {
+      shared_ptr<Msg> m = this->sockp_arr_[i]->RecvMsg(true);
+      
+      if (m->dst() == ROOT_THREAD_ID) {
+        this->sockp_arr_[ps_thread_index_]->SendMsg(m);
+      } else if (m->dst() == PS_ID) {
+        ps_client_->SendMsg(m);
+      } else {
+        fc_client_->SendMsg(m);
+      }
+    }
+  }
+  
+  //from the parameter client thread
+  if (this->poll_items_[ps_thread_index_].revents & ZMQ_POLLIN) {
+    shared_ptr<Msg> m = this->sockp_arr_[ps_thread_index_]->RecvMsg(true);
+    ps_client_->SendMsg(m);
+  }
+
+  //incoming packet from fc gateway
+  if (this->poll_items_[fc_sock_index_].revents & ZMQ_POLLIN) {
+    shared_ptr<Msg> m = fc_client_->RecvMsg(true);
+
+    this->sockp_arr_[0]->SendMsg(m);
+    //ProcessMsg(m);
+  }
+  
+  //incoming packet from parameter server
+  if (this->poll_items_[ps_sock_index_].revents & ZMQ_POLLIN) {
+    shared_ptr<Msg> m = ps_client_->RecvMsg(true);
+    
+    //forwarding the message from PS to PS client
+    this->sockp_arr_[ps_thread_index_]->SendMsg(m);
+  }
+
+  return 0;
+}
+
+INSTANTIATE_CLASS(ConvClient);
+
+}
+
+

--- a/src/caffe/multi_node/conv_thread.cpp
+++ b/src/caffe/multi_node/conv_thread.cpp
@@ -1,0 +1,145 @@
+
+#include "caffe/multi_node/conv_thread.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+boost::mutex ConvThread<Dtype>::conv_id_mutex_;
+
+template <typename Dtype>
+int64_t ConvThread<Dtype>::conv_id_ = 0;
+
+template <typename Dtype>
+shared_ptr<Msg> ConvThread<Dtype>::ConvForward()
+{
+  WorkerSolver<Dtype> *pconv = (WorkerSolver<Dtype> *)NodeEnv::Instance()->PopFreeSolver();
+  if (NULL == pconv) {
+    pconv = (WorkerSolver<Dtype> *)this->NewSolver();
+  }
+
+  shared_ptr<Net<Dtype> > conv_net = pconv->net();
+  conv_net->ClearParamDiffs();
+  conv_net->ForwardPrefilled();
+  
+  //copyout the activations
+  shared_ptr<Msg> m(new Msg());
+  this->CopyOutputData(conv_net, m);
+  
+  m->set_src(NodeEnv::Instance()->ID());
+  int64_t conv_id = NewConvId();
+  m->set_type(FORWARD);
+  m->set_conv_id(conv_id);
+  NodeEnv::Instance()->PutSolver(conv_id, pconv);
+
+  return m;
+}
+
+template <typename Dtype>
+int ConvThread<Dtype>::ConvBackward(shared_ptr<Msg> m)
+{
+  WorkerSolver<Dtype> *pconv = (WorkerSolver<Dtype> *)NodeEnv::Instance()->FindSolver(m->conv_id());
+  CHECK(pconv != NULL);
+  
+  shared_ptr<Net<Dtype> > conv_net = pconv->net();
+  this->GetOutputDiff(conv_net, m);
+
+  //copy activations
+  conv_net->Backward();
+  
+  //notify the param thread that delta is ready
+  shared_ptr<Msg> notify(new Msg(m));
+  
+  notify->set_dst(ROOT_THREAD_ID);
+  notify->set_type(PUT_GRADIENT);
+  notify->AppendData(&pconv, sizeof(pconv));
+  
+  this->SendMsg(notify);
+
+  return 0;
+}
+
+
+template <typename Dtype>
+void ConvThread<Dtype>::Run()
+{
+
+  while (!this->must_stop()) {
+    shared_ptr<Msg> f = ConvForward();
+    this->SendMsg(f);
+
+    shared_ptr<Msg> r;
+    while ( (r = this->RecvMsg(false)) != NULL) {  //unblocked
+    //if ( (r = this->RecvMsg(true)) != NULL) {        //blocked
+      ConvBackward(r);      
+    }
+  }
+}
+
+
+template <typename Dtype>
+int ConvParamThread<Dtype>::PutGradient(shared_ptr<Msg> m)
+{
+  WorkerSolver<Dtype> *psolver = (WorkerSolver<Dtype> *)NodeEnv::Instance()->FindSolver(m->conv_id());
+  CHECK(psolver != NULL);
+  
+  shared_ptr<Msg> ps_msg(new Msg());
+  ps_msg->set_type(PUT_GRADIENT);
+  ps_msg->set_dst(PS_ID);
+  ps_msg->set_src(NodeEnv::Instance()->ID());
+
+  const vector<Blob<Dtype>*>& net_params = psolver->net()->learnable_params();
+  for (int i = 0; i < net_params.size(); i++) {
+    ps_msg->AppendData(net_params[i]->cpu_diff(), net_params[i]->count() * sizeof(Dtype));
+  }
+  
+  this->SendMsg(ps_msg);
+ 
+  NodeEnv::Instance()->DeleteSolver(m->conv_id());
+  NodeEnv::Instance()->PushFreeSolver(psolver);
+
+  return 0;
+}
+
+template <typename Dtype>
+int ConvParamThread<Dtype>::UpdateParam(shared_ptr<Msg> m)
+{
+  WorkerSolver<Dtype> *root_solver = (WorkerSolver<Dtype> *) NodeEnv::Instance()->GetRootSolver();
+  
+  const vector<Blob<Dtype>*>& root_params = root_solver->net()->learnable_params();
+  
+  CHECK_EQ(root_params.size(), m->ZmsgCnt());
+
+  for (int i = 0; i < root_params.size(); i++) {
+    CHECK_EQ(root_params[i]->count() * sizeof(Dtype), m->ZmsgSize(i));
+
+    memcpy(root_params[i]->mutable_cpu_data(), m->ZmsgData(i), m->ZmsgSize(i));
+  }
+
+  return 0;
+}
+
+template <typename Dtype>
+void ConvParamThread<Dtype>::Run()
+{
+  Caffe::set_root_solver(true);
+
+  while (!this->must_stop()) {
+    shared_ptr<Msg> m = this->RecvMsg(true);
+
+    if (m->type() == PUT_GRADIENT) {
+      PutGradient(m);
+    } else if (m->type() == PUT_PARAM) {
+      UpdateParam(m);
+    } else {
+      LOG(ERROR) << "PS client: unknown type " << m->type();
+    }
+  }
+  
+}
+
+INSTANTIATE_CLASS(ConvThread);
+INSTANTIATE_CLASS(ConvParamThread);
+
+} // end namespace caffe
+
+

--- a/src/caffe/multi_node/fc_node.cpp
+++ b/src/caffe/multi_node/fc_node.cpp
@@ -1,0 +1,292 @@
+
+
+#include "caffe/multi_node/fc_node.hpp"
+
+
+namespace caffe {
+
+template <typename Dtype>
+int FcNode<Dtype>::SetUpPoll()
+{
+  CHECK(this->poll_items_ != NULL);
+
+  this->poll_items_[back_sock_index_].socket = sock_back_->GetSock();
+  this->poll_items_[back_sock_index_].events = ZMQ_POLLIN;
+  this->poll_items_[back_sock_index_].fd = 0;
+  this->poll_items_[back_sock_index_].revents = 0;
+  
+  return MsgHub<Dtype>::SetUpPoll();
+}
+
+template <typename Dtype>
+int FcNode<Dtype>::Init()
+{
+  const vector<string>& next = NodeEnv::Instance()->ClientAddrs();
+  
+  for (int i = 0; i < this->nworkers_; i++) {
+    if (next.size() > 0) {
+      this->threads_[i].reset(new FcThread<Dtype>());
+    } else {
+      this->threads_[i].reset(new FcEndThread<Dtype>());
+    }
+  }
+  
+  //the last slot for param thread
+  this->threads_[param_thread_index_].reset(new FcParamThread<Dtype>());
+  
+  //wait for the downstream nodes to connect
+  for (int i = 0; i < next.size(); i++) {
+    shared_ptr<Msg> m = sock_back_->RecvMsg(true);
+
+    CHECK (m->type() == PING);
+    
+    string node((char *)m->ZmsgData(0), m->ZmsgSize(0));
+    LOG(INFO) << "Accepted Connection from: " << node;
+  }
+  
+  num_next_hops_ = next.size();
+  
+  const SolverParameter& param = NodeEnv::Instance()->SolverParam();
+  //set up solvers
+  SGDSolver<Dtype> *pfc0 = new SGDSolver<Dtype>(param);
+  NodeEnv::Instance()->PushFreeSolver(pfc0);
+
+  //init the threads
+  return this->StartThreads();
+}
+
+template <typename Dtype>
+int FcNode<Dtype>::RouteMsg()
+{
+  //Got messages from the work threads:
+  for (int i = 0; i < this->nworkers_; i++) {
+    //
+    if (this->poll_items_[i].revents & ZMQ_POLLIN) {
+      shared_ptr<Msg> m = this->sockp_arr_[i]->RecvMsg(true);
+      
+      //route the msg to root thread for updating parameter
+      if (m->dst() == ROOT_THREAD_ID) {
+        this->sockp_arr_[param_thread_index_]->SendMsg(m);
+      } else {
+        SendOutMsg(m);
+      }
+    }
+  }
+  
+  //Paramter update thread
+  if (this->poll_items_[param_thread_index_].revents & ZMQ_POLLIN) {
+    shared_ptr<Msg> m = this->sockp_arr_[param_thread_index_]->RecvMsg(true);
+    
+    //the parameter thread shouldn't send out any message
+    LOG(ERROR) << "Received unsupported message";
+  }
+
+  //only deal with the backward packets from rear REP socket
+  if (this->poll_items_[back_sock_index_].revents & ZMQ_POLLIN) {
+    shared_ptr<Msg> m = sock_back_->RecvMsg(true);
+    
+    LOG(INFO) << "back server received message";
+    
+    //forward packets in the back server usually the labels
+    if (m->type() == FORWARD) {
+      this->ProcessMsg(m);
+    } else if (m->type() == BACKWARD) {
+      this->ProcessMsg(m);
+    } else {
+      LOG(ERROR) << "unknown message: ";
+      m->PrintHeader();
+    }
+  }
+  
+  return 0;
+}
+
+
+//send out the message which has been processed by the threads
+template <typename Dtype>
+int FcNode<Dtype>::SendOutMsg(shared_ptr<Msg> m)
+{
+  //broadcast address, send the message to hub sock to broadcast
+  if (m->dst() < 0) {
+    sock_pub_->SendMsg(m);
+
+    return 0;
+  }
+  
+  //looking up the route table
+  unordered_map<int, shared_ptr<SkSock> >::iterator iter = node_to_sock_.find(m->dst());
+
+  CHECK( iter != node_to_sock_.end() ) << "Cannot find routes for id: " << m->dst();
+
+  iter->second->SendMsg(m);
+
+  return 0;
+}
+
+template <typename Dtype>
+int FcNode<Dtype>::InitRoute()
+{
+  const vector<string>& dealer_addrs = NodeEnv::Instance()->DealerAddrs();
+  const vector<int>& dealer_ids = NodeEnv::Instance()->DealerIDs();
+  
+  for (int i = 0; i < dealer_addrs.size(); i++) {
+    //connect ROUTER node
+    shared_ptr<SkSock> dealer(new SkSock(ZMQ_DEALER));
+    dealer->SetId(node_id_);
+    dealer->Connect(dealer_addrs[i]);
+    
+    //Unique CHECK
+    CHECK(node_to_sock_.find(dealer_ids[i]) == node_to_sock_.end());
+    node_to_sock_[dealer_ids[i]] = dealer;
+    
+    //send notification to upstream node
+    shared_ptr<Msg> m(new Msg());
+    m->set_src(node_id_);
+    m->set_type(PING);
+    m->AppendData(this->node_ip_.data(), this->node_ip_.length());
+
+    dealer->SendMsg(m);
+
+    vec_dealer_.push_back(dealer);
+  }
+
+  return 0;
+}
+
+template <typename Dtype>
+int FcClient<Dtype>::Init()
+{
+  //Connect Upstream ROUTER & PUB nodes
+  const vector<string>& sub_addrs = NodeEnv::Instance()->SubAddrs();
+
+  for (int i = 0; i < sub_addrs.size(); i++) {
+    //connect PUB node
+    shared_ptr<SkSock> sub(new SkSock(ZMQ_SUB));
+    sub->Connect(sub_addrs[i]);
+    zmq_setsockopt(sub->GetSock(), ZMQ_SUBSCRIBE, "", 0);
+    
+    vec_sub_sock_.push_back(sub);
+  }
+
+
+  this->InitRoute();
+  FcNode<Dtype>::Init();
+
+  LOG(INFO) << "FcClient successfully initialized.";
+  
+  return 0;
+}
+
+template <typename Dtype>
+int FcClient<Dtype>::SetUpPoll()
+{
+  this->num_poll_items_ = this->nthreads_ + 1 + vec_sub_sock_.size();
+  this->poll_items_ = new zmq_pollitem_t[this->num_poll_items_];
+
+  //adding the subscribers to the polling items
+  int poll_index = sub_sock_index_;
+  for (int i = 0; i < vec_sub_sock_.size(); i++, poll_index++) {
+    this->poll_items_[poll_index].socket = vec_sub_sock_[i]->GetSock();
+    this->poll_items_[poll_index].events = ZMQ_POLLIN;
+    this->poll_items_[poll_index].fd = 0;
+    this->poll_items_[poll_index].revents = 0;
+  }
+
+  return FcNode<Dtype>::SetUpPoll();
+}
+
+template <typename Dtype>
+int FcClient<Dtype>::RouteMsg()
+{
+  int poll_index = sub_sock_index_;
+  for (int i = 0; i < vec_sub_sock_.size(); i++, poll_index++) {
+    if (this->poll_items_[poll_index].revents & ZMQ_POLLIN) {
+      shared_ptr<Msg> m = vec_sub_sock_[i]->RecvMsg(true);
+      
+      LOG(INFO) << "sub received msg id: " << m->msg_id();
+
+      this->ProcessMsg(m);
+    }
+  }
+
+  return FcNode<Dtype>::RouteMsg();
+}
+
+template <typename Dtype>
+int FcGateway<Dtype>::Init()
+{
+  //connect to the bottom layer (usally the loss layer)
+  const vector<string>& bottom_addrs = NodeEnv::Instance()->BottomAddrs();
+  const vector<int>& bottom_ids = NodeEnv::Instance()->BottomIDs();
+
+  for (int i = 0; i < bottom_addrs.size(); i++) {
+    shared_ptr<SkSock> dealer(new SkSock(ZMQ_DEALER));
+    dealer->SetId(this->node_id_);
+    dealer->Connect(bottom_addrs[i]);
+    //Unique CHECK
+    CHECK(this->node_to_sock_.find(bottom_ids[i]) == this->node_to_sock_.end() );
+    this->node_to_sock_[bottom_ids[i]] = dealer;
+
+    bottom_socks_.push_back(dealer);
+  }
+
+  this->InitRoute();
+  FcNode<Dtype>::Init();
+
+  LOG(INFO) << "FcGateway successfully inited.";
+  
+  return 0;
+}
+
+template <typename Dtype>
+int FcGateway<Dtype>::SetUpPoll()
+{
+  //backward sock for downstream nodes
+  // + server sock for the conv clients
+  this->num_poll_items_ = this->nthreads_ + 2;
+  this->poll_items_ = new zmq_pollitem_t[this->num_poll_items_];
+
+  this->poll_items_[server_sock_index_].socket = sock_server_->GetSock();
+  this->poll_items_[server_sock_index_].events = ZMQ_POLLIN;
+  this->poll_items_[server_sock_index_].fd = 0;
+  this->poll_items_[server_sock_index_].revents = 0;
+ 
+  return FcNode<Dtype>::SetUpPoll();
+}
+
+template <typename Dtype>
+int FcGateway<Dtype>::RouteMsg()
+{
+  //process the packets comes from the convolution clients
+  if (this->poll_items_[server_sock_index_].revents & ZMQ_POLLIN) {
+    shared_ptr<Msg> m = sock_server_->RecvMsg(true);
+    
+    //adding a unique id for each incoming message
+    msg_id_++;
+    m->set_msg_id(msg_id_);
+    
+    this->ProcessMsg(m);
+  }
+
+  return FcNode<Dtype>::RouteMsg();
+}
+
+template <typename Dtype>
+int FcGateway<Dtype>::SendOutMsg(shared_ptr<Msg> m)
+{
+  //directly send out the message to the conv clients
+  if (m->type() == BACKWARD) {
+    sock_server_->SendMsg(m);
+
+    return 0;
+  }
+
+  return FcNode<Dtype>::SendOutMsg(m);
+}
+
+INSTANTIATE_CLASS(FcGateway);
+INSTANTIATE_CLASS(FcNode);
+INSTANTIATE_CLASS(FcClient);
+
+} //end caffe
+

--- a/src/caffe/multi_node/fc_thread.cpp
+++ b/src/caffe/multi_node/fc_thread.cpp
@@ -1,0 +1,156 @@
+
+#include "caffe/multi_node/fc_thread.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+shared_ptr<Msg> FcThread<Dtype>::FcForward(shared_ptr<Msg> m)
+{
+  SGDSolver<Dtype> *pfc = (SGDSolver<Dtype> *)NodeEnv::Instance()->PopFreeSolver();
+  if (NULL == pfc) {
+    pfc = (SGDSolver<Dtype> *)this->NewSolver();
+  }
+  
+  shared_ptr<Net<Dtype> > fc_net = pfc->net();
+  fc_net->ClearParamDiffs();
+
+  this->GetInputData(fc_net, m);
+  fc_net->ForwardPrefilled();
+  
+  shared_ptr<Msg> r(new Msg(m));
+  //broadcast the message
+  r->set_dst(-1);
+  this->CopyOutputData(fc_net, r);
+
+  NodeEnv::Instance()->PutSolver(m->msg_id(), pfc);
+
+  return r;
+}
+
+template <typename Dtype>
+void FcThread<Dtype>::FcBackward(shared_ptr<Msg> m, vector<shared_ptr<Msg> >& replies)
+{
+  SGDSolver<Dtype> *pfc = (SGDSolver<Dtype> *)NodeEnv::Instance()->FindSolver(m->msg_id());
+  CHECK(pfc != NULL);
+
+  shared_ptr<Net<Dtype> > fc_net = pfc->net();
+  this->GetOutputDiff(fc_net, m);
+
+  fc_net->Backward();
+
+  const vector<int>& pre_ids = NodeEnv::Instance()->DealerIDs();
+
+  if (pre_ids.size() == 0) { //we are the gateway node
+    shared_ptr<Msg> r(new Msg(m));
+    r->set_dst(m->src());
+    replies.push_back(r);
+  } else if (pre_ids.size() > 0) {
+    for (int i = 0; i < pre_ids.size(); i++) {
+      shared_ptr<Msg> r(new Msg(m));
+      r->set_dst(pre_ids[i]);
+      replies.push_back(r);
+    }
+  } else {
+    //array size cannot be less than 0
+  }
+  
+  //copy data
+  for (int i = 0; i < replies.size(); i++) {
+    shared_ptr<Msg> r = replies[i];
+
+    r->set_type(BACKWARD);
+    this->CopyInputDiff(fc_net, r);
+  }
+  
+  //notify the param thread
+  shared_ptr<Msg> notify(new Msg(m));
+
+  notify->set_dst(ROOT_THREAD_ID);
+  notify->AppendData(&pfc, sizeof(pfc));
+  replies.push_back(notify);
+}
+
+template <typename Dtype>
+void FcThread<Dtype>::Run()
+{
+  while (!this->must_stop()) {
+    shared_ptr<Msg> m = this->RecvMsg(true);
+
+    LOG(INFO) << "received message id: " << m->msg_id() << " with blobs: " << m->num_blobs();
+    
+    vector<shared_ptr<Msg> > msg_arr;
+
+    if (m->type() == FORWARD) {
+      shared_ptr<Msg> f = FcForward(m);
+      msg_arr.push_back(f);
+    } else if (m->type() == BACKWARD) {
+      LOG(INFO) << "received backward message";
+
+      FcBackward(m, msg_arr);
+    } else {
+      LOG(INFO) << "unkown type: " << m->msg_id();
+    }
+    
+    for (int i = 0; i < msg_arr.size(); i++) {
+      this->SendMsg(msg_arr[i]);
+    }
+  }
+}
+
+template <typename Dtype>
+boost::atomic_int FcEndThread<Dtype>::iter_(0);
+
+template <typename Dtype>
+void FcEndThread<Dtype>::Run()
+{
+  while (!this->must_stop()) {
+    shared_ptr<Msg> m = this->RecvMsg(true);
+    
+    shared_ptr<Msg> f = this->FcForward(m);
+    
+    vector<shared_ptr<Msg> > replies;
+    this->FcBackward(f, replies);
+    
+    iter_++;
+    Dtype loss = *((Dtype *)f->ZmsgData(0));
+    LOG(INFO) << "iteration: " << iter_ << " loss: " << loss;
+
+    for (int i = 0; i < replies.size(); i++) {
+      this->SendMsg(replies[i]);
+    }
+  }
+}
+
+template <typename Dtype>
+void FcParamThread<Dtype>::UpdateParam(shared_ptr<Msg> m)
+{
+  SGDSolver<Dtype> *psolver = (SGDSolver<Dtype> *)NodeEnv::Instance()->FindSolver(m->msg_id());
+  CHECK(psolver != NULL);
+
+  psolver->CommitGradient();
+  
+  //update table
+  NodeEnv::Instance()->DeleteSolver(m->msg_id());
+  NodeEnv::Instance()->PushFreeSolver(psolver);
+}
+
+template <typename Dtype>
+void FcParamThread<Dtype>::Run()
+{
+  //use the root solver
+  Caffe::set_root_solver(true);
+
+  while (!this->must_stop()) {
+    shared_ptr<Msg> m = this->RecvMsg(true);
+    
+    UpdateParam(m);
+  }
+}
+
+INSTANTIATE_CLASS(FcThread);
+INSTANTIATE_CLASS(FcEndThread);
+INSTANTIATE_CLASS(FcParamThread);
+
+} //end caffe
+
+

--- a/src/caffe/multi_node/model_map.cpp
+++ b/src/caffe/multi_node/model_map.cpp
@@ -1,0 +1,383 @@
+
+
+#include "caffe/multi_node/model_map.hpp"
+#include <string>
+#include <map>
+
+namespace caffe {
+
+template <typename Dtype>
+int ModelMap<Dtype>::FindLayer(string name)
+{
+  //we only deal with consecutive layers
+  for (int i = 0; i < net_->layer_names().size(); i++) {
+    if ( net_->layer_names()[i] == name ) {
+      return i;
+    }
+  }
+  
+  return -1;
+}
+
+template <typename Dtype>
+int ModelMap<Dtype>::GenerateSolver(SolverParameter &sparam, shared_ptr<ModelRequest> r)
+{
+  int first = FindLayer(r->start_layer());
+  int end = FindLayer(r->end_layer());
+
+  map<string, int> blob_name_top_idx;
+  
+  //preparing new net param
+  NetParameter nparam;
+
+  nparam.CopyFrom(clear_net_);
+  
+  for (int i = first; i <= end; i++) {
+    const LayerParameter& layer_param = net_param_.layer(i);
+    nparam.add_layer()->CopyFrom(layer_param);
+
+    //replace Data layer
+    if (layer_param.type() == "Data") {
+      nparam.mutable_layer(i)->set_type(string("AsyncData"));
+    }
+  }
+  
+  nparam.set_force_backward(true);
+  
+  //add unknown blobs as input blobs
+  int ninputs = 0;
+  for (int i = first; i <= end; i++) {
+    const LayerParameter& layer_param = net_param_.layer(i);
+
+    for (int j = 0; j < layer_param.bottom_size(); j++) {
+      const string& blob_name = layer_param.bottom(j);
+      
+      if (blob_name_top_idx.find(blob_name) == blob_name_top_idx.end()) {
+
+        LOG(INFO) << "add input " << blob_name;
+
+        nparam.add_input( blob_name );
+
+        //find the blob in net
+        const shared_ptr<Blob<Dtype> > b = net_->blob_by_name ( blob_name );
+
+        //add blob shapes
+        nparam.add_input_shape();
+        for (int k = 0; k < b->shape().size(); k++) {
+          nparam.mutable_input_shape(ninputs)->add_dim(b->shape()[k]);
+        }
+        ninputs++;
+      }
+    }
+
+
+    for (int j = 0; j < net_param_.layer(i).top_size(); j++) {
+      const string& blob_name = layer_param.top(j);
+      blob_name_top_idx[blob_name] = i;
+    }
+  }
+
+  //preparing solver param
+  sparam.CopyFrom(clear_solver_);
+
+  //copy the generated NET to solver
+  sparam.mutable_net_param()->CopyFrom(nparam);
+  
+  return 0;
+}
+
+template <typename Dtype>
+int ModelMap<Dtype>::GenerateRoute(RouteInfo &rt, vector<shared_ptr<ModelRequest> > *pre, vector<shared_ptr<ModelRequest> > *next)
+{
+  //TODO: make it clearer?
+  if (NULL != pre) {
+    for (int i = 0; i < pre->size(); i++) {
+      rt.add_prev_nodes()->CopyFrom( (*pre)[i]->node_info() );
+    }
+  }
+
+  if (NULL != next) {
+    for (int j = 0; j < next->size(); j++) {
+      rt.add_next_nodes()->CopyFrom( (*next)[j]->node_info() );
+    }
+  }
+
+  //adding bottom nodes to the route info
+  for (int i = 0; i < bottom_nodes_.size(); i++) {
+    rt.add_bottom_nodes()->CopyFrom(bottom_nodes_[i]);
+  }
+  
+  rt.set_train_batch_size(train_batch_size_);
+
+  return 0;
+}
+
+template <typename Dtype>
+int ModelMap<Dtype>::PrepareMessages()
+{
+  //
+  CHECK( fc_filled_) << "Need to get the FC layers prepared before sending route infomation";
+
+  int start = first_fc_;
+  int nlayers = net_->layer_names().size();
+  
+  vector<shared_ptr<ModelRequest> > *pre = NULL;
+  vector<shared_ptr<ModelRequest> > *next = NULL;
+
+  while (start < nlayers) {
+    int end = FindLayer(requests_[start][0]->end_layer());
+
+    if ((end + 1) >= nlayers) {
+      next = NULL;
+    } else {
+      next = &(requests_[end + 1]);
+    }
+
+    RouteInfo rt;
+    GenerateRoute(rt, pre, next);
+
+    string rt_str;
+    rt.SerializeToString(&rt_str);
+
+    //generate message for each part of message
+    for (int i = 0; i < requests_[start].size(); i++) {
+      shared_ptr<Msg> m(new Msg());
+
+      SolverParameter sparam;
+      GenerateSolver(sparam, requests_[start][i]);
+
+      string solver_str;
+      sparam.SerializeToString(&solver_str);
+
+      //setup m
+      m->AppendData(rt_str.data(), rt_str.length());
+      m->AppendData(solver_str.data(), solver_str.length());
+
+      m->set_type(GET_TRAIN_MODEL);
+      m->set_dst(requests_[start][i]->node_info().node_id());
+      
+      //push it to buffer
+      replies_.push_back(m);
+    }
+
+    pre = &(requests_[start]);
+    start = end + 1;
+  }
+  
+  //check whether we need to prepare full model messages
+  if (full_request_msg_ != NULL) {
+    PrepareFullModel();
+  }
+
+  return 0;
+}
+
+template <typename Dtype>
+bool ModelMap<Dtype>::CheckIntegrity()
+{
+  if (requests_[first_fc_].size() <= 0) {
+    return false;
+  }
+  
+  //we assume the layers in FC are always linear and straightforward
+  int start = first_fc_;
+
+  int nlayers = net_->layer_names().size();
+
+  while (start < nlayers) {
+    if (requests_[start].size() <= 0) {
+      return false;
+    }
+
+    //check the layer segment is full filled
+    for (int i = 0; i < requests_[start].size(); i++) {
+      if (requests_[start][i] == NULL) {
+        return false;
+      }
+    }
+
+    //move to the next layer segment
+    int end = FindLayer(requests_[start][0]->end_layer());
+    start = end + 1;
+  }
+  
+  fc_filled_ = true;
+
+  //store all the fc nodes 
+  start = first_fc_;
+  while (start < nlayers) {
+    for (int i = 0; i < requests_[start].size(); i++) {
+      fc_requests_.push_back(requests_[start][i]);
+    }
+
+    int end = FindLayer(requests_[start][0]->end_layer());
+    start = end + 1;
+  }
+
+  //all the FC layers are filled
+  return true;
+}
+
+template <typename Dtype>
+int ModelMap<Dtype>::ProcessConv(shared_ptr<Msg> m)
+{
+  shared_ptr<Msg> r(new Msg());
+  
+  //routing is empty
+  RouteInfo rt;
+
+  string rt_str;
+  rt.SerializeToString(&rt_str);
+
+  r->AppendData(rt_str.data(), rt_str.length());
+  
+  //preparing net param
+  NetParameter nparam;
+
+  nparam.CopyFrom(clear_net_);
+  
+  for (int i = 0; i < first_fc_; i++) {
+    const LayerParameter& layer_param = net_param_.layer(i);
+    nparam.add_layer()->CopyFrom(layer_param);
+    
+    //replace Data layer
+    if (layer_param.type() == "Data") {
+      nparam.mutable_layer(i)->set_type(string("AsyncData"));
+    }
+
+  }
+  
+  nparam.set_force_backward(true);
+  
+  //preparing solver param
+  SolverParameter sparam;
+  sparam.CopyFrom(clear_solver_);
+
+  //copy the generated NET to solver
+  sparam.mutable_net_param()->CopyFrom(nparam);
+  
+  string solver_str;
+
+  sparam.SerializeToString(&solver_str);
+  
+  r->AppendData(solver_str.data(), solver_str.length());
+
+  r->set_type(GET_TRAIN_MODEL);
+  r->set_dst(m->src());
+          
+  //push it to buffer
+  replies_.push_back(r);
+
+
+  if (fc_filled_) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+template <typename Dtype>
+int ModelMap<Dtype>::PrepareFullModel()
+{
+  CHECK(fc_filled_);
+
+  shared_ptr<Msg> r(new Msg());
+
+  string full_model_str;
+  orig_solver_param_.SerializeToString(&full_model_str);
+
+  r->AppendData(full_model_str.data(), full_model_str.length());
+
+  for (int i = 0; i < fc_requests_.size(); i++) {
+    string request_str;
+    fc_requests_[i]->SerializeToString(&request_str);
+
+    r->AppendData(request_str.data(), request_str.length());
+  }
+
+  r->set_dst(full_request_msg_->dst());
+  r->set_type(full_request_msg_->type());
+
+  full_request_msg_.reset();
+
+  replies_.push_back(r);
+  
+  return 1;
+}
+
+template <typename Dtype>
+int ModelMap<Dtype>::GetFullModel(shared_ptr<Msg> m)
+{
+  full_request_msg_ = m;
+  
+  //wait until 
+  if (fc_filled_) {
+    return PrepareFullModel();
+  } else {
+    return 0;
+  }
+}
+
+template <typename Dtype>
+int ModelMap<Dtype>::GetModel(shared_ptr<Msg> m)
+{
+  CHECK_GT(m->ZmsgCnt(), 0);
+
+  shared_ptr<ModelRequest> rq(new ModelRequest());
+  //route request is stored in the first message
+  rq->ParseFromString( string( (char *)m->ZmsgData(0), m->ZmsgSize(0) ) );
+
+  LOG(INFO) << "Get Model Request: " << std::endl << rq->DebugString();
+
+  int start = FindLayer(rq->start_layer());
+  CHECK_GE(start, 0);
+  CHECK_LT(start, net_->layer_names().size());
+
+  int end = FindLayer(rq->end_layer());
+  int nlayers = net_->layer_names().size();
+  CHECK_GT(end, 0);
+  CHECK_LT(end, nlayers);
+  
+  int pos = rq->node_info().position();
+  CHECK_LT(pos, rq->num_splits());
+ 
+  //CHECK the node ID has been inited
+  CHECK_GT(rq->node_info().node_id(), 0);
+
+  if (start < first_fc_) {
+    return ProcessConv(m);
+  }
+
+  if (requests_[start].size() <= 0) {
+    //init the vector
+    requests_[start].resize(rq->num_splits());
+    requests_[start][pos] = rq;
+  } else {
+    CHECK_EQ(rq->end_layer(), requests_[start][0]->end_layer());
+    CHECK_LT(pos, requests_[start].size());
+    
+    //only have one corresponding node
+    CHECK(requests_[start][pos] == NULL) << "Two nodes are in the same position.";
+
+    requests_[start][pos] = rq;
+  }
+  
+  //adding bottom nodes
+  if (end == nlayers - 1) {
+    bottom_nodes_.push_back(rq->node_info());
+  }
+
+  if ( !CheckIntegrity() ) {
+    return 0;
+  } else {
+    PrepareMessages();
+
+    return 1;
+  }
+
+}
+
+INSTANTIATE_CLASS(ModelMap);
+
+} //end caffe
+

--- a/src/caffe/multi_node/msg.cpp
+++ b/src/caffe/multi_node/msg.cpp
@@ -1,0 +1,158 @@
+
+
+#include "caffe/multi_node/msg.hpp"
+
+namespace caffe {
+
+int Msg::MergeMsg(shared_ptr<Msg> m)
+{
+  CHECK_EQ(m->msg_id(), header_.msg_id());
+  
+  for (int i = 0; i < m->num_blobs(); i++) {
+    const BlobInfo &src_blob = m->blob_info(i);
+
+    int blob_index = blob_index_by_name(src_blob.blob_name());
+    
+    if (blob_index >= 0) {   //atatching the blobs to the packet
+      BlobInfo *tgt_blob = header_.mutable_blobs(blob_index); 
+      
+      for (int k = 0; k < src_blob.fragment_offset_size(); k++) {
+        tgt_blob->add_fragment_offset(src_blob.fragment_offset(k));
+        
+        int msg_index = AppendZmsg(m->GetZmsg(src_blob.msg_index(k)));
+        tgt_blob->add_msg_index(msg_index);
+      }
+
+    } else {    //add a new blob
+      //add message data
+      BlobInfo new_blob(src_blob);
+      
+      for (int k = 0; k < src_blob.fragment_offset_size(); k++) {
+        new_blob.set_msg_index(k, AppendZmsg(m->GetZmsg(src_blob.msg_index(k))));
+      }
+
+      add_blob_info(new_blob);
+    }
+  }
+
+  //clear the incoming packet
+  m->ClearMsg();
+
+  return 0;
+}
+
+//extract a blob from the message
+shared_ptr<Msg> Msg::ExtractMsg(const string blob_name)
+{
+  shared_ptr<Msg> m;
+  
+  //skip if only have 1 blob
+  if (num_blobs() <= 1) {
+    return m;
+  }
+
+  int blob_index = blob_index_by_name(blob_name);
+  
+  if (blob_index < 0) {
+    LOG(WARNING) << "cannot find blob: " << blob_name;
+    return m;
+  }
+
+  m.reset(new Msg(this));
+  
+  const BlobInfo& chosen_blob = blob_info(blob_index);
+  BlobInfo new_blob;
+  
+  new_blob.set_blob_name(chosen_blob.blob_name());
+  new_blob.set_num_fragments(chosen_blob.num_fragments());
+
+  for (int i = 0; i < chosen_blob.msg_index_size(); i++) {
+    int msg_index = chosen_blob.msg_index(i);
+    zmq_msg_t *pmsg = zmsg_vec_[msg_index];
+    zmsg_vec_[msg_index] = NULL;
+
+    new_blob.add_msg_index(m->AppendZmsg(pmsg));
+    new_blob.add_fragment_offset(chosen_blob.fragment_offset(i)); 
+  }
+
+  m->add_blob_info(new_blob);
+
+  vector<BlobInfo> update_info;
+  vector<zmq_msg_t *> update_msg;
+
+  //update the old blobs
+  for (int i = 0; i < num_blobs(); i++) {
+    if (i == blob_index) {
+      continue;
+    }
+    
+    const BlobInfo old_blob = blob_info(i);
+    BlobInfo update_blob;
+    
+    update_blob.set_blob_name(old_blob.blob_name());
+    update_blob.set_num_fragments(old_blob.num_fragments());
+
+    for (int j = 0; j < old_blob.msg_index_size(); j++) {
+      update_blob.add_msg_index( update_msg.size() );
+      update_msg.push_back( zmsg_vec_[old_blob.msg_index(j)] );
+      
+      update_blob.add_fragment_offset(old_blob.fragment_offset(j));
+    }
+
+    update_info.push_back(update_blob);
+  }
+
+  header_.clear_blobs();
+  for (int i = 0; i < update_info.size(); i++) {
+    header_.add_blobs()->CopyFrom(update_info[i]);
+  }
+
+  zmsg_vec_.clear();
+  for (int i = 0; i < update_msg.size(); i++) {
+    zmsg_vec_.push_back(update_msg[i]);
+  }
+ 
+  return m;
+}
+
+void Msg::AddNewBlob(const string& blob_name, const void *data, int sz)
+{
+  BlobInfo info;
+  info.set_blob_name(blob_name);
+  info.set_num_fragments(1);
+  info.add_fragment_offset(0);
+
+  int msg_index = AppendData(data, sz);
+  info.add_msg_index(msg_index);
+
+  add_blob_info(info);
+}
+
+void Msg::CopyBlob(const string& blob_name, void *data, int sz)
+{
+  int blob_index = blob_index_by_name(blob_name);
+
+  CHECK_GE(blob_index, 0) << "Cannot find blob: " << blob_name;
+  const BlobInfo& bi = blob_info(blob_index);
+  
+  vector<int> msgs;
+  msgs.resize(bi.msg_index_size());
+  int msg_data_size = 0;
+  //sequetialize the messages
+  for (int i = 0; i < bi.msg_index_size(); i++) {
+    msgs[bi.fragment_offset(i)] = bi.msg_index(i);
+    msg_data_size += ZmsgSize(bi.msg_index(i));
+  }
+
+  CHECK_EQ(msg_data_size, sz);
+  
+  char *blob_data = (char *) data;
+  for (int i = 0; i < msgs.size(); i++) {
+    memcpy(blob_data, ZmsgData(msgs[i]), ZmsgSize(msgs[i]));
+    blob_data += ZmsgSize(msgs[i]);
+  }
+
+}
+
+} //end caffe
+

--- a/src/caffe/multi_node/msg_hub.cpp
+++ b/src/caffe/multi_node/msg_hub.cpp
@@ -1,0 +1,97 @@
+
+
+#include "caffe/multi_node/msg_hub.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+int MsgHub<Dtype>::StartThreads()
+{
+  for (int i = 0; i < nthreads_; i++) {
+    string sk_addr(SERVER_SK_STR);
+    sk_addr += "_";
+    sk_addr += boost::lexical_cast<string>(i);
+    
+    sockp_arr_[i]->Bind(sk_addr);
+    
+    threads_[i]->SetWorkerId(i);
+    threads_[i]->SetAddr(sk_addr);
+    threads_[i]->StartInternalThread();
+  }
+
+  return 0;
+}
+
+template <typename Dtype>
+int MsgHub<Dtype>::SetUpPoll()
+{
+  CHECK_GT (num_poll_items_, nthreads_);
+  CHECK (poll_items_ != NULL);
+  
+  //initialize polling items for the work threads
+  for (int i = 0; i < nthreads_; i++) {
+    poll_items_[i].socket = sockp_arr_[i]->GetSock();
+    poll_items_[i].events = ZMQ_POLLIN;
+    poll_items_[i].fd = 0;
+    poll_items_[i].revents = 0;
+  }
+
+  return 0;
+}
+
+//dispatch thread via poll
+template <typename Dtype>
+int MsgHub<Dtype>::Poll()
+{
+  SetUpPoll();
+
+  while (true) {
+    //blocked poll
+    zmq_poll(poll_items_, num_poll_items_, -1);
+
+    if (RouteMsg() < 0) {
+      break;
+    }
+  }
+
+  return 0;
+}
+
+//Worker threads process the incoming packets
+template <typename Dtype>
+int MsgHub<Dtype>::ProcessMsg(shared_ptr<Msg> m)
+{ 
+  int num_inputs = NodeEnv::Instance()->NumInputBlobs();
+
+  if (num_inputs == 1 || num_inputs == 0) {
+    sockp_arr_[0]->SendMsg(m);
+  } else if (num_inputs == 2) {
+    unordered_map<int64_t, shared_ptr<Msg> >::iterator iter = id_to_msg_.find(m->msg_id());
+
+    if (iter == id_to_msg_.end()) {
+        id_to_msg_[m->msg_id()] = m;
+    } else {
+        shared_ptr<Msg> s = iter->second;
+        m->MergeMsg(s);
+    }
+    
+    //double check the new msg
+    iter = id_to_msg_.find(m->msg_id());
+    shared_ptr<Msg> new_msg = iter->second;
+
+    if (new_msg->num_blobs() == 2) {
+        id_to_msg_.erase(iter);
+        sockp_arr_[0]->SendMsg(m);
+    }
+  } else {
+    LOG(ERROR) << "Cannot deal with input number: " << num_inputs;
+    return -1;
+  }
+
+  return 0;
+}
+
+INSTANTIATE_CLASS(MsgHub);
+
+} // end caffe
+

--- a/src/caffe/multi_node/node_env.cpp
+++ b/src/caffe/multi_node/node_env.cpp
@@ -1,0 +1,168 @@
+
+
+#include "caffe/multi_node/node_env.hpp"
+
+namespace caffe {
+
+NodeEnv *NodeEnv::instance_ = NULL;
+boost::once_flag NodeEnv::once_;
+string NodeEnv::id_server_addr_;
+string NodeEnv::model_server_addr_;
+string NodeEnv::request_file_addr_;
+NodeRole NodeEnv::node_role_ = INVALID_ROLE;
+
+NodeEnv* NodeEnv::Instance()
+{
+  boost::call_once(once_, InitNode);
+
+  return instance_;
+}
+
+void NodeEnv::InitNode(void)
+{
+  // check enviroment settings
+  CHECK(!id_server_addr_.empty()) << "Need to set id server address before start";
+  CHECK(!model_server_addr_.empty()) << "Need to set model server address before start";
+  CHECK(!request_file_addr_.empty()) << "Need to set the location of model request file";
+  CHECK(node_role_ != INVALID_ROLE) << "Need to set node role before start";
+
+  instance_ = new NodeEnv();
+  
+  instance_->InitIP();
+  instance_->InitNodeID();
+  instance_->InitModel();
+}
+
+int NodeEnv::InitNodeID()
+{
+  shared_ptr<SkSock> req(new SkSock(ZMQ_REQ));
+
+  req->Connect(id_server_addr_);
+  shared_ptr<Msg> m(new Msg());
+  
+  //adding ip to the message
+  m->AppendData(node_ip_.data(), node_ip_.length());
+  m->set_type(PING);
+
+  req->SendMsg(m);
+
+  shared_ptr<Msg> r = req->RecvMsg(true);
+  
+  int id = *((int *)r->ZmsgData(0));
+
+  LOG(INFO) << "Got new id: " << id;
+
+  node_id_ = id;
+
+  return id;
+}
+
+int NodeEnv::InitIP()
+{
+  interface_.clear();
+  node_ip_.clear();
+
+  GetInterfaceAndIP(interface_, node_ip_);
+
+  return 0;
+}
+
+
+
+int NodeEnv::InitModel()
+{
+  shared_ptr<SkSock> dealer(new SkSock(ZMQ_DEALER));
+  dealer->SetId(node_id_);
+  dealer->Connect(model_server_addr_);
+  
+  //read the request from text file
+  ModelRequest rq;
+  ReadProtoFromTextFileOrDie(request_file_addr_, &rq);
+  
+  //init route port and pub port
+  router_port_ = rq.node_info().router_port();
+  pub_port_ = rq.node_info().pub_port();
+  
+
+  rq.mutable_node_info()->set_node_id(node_id_);
+  rq.mutable_node_info()->set_ip(node_ip_); 
+
+  string rq_str;
+  rq.SerializeToString(&rq_str);
+
+  shared_ptr<Msg> m(new Msg());
+  m->AppendData(rq_str.data(), rq_str.length());
+  
+  m->set_type(GET_TRAIN_MODEL);
+  m->set_src(node_id_);
+
+  LOG(INFO) << "Sending ModelRquest: " << std::endl << rq.DebugString();
+  
+  dealer->SendMsg(m);
+  
+  shared_ptr<Msg> r = dealer->RecvMsg(true);
+
+  LOG(INFO) << "received message count: " << r->ZmsgCnt();
+  
+  
+  rt_info_.ParseFromString(string( (char *)r->ZmsgData(0), r->ZmsgSize(0) ));
+  solver_param_.ParseFromString(string( (char *) r->ZmsgData(1), r->ZmsgSize(1) ));
+
+  LOG(INFO) << "received route info: " << std::endl << rt_info_.DebugString();
+  LOG(INFO) << "received solver: " << std::endl << solver_param_.DebugString();
+  
+  for (int i = 0; i < rt_info_.prev_nodes_size(); i++) {
+    //dealer addrs
+    if (rt_info_.prev_nodes(i).router_port() > 0) {
+      string addr = "tcp://";
+      addr += rt_info_.prev_nodes(i).ip();
+      addr += ":";
+      addr += boost::lexical_cast<string>(rt_info_.prev_nodes(i).router_port());
+
+      dealer_addrs_.push_back(addr);
+      dealer_ids_.push_back(rt_info_.prev_nodes(i).node_id());
+    }
+
+    //sub addrs
+    if (rt_info_.prev_nodes(i).pub_port() > 0) {
+      string addr = "tcp://";
+      addr += rt_info_.prev_nodes(i).ip();
+      addr += ":";
+      addr += boost::lexical_cast<string>(rt_info_.prev_nodes(i).pub_port());
+
+      sub_addrs_.push_back(addr);
+    }
+  }
+  
+  
+  for (int i = 0; i < rt_info_.next_nodes_size(); i++) {
+    //we don't add port to the string
+    client_addrs_.push_back(rt_info_.next_nodes(i).ip());
+  }
+
+  for (int i = 0; i < rt_info_.bottom_nodes_size(); i++) {
+    //
+    string addr = "tcp://";
+    addr += rt_info_.bottom_nodes(i).ip();
+    addr += ":";
+    addr += boost::lexical_cast<string>(rt_info_.bottom_nodes(i).router_port());
+
+    bottom_addrs_.push_back(addr);
+    bottom_ids_.push_back(rt_info_.bottom_nodes(i).node_id());
+  }
+  
+  num_input_blobs_ = 0;
+
+  if (solver_param_.has_net_param()) {
+    num_input_blobs_ = solver_param_.net_param().input_size();
+  }
+
+  return 0;
+}
+
+} //end caffe
+
+
+
+
+

--- a/src/caffe/multi_node/ps_node.cpp
+++ b/src/caffe/multi_node/ps_node.cpp
@@ -1,0 +1,71 @@
+
+#include "caffe/multi_node/ps_node.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+ParamServer<Dtype>::ParamServer(int nthreads, const string& ps_bind_addr) : MsgHub<Dtype>(nthreads, nthreads)
+{
+  ps_router_.reset(new SkServer());
+  ps_router_->Bind(ps_bind_addr);
+
+  ps_sock_index_ = nthreads;
+  ps_bind_addr_ = ps_bind_addr;
+}
+
+template <typename Dtype>
+int ParamServer<Dtype>::Init()
+{
+  for (int i = 0; i < this->nthreads_; i++) {
+    this->threads_[i].reset(new PSThread<Dtype>());
+  }
+  
+  const SolverParameter& param = NodeEnv::Instance()->SolverParam();
+  //set up solvers
+  Caffe::set_root_solver(true);
+  SGDSolver<Dtype> *root_solver = new SGDSolver<Dtype>(param);
+  NodeEnv::Instance()->PushFreeSolver(root_solver);
+
+  return this->StartThreads(); 
+}
+
+template <typename Dtype>
+int ParamServer<Dtype>::RouteMsg()
+{
+  if (this->poll_items_[ps_sock_index_].revents & ZMQ_POLLIN) {
+    shared_ptr<Msg> m = ps_router_->RecvMsg(true);
+        
+    this->sockp_arr_[0]->SendMsg(m);
+  }
+
+  for (int i = 0; i < this->nthreads_; i++) {
+    //
+    if (this->poll_items_[i].revents & ZMQ_POLLIN) {
+      shared_ptr<Msg> m = this->sockp_arr_[i]->RecvMsg(true);
+      
+      ps_router_->SendMsg(m);
+    }
+  }
+
+  return 0;
+}
+
+template <typename Dtype>
+int ParamServer<Dtype>::SetUpPoll()
+{
+  this->num_poll_items_ = this->nthreads_ + 1;
+  this->poll_items_ = new zmq_pollitem_t[this->num_poll_items_];
+
+  this->poll_items_[ps_sock_index_].socket = ps_router_->GetSock();
+  this->poll_items_[ps_sock_index_].events = ZMQ_POLLIN;
+  this->poll_items_[ps_sock_index_].fd = 0;
+  this->poll_items_[ps_sock_index_].revents = 0;
+ 
+  return MsgHub<Dtype>::SetUpPoll();
+}
+
+INSTANTIATE_CLASS(ParamServer);
+
+} //end caffe
+
+

--- a/src/caffe/multi_node/ps_thread.cpp
+++ b/src/caffe/multi_node/ps_thread.cpp
@@ -1,0 +1,68 @@
+
+#include "caffe/multi_node/ps_thread.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void PSThread<Dtype>::UpdateParam(shared_ptr<Msg> m)
+{
+  const vector<Blob<Dtype>*>& net_params = ps_solver_->net()->learnable_params();
+
+  CHECK_EQ(net_params.size(), m->ZmsgCnt());
+
+  for (int i = 0; i < net_params.size(); i++) {
+      CHECK_EQ(net_params[i]->count() * sizeof(Dtype), m->ZmsgSize(i));
+      memcpy(net_params[i]->mutable_cpu_diff(), m->ZmsgData(i), m->ZmsgSize(i));
+  }
+
+  ps_solver_->CommitGradient();
+}
+
+
+template <typename Dtype>
+void PSThread<Dtype>::SendParam(shared_ptr<Msg> m)
+{
+  const vector<Blob<Dtype>*>& net_params = ps_solver_->net()->learnable_params();
+
+  shared_ptr<Msg> r(new Msg());
+  r->set_type(PUT_PARAM);
+  r->set_dst(m->src());
+  r->set_src(NodeEnv::Instance()->ID());
+
+  for (int i = 0; i < net_params.size(); i++) {
+    r->AppendData(net_params[i]->cpu_data(), net_params[i]->count() * sizeof(Dtype));
+  }
+
+  this->SendMsg(r);
+}
+
+
+template <typename Dtype>
+void PSThread<Dtype>::Run()
+{
+  Caffe::set_root_solver(false);
+  //create a solver that shares data params with root solver
+  ps_solver_ = (SGDSolver<Dtype> *)this->NewSolver();
+  Caffe::set_root_solver(true);
+
+  while (true) {
+    shared_ptr<Msg> m = this->RecvMsg(true);
+
+    if (m->type() == PUT_GRADIENT) {
+      UpdateParam(m);
+      SendParam(m);
+    } else if (m->type() == GET_PARAM) {
+      SendParam(m);
+    } else {
+      LOG(ERROR) << "Cannot deal with message type: " << m->type() 
+        << " from: " << m->src();
+    }
+
+  }
+}
+
+INSTANTIATE_CLASS(PSThread);
+} //end caffe
+
+
+

--- a/src/caffe/multi_node/sk_server.cpp
+++ b/src/caffe/multi_node/sk_server.cpp
@@ -1,0 +1,76 @@
+
+#include "caffe/multi_node/sk_server.hpp"
+
+namespace caffe {
+
+//TODO: remove the default ID
+SkServer::SkServer()
+  : SkSock(ZMQ_ROUTER, REQ_SERVER_ID)
+{
+
+}
+
+
+SkServer::~SkServer()
+{
+
+}
+
+
+int SkServer::Connect(string addr)
+{
+  LOG(ERROR) << "Cannot connect to " << addr << " in router";
+  exit(-1);
+}
+
+
+shared_ptr<Msg> SkServer::RecvMsg(bool blocked)
+{
+  int src = 0;
+  int r = 0;
+
+  shared_ptr<Msg> m;
+
+  zmq_msg_t zmsg;
+  zmq_msg_init(&zmsg);
+  
+  if ( blocked ) {
+    r = zmq_msg_recv (&zmsg, sock_, 0);
+  } else {
+    r = zmq_msg_recv (&zmsg, sock_, ZMQ_DONTWAIT);
+    
+    //return a null message
+    if (r < 0) {
+      m.reset();
+      return m; 
+    }
+  }
+
+  //deal with src, it is automatically added by zmq
+  int size = zmq_msg_size (&zmsg);
+  CHECK( size == sizeof(int) ) << "Please init zmq socket client id to a integer";
+  memcpy( &src, zmq_msg_data(&zmsg), sizeof(int) );
+
+  zmq_msg_close(&zmsg);
+  
+  //Make sure we have payloads
+  CHECK(zmq_msg_more(&zmsg));
+  
+  return SkSock::RecvMsg(blocked);
+}
+
+
+int SkServer::SendMsg(shared_ptr<Msg> msg)
+{
+  //attaching dst
+  zmq_msg_t header_dst;
+  zmq_msg_init_size (&header_dst, sizeof(int));
+  int dst = msg->dst();
+  memcpy (zmq_msg_data (&header_dst), &dst, sizeof(int));
+  zmq_msg_send (&header_dst, sock_, ZMQ_SNDMORE);
+
+  return SkSock::SendMsg(msg);
+}
+
+} //end caffe
+

--- a/src/caffe/multi_node/sk_sock.cpp
+++ b/src/caffe/multi_node/sk_sock.cpp
@@ -1,0 +1,136 @@
+
+
+#include "caffe/multi_node/sk_sock.hpp"
+
+namespace caffe {
+
+void *SkSock::zmq_ctx_ = NULL;
+boost::mutex SkSock::zmq_init_mutex_;
+int SkSock::inited_cnt_ = 0;
+
+void SkSock::InitZmq(void)
+{
+  boost::mutex::scoped_lock lock(zmq_init_mutex_);
+
+  if (0 == inited_cnt_) {
+      zmq_ctx_ = zmq_ctx_new();
+  }
+
+  inited_cnt_++;
+}
+
+
+inline int SkSock::SendHeader(shared_ptr<Msg> msg)
+{
+  //ataching meta data, including type, src, dst etc.
+  string header_str;
+  msg->SerializeHeader(header_str);
+
+  zmq_msg_t header_msg;
+  zmq_msg_init_size (&header_msg, header_str.length());
+
+  memcpy (zmq_msg_data (&header_msg), header_str.data(), header_str.length());
+  zmq_msg_send (&header_msg, sock_, ZMQ_SNDMORE);
+  
+  return 0;
+}
+
+
+int SkSock::SendMsg(shared_ptr<Msg> msg)
+{
+  if (sk_type_ == ZMQ_DEALER) {
+    CHECK_GT(msg->src(), 0) << "Message source must be set for dealer socket";
+  }
+  
+  if (msg->ZmsgCnt() <= 0) {
+    LOG(WARNING) << "Cannot send message with length " << msg->ZmsgCnt();
+
+    return -1;
+  }
+  
+  SendHeader(msg);
+
+  for (int i = 0; i < msg->ZmsgCnt() - 1; i++) {
+    zmq_msg_send(msg->GetZmsg(i), sock_, ZMQ_SNDMORE);
+  }
+
+  zmq_msg_send(msg->GetZmsg(msg->ZmsgCnt() - 1), sock_, 0);
+
+  return 0;
+}
+
+
+shared_ptr<Msg> SkSock::RecvMsg(bool blocked)
+{
+  shared_ptr<Msg> m(new Msg());
+
+  int r = 0;
+
+  zmq_msg_t header_msg;
+  zmq_msg_init(&header_msg);
+  if ( blocked ) {
+    r = zmq_msg_recv (&header_msg, sock_, 0);
+  } else {
+    r = zmq_msg_recv (&header_msg, sock_, ZMQ_DONTWAIT);
+
+    if (r < 0) {
+        m.reset();
+        return m;
+    }
+  }
+  
+  string header_str( string( (char *) zmq_msg_data(&header_msg), zmq_msg_size (&header_msg) ) );
+
+  m->ParseHeader(header_str);
+  zmq_msg_close(&header_msg);
+  
+  CHECK(zmq_msg_more (&header_msg));
+
+  for (int i = 0; ; i++) {
+    zmq_msg_t *zmsg = new zmq_msg_t;
+    zmq_msg_init(zmsg);
+    
+    if ( blocked ) {
+      r = zmq_msg_recv (zmsg, sock_, 0);
+    } else {
+      r = zmq_msg_recv (zmsg, sock_, ZMQ_DONTWAIT);    
+    }
+
+    CHECK( r >= 0 );
+
+    m->AppendZmsg(zmsg);
+        
+    if (! zmq_msg_more(zmsg)) {
+      break;
+    }
+  }
+
+  return m;
+}
+
+int SkSock::Bind(const string& addr)
+{
+  CHECK(sock_ != NULL) << "cannot bind null sock";
+
+  int rc = 0;
+  rc = zmq_bind(sock_, addr.c_str());
+  CHECK( 0 == rc) << "failed to bind zmq sock to " << addr;
+
+  addr_ = addr;
+
+  return 0;
+}
+
+
+int SkSock::Connect(const string& addr)
+{
+  CHECK (sock_ != NULL) << "cannot connect to NULL sock";
+
+  zmq_connect(sock_, addr.c_str());
+  addr_ = addr;
+
+  return 0;
+}
+
+}  //end caffe
+

--- a/src/caffe/multi_node/worker_thread.cpp
+++ b/src/caffe/multi_node/worker_thread.cpp
@@ -1,0 +1,14 @@
+
+
+#include "caffe/multi_node/worker_thread.hpp"
+#include "caffe/multi_node/node_env.hpp"
+
+namespace caffe {
+template <typename Dtype>
+boost::mutex  WorkerThread<Dtype>::new_solver_mutex_;
+
+INSTANTIATE_CLASS(WorkerThread);
+
+} // end caffe
+
+

--- a/src/caffe/proto/multi_node.proto
+++ b/src/caffe/proto/multi_node.proto
@@ -1,0 +1,94 @@
+
+syntax = "proto2";
+
+package caffe;
+
+enum NodeRole {
+  INVALID_ROLE = 0;
+  CONV_CLIENT = 1;
+  PARAM_SERVER = 2;
+  FC_NODE = 3;      // nodes that runs a part of FC models
+}
+
+message NodeInfo {
+  optional string ip = 1 [default = "127.0.0.1"];
+  
+  //port # less or equal than 0 means it is invalid & un-initialized
+  required int32 router_port = 2 [default = 0];
+  required int32 pub_port = 3 [default = 0];
+  
+  //which part of the layer it has
+  optional int32 position = 4 [default = 0];
+  //used by zmq to identify node
+  optional int32 node_id = 5 [default = 0];
+  
+  optional NodeRole role = 6 [default = INVALID_ROLE];
+}
+
+
+message RouteInfo {
+  //upstream and downstream nodes in the network
+  repeated NodeInfo prev_nodes = 1;
+  repeated NodeInfo next_nodes = 2;
+
+  //usually the loss layer in the network
+  repeated NodeInfo bottom_nodes = 3;
+
+  //
+  optional int32 train_batch_size = 4 [default = 0];
+}
+
+
+message ModelRequest {
+  required string start_layer = 1;
+  required string end_layer = 2;
+  optional int32 num_splits = 3 [default = 1];
+
+  required NodeInfo node_info = 4;
+}
+
+
+enum MsgType {
+  PING = 0;
+  PONG = 1;
+  GET_TRAIN_MODEL = 2;
+  GET_FULL_MODEL = 3;
+  GET_PARAM = 4;
+  PUT_PARAM = 5;
+  PUT_GRADIENT = 6;
+  FORWARD = 7;
+  BACKWARD = 8;
+  INVALID_MSG = 9;
+}
+
+message BlobInfo {
+  optional string blob_name = 1;
+
+  //total number of fragments (logically)
+  optional int32 num_fragments = 2 [default = 1];
+  
+  //the logical position of the fragment in the blob
+  repeated int32 fragment_offset = 3;
+
+  //the message index of fragment in the vector
+  repeated int32 msg_index = 4;
+}
+
+
+message MsgHeader {
+  //the source node which generates these series of packet
+  optional int32 src = 1 [default = 0];
+
+  //dst is used as next hop in routing
+  optional int32 dst = 2 [default = 0];
+  optional int64 msg_id = 3 [default = 0];
+  required MsgType type = 4 [default = INVALID_MSG];
+
+  repeated BlobInfo blobs = 5;
+  
+  //the id of the convolution thread
+  optional int64 conv_id = 6 [default = 0];
+}
+
+
+

--- a/tools/conv_client.cpp
+++ b/tools/conv_client.cpp
@@ -1,0 +1,43 @@
+
+#include "caffe/multi_node/sk_sock.hpp"
+#include "caffe/multi_node/msg_hub.hpp"
+#include "caffe/caffe.hpp"
+
+#include "boost/unordered_map.hpp"
+#include "caffe/multi_node/node_env.hpp"
+#include "caffe/multi_node/conv_node.hpp"
+
+using boost::unordered_map;
+using namespace caffe;
+
+DEFINE_int32(client_threads, 2, "number of convolution client threads");
+DEFINE_string(fc_gateway_addr, "tcp://10.239.156.44:9556", "zmq address of the fc gateway");
+DEFINE_string(ps_addr, "tcp://10.239.156.44:9558", "zmq address of the parameter server");
+
+DEFINE_string(id_server_req, "tcp://10.239.156.44:9555", "the zmq REQ addr of the id / layer-map server");
+DEFINE_string(model_server, "tcp://10.239.156.44:9557", "the address of zmq model server");
+DEFINE_string(request_file, "examples/cifar10/conv.prototxt", "the location of the model request configuration file");
+
+
+int main(int argc, char** argv)
+{
+  google::InstallFailureSignalHandler();
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  NodeEnv::set_model_server(FLAGS_model_server);
+  NodeEnv::set_id_server(FLAGS_id_server_req);
+  NodeEnv::set_request_file(FLAGS_request_file);
+  NodeEnv::set_node_role(CONV_CLIENT);
+
+  LOG(INFO) << "conv node id: " << NodeEnv::Instance()->ID();
+
+  shared_ptr<ConvClient<float> > client(new ConvClient<float>(FLAGS_client_threads, FLAGS_fc_gateway_addr, FLAGS_ps_addr));
+
+  client->Init();
+  client->Poll();
+ 
+  return 0;
+}
+
+
+

--- a/tools/fc_server.cpp
+++ b/tools/fc_server.cpp
@@ -1,0 +1,57 @@
+
+
+#include "caffe/caffe.hpp"
+#include <string>
+#include "caffe/multi_node/fc_node.hpp"
+
+using namespace caffe;
+
+DEFINE_string(fc_server, "tcp://*:9556", "the zmq server addr of the fully conneted layers");
+DEFINE_int32(server_threads, 2, "number of threads in fc server");
+DEFINE_string(function, "fc_gateway", "function list: fc_server, fc_gateway, fc_client");
+
+DEFINE_string(id_server_req, "tcp://10.239.156.44:9555", "the zmq REQ addr of the id / layer-map server");
+DEFINE_string(model_server, "tcp://10.239.156.44:9557", "the address of zmq model server");
+DEFINE_string(request_file, "examples/cifar10/fc.prototxt", "the location of the model request configuration file");
+
+
+void fc_server_thread()
+{
+  LOG(INFO) << "fc node id: " << NodeEnv::Instance()->ID();
+
+  if (FLAGS_function == "fc_gateway") {
+    shared_ptr<FcGateway<float> > fgate(new FcGateway<float>(FLAGS_server_threads, FLAGS_fc_server));
+
+    fgate->Init();
+    fgate->Poll();
+  } else if (FLAGS_function == "fc_client") {
+    shared_ptr<FcClient<float> > fclient(new FcClient<float>(FLAGS_server_threads));
+
+    fclient->Init();
+    fclient->Poll();
+  } else {
+    LOG(ERROR) << "Unknown function: " << FLAGS_function;
+  }
+
+  return;
+}
+
+
+
+int main(int argc, char** argv)
+{
+  google::InstallFailureSignalHandler();
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  
+  NodeEnv::set_model_server(FLAGS_model_server);
+  NodeEnv::set_id_server(FLAGS_id_server_req);
+  NodeEnv::set_request_file(FLAGS_request_file);
+  NodeEnv::set_node_role(FC_NODE);
+ 
+  fc_server_thread();
+
+  return 0;
+
+}
+
+

--- a/tools/model_server.cpp
+++ b/tools/model_server.cpp
@@ -1,0 +1,92 @@
+
+#include "caffe/multi_node/sk_server.hpp"
+#include "caffe/multi_node/model_map.hpp"
+#include "boost/thread/thread.hpp"
+
+DEFINE_string(id_server_req, "tcp://*:9555", "the zmq REQ addr of the id / layer-map server");
+DEFINE_string(model_server, "tcp://*:9557", "the address of zmq model server");
+
+DEFINE_string(full_solver, "examples/cifar10/cifar10_full_solver.prototxt", "location of full solver");
+
+using namespace caffe;
+
+//id server
+//low frequence update
+void rep_server_thread()
+{
+  LOG(INFO) << "starting rep server in " << FLAGS_id_server_req;
+
+  shared_ptr<SkSock> rep(new SkSock(ZMQ_REP));
+  rep->Bind(FLAGS_id_server_req);
+  
+  int id = REQ_SERVER_ID + 1;
+
+  while (true) {
+    shared_ptr<Msg> m = rep->RecvMsg(true);
+    
+    if (m->type() == PING) {
+      shared_ptr<Msg> s(new Msg());
+      s->set_type(PONG);
+      s->AppendData(&id, sizeof(id));
+      rep->SendMsg(s);
+  
+      LOG(INFO) << "RP server add new sock id: " << id;
+
+      id++;
+    } else {
+      LOG(ERROR) << "unknow message type: " << m->type();
+    }
+  }
+}
+
+
+//layer server, to send route info and solver parameters to clients
+void model_server_thread()
+{
+  LOG(INFO) << "starting model server in " << FLAGS_model_server;
+
+  shared_ptr<SkServer> mserver(new SkServer());
+  mserver->Bind(FLAGS_model_server);
+  
+  ModelMap<float> lmap(FLAGS_full_solver);
+  
+  while (true) {
+    shared_ptr<Msg> m = mserver->RecvMsg(true);
+    
+    if (m->type() == GET_TRAIN_MODEL) {
+      int r = lmap.GetModel(m);
+
+      if (r > 0) {
+        const vector<shared_ptr<Msg> > &reply = lmap.Replies();
+        
+        LOG(INFO) << "Send back response.";
+        for (int i = 0; i < reply.size(); i++) {
+          mserver->SendMsg( reply[i] );
+        }
+        
+        //clear the message after send
+        lmap.ClearMsg();
+      }
+
+    } else {
+      LOG(ERROR) << "unknown message type: " << m->type();
+    }
+  }
+}
+
+
+int main(int argc, char** argv)
+{
+  google::InstallFailureSignalHandler();
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  
+  boost::thread id_thrd(&rep_server_thread);
+  boost::thread model_thrd(&model_server_thread);
+
+  id_thrd.join();
+  model_thrd.join();
+
+  return 0;
+}
+
+

--- a/tools/param_server.cpp
+++ b/tools/param_server.cpp
@@ -1,0 +1,35 @@
+
+
+
+#include "caffe/caffe.hpp"
+#include "caffe/multi_node/ps_node.hpp"
+
+using namespace caffe;
+
+DEFINE_int32(ps_threads, 1, "number of parameter server threads");
+DEFINE_string(ps_bind_addr, "tcp://*:9558", "zmq addr of the parameter server");
+
+DEFINE_string(id_server_req, "tcp://10.239.156.44:9555", "the zmq REQ addr of the id / layer-map server");
+DEFINE_string(model_server, "tcp://10.239.156.44:9557", "the address of zmq model server");
+DEFINE_string(request_file, "examples/cifar10/conv.prototxt", "the location of the model request configuration file");
+
+int main(int argc, char** argv)
+{
+  google::InstallFailureSignalHandler();
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  
+  NodeEnv::set_model_server(FLAGS_model_server);
+  NodeEnv::set_id_server(FLAGS_id_server_req);
+  NodeEnv::set_request_file(FLAGS_request_file);
+  NodeEnv::set_node_role(PARAM_SERVER);
+ 
+  LOG(INFO) << "node id: " << NodeEnv::Instance()->ID();
+  shared_ptr<ParamServer<float> > ps(new ParamServer<float>(FLAGS_ps_threads, FLAGS_ps_bind_addr));
+
+  ps->Init();
+  ps->Poll();
+
+  return 0;
+}
+
+


### PR DESCRIPTION
We are working to scale caffe to hundreds of nodes in a cluster. This version of change contains:
Data parallel in convolution layers. Conv. weights are exchanged via parameter server.
Model parallel for fully connected layers. A model server is created as a centralized scheduler to split big models (e.g. Alex / VGG net) into smaller ones and generate routing tables to connect the full connected nodes together.
