### PR TITLE
Not enable peer access in case of the GPUs are located over QPI

### DIFF
--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -7,6 +7,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 
+#include <algorithm>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -232,7 +233,19 @@ P2PSync<Dtype>::P2PSync(shared_ptr<Solver<Dtype> > root_solver,
     int access;
     CUDA_CHECK(cudaDeviceCanAccessPeer(&access, self, peer));
     if (access) {
-      CUDA_CHECK(cudaDeviceEnablePeerAccess(peer, 0));
+      cudaDeviceProp a, b;
+      CUDA_CHECK(cudaGetDeviceProperties(&a, self));
+      CUDA_CHECK(cudaGetDeviceProperties(&b, peer));
+      const int pci_bus_id_offset = 0x80;
+      if (std::max(a.pciBusID, b.pciBusID) < pci_bus_id_offset ||
+          std::min(a.pciBusID, b.pciBusID) >= pci_bus_id_offset) {
+        CUDA_CHECK(cudaDeviceEnablePeerAccess(peer, 0));
+      } else {
+        LOG(INFO) << "This will result in poor memcpy performance over QPI, "
+                  << "if enables peer to peer access from GPU "
+                  << self << " (pciBusID " << a.pciBusID << ") to GPU "
+                  << peer << " (pciBusID " << b.pciBusID << ")";
+      }
     } else {
       LOG(INFO)<< "GPU " << self << " does not have p2p access to GPU " << peer;
     }
@@ -262,7 +275,14 @@ P2PSync<Dtype>::~P2PSync() {
     int access;
     CUDA_CHECK(cudaDeviceCanAccessPeer(&access, self, peer));
     if (access) {
-      CUDA_CHECK(cudaDeviceDisablePeerAccess(peer));
+      cudaDeviceProp a, b;
+      CUDA_CHECK(cudaGetDeviceProperties(&a, self));
+      CUDA_CHECK(cudaGetDeviceProperties(&b, peer));
+      const int pci_bus_id_offset = 0x80;
+      if (std::max(a.pciBusID, b.pciBusID) < pci_bus_id_offset ||
+          std::min(a.pciBusID, b.pciBusID) >= pci_bus_id_offset) {
+        CUDA_CHECK(cudaDeviceDisablePeerAccess(peer));
+      }
     }
   }
 


### PR DESCRIPTION
I've found that for some hardware architectures, such as several types of HP server, the GPUs over QPI can even enable p2p access between each others, however, the bandwidth is quit low (less than 200MB/s instead of 6~8GB/s in normal). So I think there should not to enable peer access between GPUs which were plugged on the different I/O Hubs (IOH) to ensure at least normal cudaMemcpy performance.

The following quote is from our related hardware engineer.

quote:
"""
NVIDIA GPUs are designed to take full advantage of the PCI-e Gen2 standard, including the Peer-to-Peer communication, but the IOH chipset does not support the full PCI-e Gen2 specification for P2P communication with other IOH chipsets
The cudaPeerEnable() API call will return an error code if the application tries to establish a P2P relationship between two GPUs that would require P2P communication over QPI. The cudaMemcopy() function for P2P Direct Transfers automatically falls back to using a Device-to-Host-to-Device path, but there is no automatic fallback for P2P Direct Access (P2P load/store instructions in device code).
One known example system is the HP Z800 workstation with dual IOH chipsets which can run the simpleP2P example, but bandwidth is very low (100s of MB/s instead of several GB/s) because of the fallback path.
NVIDIA is investigating whether GPU P2P across QPI can be supported by adding functionality to future GPU architectures.
"""
