### PR TITLE
TestDataTransformer: fix some memory leaks

### DIFF
--- a/src/caffe/test/test_data_transformer.cpp
+++ b/src/caffe/test/test_data_transformer.cpp
@@ -40,23 +40,21 @@ class DataTransformTest : public ::testing::Test {
   int NumSequenceMatches(const TransformationParameter transform_param,
       const Datum& datum, Phase phase) {
     // Get crop sequence with Caffe seed 1701.
-    DataTransformer<Dtype>* transformer =
-        new DataTransformer<Dtype>(transform_param, phase);
+    DataTransformer<Dtype> transformer(transform_param, phase);
     const int crop_size = transform_param.crop_size();
     Caffe::set_random_seed(seed_);
-    transformer->InitRand();
-    Blob<Dtype>* blob =
-        new Blob<Dtype>(1, datum.channels(), datum.height(), datum.width());
+    transformer.InitRand();
+    Blob<Dtype> blob(1, datum.channels(), datum.height(), datum.width());
     if (transform_param.crop_size() > 0) {
-      blob->Reshape(1, datum.channels(), crop_size, crop_size);
+      blob.Reshape(1, datum.channels(), crop_size, crop_size);
     }
 
     vector<vector<Dtype> > crop_sequence;
     for (int iter = 0; iter < this->num_iter_; ++iter) {
       vector<Dtype> iter_crop_sequence;
-      transformer->Transform(datum, blob);
-      for (int j = 0; j < blob->count(); ++j) {
-        iter_crop_sequence.push_back(blob->cpu_data()[j]);
+      transformer.Transform(datum, &blob);
+      for (int j = 0; j < blob.count(); ++j) {
+        iter_crop_sequence.push_back(blob.cpu_data()[j]);
       }
       crop_sequence.push_back(iter_crop_sequence);
     }
@@ -64,16 +62,13 @@ class DataTransformTest : public ::testing::Test {
     int num_sequence_matches = 0;
     for (int iter = 0; iter < this->num_iter_; ++iter) {
       vector<Dtype> iter_crop_sequence = crop_sequence[iter];
-      transformer->Transform(datum, blob);
-      for (int j = 0; j < blob->count(); ++j) {
-        num_sequence_matches +=
-            (crop_sequence[iter][j] == blob->cpu_data()[j]);
+      transformer.Transform(datum, &blob);
+      for (int j = 0; j < blob.count(); ++j) {
+        num_sequence_matches += (crop_sequence[iter][j] == blob.cpu_data()[j]);
       }
     }
     return num_sequence_matches;
   }
-
-  virtual ~DataTransformTest() { }
 
   int seed_;
   int num_iter_;
@@ -91,17 +86,16 @@ TYPED_TEST(DataTransformTest, TestEmptyTransform) {
 
   Datum datum;
   FillDatum(label, channels, height, width, unique_pixels, &datum);
-  Blob<TypeParam>* blob = new Blob<TypeParam>(1, channels, height, width);
-  DataTransformer<TypeParam>* transformer =
-      new DataTransformer<TypeParam>(transform_param, TEST);
-  transformer->InitRand();
-  transformer->Transform(datum, blob);
-  EXPECT_EQ(blob->num(), 1);
-  EXPECT_EQ(blob->channels(), datum.channels());
-  EXPECT_EQ(blob->height(), datum.height());
-  EXPECT_EQ(blob->width(), datum.width());
-  for (int j = 0; j < blob->count(); ++j) {
-    EXPECT_EQ(blob->cpu_data()[j], label);
+  Blob<TypeParam> blob(1, channels, height, width);
+  DataTransformer<TypeParam> transformer(transform_param, TEST);
+  transformer.InitRand();
+  transformer.Transform(datum, &blob);
+  EXPECT_EQ(blob.num(), 1);
+  EXPECT_EQ(blob.channels(), datum.channels());
+  EXPECT_EQ(blob.height(), datum.height());
+  EXPECT_EQ(blob.width(), datum.width());
+  for (int j = 0; j < blob.count(); ++j) {
+    EXPECT_EQ(blob.cpu_data()[j], label);
   }
 }
 
@@ -115,17 +109,16 @@ TYPED_TEST(DataTransformTest, TestEmptyTransformUniquePixels) {
 
   Datum datum;
   FillDatum(label, channels, height, width, unique_pixels, &datum);
-  Blob<TypeParam>* blob = new Blob<TypeParam>(1, 3, 4, 5);
-  DataTransformer<TypeParam>* transformer =
-      new DataTransformer<TypeParam>(transform_param, TEST);
-  transformer->InitRand();
-  transformer->Transform(datum, blob);
-  EXPECT_EQ(blob->num(), 1);
-  EXPECT_EQ(blob->channels(), datum.channels());
-  EXPECT_EQ(blob->height(), datum.height());
-  EXPECT_EQ(blob->width(), datum.width());
-  for (int j = 0; j < blob->count(); ++j) {
-    EXPECT_EQ(blob->cpu_data()[j], j);
+  Blob<TypeParam> blob(1, 3, 4, 5);
+  DataTransformer<TypeParam> transformer(transform_param, TEST);
+  transformer.InitRand();
+  transformer.Transform(datum, &blob);
+  EXPECT_EQ(blob.num(), 1);
+  EXPECT_EQ(blob.channels(), datum.channels());
+  EXPECT_EQ(blob.height(), datum.height());
+  EXPECT_EQ(blob.width(), datum.width());
+  for (int j = 0; j < blob.count(); ++j) {
+    EXPECT_EQ(blob.cpu_data()[j], j);
   }
 }
 
@@ -141,19 +134,17 @@ TYPED_TEST(DataTransformTest, TestCropSize) {
   transform_param.set_crop_size(crop_size);
   Datum datum;
   FillDatum(label, channels, height, width, unique_pixels, &datum);
-  DataTransformer<TypeParam>* transformer =
-      new DataTransformer<TypeParam>(transform_param, TEST);
-  transformer->InitRand();
-  Blob<TypeParam>* blob =
-      new Blob<TypeParam>(1, channels, crop_size, crop_size);
+  DataTransformer<TypeParam> transformer(transform_param, TEST);
+  transformer.InitRand();
+  Blob<TypeParam> blob(1, channels, crop_size, crop_size);
   for (int iter = 0; iter < this->num_iter_; ++iter) {
-    transformer->Transform(datum, blob);
-    EXPECT_EQ(blob->num(), 1);
-    EXPECT_EQ(blob->channels(), datum.channels());
-    EXPECT_EQ(blob->height(), crop_size);
-    EXPECT_EQ(blob->width(), crop_size);
-    for (int j = 0; j < blob->count(); ++j) {
-      EXPECT_EQ(blob->cpu_data()[j], label);
+    transformer.Transform(datum, &blob);
+    EXPECT_EQ(blob.num(), 1);
+    EXPECT_EQ(blob.channels(), datum.channels());
+    EXPECT_EQ(blob.height(), crop_size);
+    EXPECT_EQ(blob.width(), crop_size);
+    for (int j = 0; j < blob.count(); ++j) {
+      EXPECT_EQ(blob.cpu_data()[j], label);
     }
   }
 }
@@ -280,13 +271,12 @@ TYPED_TEST(DataTransformTest, TestMeanValue) {
   transform_param.add_mean_value(mean_value);
   Datum datum;
   FillDatum(label, channels, height, width, unique_pixels, &datum);
-  Blob<TypeParam>* blob = new Blob<TypeParam>(1, channels, height, width);
-  DataTransformer<TypeParam>* transformer =
-      new DataTransformer<TypeParam>(transform_param, TEST);
-  transformer->InitRand();
-  transformer->Transform(datum, blob);
-  for (int j = 0; j < blob->count(); ++j) {
-    EXPECT_EQ(blob->cpu_data()[j], label - mean_value);
+  Blob<TypeParam> blob(1, channels, height, width);
+  DataTransformer<TypeParam> transformer(transform_param, TEST);
+  transformer.InitRand();
+  transformer.Transform(datum, &blob);
+  for (int j = 0; j < blob.count(); ++j) {
+    EXPECT_EQ(blob.cpu_data()[j], label - mean_value);
   }
 }
 
@@ -303,14 +293,13 @@ TYPED_TEST(DataTransformTest, TestMeanValues) {
   transform_param.add_mean_value(2);
   Datum datum;
   FillDatum(label, channels, height, width, unique_pixels, &datum);
-  Blob<TypeParam>* blob = new Blob<TypeParam>(1, channels, height, width);
-  DataTransformer<TypeParam>* transformer =
-      new DataTransformer<TypeParam>(transform_param, TEST);
-  transformer->InitRand();
-  transformer->Transform(datum, blob);
+  Blob<TypeParam> blob(1, channels, height, width);
+  DataTransformer<TypeParam> transformer(transform_param, TEST);
+  transformer.InitRand();
+  transformer.Transform(datum, &blob);
   for (int c = 0; c < channels; ++c) {
     for (int j = 0; j < height * width; ++j) {
-      EXPECT_EQ(blob->cpu_data()[blob->offset(0, c) + j], label - c);
+      EXPECT_EQ(blob.cpu_data()[blob.offset(0, c) + j], label - c);
     }
   }
 }
@@ -325,8 +314,8 @@ TYPED_TEST(DataTransformTest, TestMeanFile) {
   const int size = channels * height * width;
 
   // Create a mean file
-  string* mean_file = new string();
-  MakeTempFilename(mean_file);
+  string mean_file;
+  MakeTempFilename(&mean_file);
   BlobProto blob_mean;
   blob_mean.set_num(1);
   blob_mean.set_channels(channels);
@@ -337,19 +326,18 @@ TYPED_TEST(DataTransformTest, TestMeanFile) {
       blob_mean.add_data(j);
   }
 
-  LOG(INFO) << "Using temporary mean_file " << *mean_file;
-  WriteProtoToBinaryFile(blob_mean, *mean_file);
+  LOG(INFO) << "Using temporary mean_file " << mean_file;
+  WriteProtoToBinaryFile(blob_mean, mean_file);
 
-  transform_param.set_mean_file(*mean_file);
+  transform_param.set_mean_file(mean_file);
   Datum datum;
   FillDatum(label, channels, height, width, unique_pixels, &datum);
-  Blob<TypeParam>* blob = new Blob<TypeParam>(1, channels, height, width);
-  DataTransformer<TypeParam>* transformer =
-      new DataTransformer<TypeParam>(transform_param, TEST);
-  transformer->InitRand();
-  transformer->Transform(datum, blob);
-  for (int j = 0; j < blob->count(); ++j) {
-      EXPECT_EQ(blob->cpu_data()[j], 0);
+  Blob<TypeParam> blob(1, channels, height, width);
+  DataTransformer<TypeParam> transformer(transform_param, TEST);
+  transformer.InitRand();
+  transformer.Transform(datum, &blob);
+  for (int j = 0; j < blob.count(); ++j) {
+    EXPECT_EQ(blob.cpu_data()[j], 0);
   }
 }
 


### PR DESCRIPTION
This fixes some memory leaks in `TestDataTransformer` caused by the use of `new` (with no corresponding `delete` or other cleanup).