### PR TITLE
Add Randomized ReLU (RReLU) layer

### DIFF
--- a/include/caffe/layers/rrelu_layer.hpp
+++ b/include/caffe/layers/rrelu_layer.hpp
@@ -1,0 +1,90 @@
+#ifndef CAFFE_RRELU_LAYER_HPP_
+#define CAFFE_RRELU_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/neuron_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Rectified Linear Unit non-linearity @f$ y = \max(0, x) @f$.
+ *        The simple max is fast to compute, and the function does not saturate.
+ */
+template <typename Dtype>
+class RReLULayer : public NeuronLayer<Dtype> {
+ public:
+  /**
+   * @param param provides ReLUParameter relu_param,
+   *     with ReLULayer options:
+   *   - negative_slope (\b optional, default 0).
+   *     the value @f$ \nu @f$ by which negative values are multiplied.
+   */
+  explicit RReLULayer(const LayerParameter& param)
+      : NeuronLayer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+                          const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+                       const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "RReLU"; }
+
+ protected:
+  /**
+   * @param bottom input Blob vector (length 1)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the inputs @f$ x @f$
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the computed outputs @f$
+   *        y = \max(0, x)
+   *      @f$ by default.  If a non-zero negative_slope @f$ \nu @f$ is provided,
+   *      the computed outputs are @f$ y = \max(0, x) + \nu \min(0, x) @f$.
+   */
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  /**
+   * @brief Computes the error gradient w.r.t. the ReLU inputs.
+   *
+   * @param top output Blob vector (length 1), providing the error gradient with
+   *      respect to the outputs
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      containing error gradients @f$ \frac{\partial E}{\partial y} @f$
+   *      with respect to computed outputs @f$ y @f$
+   * @param propagate_down see Layer::Backward.
+   * @param bottom input Blob vector (length 1)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the inputs @f$ x @f$; Backward fills their diff with
+   *      gradients @f$
+   *        \frac{\partial E}{\partial x} = \left\{
+   *        \begin{array}{lr}
+   *            0 & \mathrm{if} \; x \le 0 \\
+   *            \frac{\partial E}{\partial y} & \mathrm{if} \; x > 0
+   *        \end{array} \right.
+   *      @f$ if propagate_down[0], by default.
+   *      If a non-zero negative_slope @f$ \nu @f$ is provided,
+   *      the computed gradients are @f$
+   *        \frac{\partial E}{\partial x} = \left\{
+   *        \begin{array}{lr}
+   *            \nu \frac{\partial E}{\partial y} & \mathrm{if} \; x \le 0 \\
+   *            \frac{\partial E}{\partial y} & \mathrm{if} \; x > 0
+   *        \end{array} \right.
+   *      @f$.
+   */
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  Blob<Dtype> rand_vec_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_RRELU_LAYER_HPP_

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -14,6 +14,7 @@
 #include "caffe/layers/sigmoid_layer.hpp"
 #include "caffe/layers/softmax_layer.hpp"
 #include "caffe/layers/tanh_layer.hpp"
+#include "caffe/layers/rrelu_layer.hpp"
 #include "caffe/proto/caffe.pb.h"
 
 #ifdef USE_CUDNN

