### PR TITLE
removed 4dimensions constraints on blob shape

### DIFF
--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -137,12 +137,9 @@ class Blob {
   /// @brief Deprecated legacy shape accessor width: use shape(3) instead.
   inline int width() const { return LegacyShape(3); }
   inline int LegacyShape(int index) const {
-    CHECK_LE(num_axes(), 4)
-        << "Cannot use legacy accessors on Blobs with > 4 axes.";
-    CHECK_LT(index, 4);
-    CHECK_GE(index, -4);
     if (index >= num_axes() || index < -num_axes()) {
-      // Axis is out of range, but still in [0, 3] (or [-4, -1] for reverse
+      // Assuming num_axes is the blob dimension (generaly 4),
+      // axis is out of range, but still in [0, num_axes[ (or [-num_axes, -1] for reverse
       // indexing) -- this special case simulates the one-padding used to fill
       // extraneous axes of legacy blobs.
       return 1;

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -139,7 +139,8 @@ class Blob {
   inline int LegacyShape(int index) const {
     if (index >= num_axes() || index < -num_axes()) {
       // Assuming num_axes is the blob dimension (generaly 4),
-      // axis is out of range, but still in [0, num_axes[ (or [-num_axes, -1] for reverse
+      // axis is out of range, but still in [0, num_axes[
+      // (or [-num_axes, -1] for reverse
       // indexing) -- this special case simulates the one-padding used to fill
       // extraneous axes of legacy blobs.
       return 1;


### PR DESCRIPTION
When trying to setup conv layer and specifying kernel size this way (see the complete conv layer at the end) :
```
kernel_size: [3, 3, 11]
```
Current master code returns error 
```
F1112 10:02:11.418356 32749 blob.hpp:140] Check failed: num_axes() <= 4 (5 vs. 4) Cannot use legacy accessors on Blobs with > 4 axes.
```
I simply removed the 4 dimension constraints following pull requests on the topic https://github.com/BVLC/caffe/pull/2049

It seems to work now, tell me if something else should be considered.

For testing, here is the beginning of the architecture and caffe log

```
layer {
  type: "DummyData"
  top: "data"
  top: "label"
  dummy_data_param {
    shape { dim: 10 dim:1 dim: 3 dim: 3 dim: 103 }
    shape { dim: 10 }
  }
}
layer {
          name: "conv1"
          type: "Convolution"
          bottom: "data"
          top: "conv1"
          param {
              name: "conv1_w"
              lr_mult:    1
              decay_mult: 1    
          }
          param {
              name: "conv1_b"
              lr_mult:    2    
              decay_mult: 0    
          }
          convolution_param {
              num_output: 20
              kernel_size: [3, 3, 11]
              stride: 1
              pad: 0
                 weight_filler{
                      type: "xavier"
                }
              bias_filler {
                    type: "constant" 
                    value: 0
              }
         }
}
```

related log:
```
I1112 10:22:45.839669 22068 net.cpp:106] Creating Layer 
I1112 10:22:45.839684 22068 net.cpp:411]  -> data
I1112 10:22:45.839702 22068 net.cpp:411]  -> label
I1112 10:22:45.839738 22068 net.cpp:150] Setting up 
I1112 10:22:45.839753 22068 net.cpp:157] Top shape: 10 1 3 3 103 (9270)
I1112 10:22:45.839767 22068 net.cpp:157] Top shape: 10 (10)
I1112 10:22:45.839777 22068 net.cpp:165] Memory required for data: 37120
I1112 10:22:45.839788 22068 layer_factory.hpp:76] Creating layer label__1_split
I1112 10:22:45.839803 22068 net.cpp:106] Creating Layer label__1_split
I1112 10:22:45.839817 22068 net.cpp:454] label__1_split <- label
I1112 10:22:45.839833 22068 net.cpp:411] label__1_split -> label__1_split_0
I1112 10:22:45.839848 22068 net.cpp:411] label__1_split -> label__1_split_1
I1112 10:22:45.839865 22068 net.cpp:150] Setting up label__1_split
I1112 10:22:45.839880 22068 net.cpp:157] Top shape: 10 (10)
I1112 10:22:45.839892 22068 net.cpp:157] Top shape: 10 (10)
I1112 10:22:45.839903 22068 net.cpp:165] Memory required for data: 37200
I1112 10:22:45.839915 22068 layer_factory.hpp:76] Creating layer conv1
I1112 10:22:45.839932 22068 net.cpp:106] Creating Layer conv1
I1112 10:22:45.839943 22068 net.cpp:454] conv1 <- data
I1112 10:22:45.839961 22068 net.cpp:411] conv1 -> conv1
I1112 10:22:45.840006 22068 net.cpp:150] Setting up conv1
I1112 10:22:45.840020 22068 net.cpp:157] Top shape: 10 20 1 1 93 (18600)
```