### PR TITLE
Fix ImageDataLayer's silent failure on file paths with spaces 

### DIFF
--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -81,7 +81,7 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   std::ifstream source_file(source.c_str());
   if (source_file.is_open()) {
     std::string line;
-    while (source_file >> line) {
+    while (std::getline(source_file, line)) {
       hdf_filenames_.push_back(line);
     }
   } else {

--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -1,6 +1,7 @@
 #ifdef USE_OPENCV
 #include <opencv2/core/core.hpp>
 
+#include <cstdlib>
 #include <fstream>  // NOLINT(readability/streams)
 #include <iostream>  // NOLINT(readability/streams)
 #include <string>
@@ -37,9 +38,11 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   const string& source = this->layer_param_.image_data_param().source();
   LOG(INFO) << "Opening file " << source;
   std::ifstream infile(source.c_str());
-  string filename;
-  int label;
-  while (infile >> filename >> label) {
+  string line;
+  while (std::getline(infile, line)) {
+    int split_i = line.find_last_of(" ");
+    string filename = line.substr(0, split_i);
+    int label = atoi(line.substr(split_i + 1).c_str());
     lines_.push_back(std::make_pair(filename, label));
   }
 

--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -91,7 +91,7 @@ void WindowDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
     CHECK_EQ(hashtag, "#");
     // read image path
     string image_path;
-    infile >> image_path;
+    std::getline(infile, image_path);
     image_path = root_folder + image_path;
     // read image dimensions
     vector<int> image_size(3);

--- a/src/caffe/test/test_image_data_layer.cpp
+++ b/src/caffe/test/test_image_data_layer.cpp
@@ -34,15 +34,15 @@ class ImageDataLayerTest : public MultiDeviceTest<TypeParam> {
     std::ofstream outfile(filename_.c_str(), std::ofstream::out);
     LOG(INFO) << "Using temporary file " << filename_;
     for (int i = 0; i < 5; ++i) {
-      outfile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << i;
+      outfile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << i << '\n';
     }
     outfile.close();
     // Create test input file for images of distinct sizes.
     MakeTempFilename(&filename_reshape_);
     std::ofstream reshapefile(filename_reshape_.c_str(), std::ofstream::out);
     LOG(INFO) << "Using temporary file " << filename_reshape_;
-    reshapefile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << 0;
-    reshapefile << EXAMPLES_SOURCE_DIR "images/fish-bike.jpg " << 1;
+    reshapefile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << 0 << '\n';
+    reshapefile << EXAMPLES_SOURCE_DIR "images/fish-bike.jpg " << 1 << '\n';
     reshapefile.close();
   }
 

--- a/tools/convert_imageset.cpp
+++ b/tools/convert_imageset.cpp
@@ -9,6 +9,7 @@
 //   ....
 
 #include <algorithm>
+#include <cstdlib>
 #include <fstream>  // NOLINT(readability/streams)
 #include <string>
 #include <utility>
@@ -73,9 +74,12 @@ int main(int argc, char** argv) {
 
   std::ifstream infile(argv[2]);
   std::vector<std::pair<std::string, int> > lines;
-  std::string filename;
-  int label;
-  while (infile >> filename >> label) {
+
+  string line;
+  while (std::getline(infile, line)) {
+    int split_i = line.find_last_of(" ");
+    string filename = line.substr(0, split_i);
+    int label = atoi(line.substr(split_i + 1).c_str());
     lines.push_back(std::make_pair(filename, label));
   }
   if (FLAGS_shuffle) {


### PR DESCRIPTION
by splitting on last space.

Also fixes its test to contain newlines. Fixes #1935 and #1951.

Note: I don't work with C++ very much, so please let me know if there's a better way of doing this.
I've also changed window_data_layer and hdf5_data_layer to read in lines. Please check that this is correct (I have never used hdf5 or window_data).