### PR TITLE
add lines to move the heads of the syncedmems of the learnable params…

### DIFF
--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -318,6 +318,15 @@ void P2PSync<Dtype>::on_start() {
     CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
     children_[i]->queue_.push(this);
   }
+
+  // Move syncedmem head to HEAD_AT_GPU
+  const vector<Blob<Dtype>*>& params = solver_->net()->learnable_params();
+  Dtype* mutable_gpu_data;
+  for (int i = 0; i < params.size(); ++i) {
+    mutable_gpu_data = params[i]->mutable_gpu_data();
+    mutable_gpu_data++; // added to prevent the warning message of compilers
+                        // warning: statement has no effect [-Wunused-value]
+  }
 #endif
 }
 


### PR DESCRIPTION
The current implementation of the multigpu support does not move the heads (of the syncedmems) of the learnable params in non-root_solvers to HEAD_AT_GPU.

Because of that, the data in the pointer not synced when you need to call cpu_data().

To solve this issue, added lines to call mutable_gpu_data() in on_start() function in parallel.cpp