### PR TITLE
Feat key value data layer

### DIFF
--- a/include/caffe/layers/key_value_data_layer.hpp
+++ b/include/caffe/layers/key_value_data_layer.hpp
@@ -1,0 +1,51 @@
+#ifndef CAFFE_KEY_VALUE_DATA_LAYER_HPP_
+#define CAFFE_KEY_VALUE_DATA_LAYER_HPP_
+
+#include <string>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/layers/base_data_layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/db.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Provides data to net from a database, data is provided in order
+ *        specified in a csv file
+ * 
+ * The layer is specified by a database to read from, a csv file seperated with
+ * the ';' character and the number of the column that should be read from.
+ * Each column then contains a list of keys that should be read from the
+ * database. The layer then outputs the values of one key after the other.
+ *
+ * TODO(dox): thorough documentation for Forward and proto params.
+ */
+template <typename Dtype>
+class KeyValueDataLayer : public BasePrefetchingDataLayer<Dtype> {
+ public:
+  explicit KeyValueDataLayer(const LayerParameter& param)
+      : BasePrefetchingDataLayer<Dtype>(param), key_index_(0) {}
+  virtual ~KeyValueDataLayer();
+  virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void load_batch(Batch<Dtype>* batch);
+  // This can be shared
+  virtual inline bool ShareInParallel() const { return true; }
+  virtual inline const char* type() const { return "KeyValueData"; }
+  virtual inline int ExactNumBottomBlobs() const { return 0; }
+  virtual inline int MinTopBlobs() const { return 1; }
+  virtual inline int MaxTopBlobs() const { return 2; }
+
+ protected:
+  vector<string> keys_;                     /// Keys to be fetched
+  int key_index_;                           /// Index of the next key to fetch
+  shared_ptr<db::DB> db_;                   /// Database to read from
+  shared_ptr<db::Cursor> cursor_;           /// Cursor to database
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_KEY_VALUE_DATA_LAYER_HPP_

--- a/include/caffe/util/db.hpp
+++ b/include/caffe/util/db.hpp
@@ -16,6 +16,7 @@ class Cursor {
   virtual ~Cursor() { }
   virtual void SeekToFirst() = 0;
   virtual void Next() = 0;
+  virtual void Get(const string& key) = 0;
   virtual string key() = 0;
   virtual string value() = 0;
   virtual bool valid() = 0;

--- a/include/caffe/util/db_leveldb.hpp
+++ b/include/caffe/util/db_leveldb.hpp
@@ -18,6 +18,9 @@ class LevelDBCursor : public Cursor {
   ~LevelDBCursor() { delete iter_; }
   virtual void SeekToFirst() { iter_->SeekToFirst(); }
   virtual void Next() { iter_->Next(); }
+  virtual void Get(const string& key) {
+    iter_->Seek(key);
+  }
   virtual string key() { return iter_->key().ToString(); }
   virtual string value() { return iter_->value().ToString(); }
   virtual bool valid() { return iter_->Valid(); }

--- a/include/caffe/util/db_lmdb.hpp
+++ b/include/caffe/util/db_lmdb.hpp
@@ -26,6 +26,11 @@ class LMDBCursor : public Cursor {
   }
   virtual void SeekToFirst() { Seek(MDB_FIRST); }
   virtual void Next() { Seek(MDB_NEXT); }
+  virtual void Get(const string& key) {
+    mdb_key_.mv_data = const_cast<char*>(key.data());
+    mdb_key_.mv_size = key.size();
+    Seek(MDB_SET_KEY);
+  }
   virtual string key() {
     return string(static_cast<const char*>(mdb_key_.mv_data), mdb_key_.mv_size);
   }

--- a/scripts/cpp_lint.py
+++ b/scripts/cpp_lint.py
@@ -1611,6 +1611,7 @@ def CheckCaffeDataLayerSetUp(filename, clean_lines, linenum, error):
        line.find('void DataLayer<Dtype>::LayerSetUp') != -1 or
        line.find('void ImageDataLayer<Dtype>::LayerSetUp') != -1 or
        line.find('void MemoryDataLayer<Dtype>::LayerSetUp') != -1 or
+       line.find('void KeyValueDataLayer<Dtype>::LayerSetUp') != -1 or
        line.find('void WindowDataLayer<Dtype>::LayerSetUp') != -1):
       error(filename, linenum, 'caffe/data_layer_setup', 2,
             'Except the base classes, Caffe DataLayer should define'
@@ -1623,6 +1624,7 @@ def CheckCaffeDataLayerSetUp(filename, clean_lines, linenum, error):
        line.find('void DataLayer<Dtype>::DataLayerSetUp') == -1 and
        line.find('void ImageDataLayer<Dtype>::DataLayerSetUp') == -1 and
        line.find('void MemoryDataLayer<Dtype>::DataLayerSetUp') == -1 and
+       line.find('void KeyValueDataLayer<Dtype>::DataLayerSetUp') == -1 and
        line.find('void WindowDataLayer<Dtype>::DataLayerSetUp') == -1):
       error(filename, linenum, 'caffe/data_layer_setup', 2,
             'Except the base classes, Caffe DataLayer should define'

--- a/src/caffe/layers/key_value_data_layer.cpp
+++ b/src/caffe/layers/key_value_data_layer.cpp
@@ -1,0 +1,146 @@
+#include <stdint.h>
+
+#include <string>
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/layers/key_value_data_layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/benchmark.hpp"
+#include "caffe/util/db.hpp"
+#include "caffe/util/io.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+KeyValueDataLayer<Dtype>::~KeyValueDataLayer<Dtype>() {
+  this->StopInternalThread();
+}
+
+template <typename Dtype>
+void KeyValueDataLayer<Dtype>::DataLayerSetUp(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  // Read the file with keys to look up in database
+  const string& key_file = this->layer_param_.key_value_data_param().key_file();
+  const int column_index = this->layer_param_.key_value_data_param().column();
+  CHECK_GE(column_index, 1) << "the column index starts with one";
+  LOG(INFO) << "Opening file " << key_file;
+  std::ifstream infile(key_file.c_str());
+  string line;
+  int line_count = 0;
+  while (getline(infile, line)) {
+    ++line_count;
+    for (int i = 0; i < column_index-1; ++i) {
+      size_t end = line.find(';');
+      CHECK_NE(end, string::npos)
+        << "line number " << line_count << " has too few columns";
+      line = line.substr(end+1);
+    }
+    size_t end = line.find(';');
+    if (end == string::npos)
+      keys_.push_back(line);
+    else
+      keys_.push_back(line.substr(0, end));
+  }
+  CHECK_GE(keys_.size(), 1) << "you must specify at least one key to be read";
+
+  const int batch_size = this->layer_param_.data_param().batch_size();
+
+  // Initialize DB
+  db_.reset(db::GetDB(this->layer_param_.data_param().backend()));
+  db_->Open(this->layer_param_.data_param().source(), db::READ);
+  cursor_.reset(db_->NewCursor());
+
+  // Read a data point, and use it to initialize the top blob.
+  Datum datum;
+  this->cursor_->Get(keys_[0]);
+  datum.ParseFromString(this->cursor_->value());
+
+  // Use data_transformer to infer the expected blob shape from datum.
+  vector<int> top_shape = this->data_transformer_->InferBlobShape(datum);
+  this->transformed_data_.Reshape(top_shape);
+  // Reshape top[0] and prefetch_data according to the batch_size.
+  top_shape[0] = batch_size;
+  top[0]->Reshape(top_shape);
+  for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
+    this->prefetch_[i].data_.Reshape(top_shape);
+  }
+  LOG(INFO) << "output data size: " << top[0]->num() << ","
+      << top[0]->channels() << "," << top[0]->height() << ","
+      << top[0]->width();
+  // label
+  if (this->output_labels_) {
+    vector<int> label_shape(1, batch_size);
+    top[1]->Reshape(label_shape);
+    for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
+      this->prefetch_[i].label_.Reshape(label_shape);
+    }
+  }
+}
+
+// This function is called on prefetch thread
+template <typename Dtype>
+void KeyValueDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
+  CPUTimer batch_timer;
+  batch_timer.Start();
+  double read_time = 0;
+  double trans_time = 0;
+  CPUTimer timer;
+  CHECK(batch->data_.count());
+  CHECK(this->transformed_data_.count());
+
+  // Reshape according to the first datum of each batch
+  // on single input batches allows for inputs of varying dimension.
+  const int batch_size = this->layer_param_.data_param().batch_size();
+  Datum datum;
+  datum.ParseFromString(this->cursor_->value());
+  // Use data_transformer to infer the expected blob shape from datum.
+  vector<int> top_shape = this->data_transformer_->InferBlobShape(datum);
+  this->transformed_data_.Reshape(top_shape);
+  // Reshape batch according to the batch_size.
+  top_shape[0] = batch_size;
+  batch->data_.Reshape(top_shape);
+
+  Dtype* top_data = batch->data_.mutable_cpu_data();
+  Dtype* top_label = NULL;  // suppress warnings about uninitialized variables
+
+  if (this->output_labels_) {
+    top_label = batch->label_.mutable_cpu_data();
+  }
+  timer.Start();
+  for (int item_id = 0; item_id < batch_size; ++item_id) {
+    // get the datum at the next key
+    Datum datum;
+    this->cursor_->Get(keys_[key_index_++]);
+    CHECK(this->cursor_->valid())
+      << "invalid key " << keys_[key_index_-1] << ";";
+    datum.ParseFromString(this->cursor_->value());
+    read_time += timer.MicroSeconds();
+    timer.Start();
+    // Apply data transformations (mirror, scale, crop...)
+    int offset = batch->data_.offset(item_id);
+    this->transformed_data_.set_cpu_data(top_data + offset);
+    this->data_transformer_->Transform(datum, &(this->transformed_data_));
+    // Copy label.
+    if (this->output_labels_) {
+      top_label[item_id] = datum.label();
+    }
+    trans_time += timer.MicroSeconds();
+    timer.Start();
+    if (key_index_ == keys_.size()) {
+      key_index_ = 0;
+      DLOG(INFO) << "Restarting data prefetching from start.";
+    }
+  }
+  timer.Stop();
+  batch_timer.Stop();
+  DLOG(INFO) << "Prefetch batch: " << batch_timer.MilliSeconds() << " ms.";
+  DLOG(INFO) << "     Read time: " << read_time / 1000 << " ms.";
+  DLOG(INFO) << "Transform time: " << trans_time / 1000 << " ms.";
+}
+
+INSTANTIATE_CLASS(KeyValueDataLayer);
+REGISTER_LAYER_CLASS(KeyValueData);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -306,7 +306,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 140 (last added: batch_norm_param)
+// LayerParameter next available layer-specific ID: 141 (last added: key_value_data_param)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -372,6 +372,7 @@ message LayerParameter {
   optional ImageDataParameter image_data_param = 115;
   optional InfogainLossParameter infogain_loss_param = 116;
   optional InnerProductParameter inner_product_param = 117;
