### PR TITLE
Support to specify layer name to extract from the network.

### DIFF
--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -22,7 +22,7 @@ class Classifier(caffe.Net):
     """
     def __init__(self, model_file, pretrained_file, image_dims=None,
                  mean=None, input_scale=None, raw_scale=None,
-                 channel_swap=None):
+                 channel_swap=None, layer_name=None):
         caffe.Net.__init__(self, model_file, pretrained_file, caffe.TEST)
 
         # configure pre-processing
@@ -43,6 +43,8 @@ class Classifier(caffe.Net):
         if not image_dims:
             image_dims = self.crop_dims
         self.image_dims = image_dims
+
+        self.layer_name = layer_name
 
     def predict(self, inputs, oversample=True):
         """
@@ -86,8 +88,12 @@ class Classifier(caffe.Net):
                             dtype=np.float32)
         for ix, in_ in enumerate(input_):
             caffe_in[ix] = self.transformer.preprocess(self.inputs[0], in_)
-        out = self.forward_all(**{self.inputs[0]: caffe_in})
-        predictions = out[self.outputs[0]]
+        if self.layer_name:
+            out = self.forward_all(**{self.inputs[0]: caffe_in, 'blobs': [self.layer_name]})
+            predictions = out[self.layer_name]
+        else:
+            out = self.forward_all(**{self.inputs[0]: caffe_in})
+            predictions = out[self.outputs[0]]
 
         # For oversampling, average predictions across crops.
         if oversample:

--- a/python/classify.py
+++ b/python/classify.py
@@ -86,6 +86,10 @@ def main(argv):
         help="Image file extension to take as input when a directory " +
              "is given as the input file."
     )
+    parser.add_argument(
+        "--layer_name",
+        help="Name of the layer to extract from classifier (e.g. fc7)"
+    )
     args = parser.parse_args()
 
     image_dims = [int(s) for s in args.images_dim.split(',')]
@@ -107,7 +111,7 @@ def main(argv):
     classifier = caffe.Classifier(args.model_def, args.pretrained_model,
             image_dims=image_dims, mean=mean,
             input_scale=args.input_scale, raw_scale=args.raw_scale,
-            channel_swap=channel_swap)
+            channel_swap=channel_swap, layer_name=args.layer_name)
 
     # Load numpy array (.npy), directory glob (*.jpg), or image file.
     args.input_file = os.path.expanduser(args.input_file)


### PR DESCRIPTION
You can pass an argument like '--layer_name fc7' to classify.py
to extract the required layer instead of output probabilities -- a
useful feature to have for feature extraction.

Change-Id: I468504b156b0c0d8fad54ad5569229f592216979
