### PR TITLE
use relative paths on making build/tools/ links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -601,7 +601,7 @@ $(TEST_CXX_BINS): $(TEST_BIN_DIR)/%.testbin: $(TEST_CXX_BUILD_DIR)/%.o \
 # Target for extension-less symlinks to tool binaries with extension '*.bin'.
 $(TOOL_BUILD_DIR)/%: $(TOOL_BUILD_DIR)/%.bin | $(TOOL_BUILD_DIR)
 	@ $(RM) $@
-	@ ln -s $(abspath $<) $@
+	@ ln -s $(notdir $<) $@
 
 $(TOOL_BINS): %.bin : %.o | $(DYNAMIC_NAME)
 	@ echo CXX/LD -o $@


### PR DESCRIPTION
The old uses `abspath`, which I think is so harmful:
* If I `cp -a` the whole project, `build/tools/caffe` still refer to
    the old file, until `make clean`, making debugging very hard
* For `tar` and `scp`, the soft links can not work
    unless the target project folder has the same path

The solution is to use `notdir`. I've re-compiled the master branch with it
and `build/tools/caffe` works well.