### PR TITLE
ReshapeLayer and FlattenLayer should not allow in-place computation

### DIFF
--- a/src/caffe/layers/flatten_layer.cpp
+++ b/src/caffe/layers/flatten_layer.cpp
@@ -7,6 +7,8 @@ namespace caffe {
 template <typename Dtype>
 void FlattenLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+  CHECK_NE(top[0], bottom[0]) << this->type() << " Layer does not "
+        "allow in-place computation.";
   const int start_axis = bottom[0]->CanonicalAxisIndex(
       this->layer_param_.flatten_param().axis());
   const int end_axis = bottom[0]->CanonicalAxisIndex(

--- a/src/caffe/layers/reshape_layer.cpp
+++ b/src/caffe/layers/reshape_layer.cpp
@@ -7,6 +7,8 @@ namespace caffe {
 template <typename Dtype>
 void ReshapeLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
+  CHECK_NE(top[0], bottom[0]) << this->type() << " Layer does not "
+        "allow in-place computation.";
   inferred_axis_ = -1;
   copy_axes_.clear();
   const BlobShape& top_blob_shape = this->layer_param_.reshape_param().shape();


### PR DESCRIPTION
This PR is to prevent incorrect gradients caused by in-place reshaping of Blobs in ReshapeLayer and FlattenLayer.

If bottom and top blobs are the same in both of these layers and they are on top of a layer which uses the shape of its top blob for backward (such as SliceLayer or PoolingLayer) , then its gradients can be calculated in a wrong way. It can also allow bottom and top blobs of different counts since currently the count checks are performed after reshaping the blob.

A simple solution to this is not allow in-place operation for these layers. Another solution can be save the bottom shape and restore it during backward. 

This PR is the former simpler solution.