+  optional KeyValueDataParameter key_value_data_param = 140;
   optional LogParameter log_param = 134;
   optional LRNParameter lrn_param = 118;
   optional MemoryDataParameter memory_data_param = 119;
@@ -743,6 +744,14 @@ message InnerProductParameter {
   // all preceding axes are retained in the output.
   // May be negative to index from the end (e.g., -1 for the last axis).
   optional int32 axis = 5 [default = 1];
+}
+
+message KeyValueDataParameter {
+  // CSV file with ';' delimiter that specifies which keys to read from the 
+  // database and what order to read them in
+  optional string key_file = 1;
+  // Column (starting with 1) of the CSV file to read for the keys
+  optional uint32 column = 2 [default = 1];
 }
 
 // Message that stores parameters used by LogLayer

--- a/src/caffe/test/test_db.cpp
+++ b/src/caffe/test/test_db.cpp
@@ -132,5 +132,30 @@ TYPED_TEST(DBTest, TestWrite) {
   txn->Commit();
 }
 
+TYPED_TEST(DBTest, TestGet) {
+  scoped_ptr<db::DB> db(db::GetDB(TypeParam::backend));
+  db->Open(this->source_, db::READ);
+  scoped_ptr<db::Cursor> cursor(db->NewCursor());
+  cursor->Get("fish-bike.jpg");
+  EXPECT_TRUE(cursor->valid());
+  Datum datum;
+  string key = cursor->key();
+  datum.ParseFromString(cursor->value());
+  EXPECT_EQ(key, "fish-bike.jpg");
+  EXPECT_EQ(datum.channels(), 3);
+  EXPECT_EQ(datum.height(), 323);
+  EXPECT_EQ(datum.width(), 481);
+  EXPECT_TRUE(cursor->valid());
+  cursor->Get("cat.jpg");
+  key = cursor->key();
+  datum.ParseFromString(cursor->value());
+  EXPECT_EQ(key, "cat.jpg");
+  EXPECT_EQ(datum.channels(), 3);
+  EXPECT_EQ(datum.height(), 360);
+  EXPECT_EQ(datum.width(), 480);
+  cursor->Get("not-here.jpg");
+  EXPECT_FALSE(cursor->valid());
+}
+
 }  // namespace caffe
 #endif  // USE_LEVELDB, USE_LMDB and USE_OPENCV

