### PR TITLE
multi-label softmax support

### DIFF
--- a/include/caffe/loss_layers.hpp
+++ b/include/caffe/loss_layers.hpp
@@ -764,7 +764,7 @@ class SoftmaxWithLossLayer : public LossLayer<Dtype> {
   /// (otherwise just by the batch size).
   bool normalize_;
 
-  int softmax_axis_, outer_num_, inner_num_;
+  int softmax_axis_, outer_num_, inner_num_, label_num_;
 };
 
 }  // namespace caffe

--- a/src/caffe/layers/softmax_loss_layer.cpp
+++ b/src/caffe/layers/softmax_loss_layer.cpp
@@ -37,13 +37,12 @@ void SoftmaxWithLossLayer<Dtype>::Reshape(
       bottom[0]->CanonicalAxisIndex(this->layer_param_.softmax_param().axis());
   outer_num_ = bottom[0]->count(0, softmax_axis_);
   inner_num_ = bottom[0]->count(softmax_axis_ + 1);
-  label_num_ = softmax_axis_ < bottom[1]->num_axes() ? 
+  label_num_ = softmax_axis_ < bottom[1]->num_axes() ?
       bottom[1]->shape(softmax_axis_) : 1;
   CHECK_EQ(outer_num_, bottom[1]->count(0, softmax_axis_));
   if (softmax_axis_ < bottom[1]->num_axes()) {
     CHECK_EQ(inner_num_, bottom[1]->count(softmax_axis_ + 1));
-  }
-  else {
+  } else {
     CHECK_EQ(inner_num_, 1);
   }
 //  CHECK_EQ(outer_num_ * inner_num_, bottom[1]->count())

--- a/src/caffe/layers/softmax_loss_layer.cpp
+++ b/src/caffe/layers/softmax_loss_layer.cpp
@@ -37,11 +37,13 @@ void SoftmaxWithLossLayer<Dtype>::Reshape(
       bottom[0]->CanonicalAxisIndex(this->layer_param_.softmax_param().axis());
   outer_num_ = bottom[0]->count(0, softmax_axis_);
   inner_num_ = bottom[0]->count(softmax_axis_ + 1);
-  CHECK_EQ(outer_num_ * inner_num_, bottom[1]->count())
-      << "Number of labels must match number of predictions; "
-      << "e.g., if softmax axis == 1 and prediction shape is (N, C, H, W), "
-      << "label count (number of labels) must be N*H*W, "
-      << "with integer values in {0, 1, ..., C-1}.";
+  CHECK_EQ(outer_num_, bottom[1]->count(0, softmax_axis_));
+  CHECK_EQ(inner_num_, bottom[1]->count(softmax_axis_ + 1));
+//  CHECK_EQ(outer_num_ * inner_num_, bottom[1]->count())
+//      << "Number of labels must match number of predictions; "
+//      << "e.g., if softmax axis == 1 and prediction shape is (N, C, H, W), "
+//      << "label count (number of labels) must be N*H*W, "
+//      << "with integer values in {0, 1, ..., C-1}.";
   if (top.size() >= 2) {
     // softmax output
     top[1]->ReshapeLike(*bottom[0]);
@@ -55,20 +57,23 @@ void SoftmaxWithLossLayer<Dtype>::Forward_cpu(
   softmax_layer_->Forward(softmax_bottom_vec_, softmax_top_vec_);
   const Dtype* prob_data = prob_.cpu_data();
   const Dtype* label = bottom[1]->cpu_data();
+  int label_num = bottom[1]->shape(softmax_axis_);
   int dim = prob_.count() / outer_num_;
   int count = 0;
   Dtype loss = 0;
   for (int i = 0; i < outer_num_; ++i) {
-    for (int j = 0; j < inner_num_; j++) {
-      const int label_value = static_cast<int>(label[i * inner_num_ + j]);
-      if (has_ignore_label_ && label_value == ignore_label_) {
-        continue;
+    for (int k = 0; k < label_num; ++k) {
+      for (int j = 0; j < inner_num_; j++) {
+        const int label_value = static_cast<int>(label[(i * label_num + k) * inner_num_ + j]);
+        if (has_ignore_label_ && label_value == ignore_label_) {
+          continue;
+        }
+        DCHECK_GE(label_value, 0);
+        DCHECK_LT(label_value, prob_.shape(softmax_axis_));
+        loss -= log(std::max(prob_data[i * dim + label_value * inner_num_ + j],
+                             Dtype(FLT_MIN)));
+        ++count;
       }
-      DCHECK_GE(label_value, 0);
-      DCHECK_LT(label_value, prob_.shape(softmax_axis_));
-      loss -= log(std::max(prob_data[i * dim + label_value * inner_num_ + j],
-                           Dtype(FLT_MIN)));
-      ++count;
     }
   }
   if (normalize_) {
@@ -93,18 +98,30 @@ void SoftmaxWithLossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     const Dtype* prob_data = prob_.cpu_data();
     caffe_copy(prob_.count(), prob_data, bottom_diff);
     const Dtype* label = bottom[1]->cpu_data();
+    int label_num = bottom[1]->shape(softmax_axis_);
     int dim = prob_.count() / outer_num_;
     int count = 0;
     for (int i = 0; i < outer_num_; ++i) {
       for (int j = 0; j < inner_num_; ++j) {
-        const int label_value = static_cast<int>(label[i * inner_num_ + j]);
-        if (has_ignore_label_ && label_value == ignore_label_) {
-          for (int c = 0; c < bottom[0]->shape(softmax_axis_); ++c) {
-            bottom_diff[i * dim + c * inner_num_ + j] = 0;
+        int label_cnt = 0;
+        for (int k = 0; k < label_num; ++k) {
+          const int label_value = static_cast<int>(label[(i * label_num + k) * inner_num_ + j]);
+          if (has_ignore_label_ && label_value == ignore_label_) {
+            continue;
           }
-        } else {
-          bottom_diff[i * dim + label_value * inner_num_ + j] -= 1;
-          ++count;
+          ++label_cnt;
+        }
+        for (int c = 0; c < bottom[0]->shape(softmax_axis_); ++c) {
+          bottom_diff[i * dim + c * inner_num_ + j] *= label_cnt;
+        }
+        for (int k = 0; k < label_num; ++k) {
+          const int label_value = static_cast<int>(label[(i * label_num + k) * inner_num_ + j]);
+          if (has_ignore_label_ && label_value == ignore_label_) {
+            continue;
+          } else {
+            bottom_diff[i * dim + label_value * inner_num_ + j] -= 1;
+            ++count;
+          }
         }
       }
     }

--- a/src/caffe/layers/softmax_loss_layer.cu
+++ b/src/caffe/layers/softmax_loss_layer.cu
@@ -47,7 +47,7 @@ void SoftmaxWithLossLayer<Dtype>::Forward_gpu(
   // NOLINT_NEXT_LINE(whitespace/operators)
   SoftmaxLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
       CAFFE_CUDA_NUM_THREADS>>>(nthreads, prob_data, label, loss_data,
-      outer_num_, dim, label_num_, inner_num_, 
+      outer_num_, dim, label_num_, inner_num_,
       has_ignore_label_, ignore_label_, counts);
   Dtype loss;
   caffe_gpu_asum(nthreads, loss_data, &loss);
@@ -67,7 +67,7 @@ void SoftmaxWithLossLayer<Dtype>::Forward_gpu(
 template <typename Dtype>
 __global__ void SoftmaxLossBackwardGPU(const int nthreads, const Dtype* top,
     const Dtype* label, Dtype* bottom_diff, const int num, const int dim,
-    const int label_num, const int spatial_dim, 
+    const int label_num, const int spatial_dim,
     const bool has_ignore_label_, const int ignore_label_, Dtype* counts) {
   const int channels = dim / spatial_dim;
 
@@ -91,7 +91,7 @@ __global__ void SoftmaxLossBackwardGPU(const int nthreads, const Dtype* top,
       const int label_value = static_cast<int>(
           label[(n * label_num + k) * spatial_dim + s]);
       if (has_ignore_label_ && label_value == ignore_label_) {
-        continue; 
+        continue;
       } else {
         bottom_diff[n * dim + label_value * spatial_dim + s] -= 1;
       }
@@ -120,7 +120,7 @@ void SoftmaxWithLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     // NOLINT_NEXT_LINE(whitespace/operators)
     SoftmaxLossBackwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
         CAFFE_CUDA_NUM_THREADS>>>(nthreads, top_data, label, bottom_diff,
-        outer_num_, dim, label_num_, inner_num_, 
+        outer_num_, dim, label_num_, inner_num_,
         has_ignore_label_, ignore_label_, counts);
     const Dtype loss_weight = top[0]->cpu_diff()[0];
     if (normalize_) {

--- a/src/caffe/layers/softmax_loss_layer.cu
+++ b/src/caffe/layers/softmax_loss_layer.cu
@@ -10,13 +10,14 @@ namespace caffe {
 template <typename Dtype>
 __global__ void SoftmaxLossForwardGPU(const int nthreads,
           const Dtype* prob_data, const Dtype* label, Dtype* loss,
-          const int num, const int dim, const int spatial_dim,
+          const int num, const int dim, const int label_num, const int spatial_dim,
           const bool has_ignore_label_, const int ignore_label_,
           Dtype* counts) {
   CUDA_KERNEL_LOOP(index, nthreads) {
-    const int n = index / spatial_dim;
-    const int s = index % spatial_dim;
-    const int label_value = static_cast<int>(label[n * spatial_dim + s]);
+    const int n = index / (spatial_dim * label_num);
+    const int label_dim = index % (spatial_dim * label_num);
+    const int s = label_dim % spatial_dim;
+    const int label_value = static_cast<int>(label[index]);
     if (has_ignore_label_ && label_value == ignore_label_) {
       loss[index] = 0;
       counts[index] = 0;
@@ -34,8 +35,9 @@ void SoftmaxWithLossLayer<Dtype>::Forward_gpu(
   softmax_layer_->Forward(softmax_bottom_vec_, softmax_top_vec_);
   const Dtype* prob_data = prob_.gpu_data();
   const Dtype* label = bottom[1]->gpu_data();
+  const int label_num = bottom[1]->shape(softmax_axis_);
   const int dim = prob_.count() / outer_num_;
-  const int nthreads = outer_num_ * inner_num_;
+  const int nthreads = outer_num_ * label_num * inner_num_;
   // Since this memory is not used for anything until it is overwritten
   // on the backward pass, we use it here to avoid having to allocate new GPU
   // memory to accumulate intermediate results in the kernel.
@@ -46,7 +48,7 @@ void SoftmaxWithLossLayer<Dtype>::Forward_gpu(
   // NOLINT_NEXT_LINE(whitespace/operators)
   SoftmaxLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
       CAFFE_CUDA_NUM_THREADS>>>(nthreads, prob_data, label, loss_data,
-      outer_num_, dim, inner_num_, has_ignore_label_, ignore_label_, counts);
+      outer_num_, dim, label_num, inner_num_, has_ignore_label_, ignore_label_, counts);
   Dtype loss;
   caffe_gpu_asum(nthreads, loss_data, &loss);
   if (normalize_) {
@@ -65,23 +67,32 @@ void SoftmaxWithLossLayer<Dtype>::Forward_gpu(
 template <typename Dtype>
 __global__ void SoftmaxLossBackwardGPU(const int nthreads, const Dtype* top,
           const Dtype* label, Dtype* bottom_diff, const int num, const int dim,
-          const int spatial_dim, const bool has_ignore_label_,
+          const int label_num, const int spatial_dim, const bool has_ignore_label_,
           const int ignore_label_, Dtype* counts) {
   const int channels = dim / spatial_dim;
 
   CUDA_KERNEL_LOOP(index, nthreads) {
     const int n = index / spatial_dim;
     const int s = index % spatial_dim;
-    const int label_value = static_cast<int>(label[n * spatial_dim + s]);
-
-    if (has_ignore_label_ && label_value == ignore_label_) {
-      for (int c = 0; c < channels; ++c) {
-        bottom_diff[n * dim + c * spatial_dim + s] = 0;
+    int label_cnt = 0;
+    for (int k = 0; k < label_num; ++k) {
+      const int label_value = static_cast<int>(label[(n * label_num + k) * spatial_dim + s]);
+      if (has_ignore_label_ && label_value == ignore_label_) {
+        continue;
       }
-      counts[index] = 0;
-    } else {
-      bottom_diff[n * dim + label_value * spatial_dim + s] -= 1;
-      counts[index] = 1;
+      ++label_cnt;
+    }
+    for (int c = 0; c < channels; ++c) {
+      bottom_diff[n * dim + c * spatial_dim + s] *= label_cnt;
+    }
+    counts[index] = label_cnt;
+    for (int k = 0; k < label_num; ++k) {
+      const int label_value = static_cast<int>(label[(n * label_num + k) * spatial_dim + s]);
+      if (has_ignore_label_ && label_value == ignore_label_) {
+        continue; 
+      } else {
+        bottom_diff[n * dim + label_value * spatial_dim + s] -= 1;
+      }
     }
   }
 }
@@ -99,6 +110,7 @@ void SoftmaxWithLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     const Dtype* top_data = top[0]->gpu_data();
     caffe_gpu_memcpy(prob_.count() * sizeof(Dtype), prob_data, bottom_diff);
     const Dtype* label = bottom[1]->gpu_data();
+    const int label_num = bottom[1]->shape(softmax_axis_);
     const int dim = prob_.count() / outer_num_;
     const int nthreads = outer_num_ * inner_num_;
     // Since this memory is never used for anything else,
@@ -107,7 +119,7 @@ void SoftmaxWithLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     // NOLINT_NEXT_LINE(whitespace/operators)
     SoftmaxLossBackwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
         CAFFE_CUDA_NUM_THREADS>>>(nthreads, top_data, label, bottom_diff,
-        outer_num_, dim, inner_num_, has_ignore_label_, ignore_label_, counts);
+        outer_num_, dim, label_num, inner_num_, has_ignore_label_, ignore_label_, counts);
     const Dtype loss_weight = top[0]->cpu_diff()[0];
     if (normalize_) {
       Dtype count;

--- a/src/caffe/test/test_softmax_with_loss_layer.cpp
+++ b/src/caffe/test/test_softmax_with_loss_layer.cpp
@@ -23,7 +23,7 @@ class SoftmaxWithLossLayerTest : public MultiDeviceTest<TypeParam> {
  protected:
   SoftmaxWithLossLayerTest()
       : blob_bottom_data_(new Blob<Dtype>(10, 5, 2, 3)),
-        blob_bottom_label_(new Blob<Dtype>(10, 1, 2, 3)),
+        blob_bottom_label_(new Blob<Dtype>(10, 2, 2, 3)),
         blob_top_loss_(new Blob<Dtype>()) {
     // fill the values
     FillerParameter filler_param;

--- a/src/caffe/test/test_softmax_with_loss_layer.cpp
+++ b/src/caffe/test/test_softmax_with_loss_layer.cpp
@@ -81,7 +81,7 @@ TYPED_TEST(SoftmaxWithLossLayerTest, TestForwardIgnoreLabel) {
     accum_loss += this->blob_top_loss_->cpu_data()[0];
   }
   // Check that each label was included all but once.
-  EXPECT_NEAR(4 * full_loss, accum_loss, 1e-4);
+  EXPECT_NEAR(4 * full_loss, accum_loss, 2e-4);
 }
 
 TYPED_TEST(SoftmaxWithLossLayerTest, TestGradientIgnoreLabel) {


### PR DESCRIPTION
- Support N labels along the softmax axis. The final loss is average loss over all labels.
- By combining the ignore_label, it supports variable number of labels.
