### PR TITLE
Safely create temporary files and directories

### DIFF
--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -2,12 +2,15 @@
 #define CAFFE_UTIL_IO_H_
 
 #include <boost/filesystem.hpp>
+#include <iomanip>
+#include <iostream>  // NOLINT(readability/streams)
 #include <string>
 
 #include "google/protobuf/message.h"
 
 #include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"
+#include "caffe/util/format.hpp"
 
 #ifndef CAFFE_TMP_DIR_RETRIES
 #define CAFFE_TMP_DIR_RETRIES 100
@@ -17,13 +20,6 @@ namespace caffe {
 
 using ::google::protobuf::Message;
 using ::boost::filesystem::path;
-
-inline void MakeTempFilename(string* temp_filename) {
-  temp_filename->clear();
-  const path& model = boost::filesystem::temp_directory_path()
-    /"caffe_test.%%%%%%";
-  *temp_filename = boost::filesystem::unique_path(model).string();
-}
 
 inline void MakeTempDir(string* temp_dirname) {
   temp_dirname->clear();
@@ -38,6 +34,19 @@ inline void MakeTempDir(string* temp_dirname) {
     }
   }
   LOG(FATAL) << "Failed to create a temporary directory.";
+}
+
+inline void MakeTempFilename(string* temp_filename) {
+  static path temp_files_subpath;
+  static uint64_t next_temp_file = 0;
+  temp_filename->clear();
+  if ( temp_files_subpath.empty() ) {
+    string path_string="";
+    MakeTempDir(&path_string);
+    temp_files_subpath = path_string;
+  }
+  *temp_filename =
+    (temp_files_subpath/caffe::format_int(next_temp_file++, 9)).string();
 }
 
 bool ReadProtoFromTextFile(const char* filename, Message* proto);


### PR DESCRIPTION
With reference to #3324 I propose a modified implementation of `MakeTempDir`.
@futurely and @netheril96 suggested that the designated issue may be caused by a race condition. 

Upon closer inspection, I find that:

* Boost `unique_path` is specified to return a randomly generated path, which may or may not be unique. Boost implementations typically system level entropy sources to generate the path.
* Typical `mkdtemp` implementations rely on `mkdir` to generate temporary directories. Race conditions are avoided by checking the return value of `mkdir` instead of checking whether a generated path already exists.
* Paths generated using Boost use 4 bits of randomness per character. By comparison typical `mkdtemp` implementations may use 5 or 6 bits of randomness.

With this in mind the proposed solution is similar to how Python implements `mkdtemp` ([tempfile.py, line 322] (https://github.com/python-git/python/blob/715a6e5035bb21ac49382772076ec4c630d6e960/Lib/tempfile.py#L296)).