--- a/src/caffe/layers/rrelu_layer.cpp
+++ b/src/caffe/layers/rrelu_layer.cpp
@@ -1,0 +1,86 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/layers/rrelu_layer.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void RReLULayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  NeuronLayer<Dtype>::LayerSetUp(bottom, top);
+}
+
+template <typename Dtype>
+void RReLULayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  NeuronLayer<Dtype>::Reshape(bottom, top);
+  // Set up the cache for random number generation
+  rand_vec_.Reshape(bottom[0]->num(), bottom[0]->channels(),
+      bottom[0]->height(), bottom[0]->width());
+}
+
+  template <typename Dtype>
+void RReLULayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  const int count = bottom[0]->count();
+  Dtype negative_slope_lower = this->layer_param_.rrelu_param().negative_slope_lower();
+  Dtype negative_slope_upper = this->layer_param_.rrelu_param().negative_slope_upper();
+  if (this->phase_ == TRAIN) {
+    // Create random numbers
+    Dtype *mask = rand_vec_.mutable_cpu_data();
+    caffe_rng_uniform(count,negative_slope_lower,negative_slope_upper,mask);
+    for (int i = 0; i < count; ++i) {
+      top_data[i] = std::max(bottom_data[i], Dtype(0))
+        + Dtype(1) / mask[i] * std::min(bottom_data[i], Dtype(0));
+  }
+  }
+  else
+  {
+    for (int i = 0; i < count; ++i) {
+      top_data[i] = std::max(bottom_data[i], Dtype(0))
+        + Dtype(2) / (negative_slope_lower+negative_slope_upper) * std::min(bottom_data[i], Dtype(0));
+    }
+  }
+}
+
+template <typename Dtype>
+void RReLULayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
+  if (propagate_down[0]) {
+    const Dtype* bottom_data = bottom[0]->cpu_data();
+    const Dtype* top_diff = top[0]->cpu_diff();
+    Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+    const int count = bottom[0]->count();
+    Dtype negative_slope_lower = this->layer_param_.rrelu_param().negative_slope_lower();
+    Dtype negative_slope_upper = this->layer_param_.rrelu_param().negative_slope_upper();
+    if (this->phase_ == TRAIN) {
+      Dtype *mask = rand_vec_.mutable_cpu_data();
+      for (int i = 0; i < count; ++i) {
+        bottom_diff[i] = top_diff[i] * ((bottom_data[i] > 0)
+                                        + Dtype(1) / mask[i] * (bottom_data[i] <= 0));
+
+      }
+    }
+    else
+    {
+      for (int i = 0; i < count; ++i) {
+        bottom_diff[i] = top_diff[i] * ((bottom_data[i] > 0)
+                                        + Dtype(2) / (negative_slope_lower+negative_slope_upper) * (bottom_data[i] <= 0));
+      }
+    }
+  }
+}
+
+
+#ifdef CPU_ONLY
+STUB_GPU(RReLULayer);
+#endif
+
+INSTANTIATE_CLASS(RReLULayer);
+REGISTER_LAYER_CLASS(RReLU);
+
+}  // namespace caffe

