### PR TITLE
Fix syntax inside switch

### DIFF
--- a/src/caffe/util/hdf5.cpp
+++ b/src/caffe/util/hdf5.cpp
@@ -29,10 +29,10 @@ void hdf5_load_nd_dataset_helper(
   CHECK_GE(status, 0) << "Failed to get dataset info for " << dataset_name_;
   switch (class_) {
   case H5T_FLOAT:
-    LOG_FIRST_N(INFO, 1) << "Datatype class: H5T_FLOAT";
+    { LOG_FIRST_N(INFO, 1) << "Datatype class: H5T_FLOAT"; }
     break;
   case H5T_INTEGER:
-    LOG_FIRST_N(INFO, 1) << "Datatype class: H5T_INTEGER";
+    { LOG_FIRST_N(INFO, 1) << "Datatype class: H5T_INTEGER"; }
     break;
   case H5T_TIME:
     LOG(FATAL) << "Unsupported datatype class: H5T_TIME";


### PR DESCRIPTION
glog macros inside `switch` cause the MSVC compiler to emit [error C2360](https://msdn.microsoft.com/en-us/library/61af7cx3.aspx). 
I find that GCC may be lenient in this case; standards compliance should we require that we manually define scopes to declare and initialise variables within `case` statements.
Additionally, `LOG(FATAL)` doesn't exonerate us from the requirement to `break` after `case`.
