### PR TITLE
Allow the access of same LMDB for parallel caffe instances.

### DIFF
--- a/src/caffe/util/db_lmdb.cpp
+++ b/src/caffe/util/db_lmdb.cpp
@@ -17,7 +17,7 @@ void LMDB::Open(const string& source, Mode mode) {
   }
   int flags = 0;
   if (mode == READ) {
-    flags = MDB_RDONLY | MDB_NOTLS;
+    flags = MDB_RDONLY | MDB_NOTLS | MDB_NOLOCK;
   }
   int rc = mdb_env_open(mdb_env_, source.c_str(), flags, 0664);
 #ifndef ALLOW_LMDB_NOLOCK


### PR DESCRIPTION
Running multiple instances of caffe (with different networks) on the same LMDB was impossible because the mdb_env_open() locked the database. I removed locking of the database when opening it in read only mode.