--- a/src/caffe/test/test_key_value_data_layer.cpp
+++ b/src/caffe/test/test_key_value_data_layer.cpp
@@ -1,0 +1,177 @@
+#ifdef USE_OPENCV
+#include <string>
+#include <vector>
+
+#include "boost/scoped_ptr.hpp"
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/key_value_data_layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/db.hpp"
+#include "caffe/util/io.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+using boost::scoped_ptr;
+
+template <typename TypeParam>
+class KeyValueDataLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  KeyValueDataLayerTest()
+      : backend_(DataParameter_DB_LEVELDB),
+        blob_top_data_(new Blob<Dtype>()),
+        blob_top_label_(new Blob<Dtype>()),
+        seed_(1701) {}
+  virtual void SetUp() {
+    filename_.reset(new string());
+    MakeTempDir(filename_.get());
+    *filename_ += "/db";
+    blob_top_vec_.push_back(blob_top_data_);
+    blob_top_vec_.push_back(blob_top_label_);
+  }
+
+  // Fill the DB with data: if unique_pixels, each pixel is unique but
+  // all images are the same; else each image is unique but all pixels within
+  // an image are the same.
+  void Fill(DataParameter_DB backend) {
+    backend_ = backend;
+    LOG(INFO) << "Using temporary dataset " << *filename_;
+    scoped_ptr<db::DB> db(db::GetDB(backend));
+    db->Open(*filename_, db::NEW);
+    scoped_ptr<db::Transaction> txn(db->NewTransaction());
+    for (int i = 0; i < 5; ++i) {
+      Datum datum;
+      datum.set_label(i);
+      datum.set_channels(2);
+      datum.set_height(3);
+      datum.set_width(4);
+      std::string* data = datum.mutable_data();
+      for (int j = 0; j < 24; ++j) {
+        data->push_back(static_cast<uint8_t>(i));
+      }
+      stringstream ss;
+      ss << i;
+      string out;
+      CHECK(datum.SerializeToString(&out));
+      txn->Put(ss.str(), out);
+    }
+    txn->Commit();
+    db->Close();
+  }
+
+  void FillFile() {
+    // Create test input file.
+    MakeTempFilename(&keyfilename_);
+    std::ofstream outfile(keyfilename_.c_str(), std::ofstream::out);
+    LOG(INFO) << "Using temporary file " << keyfilename_;
+    for (int i = 0; i < 5; ++i) {
+      outfile << i << ";" << 4-i << ";" << 1 << '\n';
+    }
+    outfile.close();
+  }
+
+  void TestRead(const vector<int>& keys, int column) {
+    const Dtype scale = 3;
+    LayerParameter param;
+    param.set_phase(TRAIN);
+    DataParameter* data_param = param.mutable_data_param();
+    data_param->set_batch_size(5);
+    data_param->set_source(filename_->c_str());
+    data_param->set_backend(backend_);
+
+    TransformationParameter* transform_param =
+        param.mutable_transform_param();
+    transform_param->set_scale(scale);
+
+    KeyValueDataParameter* kvdata_param = param.mutable_key_value_data_param();
+    kvdata_param->set_key_file(keyfilename_.c_str());
+    kvdata_param->set_column(column);
+
+    KeyValueDataLayer<Dtype> layer(param);
+    layer.SetUp(blob_bottom_vec_, blob_top_vec_);
+    EXPECT_EQ(blob_top_data_->num(), 5);
+    EXPECT_EQ(blob_top_data_->channels(), 2);
+    EXPECT_EQ(blob_top_data_->height(), 3);
+    EXPECT_EQ(blob_top_data_->width(), 4);
+    EXPECT_EQ(blob_top_label_->num(), 5);
+    EXPECT_EQ(blob_top_label_->channels(), 1);
+    EXPECT_EQ(blob_top_label_->height(), 1);
+    EXPECT_EQ(blob_top_label_->width(), 1);
+
+    for (int iter = 0; iter < 100; ++iter) {
+      layer.Forward(blob_bottom_vec_, blob_top_vec_);
+      for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(keys[i], blob_top_label_->cpu_data()[i]);
+      }
+      for (int i = 0; i < 5; ++i) {
+        for (int j = 0; j < 24; ++j) {
+          EXPECT_EQ(scale * keys[i], blob_top_data_->cpu_data()[i * 24 + j])
+              << "debug: iter " << iter << " i " << i << " j " << j;
+        }
+      }
+    }
+  }
+  virtual ~KeyValueDataLayerTest() {
+    delete blob_top_data_;
+    delete blob_top_label_;
+  }
+
+  DataParameter_DB backend_;
+  shared_ptr<string> filename_;
+  string keyfilename_;
+  Blob<Dtype>* const blob_top_data_;
+  Blob<Dtype>* const blob_top_label_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+  int seed_;
+};
+
+TYPED_TEST_CASE(KeyValueDataLayerTest, TestDtypesAndDevices);
+#ifdef USE_LEVELDB
+TYPED_TEST(KeyValueDataLayerTest, TestReadLevelDB) {
+  this->Fill(DataParameter_DB_LEVELDB);
+  this->FillFile();
+  vector<int> keys(5);
+
+  for (int i = 0; i < 5; ++i)
+    keys[i] = i;
+  this->TestRead(keys, 1);
+
+  for (int i = 0; i < 5; ++i)
+    keys[i] = 4-i;
+  this->TestRead(keys, 2);
+
+  for (int i = 0; i < 5; ++i)
+    keys[i] = 1;
+  this->TestRead(keys, 3);
+}
+#endif  // USE_LEVELDB
+
+#ifdef USE_LMDB
+TYPED_TEST(KeyValueDataLayerTest, TestReadLMDB) {
+  this->Fill(DataParameter_DB_LMDB);
+  this->FillFile();
+  vector<int> keys(5);
+
+  for (int i = 0; i < 5; ++i)
+    keys[i] = i;
+  this->TestRead(keys, 1);
+
+  for (int i = 0; i < 5; ++i)
+    keys[i] = 4-i;
+  this->TestRead(keys, 2);
+
+  for (int i = 0; i < 5; ++i)
+    keys[i] = 1;
+  this->TestRead(keys, 3);
+}
+#endif  // USE_LMDB
+}  // namespace caffe
+#endif  // USE_OPENCV


### PR DESCRIPTION
The KeyValueDataLayer allows fetching of information from an LMDB or level_db in arbitrary order. The order is specified by creating a CSV file with the keys for the values of data.

Many things are made possible by the KeyValueDataLayer. For example, if there are 100000 images in a database, and it is desired to train a network on specific pairs of these images, then it is easy put pairs of keys into the CSV file and have two KeyValueDataLayers, with each reading out one image of the pair. In this way, it is possible to create millions of training examples from a database with far fewer entries.

Another useful application is new test / training splits can easily be created by shuffling a CSV file instead of creating a whole new set of databases.
