### PR TITLE
Constrain Prelu negative slope

### DIFF
--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -316,10 +316,21 @@ class Layer {
     param_propagate_down_[param_id] = value;
   }
   /**
-   * @brief Called after net's parameters have been updated. May be overridden
-   *        by a layer to apply constraints to parameters.
+   * @brief Called on each layer after net's parameters have been updated
+   *        using the solver.
    */
-  virtual void PostUpdateProcessing() {}
+  void PostUpdateProcessing() {
+    switch (Caffe::mode()) {
+    case Caffe::CPU:
+      PostUpdateProcessing_cpu();
+      break;
+    case Caffe::GPU:
+      PostUpdateProcessing_gpu();
+      break;
+    default:
+      LOG(FATAL) << "Unknown caffe mode.";
+    }
+  }
 
  protected:
   /** The protobuf that stores the layer parameters */
@@ -365,6 +376,20 @@ class Layer {
       const vector<Blob<Dtype>*>& bottom) {
     // LOG(WARNING) << "Using CPU code as backup.";
     Backward_cpu(top, propagate_down, bottom);
+  }
+
+  /**
+   * @brief Perform any processing required after the solver has updated
+   *        network parameters. Called only when Caffe mode is CPU.
+   */
+  virtual void PostUpdateProcessing_cpu() { /* Default behavior: no action.*/ }
+  /**
+   * @brief Perform any processing required after the solver has updated
+   *        network parameters. Called only when Caffe mode is GPU.
+   */
+  virtual void PostUpdateProcessing_gpu() {
+    // Call cpu code as a backup.
+    PostUpdateProcessing_cpu();
   }
 
   /**
@@ -516,9 +541,6 @@ void Layer<Dtype>::ToProto(LayerParameter* param, bool write_diff) {
     blobs_[i]->ToProto(param->add_blobs(), write_diff);
   }
 }
-
-
-
 
 }  // namespace caffe
 

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -315,7 +315,11 @@ class Layer {
     }
     param_propagate_down_[param_id] = value;
   }
-
+  /**
+   * @brief Called after net's parameters have been updated. May be overridden
+   *        by a layer to apply constraints to parameters.
+   */
+  virtual void PostUpdateProcessing() {}
 
  protected:
   /** The protobuf that stores the layer parameters */
@@ -512,6 +516,9 @@ void Layer<Dtype>::ToProto(LayerParameter* param, bool write_diff) {
     blobs_[i]->ToProto(param->add_blobs(), write_diff);
   }
 }
+
+
+
 
 }  // namespace caffe
 

