### PR TITLE
Replace unistd functions with cross platform counterparts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ ifneq ($(CPU_ONLY), 1)
 	LIBRARIES := cudart cublas curand
 endif
 
-LIBRARIES += glog gflags protobuf boost_system m hdf5_hl hdf5
+LIBRARIES += glog gflags protobuf boost_system boost_filesystem m hdf5_hl hdf5
 
 # handle IO dependencies
 USE_LEVELDB ?= 1

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -2,7 +2,7 @@
 set(Caffe_LINKER_LIBS "")
 
 # ---[ Boost
-find_package(Boost 1.46 REQUIRED COMPONENTS system thread)
+find_package(Boost 1.46 REQUIRED COMPONENTS system thread filesystem)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 list(APPEND Caffe_LINKER_LIBS ${Boost_LIBRARIES})
 

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -1,7 +1,7 @@
 #ifndef CAFFE_UTIL_IO_H_
 #define CAFFE_UTIL_IO_H_
 
-#include <unistd.h>
+#include <boost/filesystem.hpp>
 #include <string>
 
 #include "google/protobuf/message.h"
@@ -12,31 +12,23 @@
 namespace caffe {
 
 using ::google::protobuf::Message;
+using ::boost::filesystem::path;
 
 inline void MakeTempFilename(string* temp_filename) {
   temp_filename->clear();
-  *temp_filename = "/tmp/caffe_test.XXXXXX";
-  char* temp_filename_cstr = new char[temp_filename->size() + 1];
-  // NOLINT_NEXT_LINE(runtime/printf)
-  strcpy(temp_filename_cstr, temp_filename->c_str());
-  int fd = mkstemp(temp_filename_cstr);
-  CHECK_GE(fd, 0) << "Failed to open a temporary file at: " << *temp_filename;
-  close(fd);
-  *temp_filename = temp_filename_cstr;
-  delete[] temp_filename_cstr;
+  const path& model = boost::filesystem::temp_directory_path()
+    /"caffe_test.%%%%%%";
+  *temp_filename = boost::filesystem::unique_path(model).string();
 }
 
 inline void MakeTempDir(string* temp_dirname) {
   temp_dirname->clear();
-  *temp_dirname = "/tmp/caffe_test.XXXXXX";
-  char* temp_dirname_cstr = new char[temp_dirname->size() + 1];
-  // NOLINT_NEXT_LINE(runtime/printf)
-  strcpy(temp_dirname_cstr, temp_dirname->c_str());
-  char* mkdtemp_result = mkdtemp(temp_dirname_cstr);
-  CHECK(mkdtemp_result != NULL)
-      << "Failed to create a temporary directory at: " << *temp_dirname;
-  *temp_dirname = temp_dirname_cstr;
-  delete[] temp_dirname_cstr;
+  const path& model = boost::filesystem::temp_directory_path()
+    /"caffe_test.%%%%%%";
+  const path& dir = boost::filesystem::unique_path(model).string();
+  bool directoryCreated = boost::filesystem::create_directory(dir);
+  CHECK(directoryCreated);
+  *temp_dirname = dir.string();
 }
 
 bool ReadProtoFromTextFile(const char* filename, Message* proto);

--- a/src/caffe/test/test_benchmark.cpp
+++ b/src/caffe/test/test_benchmark.cpp
@@ -1,4 +1,4 @@
-#include <unistd.h>  // for usleep
+#include <boost/thread.hpp>
 
 #include "gtest/gtest.h"
 
@@ -64,7 +64,7 @@ TYPED_TEST(BenchmarkTest, TestTimerMilliSeconds) {
   EXPECT_FALSE(timer.running());
   EXPECT_FALSE(timer.has_run_at_least_once());
   timer.Start();
-  usleep(300 * 1000);
+  boost::this_thread::sleep(boost::posix_time::milliseconds(300));
   EXPECT_GE(timer.MilliSeconds(), 300 - kMillisecondsThreshold);
   EXPECT_LE(timer.MilliSeconds(), 300 + kMillisecondsThreshold);
   EXPECT_TRUE(timer.initted());
@@ -79,7 +79,7 @@ TYPED_TEST(BenchmarkTest, TestTimerSeconds) {
   EXPECT_FALSE(timer.running());
   EXPECT_FALSE(timer.has_run_at_least_once());
   timer.Start();
-  usleep(300 * 1000);
+  boost::this_thread::sleep(boost::posix_time::milliseconds(300));
   EXPECT_GE(timer.Seconds(), 0.3 - kMillisecondsThreshold / 1000.);
   EXPECT_LE(timer.Seconds(), 0.3 + kMillisecondsThreshold / 1000.);
   EXPECT_TRUE(timer.initted());


### PR DESCRIPTION
Via unistd.h, caffe uses a handful of functions not readily available on non-Unix systems; boost is cross platform and affords more concise, more readable implementations (notably, with reference to MakeTempFilename and MakeTempDir).
To support this, CMake and Make builds are updated to link against boost_filesystem.