### PR TITLE
replace snprintf with a C++98 equivalent

### DIFF
--- a/examples/cifar10/convert_cifar_data.cpp
+++ b/examples/cifar10/convert_cifar_data.cpp
@@ -16,6 +16,7 @@
 
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/db.hpp"
+#include "caffe/util/format.hpp"
 
 using caffe::Datum;
 using boost::scoped_ptr;
@@ -52,19 +53,18 @@ void convert_dataset(const string& input_folder, const string& output_folder,
   for (int fileid = 0; fileid < kCIFARTrainBatches; ++fileid) {
     // Open files
     LOG(INFO) << "Training Batch " << fileid + 1;
-    snprintf(str_buffer, kCIFARImageNBytes, "/data_batch_%d.bin", fileid + 1);
-    std::ifstream data_file((input_folder + str_buffer).c_str(),
+    string batchFileName = input_folder + "/data_batch_"
+      + caffe::format_int(fileid+1) + ".bin";
+    std::ifstream data_file(batchFileName.c_str(),
         std::ios::in | std::ios::binary);
     CHECK(data_file) << "Unable to open train file #" << fileid + 1;
     for (int itemid = 0; itemid < kCIFARBatchSize; ++itemid) {
       read_image(&data_file, &label, str_buffer);
       datum.set_label(label);
       datum.set_data(str_buffer, kCIFARImageNBytes);
-      int length = snprintf(str_buffer, kCIFARImageNBytes, "%05d",
-          fileid * kCIFARBatchSize + itemid);
       string out;
       CHECK(datum.SerializeToString(&out));
-      txn->Put(string(str_buffer, length), out);
+      txn->Put(caffe::format_int(fileid * kCIFARBatchSize + itemid, 5), out);
     }
   }
   txn->Commit();
@@ -82,10 +82,9 @@ void convert_dataset(const string& input_folder, const string& output_folder,
     read_image(&data_file, &label, str_buffer);
     datum.set_label(label);
     datum.set_data(str_buffer, kCIFARImageNBytes);
-    int length = snprintf(str_buffer, kCIFARImageNBytes, "%05d", itemid);
     string out;
     CHECK(datum.SerializeToString(&out));
-    txn->Put(string(str_buffer, length), out);
+    txn->Put(caffe::format_int(itemid, 5), out);
   }
   txn->Commit();
   test_db->Close();

--- a/examples/siamese/convert_mnist_siamese_data.cpp
+++ b/examples/siamese/convert_mnist_siamese_data.cpp
@@ -13,6 +13,7 @@
 #include "stdint.h"
 
 #include "caffe/proto/caffe.pb.h"
+#include "caffe/util/format.hpp"
 #include "caffe/util/math_functions.hpp"
 
 #ifdef USE_LEVELDB
@@ -75,8 +76,6 @@ void convert_dataset(const char* image_filename, const char* label_filename,
   char label_i;
   char label_j;
   char* pixels = new char[2 * rows * cols];
-  const int kMaxKeyLength = 10;
-  char key[kMaxKeyLength];
   std::string value;
 
   caffe::Datum datum;
@@ -99,8 +98,8 @@ void convert_dataset(const char* image_filename, const char* label_filename,
       datum.set_label(0);
     }
     datum.SerializeToString(&value);
-    snprintf(key, kMaxKeyLength, "%08d", itemid);
-    db->Put(leveldb::WriteOptions(), std::string(key), value);
+    std::string key_str = caffe::format_int(itemid, 8);
+    db->Put(leveldb::WriteOptions(), key_str, value);
   }
 
   delete db;

--- a/include/caffe/util/format.hpp
+++ b/include/caffe/util/format.hpp
@@ -1,0 +1,18 @@
+#ifndef CAFFE_UTIL_FORMAT_H_
+#define CAFFE_UTIL_FORMAT_H_
+
+#include <iomanip>  // NOLINT(readability/streams)
+#include <sstream>  // NOLINT(readability/streams)
+#include <string>
+
+namespace caffe {
+
+inline std::string format_int(int n, int numberOfLeadingZeros = 0 ) {
+  std::ostringstream s;
+  s << std::setw(numberOfLeadingZeros) << std::setfill('0') << n;
+  return s.str();
+}
+
+}
+
+#endif   // CAFFE_UTIL_FORMAT_H_

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "caffe/solver.hpp"
+#include "caffe/util/format.hpp"
 #include "caffe/util/hdf5.hpp"
 #include "caffe/util/io.hpp"
 #include "caffe/util/upgrade_proto.hpp"
@@ -448,11 +449,8 @@ void Solver<Dtype>::CheckSnapshotWritePermissions() {
 
 template <typename Dtype>
 string Solver<Dtype>::SnapshotFilename(const string extension) {
-  string filename(param_.snapshot_prefix());
-  const int kBufferSize = 20;
-  char iter_str_buffer[kBufferSize];
-  snprintf(iter_str_buffer, kBufferSize, "_iter_%d", iter_);
-  return filename + iter_str_buffer + extension;
+  return param_.snapshot_prefix() + "_iter_" + caffe::format_int(iter_)
+    + extension;
 }
 
 template <typename Dtype>

--- a/tools/convert_imageset.cpp
+++ b/tools/convert_imageset.cpp
@@ -20,6 +20,7 @@
 
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/db.hpp"
+#include "caffe/util/format.hpp"
 #include "caffe/util/io.hpp"
 #include "caffe/util/rng.hpp"
 
@@ -99,8 +100,6 @@ int main(int argc, char** argv) {
   std::string root_folder(argv[1]);
   Datum datum;
   int count = 0;
-  const int kMaxKeyLength = 256;
-  char key_cstr[kMaxKeyLength];
   int data_size = 0;
   bool data_size_initialized = false;
 
@@ -131,13 +130,12 @@ int main(int argc, char** argv) {
       }
     }
     // sequential
-    int length = snprintf(key_cstr, kMaxKeyLength, "%08d_%s", line_id,
-        lines[line_id].first.c_str());
+    string key_str = caffe::format_int(line_id, 8) + "_" + lines[line_id].first;
 
     // Put in db
     string out;
     CHECK(datum.SerializeToString(&out));
-    txn->Put(string(key_cstr, length), out);
+    txn->Put(key_str, out);
 
     if (++count % 1000 == 0) {
       // Commit db

--- a/tools/extract_features.cpp
+++ b/tools/extract_features.cpp
@@ -1,4 +1,3 @@
-#include <stdio.h>  // for snprintf
 #include <string>
 #include <vector>
 
@@ -10,6 +9,7 @@
 #include "caffe/net.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/db.hpp"
+#include "caffe/util/format.hpp"
 #include "caffe/util/io.hpp"
 #include "caffe/vision_layers.hpp"
 
@@ -135,8 +135,6 @@ int feature_extraction_pipeline(int argc, char** argv) {
   LOG(ERROR)<< "Extacting Features";
 
   Datum datum;
-  const int kMaxKeyStrLength = 100;
-  char key_str[kMaxKeyStrLength];
   std::vector<Blob<float>*> input_vec;
   std::vector<int> image_indices(num_features, 0);
   for (int batch_index = 0; batch_index < num_mini_batches; ++batch_index) {
@@ -158,11 +156,11 @@ int feature_extraction_pipeline(int argc, char** argv) {
         for (int d = 0; d < dim_features; ++d) {
           datum.add_float_data(feature_blob_data[d]);
         }
-        int length = snprintf(key_str, kMaxKeyStrLength, "%010d",
-            image_indices[i]);
+        string key_str = caffe::format_int(image_indices[i], 10);
+
         string out;
         CHECK(datum.SerializeToString(&out));
-        txns.at(i)->Put(std::string(key_str, length), out);
+        txns.at(i)->Put(key_str, out);
         ++image_indices[i];
         if (image_indices[i] % 1000 == 0) {
           txns.at(i)->Commit();
@@ -186,4 +184,3 @@ int feature_extraction_pipeline(int argc, char** argv) {
   LOG(ERROR)<< "Successfully extracted the features!";
   return 0;
 }
-


### PR DESCRIPTION
`snprintf` is not consistently available on Windows.
Although patchy support is [possible][1] (search snprintf in suggested reference), I find that `snprintf` may be advantageously replaced by a solution which doesn't involve defining arbitrarily sized buffers and converting between C and C++ strings.
As I understand that C++ streams are not very popular and the main use of `snprintf` in Caffe is producing numbered batches, I suggest the introduction of a utility function (`format_int`).
[1]: https://github.com/BVLC/caffe/blob/6eae122a8eb84f8371dde815986cd7524fc4cbaa/src/gtest/gtest-all.cpp