### PR TITLE
GetDB must return a value

### DIFF
--- a/src/caffe/util/db.cpp
+++ b/src/caffe/util/db.cpp
@@ -33,6 +33,7 @@ DB* GetDB(const string& backend) {
   }
 #endif  // USE_LMDB
   LOG(FATAL) << "Unknown database backend";
+  return NULL;
 }
 
 }  // namespace db


### PR DESCRIPTION
As noted by @danst18, when USE_LEVELDB and USE_LMDB are disabled, a compiler error is issued since GetDB no longer returns a value.
At runtime a fatal error would be issued anyways. However to help users who don't need a DB backend, NULL should be returned here.