### PR TITLE
Exclude core.hpp when building without OpenCV

### DIFF
--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -2,8 +2,8 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/text_format.h>
-#include <opencv2/core/core.hpp>
 #ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/highgui/highgui_c.h>
 #include <opencv2/imgproc/imgproc.hpp>


### PR DESCRIPTION
When building without OpenCV, of course we do not want any OpenCV header to be included.