### PR TITLE
DOC: Fix consistent typo in contrastive loss

### DIFF
--- a/include/caffe/loss_layers.hpp
+++ b/include/caffe/loss_layers.hpp
@@ -132,7 +132,7 @@ class LossLayer : public Layer<Dtype> {
 
 /**
  * @brief Computes the contrastive loss @f$
- *          E = \frac{1}{2N} \sum\limits_{n=1}^N \left(y\right) d +
+ *          E = \frac{1}{2N} \sum\limits_{n=1}^N \left(y\right) d^2 +
  *              \left(1-y\right) \max \left(margin-d, 0\right)^2
  *          @f$ where @f$
  *          d = \left| \left| a_n - b_n \right| \right|_2 @f$. This can be
@@ -148,7 +148,7 @@ class LossLayer : public Layer<Dtype> {
  * @param top output Blob vector (length 1)
  *   -# @f$ (1 \times 1 \times 1 \times 1) @f$
  *      the computed contrastive loss: @f$ E =
- *          \frac{1}{2N} \sum\limits_{n=1}^N \left(y\right) d +
+ *          \frac{1}{2N} \sum\limits_{n=1}^N \left(y\right) d^2 +
  *          \left(1-y\right) \max \left(margin-d, 0\right)^2
  *          @f$ where @f$
  *          d = \left| \left| a_n - b_n \right| \right|_2 @f$.


### PR DESCRIPTION
If a pair is similar, the contrastive loss should take the squared distance and not the distance. This is clearly what the code is doing, but the documentation gets it consistently wrong.

This is straight from the code with an arrow added:

```cpp
if (static_cast<int>(bottom[2]->cpu_data()[i])) {  // similar pairs
  loss += dist_sq_.cpu_data()[i];  // <---- clearly d^2 and not d
} else {  // dissimilar pairs
  if (legacy_version) {
    loss += std::max(margin - dist_sq_.cpu_data()[i], Dtype(0.0));
  } else {
    Dtype dist = std::max(margin - sqrt(dist_sq_.cpu_data()[i]), 0.0);
    loss += dist*dist;
  }
}
```