### PR TITLE
fix a bug that time duration may be 0 when downloading model binary

### DIFF
--- a/scripts/download_model_binary.py
+++ b/scripts/download_model_binary.py
@@ -18,7 +18,7 @@ def reporthook(count, block_size, total_size):
     if count == 0:
         start_time = time.time()
         return
-    duration = time.time() - start_time
+    duration = (time.time() - start_time) or 0.01
     progress_size = int(count * block_size)
     speed = int(progress_size / (1024 * duration))
     percent = int(count * block_size * 100 / total_size)


### PR DESCRIPTION
Sometimes urllib calls a hook the first time and then the second in a time distance too shorter than 1 second, in which case `download_model_binary.py` will break. This commit fixes this crash.

Extra information:
* When I ran `scripts/download_model_binary.py` to download caffe model, it once reported;
```
Traceback (most recent call last):
  File "***/caffe\scripts/download_model_binary.py", line 73, in <module>
    frontmatter['caffemodel_url'], model_filename, reporthook)
  File "d:\Python27\lib\urllib.py", line 93, in urlretrieve
    return _urlopener.retrieve(url, filename, reporthook, data)
  File "d:\Python27\lib\urllib.py", line 274, in retrieve
    reporthook(blocknum, bs, size)
ZeroDivisionError: float division by zero
```
* I saw the output file and found the `count` was about 6 KB.
* Windows 8.1 Pro x64, Python 2.7 (32 bits) with urllib-1.17