--- a/src/caffe/layers/rrelu_layer.cu
+++ b/src/caffe/layers/rrelu_layer.cu
@@ -1,0 +1,108 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/layers/rrelu_layer.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void RReLUForward(const int n, const Dtype* in, Dtype* out,
+    const Dtype *negative_slope) {
+  CUDA_KERNEL_LOOP(index, n) {
+    out[index] = in[index] > 0 ? in[index] : in[index] * Dtype(1.0) / negative_slope[index];
+  }
+}
+template <typename Dtype>
+__global__ void RReLUForward(const int n, const Dtype* in, Dtype* out,
+    Dtype negative_slope) {
+  CUDA_KERNEL_LOOP(index, n) {
+    out[index] = in[index] > 0 ? in[index] : in[index] * negative_slope;
+  }
+}
+
+template <typename Dtype>
+void RReLULayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  Dtype* top_data = top[0]->mutable_gpu_data();
+  const int count = bottom[0]->count();
+  Dtype negative_slope_lower = this->layer_param_.rrelu_param().negative_slope_lower();
+  Dtype negative_slope_upper = this->layer_param_.rrelu_param().negative_slope_upper();
+  if (this->phase_ == TRAIN) {
+    Dtype* mask =
+        static_cast<Dtype*>(rand_vec_.mutable_gpu_data());
+    caffe_gpu_rng_uniform(count, negative_slope_lower, negative_slope_upper,mask);  
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  RReLUForward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+      count, bottom_data, top_data, mask);
+  CUDA_POST_KERNEL_CHECK;
+  }
+  else
+  {
+  Dtype negative_slope = Dtype(2)/(negative_slope_lower+negative_slope_upper);
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  RReLUForward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, bottom_data, top_data, negative_slope);
+  CUDA_POST_KERNEL_CHECK;
+ }
+  // << " count: " << count << " bottom_data: "
+  //     << (unsigned long)bottom_data
+  //     << " top_data: " << (unsigned long)top_data
+  //     << " blocks: " << CAFFE_GET_BLOCKS(count)
+  //     << " threads: " << CAFFE_CUDA_NUM_THREADS;
+}
+
+template <typename Dtype>
+__global__ void RReLUBackward(const int n, const Dtype* in_diff,
+    const Dtype* in_data, Dtype* out_diff, const Dtype *negative_slope) {
+  CUDA_KERNEL_LOOP(index, n) {
+    out_diff[index] = in_diff[index] * ((in_data[index] > 0)
+        + (in_data[index] <= 0) * Dtype(1.0) / negative_slope[index]);
+  }
+}
+
+template <typename Dtype>
+__global__ void RReLUBackward(const int n, const Dtype* in_diff,
+    const Dtype* in_data, Dtype* out_diff, Dtype negative_slope) {
+  CUDA_KERNEL_LOOP(index, n) {
+    out_diff[index] = in_diff[index] * ((in_data[index] > 0)
+        + (in_data[index] <= 0) * negative_slope);
+  }
+}
+
+template <typename Dtype>
+void RReLULayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
+  if (propagate_down[0]) {
+    const Dtype* bottom_data = bottom[0]->gpu_data();
+    const Dtype* top_diff = top[0]->gpu_diff();
+    Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
+    const int count = bottom[0]->count();
+    Dtype negative_slope_lower = this->layer_param_.rrelu_param().negative_slope_lower();
+    Dtype negative_slope_upper = this->layer_param_.rrelu_param().negative_slope_upper();
+  if (this->phase_ == TRAIN) {
+    Dtype* mask =
+        static_cast<Dtype*>(rand_vec_.mutable_gpu_data());
+	    // NOLINT_NEXT_LINE(whitespace/operators)
+    RReLUBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, top_diff, bottom_data, bottom_diff, mask);
+    CUDA_POST_KERNEL_CHECK;
+}
+else
+{
+    Dtype negative_slope = Dtype(2)/(negative_slope_lower+negative_slope_upper);
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    RReLUBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        count, top_diff, bottom_data, bottom_diff, negative_slope);
+    CUDA_POST_KERNEL_CHECK;
+  }
+  
+}
+}
+
+
+INSTANTIATE_LAYER_GPU_FUNCS(RReLULayer);
+
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -306,7 +306,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 140 (last added: batch_norm_param)
+// LayerParameter next available layer-specific ID: 141 (last added: RReLU layer)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -391,6 +391,7 @@ message LayerParameter {
   optional ThresholdParameter threshold_param = 128;
   optional TileParameter tile_param = 138;
   optional WindowDataParameter window_data_param = 129;
+  optional RReLUParameter rrelu_param = 140;
 }
 
 // Message that stores parameters used to apply transformation
@@ -1253,4 +1254,12 @@ message PReLUParameter {
   optional FillerParameter filler = 1;
   // Whether or not slope paramters are shared across channels.
   optional bool channel_shared = 2 [default = false];
+}
+
+message RReLUParameter {
+  optional float negative_slope_lower = 1 [default = 3.0]; // lower bound
+  optional float negative_slope_upper = 2 [default = 8.0]; // upper bound
+  //in a recent Kaggle National Data Science Bowl (NDSB) competition,
+  //it is reported that RReLU could reduce overfitting due to its randomized nature. Moreover,
+  // suggested by the NDSB competition winner, the random slope 1/r in training is sampled from a uniform distribution r = unirand(a,b) and in test time it is fixed as its expectation 1/( (a+b)/2)
 }


### PR DESCRIPTION
This pull request implements the randomized rectified linear (RReLU) activation layer for caffe. Randomized Leaky Rectified Linear is the randomized version of leaky ReLU. It is first proposed and used in Kaggle NDSB Competition.  It is reported that RReLU could reduce overfitting due to its randomized nature.

I have used this activation layer in the recent Kaggle Right Whale Recognition Competition. Its performance  was similar with the PReLU.

Reference: http://arxiv.org/abs/1505.00853

 