### PR TITLE
Remove dead preprocessor code for number of CUDA threads

### DIFF
--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -81,14 +81,8 @@ namespace caffe {
 const char* cublasGetErrorString(cublasStatus_t error);
 const char* curandGetErrorString(curandStatus_t error);
 
-// CUDA: thread number configuration.
-// Use 1024 threads per block, which requires cuda sm_2x or above,
-// or fall back to attempt compatibility (best of luck to you).
-#if __CUDA_ARCH__ >= 200
-    const int CAFFE_CUDA_NUM_THREADS = 1024;
-#else
-    const int CAFFE_CUDA_NUM_THREADS = 512;
-#endif
+// CUDA: use 512 threads per block
+const int CAFFE_CUDA_NUM_THREADS = 512;
 
 // CUDA: number of blocks for threads.
 inline int CAFFE_GET_BLOCKS(const int N) {


### PR DESCRIPTION
See #3281, #418, and https://groups.google.com/forum/#!topic/caffe-users/4abF674UaYY/discussion.

The preprocessor check added by #62 is not correct. Although the code appears to check the CUDA architecture version, the `__CUDA_ARCH__` macro is not defined in host code, so `CAFFE_CUDA_NUM_THREADS` always gets set to 512.

This patch simply removes the misleading dead code, and keeps `CAFFE_CUDA_NUM_THREADS` at 512. Given that we've been using this value for 21 months, and to my knowledge there's no a priori compelling reason why it ought to be maxed out, I don't see any reason to add additional code right now to restore the intended behavior (although I'd welcome a future PR that does so, if it makes a compelling performance difference, which I don't expect it does).