### PR TITLE
Remove group parameter from Alexnet model

### DIFF
--- a/models/bvlc_alexnet/deploy.prototxt
+++ b/models/bvlc_alexnet/deploy.prototxt
@@ -70,7 +70,6 @@ layer {
     num_output: 256
     pad: 2
     kernel_size: 5
-    group: 2
   }
 }
 layer {
@@ -143,7 +142,6 @@ layer {
     num_output: 384
     pad: 1
     kernel_size: 3
-    group: 2
   }
 }
 layer {
@@ -169,7 +167,6 @@ layer {
     num_output: 256
     pad: 1
     kernel_size: 3
-    group: 2
   }
 }
 layer {

--- a/models/bvlc_alexnet/train_val.prototxt
+++ b/models/bvlc_alexnet/train_val.prototxt
@@ -109,7 +109,6 @@ layer {
     num_output: 256
     pad: 2
     kernel_size: 5
-    group: 2
     weight_filler {
       type: "gaussian"
       std: 0.01
@@ -198,7 +197,6 @@ layer {
     num_output: 384
     pad: 1
     kernel_size: 3
-    group: 2
     weight_filler {
       type: "gaussian"
       std: 0.01
@@ -232,7 +230,6 @@ layer {
     num_output: 256
     pad: 1
     kernel_size: 3
-    group: 2
     weight_filler {
       type: "gaussian"
       std: 0.01


### PR DESCRIPTION
Grouping is non standard in Alexnet and causes trained models
to feature fewer filters than standard models do.

As highlighted on https://github.com/BVLC/caffe/issues/778, grouping
should be removed.