### PR TITLE
Adds different types of relevance to the accuracy layer

### DIFF
--- a/include/caffe/layers/accuracy_layer.hpp
+++ b/include/caffe/layers/accuracy_layer.hpp
@@ -25,6 +25,11 @@ class AccuracyLayer : public Layer<Dtype> {
    *     Sets the maximum rank @f$ k @f$ at which a prediction is considered
    *     correct.  For example, if @f$ k = 5 @f$, a prediction is counted
    *     correct if the correct label is among the top 5 predicted labels.
+   *   - type (\b optional, default REC).
+   *     Compute with different types of relevance, such as recall (REC),
+   *     precision (PRE) or jaccard index (JAC). The jaccard index corresponds
+   *     to the intersection over union. The layer name is only symbolic and not
+   *     to be confused with the "rand accuracy" or "rand index".
    */
   explicit AccuracyLayer(const LayerParameter& param)
       : Layer<Dtype>(param) {}

--- a/include/caffe/layers/accuracy_layer.hpp
+++ b/include/caffe/layers/accuracy_layer.hpp
@@ -82,12 +82,12 @@ class AccuracyLayer : public Layer<Dtype> {
 
   int top_k_;
 
+  AccuracyParameter_AccuracyType type_;
+
   /// Whether to ignore instances with a certain label.
   bool has_ignore_label_;
   /// The label indicating that an instance should be ignored.
   int ignore_label_;
-  /// Keeps counts of the number of samples per class.
-  Blob<Dtype> nums_buffer_;
 };
 
 }  // namespace caffe

--- a/src/caffe/layers/accuracy_layer.cpp
+++ b/src/caffe/layers/accuracy_layer.cpp
@@ -11,6 +11,7 @@ template <typename Dtype>
 void AccuracyLayer<Dtype>::LayerSetUp(
   const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   top_k_ = this->layer_param_.accuracy_param().top_k();
+  type_ = this->layer_param_.accuracy_param().type();
 
   has_ignore_label_ =
     this->layer_param_.accuracy_param().has_ignore_label();
@@ -40,24 +41,24 @@ void AccuracyLayer<Dtype>::Reshape(
     vector<int> top_shape_per_class(1);
     top_shape_per_class[0] = bottom[0]->shape(label_axis_);
     top[1]->Reshape(top_shape_per_class);
-    nums_buffer_.Reshape(top_shape_per_class);
   }
 }
 
 template <typename Dtype>
 void AccuracyLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
-  Dtype accuracy = 0;
   const Dtype* bottom_data = bottom[0]->cpu_data();
   const Dtype* bottom_label = bottom[1]->cpu_data();
   const int dim = bottom[0]->count() / outer_num_;
   const int num_labels = bottom[0]->shape(label_axis_);
-  vector<Dtype> maxval(top_k_+1);
-  vector<int> max_id(top_k_+1);
+  Dtype& top_acc = top[0]->mutable_cpu_data()[0];
   if (top.size() > 1) {
-    caffe_set(nums_buffer_.count(), Dtype(0), nums_buffer_.mutable_cpu_data());
     caffe_set(top[1]->count(), Dtype(0), top[1]->mutable_cpu_data());
   }
+
+  vector<Dtype> true_pos(num_labels, 0);
+  vector<Dtype> data_count(num_labels, 0);
+  vector<Dtype> label_count(num_labels, 0);
   int count = 0;
   for (int i = 0; i < outer_num_; ++i) {
     for (int j = 0; j < inner_num_; ++j) {
@@ -66,7 +67,6 @@ void AccuracyLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       if (has_ignore_label_ && label_value == ignore_label_) {
         continue;
       }
-      if (top.size() > 1) ++nums_buffer_.mutable_cpu_data()[label_value];
       DCHECK_GE(label_value, 0);
       DCHECK_LT(label_value, num_labels);
       // Top-k accuracy
@@ -80,23 +80,64 @@ void AccuracyLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
           bottom_data_vector.end(), std::greater<std::pair<Dtype, int> >());
       // check if true label is in top k predictions
       for (int k = 0; k < top_k_; k++) {
+        ++data_count[bottom_data_vector[k].second];
         if (bottom_data_vector[k].second == label_value) {
-          ++accuracy;
-          if (top.size() > 1) ++top[1]->mutable_cpu_data()[label_value];
-          break;
+          ++true_pos[label_value];
         }
       }
+      ++label_count[label_value];
       ++count;
     }
   }
 
