### PR TITLE
parse_log.py bugfix: don't attempt to write CSV if there are no lines to write

### DIFF
--- a/tools/extra/parse_log.py
+++ b/tools/extra/parse_log.py
@@ -149,6 +149,11 @@ def write_csv(output_filename, dict_list, delimiter, verbose=False):
     """Write a CSV file
     """
 
+    if not dict_list:
+        if verbose:
+            print('Not writing %s; no lines to write' % output_filename)
+        return
+
     dialect = csv.excel
     dialect.delimiter = delimiter
 


### PR DESCRIPTION
An empty `dict_list`, which contains the contents of the to-be-written CSV, can occur if, e.g., testing is never performed in the log.

Previously, this yielded an error like:

```
Traceback (most recent call last):
  File "./parse_log.py", line 201, in <module>
    main()
  File "./parse_log.py", line 197, in main
    test_dict_list, delimiter=args.delimiter)
  File "./parse_log.py", line 146, in save_csv_files
    write_csv(test_filename, test_dict_list, delimiter, verbose)
  File "./parse_log.py", line 161, in write_csv
    dict_writer = csv.DictWriter(f, fieldnames=dict_list[0].keys(),
IndexError: list index out of range
```