### PR TITLE
Mark the expected TravisCI distro explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: precise
+
 # Use a build matrix to do two builds in parallel:
 # one using CMake, and one using make.
 env:


### PR DESCRIPTION
TravisCI is migrating to Ubuntu 14.04 (trusty) from 12.04 (precise). Let's be explicit about which version we're expecting.

> https://blog.travis-ci.com/2015-10-14-opening-up-ubuntu-trusty-beta
https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future
https://gist.github.com/meatballhat/d0c8aab9e3bd8a8bcacd

Their mechanism for deciding whether to use `trusty` or `precise` if unspecified is to look at whether the repo was added before or after Jan 1, 2015. That ought to work for this fork, but it may cause problems for anyone who has created a new fork this year and enabled Travis.

When `trusty` comes out of "beta", let's make a deliberate transition and remove some of the hackery in `scripts/travis/travis_install.sh` like building LMDB from source which is unnecessary on `trusty`.