### PR TITLE
Switched order of two layers for simpler diff with untuned file

### DIFF
--- a/models/finetune_flickr_style/train_val.prototxt
+++ b/models/finetune_flickr_style/train_val.prototxt
@@ -370,13 +370,6 @@ layer {
   }
 }
 layer {
-  name: "loss"
-  type: "SoftmaxWithLoss"
-  bottom: "fc8_flickr"
-  bottom: "label"
-  top: "loss"
-}
-layer {
   name: "accuracy"
   type: "Accuracy"
   bottom: "fc8_flickr"
@@ -385,4 +378,11 @@ layer {
   include {
     phase: TEST
   }
+}
+layer {
+  name: "loss"
+  type: "SoftmaxWithLoss"
+  bottom: "fc8_flickr"
+  bottom: "label"
+  top: "loss"
 }


### PR DESCRIPTION
Untuned file is in models/bvlc_reference_caffenet/train_val.prototxt.

The diff between the two files is shown in the example 03-fine-tuning.ipynb.