### PR TITLE
Correct transposition & channel_swap in deprocess

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -178,9 +178,9 @@ class Transformer:
         if raw_scale is not None:
             decaf_in /= raw_scale
         if channel_swap is not None:
-            decaf_in = decaf_in[channel_swap, :, :]
+            decaf_in = decaf_in[np.argsort(channel_swap), :, :]
         if transpose is not None:
-            decaf_in = decaf_in.transpose([transpose[t] for t in transpose])
+            decaf_in = decaf_in.transpose(np.argsort(transpose))
         return decaf_in
 
     def set_transpose(self, in_, order):


### PR DESCRIPTION
The deprocess( ) function should invert the preprocess( ) function, however it only worked when the permutation of your channel_swap is of order 2 and the permutation of your transpose were of order 3. This is usually the case, which is why this bug went unnoticed for a long time.

To reproduce it (on former version), try to preprocess and then deprocess with
transformer.set_transpose('data', (0,2,1)) (or (1,0,2) or (2,1,0))

Or with
transformer.set_channel_swap('data', (2,0,1)) (or (1,2,0) )

Indeed, we had

L152  (in preprocess)   caffe_in = caffe_in[channel_swap, :, :]
L181  (in deprocess)    decaf_in = decaf_in[channel_swap, :, :]
So we applied [channel_swap,:,:] twice to the initial data => not always the identity

L154 (in preprocess)    caffe_in = caffe_in.transpose(transpose)
L183 (in deprocess)     decaf_in = decaf_in.transpose([transpose[t] for t in transpose])
The transposition [transpose[t] for t in transpose] is (tranpsose)² so we applied transpose[t] three times which is not always the identity.