### PR TITLE
Replace uses of POSIX open/close

### DIFF
--- a/examples/cpp_classification/classification.cpp
+++ b/examples/cpp_classification/classification.cpp
@@ -119,7 +119,7 @@ std::vector<Prediction> Classifier::Classify(const cv::Mat& img, int N) {
 /* Load the mean file in binaryproto format. */
 void Classifier::SetMean(const string& mean_file) {
   BlobProto blob_proto;
-  ReadProtoFromBinaryFileOrDie(mean_file.c_str(), &blob_proto);
+  ReadProtoFromBinaryFile(mean_file.c_str(), &blob_proto);
 
   /* Convert from BlobProto to Blob<float> */
   Blob<float> mean_blob;

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -49,42 +49,26 @@ inline void MakeTempFilename(string* temp_filename) {
     (temp_files_subpath/caffe::format_int(next_temp_file++, 9)).string();
 }
 
-bool ReadProtoFromTextFile(const char* filename, Message* proto);
+void ReadProtoFromTextFile(const char* filename, Message* proto);
 
-inline bool ReadProtoFromTextFile(const string& filename, Message* proto) {
-  return ReadProtoFromTextFile(filename.c_str(), proto);
-}
-
-inline void ReadProtoFromTextFileOrDie(const char* filename, Message* proto) {
-  CHECK(ReadProtoFromTextFile(filename, proto));
-}
-
-inline void ReadProtoFromTextFileOrDie(const string& filename, Message* proto) {
-  ReadProtoFromTextFileOrDie(filename.c_str(), proto);
+inline void ReadProtoFromTextFile(const string& filename, Message* proto) {
+  ReadProtoFromTextFile(filename.c_str(), proto);
 }
 
 void WriteProtoToTextFile(const Message& proto, const char* filename);
+
 inline void WriteProtoToTextFile(const Message& proto, const string& filename) {
   WriteProtoToTextFile(proto, filename.c_str());
 }
 
-bool ReadProtoFromBinaryFile(const char* filename, Message* proto);
+void ReadProtoFromBinaryFile(const char* filename, Message* proto);
 
-inline bool ReadProtoFromBinaryFile(const string& filename, Message* proto) {
-  return ReadProtoFromBinaryFile(filename.c_str(), proto);
+inline void ReadProtoFromBinaryFile(const string& filename, Message* proto) {
+  ReadProtoFromBinaryFile(filename.c_str(), proto);
 }
-
-inline void ReadProtoFromBinaryFileOrDie(const char* filename, Message* proto) {
-  CHECK(ReadProtoFromBinaryFile(filename, proto));
-}
-
-inline void ReadProtoFromBinaryFileOrDie(const string& filename,
-                                         Message* proto) {
-  ReadProtoFromBinaryFileOrDie(filename.c_str(), proto);
-}
-
 
 void WriteProtoToBinaryFile(const Message& proto, const char* filename);
+
 inline void WriteProtoToBinaryFile(
     const Message& proto, const string& filename) {
   WriteProtoToBinaryFile(proto, filename.c_str());

--- a/include/caffe/util/upgrade_proto.hpp
+++ b/include/caffe/util/upgrade_proto.hpp
@@ -14,10 +14,8 @@ bool NetNeedsUpgrade(const NetParameter& net_param);
 bool UpgradeNetAsNeeded(const string& param_file, NetParameter* param);
 
 // Read parameters from a file into a NetParameter proto message.
-void ReadNetParamsFromTextFileOrDie(const string& param_file,
-                                    NetParameter* param);
-void ReadNetParamsFromBinaryFileOrDie(const string& param_file,
-                                      NetParameter* param);
+void ReadNetParamsFromTextFile(const string& param_file, NetParameter* param);
+void ReadNetParamsFromBinaryFile(const string& param_file, NetParameter* param);
 
 // Return true iff any layer contains parameters specified using
 // deprecated V0LayerParameter.
@@ -68,8 +66,8 @@ bool UpgradeSolverType(SolverParameter* solver_param);
 bool UpgradeSolverAsNeeded(const string& param_file, SolverParameter* param);
 
 // Read parameters from a file into a SolverParameter proto message.
-void ReadSolverParamsFromTextFileOrDie(const string& param_file,
-                                       SolverParameter* param);
+void ReadSolverParamsFromTextFile(const string& param_file,
+                                  SolverParameter* param);
 
 }  // namespace caffe
 

--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -189,7 +189,7 @@ static void get_solver(MEX_ARGS) {
   char* solver_file = mxArrayToString(prhs[0]);
   mxCHECK_FILE_EXIST(solver_file);
   SolverParameter solver_param;
-  ReadSolverParamsFromTextFileOrDie(solver_file, &solver_param);
+  ReadSolverParamsFromTextFile(solver_file, &solver_param);
   shared_ptr<Solver<float> > solver(
       SolverRegistry<float>::CreateSolver(solver_param));
   solvers_.push_back(solver);

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -135,7 +135,7 @@ void Net_SetInputArrays(Net<Dtype>* net, bp::object data_obj,
 
 Solver<Dtype>* GetSolverFromFile(const string& filename) {
   SolverParameter param;
-  ReadSolverParamsFromTextFileOrDie(filename, &param);
+  ReadSolverParamsFromTextFile(filename, &param);
   return SolverRegistry<Dtype>::CreateSolver(param);
 }
 

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -25,7 +25,7 @@ DataTransformer<Dtype>::DataTransformer(const TransformationParameter& param,
       LOG(INFO) << "Loading mean file from: " << mean_file;
     }
     BlobProto blob_proto;
-    ReadProtoFromBinaryFileOrDie(mean_file.c_str(), &blob_proto);
+    ReadProtoFromBinaryFile(mean_file.c_str(), &blob_proto);
     data_mean_.FromProto(blob_proto);
   }
   // check if we want to use mean_value

--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -195,7 +195,7 @@ void WindowDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
           this->transform_param_.mean_file();
     LOG(INFO) << "Loading mean file from: " << mean_file;
     BlobProto blob_proto;
-    ReadProtoFromBinaryFileOrDie(mean_file.c_str(), &blob_proto);
+    ReadProtoFromBinaryFile(mean_file.c_str(), &blob_proto);
     data_mean_.FromProto(blob_proto);
   }
   if (has_mean_values_) {

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -31,7 +31,7 @@ template <typename Dtype>
 Net<Dtype>::Net(const string& param_file, Phase phase, const Net* root_net)
     : root_net_(root_net) {
   NetParameter param;
-  ReadNetParamsFromTextFileOrDie(param_file, &param);
+  ReadNetParamsFromTextFile(param_file, &param);
   param.mutable_state()->set_phase(phase);
   Init(param);
 }
@@ -853,7 +853,7 @@ template <typename Dtype>
 void Net<Dtype>::CopyTrainedLayersFromBinaryProto(
     const string trained_filename) {
   NetParameter param;
-  ReadNetParamsFromBinaryFileOrDie(trained_filename, &param);
+  ReadNetParamsFromBinaryFile(trained_filename, &param);
   CopyTrainedLayersFrom(param);
 }
 

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -37,7 +37,7 @@ Solver<Dtype>::Solver(const string& param_file, const Solver* root_solver)
     : net_(), callbacks_(), root_solver_(root_solver),
       requested_early_exit_(false) {
   SolverParameter param;
-  ReadSolverParamsFromTextFileOrDie(param_file, &param);
+  ReadSolverParamsFromTextFile(param_file, &param);
   Init(param);
 }
 
@@ -80,7 +80,7 @@ void Solver<Dtype>::InitTrainNet() {
   } else if (param_.has_train_net()) {
     LOG_IF(INFO, Caffe::root_solver())
         << "Creating training net from train_net file: " << param_.train_net();
-    ReadNetParamsFromTextFileOrDie(param_.train_net(), &net_param);
+    ReadNetParamsFromTextFile(param_.train_net(), &net_param);
   }
   if (param_.has_net_param()) {
     LOG_IF(INFO, Caffe::root_solver())
@@ -90,7 +90,7 @@ void Solver<Dtype>::InitTrainNet() {
   if (param_.has_net()) {
     LOG_IF(INFO, Caffe::root_solver())
         << "Creating training net from net file: " << param_.net();
-    ReadNetParamsFromTextFileOrDie(param_.net(), &net_param);
+    ReadNetParamsFromTextFile(param_.net(), &net_param);
   }
   // Set the correct NetState.  We start with the solver defaults (lowest
   // precedence); then, merge in any NetState specified by the net_param itself;
@@ -149,7 +149,7 @@ void Solver<Dtype>::InitTestNets() {
   }
   for (int i = 0; i < num_test_net_files; ++i, ++test_net_id) {
       sources[test_net_id] = "test_net file: " + param_.test_net(i);
-      ReadNetParamsFromTextFileOrDie(param_.test_net(i),
+      ReadNetParamsFromTextFile(param_.test_net(i),
           &net_params[test_net_id]);
   }
   const int remaining_test_nets = param_.test_iter_size() - test_net_id;
@@ -162,7 +162,7 @@ void Solver<Dtype>::InitTestNets() {
   if (has_net_file) {
     for (int i = 0; i < remaining_test_nets; ++i, ++test_net_id) {
       sources[test_net_id] = "net file: " + param_.net();
-      ReadNetParamsFromTextFileOrDie(param_.net(), &net_params[test_net_id]);
+      ReadNetParamsFromTextFile(param_.net(), &net_params[test_net_id]);
     }
   }
   test_nets_.resize(num_test_net_instances);

--- a/src/caffe/solvers/sgd_solver.cpp
+++ b/src/caffe/solvers/sgd_solver.cpp
@@ -305,7 +305,7 @@ void SGDSolver<Dtype>::RestoreSolverStateFromBinaryProto(
   this->iter_ = state.iter();
   if (state.has_learned_net()) {
     NetParameter net_param;
-    ReadNetParamsFromBinaryFileOrDie(state.learned_net().c_str(), &net_param);
+    ReadNetParamsFromBinaryFile(state.learned_net().c_str(), &net_param);
     this->net_->CopyTrainedLayersFrom(net_param);
   }
   this->current_step_ = state.current_step();

--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -63,17 +63,15 @@ bool UpgradeNetAsNeeded(const string& param_file, NetParameter* param) {
   return success;
 }
 
-void ReadNetParamsFromTextFileOrDie(const string& param_file,
+void ReadNetParamsFromTextFile(const string& param_file,
                                     NetParameter* param) {
-  CHECK(ReadProtoFromTextFile(param_file, param))
-      << "Failed to parse NetParameter file: " << param_file;
+  ReadProtoFromTextFile(param_file, param);
   UpgradeNetAsNeeded(param_file, param);
 }
 
-void ReadNetParamsFromBinaryFileOrDie(const string& param_file,
+void ReadNetParamsFromBinaryFile(const string& param_file,
                                       NetParameter* param) {
-  CHECK(ReadProtoFromBinaryFile(param_file, param))
-      << "Failed to parse NetParameter file: " << param_file;
+  ReadProtoFromBinaryFile(param_file, param);
   UpgradeNetAsNeeded(param_file, param);
 }
 
@@ -1004,10 +1002,9 @@ bool UpgradeSolverAsNeeded(const string& param_file, SolverParameter* param) {
 }
 
 // Read parameters from a file into a SolverParameter proto message.
-void ReadSolverParamsFromTextFileOrDie(const string& param_file,
+void ReadSolverParamsFromTextFile(const string& param_file,
                                        SolverParameter* param) {
-  CHECK(ReadProtoFromTextFile(param_file, param))
-      << "Failed to parse SolverParameter file: " << param_file;
+  ReadProtoFromTextFile(param_file, param);
   UpgradeSolverAsNeeded(param_file, param);
 }
 

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -157,7 +157,7 @@ int train() {
       "but not both.";
 
   caffe::SolverParameter solver_param;
-  caffe::ReadSolverParamsFromTextFileOrDie(FLAGS_solver, &solver_param);
+  caffe::ReadSolverParamsFromTextFile(FLAGS_solver, &solver_param);
 
   // If the gpus flag is not provided, allow the mode and device to be set
   // in the solver prototxt.

--- a/tools/upgrade_net_proto_binary.cpp
+++ b/tools/upgrade_net_proto_binary.cpp
@@ -25,11 +25,7 @@ int main(int argc, char** argv) {
 
   NetParameter net_param;
   string input_filename(argv[1]);
-  if (!ReadProtoFromBinaryFile(input_filename, &net_param)) {
-    LOG(ERROR) << "Failed to parse input binary file as NetParameter: "
-               << input_filename;
-    return 2;
-  }
+  ReadProtoFromBinaryFile(input_filename, &net_param);
   bool need_upgrade = NetNeedsUpgrade(net_param);
   bool success = true;
   if (need_upgrade) {

--- a/tools/upgrade_net_proto_text.cpp
+++ b/tools/upgrade_net_proto_text.cpp
@@ -25,11 +25,7 @@ int main(int argc, char** argv) {
 
   NetParameter net_param;
   string input_filename(argv[1]);
-  if (!ReadProtoFromTextFile(input_filename, &net_param)) {
-    LOG(ERROR) << "Failed to parse input text file as NetParameter: "
-               << input_filename;
-    return 2;
-  }
+  ReadProtoFromTextFile(input_filename, &net_param);
   bool need_upgrade = NetNeedsUpgrade(net_param);
   bool need_data_upgrade = NetNeedsDataUpgrade(net_param);
   bool success = true;

--- a/tools/upgrade_solver_proto_text.cpp
+++ b/tools/upgrade_solver_proto_text.cpp
@@ -25,11 +25,7 @@ int main(int argc, char** argv) {
 
   SolverParameter solver_param;
   string input_filename(argv[1]);
-  if (!ReadProtoFromTextFile(input_filename, &solver_param)) {
-    LOG(ERROR) << "Failed to parse input text file as SolverParameter: "
-               << input_filename;
-    return 2;
-  }
+  ReadProtoFromTextFile(input_filename, &solver_param);
   bool need_upgrade = SolverNeedsTypeUpgrade(solver_param);
   bool success = true;
   if (need_upgrade) {


### PR DESCRIPTION
Protobuf related i/o in Caffe relies on POSIX `open`/`close`. These functions are not cross-platform.
If performance concerns are not critical, the proposed solution (suggested by @willyd and @keenbrowne) may be adequate.

Previously, `ReadXXX`/`ReadXXXOrDie`, `WriteXXX`/`WriteXXXOrDie` variants were available; Fail-slow variants have no uses in higher level APIs and possibly unsafe uses in tests and examples.