--- a/include/caffe/neuron_layers.hpp
+++ b/include/caffe/neuron_layers.hpp
@@ -746,8 +746,6 @@ class PReLULayer : public NeuronLayer<Dtype> {
 
   virtual inline const char* type() const { return "PReLU"; }
 
-  virtual void PostUpdateProcessing();
-
  protected:
   /**
    * @param bottom input Blob vector (length 1)
@@ -797,8 +795,12 @@ class PReLULayer : public NeuronLayer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
-  void ConstrainNegSlopeCPU();
-  void ConstrainNegSlopeGPU();
+  /*********
+   * @brief Perform the post-update processing to constrain the negative slopes
+   *        of the Prelu.
+   *********/
+  virtual void PostUpdateProcessing_cpu();
+  virtual void PostUpdateProcessing_gpu();
 
   bool channel_shared_;
   bool constrain_neg_slope_;

--- a/include/caffe/neuron_layers.hpp
+++ b/include/caffe/neuron_layers.hpp
@@ -746,6 +746,8 @@ class PReLULayer : public NeuronLayer<Dtype> {
 
   virtual inline const char* type() const { return "PReLU"; }
 
+  virtual void PostUpdateProcessing();
+
  protected:
   /**
    * @param bottom input Blob vector (length 1)
@@ -795,7 +797,13 @@ class PReLULayer : public NeuronLayer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
+  void ConstrainNegSlopeCPU();
+  void ConstrainNegSlopeGPU();
+
   bool channel_shared_;
+  bool constrain_neg_slope_;
+  Dtype min_neg_slope_;
+  Dtype max_neg_slope_;
   Blob<Dtype> multiplier_;  // dot multiplier for backward computation of params
   Blob<Dtype> backward_buff_;  // temporary buffer for backward computation
   Blob<Dtype> bottom_memory_;  // memory for in-place computation

--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -29,6 +29,10 @@ void classname<Dtype>::funcname##_##gpu(const vector<Blob<Dtype>*>& top, \
     const vector<bool>& propagate_down, \
     const vector<Blob<Dtype>*>& bottom) { NO_GPU; } \
 
+#define STUB_GPU_POSTUPDATEPROCESSING(classname) \
+template <typename Dtype> \
+void classname<Dtype>::PostUpdateProcessing_gpu() { NO_GPU; }
+
 #else  // Normal GPU + CPU Caffe.
 
 #include <cublas_v2.h>

--- a/src/caffe/layers/prelu_layer.cpp
+++ b/src/caffe/layers/prelu_layer.cpp
@@ -133,7 +133,12 @@ void PReLULayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
 }
 
 template<typename Dtype>
-void PReLULayer<Dtype>::ConstrainNegSlopeCPU() {
+void PReLULayer<Dtype>::PostUpdateProcessing_cpu() {
+  if (!this->constrain_neg_slope_) {
+    return;
+  }
+
+  // Constrain the slopes to be between the limits.
   Dtype* slopes = this->blobs_[0]->mutable_cpu_data();
   int slope_count = this->blobs_[0]->count();
   for (int i = 0; i < slope_count; ++i) {
@@ -147,26 +152,9 @@ void PReLULayer<Dtype>::ConstrainNegSlopeCPU() {
   }
 }
 
-template <typename Dtype>
-void PReLULayer<Dtype>::PostUpdateProcessing() {
-  if (!this->constrain_neg_slope_) {
-    return;
-  }
-  switch (Caffe::mode()) {
-  case Caffe::CPU:
-    ConstrainNegSlopeCPU();
-    break;
-  case Caffe::GPU:
-    ConstrainNegSlopeGPU();
-    break;
-  default:
-    LOG(FATAL) << "Unknown caffe mode.";
-  }
-}
-
-
 #ifdef CPU_ONLY
 STUB_GPU(PReLULayer);
+STUB_GPU_POSTUPDATEPROCESSING(PReLULayer);
 #endif
 
 INSTANTIATE_CLASS(PReLULayer);

--- a/src/caffe/layers/prelu_layer.cu
+++ b/src/caffe/layers/prelu_layer.cu
@@ -5,6 +5,20 @@
 
 namespace caffe {
 
+// CUDA kernel for constraining negative slope.
+template <typename Dtype>
+__global__ void ConstrainNegSlope(Dtype* slopes, int slope_count,
+                                         Dtype min_slope, Dtype max_slope) {
+  CUDA_KERNEL_LOOP(index, slope_count) {
+    Dtype slope = slopes[index];
+    if (slope < min_slope) {
+      slopes[index] = min_slope;
+    } else if (slope > max_slope) {
+      slopes[index] = max_slope;
+    }
+  }
+}
+
 // CUDA kernele for forward
 template <typename Dtype>
 __global__ void PReLUForward(const int n, const int channels, const int dim,
@@ -120,8 +134,18 @@ void PReLULayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   }
 }
 
+template<typename Dtype>
+void PReLULayer<Dtype>::ConstrainNegSlopeGPU() {
+  Dtype* slopes = this->blobs_[0]->mutable_gpu_data();
+  int slope_count = this->blobs_[0]->count();
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  ConstrainNegSlope<Dtype><<<CAFFE_GET_BLOCKS(slope_count),
+      CAFFE_CUDA_NUM_THREADS>>>(
+      slopes, slope_count, this->min_neg_slope_, this->max_neg_slope_);
+}
 
 INSTANTIATE_LAYER_GPU_FUNCS(PReLULayer);
-
+template void PReLULayer<float>::ConstrainNegSlopeGPU();
+template void PReLULayer<double>::ConstrainNegSlopeGPU();
 
 }  // namespace caffe

--- a/src/caffe/layers/prelu_layer.cu
+++ b/src/caffe/layers/prelu_layer.cu
@@ -135,7 +135,11 @@ void PReLULayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
 }
 
 template<typename Dtype>
-void PReLULayer<Dtype>::ConstrainNegSlopeGPU() {
+void PReLULayer<Dtype>::PostUpdateProcessing_gpu() {
+  if (!this->constrain_neg_slope_) {
+    return;
+  }
+
   Dtype* slopes = this->blobs_[0]->mutable_gpu_data();
   int slope_count = this->blobs_[0]->count();
   // NOLINT_NEXT_LINE(whitespace/operators)
@@ -145,7 +149,7 @@ void PReLULayer<Dtype>::ConstrainNegSlopeGPU() {
 }
 
 INSTANTIATE_LAYER_GPU_FUNCS(PReLULayer);
-template void PReLULayer<float>::ConstrainNegSlopeGPU();
-template void PReLULayer<double>::ConstrainNegSlopeGPU();
+template void PReLULayer<float>::PostUpdateProcessing_gpu();
+template void PReLULayer<double>::PostUpdateProcessing_gpu();
 
 }  // namespace caffe

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -984,6 +984,9 @@ void Net<Dtype>::Update() {
   for (int i = 0; i < learnable_params_.size(); ++i) {
     learnable_params_[i]->Update();
   }
+  for (int i = 0; i < layers_.size(); ++i) {
+    layers_[i]->PostUpdateProcessing();
+  }
 }
 
 template <typename Dtype>

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1231,4 +1231,11 @@ message PReLUParameter {
   optional FillerParameter filler = 1;
   // Whether or not slope paramters are shared across channels.
   optional bool channel_shared = 2 [default = false];
+  // Whether or not to constrain the negative slope between min_neg_slope and
+  // max_neg_slope.
+  optional bool constrain_neg_slope = 3;
+  // limits on the value that the negative slope is allowed to acquire.
+  // Enforced only if constrain_neg_slope = true.
+  optional float min_neg_slope = 4 [default = 0.0];
+  optional float max_neg_slope = 5 [default = 1.0];
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1233,7 +1233,7 @@ message PReLUParameter {
   optional bool channel_shared = 2 [default = false];
   // Whether or not to constrain the negative slope between min_neg_slope and
   // max_neg_slope.
-  optional bool constrain_neg_slope = 3;
+  optional bool constrain_neg_slope = 3 [default = true];
   // limits on the value that the negative slope is allowed to acquire.
   // Enforced only if constrain_neg_slope = true.
   optional float min_neg_slope = 4 [default = 0.0];


### PR DESCRIPTION
This PR allows the negative slope on a PReLU unit to be constrained between min and max values which default to zero and -1.0. Which means it constrains the PReLU to be between ReLU and a linear unit. As the PR stands, this is now the default behavior, but could be changed to leave the negative slope unconstrained by default. 

[Edited for clarity, after seanbell replied.]
