### PR TITLE
Remove un-necessary includes

### DIFF
--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -3,9 +3,6 @@
 #endif
 #include <glog/logging.h>
 #include <stdio.h>
-#include <sys/ioctl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
 
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Removing unnecessary includes which cause compatibility issues