### PR TITLE
TravisCI: wget cmake with --no-check-certificate

### DIFF
--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -23,7 +23,7 @@ apt-get install \
 # Caffe requires a minimum CMake version of 2.8.8.
 if $WITH_CMAKE; then
   # cmake 3 will make sure that the python interpreter and libraries match
-  wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.sh -O cmake3.sh
+  wget --no-check-certificate http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.sh -O cmake3.sh
   chmod +x cmake3.sh
   ./cmake3.sh --prefix=/usr/ --skip-license --exclude-subdir
 fi


### PR DESCRIPTION
Pulling fix from https://github.com/BVLC/caffe/pull/3272.

```
--2015-11-03 22:31:11--  http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.sh
Resolving www.cmake.org (www.cmake.org)... 66.194.253.19
Connecting to www.cmake.org (www.cmake.org)|66.194.253.19|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: http://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.sh [following]
--2015-11-03 22:31:11--  http://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.sh
Resolving cmake.org (cmake.org)... 66.194.253.19
Connecting to cmake.org (cmake.org)|66.194.253.19|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.sh [following]
--2015-11-03 22:31:11--  https://cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.sh
Connecting to cmake.org (cmake.org)|66.194.253.19|:443... connected.
ERROR: no certificate subject alternative name matches
        requested host name `cmake.org'.
To connect to cmake.org insecurely, use `--no-check-certificate'.
```