### PR TITLE
Replace mkdir by cross-platform counterpart

### DIFF
--- a/examples/mnist/convert_mnist_data.cpp
+++ b/examples/mnist/convert_mnist_data.cpp
@@ -24,6 +24,7 @@
 
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/format.hpp"
+#include "caffe/util/io.hpp"
 
 #if defined(USE_LEVELDB) && defined(USE_LMDB)
 
@@ -90,8 +91,8 @@ void convert_dataset(const char* image_filename, const char* label_filename,
     batch = new leveldb::WriteBatch();
   } else if (db_backend == "lmdb") {  // lmdb
     LOG(INFO) << "Opening lmdb " << db_path;
-    CHECK_EQ(mkdir(db_path, 0744), 0)
-        << "mkdir " << db_path << "failed";
+    CHECK(MakeDir(db_path, 0744))
+        << "MakeDir " << db_path << "failed";
     CHECK_EQ(mdb_env_create(&mdb_env), MDB_SUCCESS) << "mdb_env_create failed";
     CHECK_EQ(mdb_env_set_mapsize(mdb_env, 1099511627776), MDB_SUCCESS)  // 1TB
         << "mdb_env_set_mapsize failed";

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -21,13 +21,22 @@ namespace caffe {
 using ::google::protobuf::Message;
 using ::boost::filesystem::path;
 
+inline bool MakeDir(const char* dirname, int perms = 0777) {
+  bool success = boost::filesystem::create_directory(dirname);
+  if (success) {
+    boost::filesystem::permissions(
+        dirname, static_cast<boost::filesystem::perms>(perms));
+  }
+  return success;
+}
+
 inline void MakeTempDir(string* temp_dirname) {
   temp_dirname->clear();
   const path& model =
     boost::filesystem::temp_directory_path()/"caffe_test.%%%%-%%%%";
   for ( int i = 0; i < CAFFE_TMP_DIR_RETRIES; i++ ) {
     const path& dir = boost::filesystem::unique_path(model).string();
-    bool done = boost::filesystem::create_directory(dir);
+    bool done = MakeDir(dir.string().c_str());
     if ( done ) {
       *temp_dirname = dir.string();
       return;

--- a/src/caffe/util/db_lmdb.cpp
+++ b/src/caffe/util/db_lmdb.cpp
@@ -5,6 +5,8 @@
 
 #include <string>
 
+#include "caffe/util/io.hpp"
+
 namespace caffe { namespace db {
 
 const size_t LMDB_MAP_SIZE = 1099511627776;  // 1 TB
@@ -13,7 +15,7 @@ void LMDB::Open(const string& source, Mode mode) {
   MDB_CHECK(mdb_env_create(&mdb_env_));
   MDB_CHECK(mdb_env_set_mapsize(mdb_env_, LMDB_MAP_SIZE));
   if (mode == NEW) {
-    CHECK_EQ(mkdir(source.c_str(), 0744), 0) << "mkdir " << source << "failed";
+    CHECK(MakeDir(source.c_str(), 0744)) << "MakeDir " << source << "failed";
   }
   int flags = 0;
   if (mode == READ) {


### PR DESCRIPTION
`mkdir` is not directly available on Windows. Since `boost::filesystem` was recently introduced in #3300 a new cross-platform `MakeDir` function is introduced to replace it.
