### PR TITLE
GetDB must return a value.

### DIFF
--- a/src/caffe/util/db.cpp
+++ b/src/caffe/util/db.cpp
@@ -18,6 +18,7 @@ DB* GetDB(DataParameter::DB backend) {
 #endif  // USE_LMDB
   default:
     LOG(FATAL) << "Unknown database backend";
+    return NULL;
   }
 }
 


### PR DESCRIPTION
Currently compilation will fail with some compilers when LevelDB and LMDB are disabled.
Similar to #3303.