### PR TITLE
Improve the AdaDelta performance

### DIFF
--- a/include/caffe/util/math_functions.hpp
+++ b/include/caffe/util/math_functions.hpp
@@ -53,6 +53,9 @@ template <typename Dtype>
 void caffe_sqr(const int N, const Dtype* a, Dtype* y);
 
 template <typename Dtype>
+void caffe_sqrt(const int N, const Dtype* a, Dtype* y);
+
+template <typename Dtype>
 void caffe_add(const int N, const Dtype* a, const Dtype* b, Dtype* y);
 
 template <typename Dtype>

--- a/include/caffe/util/math_functions.hpp
+++ b/include/caffe/util/math_functions.hpp
@@ -247,6 +247,12 @@ template <typename Dtype>
 void caffe_gpu_fabs(const int n, const Dtype* x, Dtype* y);
 
 template <typename Dtype>
+void caffe_gpu_sqr(const int n, const Dtype* x, Dtype* y);
+
+template <typename Dtype>
+void caffe_gpu_sqrt(const int n, const Dtype* x, Dtype* y);
+
+template <typename Dtype>
 void caffe_gpu_scale(const int n, const Dtype alpha, const Dtype *x, Dtype* y);
 
 #define DEFINE_AND_INSTANTIATE_GPU_UNARY_FUNC(name, operation) \

--- a/include/caffe/util/mkl_alternate.hpp
+++ b/include/caffe/util/mkl_alternate.hpp
@@ -35,6 +35,7 @@ DEFINE_VSL_UNARY_FUNC(Sqr, y[i] = a[i] * a[i]);
 DEFINE_VSL_UNARY_FUNC(Exp, y[i] = exp(a[i]));
 DEFINE_VSL_UNARY_FUNC(Ln, y[i] = log(a[i]));
 DEFINE_VSL_UNARY_FUNC(Abs, y[i] = fabs(a[i]));
+DEFINE_VSL_UNARY_FUNC(Sqrt, y[i] = sqrt(a[i]));
 
 // A simple way to define the vsl unary functions with singular parameter b.
 // The operation should be in the form e.g. y[i] = pow(a[i], b)

--- a/src/caffe/solvers/adadelta_solver.cpp
+++ b/src/caffe/solvers/adadelta_solver.cpp
@@ -27,8 +27,8 @@ void AdaDeltaSolver<Dtype>::ComputeUpdateValue(int param_id, Dtype rate) {
   switch (Caffe::mode()) {
   case Caffe::CPU: {
     // compute square of gradient in update
-    caffe_powx(net_params[param_id]->count(),
-        net_params[param_id]->cpu_diff(), Dtype(2),
+    caffe_sqr(net_params[param_id]->count(),
+        net_params[param_id]->cpu_diff(),
         this->update_[param_id]->mutable_cpu_data());
 
     // update history of gradients
@@ -57,8 +57,8 @@ void AdaDeltaSolver<Dtype>::ComputeUpdateValue(int param_id, Dtype rate) {
         this->update_[param_id]->mutable_cpu_data());
 
     // jointly compute the RMS of both for update and gradient history
-    caffe_powx(net_params[param_id]->count(),
-        this->update_[param_id]->cpu_data(), Dtype(0.5),
+    caffe_sqrt(net_params[param_id]->count(),
+        this->update_[param_id]->cpu_data(),
         this->update_[param_id]->mutable_cpu_data());
 
     // compute the update
@@ -68,8 +68,8 @@ void AdaDeltaSolver<Dtype>::ComputeUpdateValue(int param_id, Dtype rate) {
         net_params[param_id]->mutable_cpu_diff());
 
     // compute square of update
-    caffe_powx(net_params[param_id]->count(),
-        net_params[param_id]->cpu_diff(), Dtype(2),
+    caffe_sqr(net_params[param_id]->count(),
+        net_params[param_id]->cpu_diff(),
         this->update_[param_id]->mutable_cpu_data());
 
     // update history of updates

--- a/src/caffe/solvers/adadelta_solver.cpp
+++ b/src/caffe/solvers/adadelta_solver.cpp
@@ -86,8 +86,8 @@ void AdaDeltaSolver<Dtype>::ComputeUpdateValue(int param_id, Dtype rate) {
   case Caffe::GPU: {
 #ifndef CPU_ONLY
     // compute square of gradient in update
-    caffe_gpu_powx(net_params[param_id]->count(),
-        net_params[param_id]->gpu_diff(), Dtype(2),
+    caffe_gpu_sqr(net_params[param_id]->count(),
+        net_params[param_id]->gpu_diff(),
         this->update_[param_id]->mutable_gpu_data());
 
     // update history of gradients
@@ -116,8 +116,8 @@ void AdaDeltaSolver<Dtype>::ComputeUpdateValue(int param_id, Dtype rate) {
         this->update_[param_id]->mutable_gpu_data());
 
     // jointly compute the RMS of both for update and gradient history
-    caffe_gpu_powx(net_params[param_id]->count(),
-        this->update_[param_id]->gpu_data(), Dtype(0.5),
+    caffe_gpu_sqrt(net_params[param_id]->count(),
+        this->update_[param_id]->gpu_data(),
         this->update_[param_id]->mutable_gpu_data());
 
     // compute the update and copy to net_diff
@@ -127,8 +127,8 @@ void AdaDeltaSolver<Dtype>::ComputeUpdateValue(int param_id, Dtype rate) {
         net_params[param_id]->mutable_gpu_diff());
 
     // compute square of update
-    caffe_gpu_powx(net_params[param_id]->count(),
-        net_params[param_id]->gpu_diff(), Dtype(2),
+    caffe_gpu_sqr(net_params[param_id]->count(),
+        net_params[param_id]->gpu_diff(),
         this->update_[param_id]->mutable_gpu_data());
 
     // update history of updates

--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -197,6 +197,16 @@ void caffe_sqr<double>(const int n, const double* a, double* y) {
 }
 
 template <>
+void caffe_sqrt<float>(const int n, const float* a, float* y) {
+  vsSqrt(n, a, y);
+}
+
+template <>
+void caffe_sqrt<double>(const int n, const double* a, double* y) {
+  vdSqrt(n, a, y);
+}
+
+template <>
 void caffe_exp<float>(const int n, const float* a, float* y) {
   vsExp(n, a, y);
 }

--- a/src/caffe/util/math_functions.cu
+++ b/src/caffe/util/math_functions.cu
@@ -371,6 +371,10 @@ DEFINE_AND_INSTANTIATE_GPU_UNARY_FUNC(sign, y[index] = (Dtype(0) < x[index])
                                       - (x[index] < Dtype(0)));
 DEFINE_AND_INSTANTIATE_GPU_UNARY_FUNC(sgnbit, y[index] = signbit(x[index]));
 
+DEFINE_AND_INSTANTIATE_GPU_UNARY_FUNC(sqr, y[index] = (x[index] * x[index]));
+
+DEFINE_AND_INSTANTIATE_GPU_UNARY_FUNC(sqrt, y[index] = sqrt(x[index]));
+
 void caffe_gpu_rng_uniform(const int n, unsigned int* r) {
   CURAND_CHECK(curandGenerate(Caffe::curand_generator(), r, n));
 }


### PR DESCRIPTION
I found that the AdaDelta computing is quite slow, due to the bad performance of pow(x, 2) and pow(x, 0.5). So it's better to use x*x and sqrt(x) to instead of pow, especially the sqrt may takes advantage of Intel hardware optimization in CPU mode.

For more information, here is the reference: http://stackoverflow.com/questions/17417490/difference-between-sqrtx-and-powx-0-5