-  // LOG(INFO) << "Accuracy: " << accuracy;
-  top[0]->mutable_cpu_data()[0] = accuracy / count;
+  top_acc = 0;
+  switch (type_) {
+  case AccuracyParameter_AccuracyType_REC:
+    for (int i = 0; i < num_labels; i++) {
+      top_acc += true_pos[i];
+    }
+    break;
+  case AccuracyParameter_AccuracyType_PRE:
+    for (int i = 0; i < num_labels; i++) {
+      top_acc += true_pos[i];
+    }
+    break;
+  case AccuracyParameter_AccuracyType_JAC:
+    // average labelwise IoU scores
+    for (int i = 0; i < num_labels; i++) {
+      // union
+      Dtype uni = label_count[i] + data_count[i] - true_pos[i];
+      top_acc += uni == 0 ? 0 : label_count[i] * true_pos[i] / uni;
+    }
+    break;
+  default:
+    LOG(FATAL) << "Unknown accuracy type.";
+  }
+  top_acc = count == 0 ? 0 : top_acc / count;
+
   if (top.size() > 1) {
-    for (int i = 0; i < top[1]->count(); ++i) {
-      top[1]->mutable_cpu_data()[i] =
-          nums_buffer_.cpu_data()[i] == 0 ? 0
-          : top[1]->cpu_data()[i] / nums_buffer_.cpu_data()[i];
+    switch (type_) {
+    case AccuracyParameter_AccuracyType_REC:
+      for (int i = 0; i < num_labels; i++) {
+        top[1]->mutable_cpu_data()[i]
+          = label_count[i] == 0 ? 0 : true_pos[i] / label_count[i];
+      }
+      break;
+    case AccuracyParameter_AccuracyType_PRE:
+      for (int i = 0; i < num_labels; i++) {
+        top[1]->mutable_cpu_data()[i]
+          = data_count[i] == 0 ? 0 : true_pos[i] / data_count[i];
+      }
+      break;
+    case AccuracyParameter_AccuracyType_JAC:
+      for (int i = 0; i < num_labels; i++) {
+        // union
+        Dtype uni = label_count[i] + data_count[i] - true_pos[i];
+        top[1]->mutable_cpu_data()[i] = uni == 0 ? 0 : true_pos[i] / uni;
+      }
+      break;
+    default:
+      LOG(FATAL) << "Unknown accuracy type.";
     }
   }
   // Accuracy layer should not be used as a loss function.

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -447,20 +447,26 @@ message LossParameter {
 // alphabetical order.
 
 message AccuracyParameter {
+  enum AccuracyType {
+    REC = 0;
+    PRE = 1;
+    JAC = 2;
+  }
+  optional AccuracyType type = 1 [default = REC];
   // When computing accuracy, count as correct by comparing the true label to
   // the top k scoring classes.  By default, only compare to the top scoring
   // class (i.e. argmax).
-  optional uint32 top_k = 1 [default = 1];
+  optional uint32 top_k = 2 [default = 1];
 
   // The "label" axis of the prediction blob, whose argmax corresponds to the
   // predicted label -- may be negative to index from the end (e.g., -1 for the
   // last axis).  For example, if axis == 1 and the predictions are
   // (N x C x H x W), the label blob is expected to contain N*H*W ground truth
   // labels with integer values in {0, 1, ..., C-1}.
-  optional int32 axis = 2 [default = 1];
+  optional int32 axis = 3 [default = 1];
 
   // If specified, ignore instances with the given label.
-  optional int32 ignore_label = 3;
+  optional int32 ignore_label = 4;
 }
 
 message ArgMaxParameter {


### PR DESCRIPTION
This PR adds a type option to the accuracy layer, which can be set to either recall (REC), precision (PRE) or jaccard index (JAC). The default option is REC which corresponds to the previously existing implementation and therefore does not break any existing usages. All other options and the accuracy per class top blob work seamlessly with the different types.
Especially the jaccard index, which corresponds to the intersection over union, is a useful relevance measurement for segmentation tasks.

I want to point out that the layer name "accuracy" might be confused with the "rand accuracy" or "rand index" (sometimes only called "accuracy") which is a relevance measurement in itself. For the sake of consistency the layer should actually be called "relevance", but I wanted to keep backwards compatibility.

Also one should be aware of what using a top_k > 1 in combination with the jaccard index actually means. The accuracy per class will not always increase, because the intersection is effectively increased.

I appreciate any comments or improvements and hope that this feature is regarded as useful.

