### PR TITLE
Support OpenCV 2 and 3 in Preprocess function.

### DIFF
--- a/examples/cpp_classification/classification.cpp
+++ b/examples/cpp_classification/classification.cpp
@@ -192,7 +192,7 @@ void Classifier::Preprocess(const cv::Mat& img,
   /* Convert the input image to the input image format of the network. */
   cv::Mat sample;
   /* OpenCV 2 preprocess*/
-  #if (defined(CV_VERSION_EPOCH) && CV_VERSION_EPOCH == 2) 
+  #if (defined(CV_VERSION_EPOCH) && CV_VERSION_EPOCH == 2)
     if (img.channels() == 3 && num_channels_ == 1)
       cv::cvtColor(img, sample, CV_BGR2GRAY);
     else if (img.channels() == 4 && num_channels_ == 1)

--- a/examples/cpp_classification/classification.cpp
+++ b/examples/cpp_classification/classification.cpp
@@ -191,7 +191,8 @@ void Classifier::Preprocess(const cv::Mat& img,
                             std::vector<cv::Mat>* input_channels) {
   /* Convert the input image to the input image format of the network. */
   cv::Mat sample;
-  #if CV_MAJOR_VERSION == 2
+  /* OpenCV 2 preprocess*/
+  #if (defined(CV_VERSION_EPOCH) && CV_VERSION_EPOCH == 2) 
     if (img.channels() == 3 && num_channels_ == 1)
       cv::cvtColor(img, sample, CV_BGR2GRAY);
     else if (img.channels() == 4 && num_channels_ == 1)
@@ -202,7 +203,8 @@ void Classifier::Preprocess(const cv::Mat& img,
       cv::cvtColor(img, sample, CV_GRAY2BGR);
     else
       sample = img;
-  #elif CV_MAJOR_VERSION == 3
+  /* OpenCV 3 preprocess*/
+  #else
     if (img.channels() == 3 && num_channels_ == 1)
       cv::cvtColor(img, sample, cv::COLOR_BGR2GRAY);
     else if (img.channels() == 4 && num_channels_ == 1)

--- a/examples/cpp_classification/classification.cpp
+++ b/examples/cpp_classification/classification.cpp
@@ -1,6 +1,7 @@
 #include <caffe/caffe.hpp>
 #ifdef USE_OPENCV
 #include <opencv2/core/core.hpp>
+#include <opencv2/core/version.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #endif  // USE_OPENCV
@@ -190,16 +191,29 @@ void Classifier::Preprocess(const cv::Mat& img,
                             std::vector<cv::Mat>* input_channels) {
   /* Convert the input image to the input image format of the network. */
   cv::Mat sample;
-  if (img.channels() == 3 && num_channels_ == 1)
-    cv::cvtColor(img, sample, CV_BGR2GRAY);
-  else if (img.channels() == 4 && num_channels_ == 1)
-    cv::cvtColor(img, sample, CV_BGRA2GRAY);
-  else if (img.channels() == 4 && num_channels_ == 3)
-    cv::cvtColor(img, sample, CV_BGRA2BGR);
-  else if (img.channels() == 1 && num_channels_ == 3)
-    cv::cvtColor(img, sample, CV_GRAY2BGR);
-  else
-    sample = img;
+  #if CV_MAJOR_VERSION == 2
+    if (img.channels() == 3 && num_channels_ == 1)
+      cv::cvtColor(img, sample, CV_BGR2GRAY);
+    else if (img.channels() == 4 && num_channels_ == 1)
+      cv::cvtColor(img, sample, CV_BGRA2GRAY);
+    else if (img.channels() == 4 && num_channels_ == 3)
+      cv::cvtColor(img, sample, CV_BGRA2BGR);
+    else if (img.channels() == 1 && num_channels_ == 3)
+      cv::cvtColor(img, sample, CV_GRAY2BGR);
+    else
+      sample = img;
+  #elif CV_MAJOR_VERSION == 3
+    if (img.channels() == 3 && num_channels_ == 1)
+      cv::cvtColor(img, sample, cv::COLOR_BGR2GRAY);
+    else if (img.channels() == 4 && num_channels_ == 1)
+      cv::cvtColor(img, sample, cv::COLOR_BGRA2GRAY);
+    else if (img.channels() == 4 && num_channels_ == 3)
+      cv::cvtColor(img, sample, cv::COLOR_BGRA2BGR);
+    else if (img.channels() == 1 && num_channels_ == 3)
+      cv::cvtColor(img, sample, cv::COLOR_GRAY2BGR);
+    else
+      sample = img;
+  #endif
 
   cv::Mat sample_resized;
   if (sample.size() != input_geometry_)


### PR DESCRIPTION
Support both versions of OpenCV in Preprocess function. This fix allow users to install Caffe using the last two major versions of OpenCV (branch 2 and branch 3).