### PR TITLE
solver trace feature to trace weights, loss, diffs and much more

### DIFF
--- a/examples/mnist/lenet_solver_with_trace.prototxt
+++ b/examples/mnist/lenet_solver_with_trace.prototxt
@@ -1,0 +1,32 @@
+# The train/test net protocol buffer definition
+net: "examples/mnist/lenet_train_test.prototxt"
+# test_iter specifies how many forward passes the test should carry out.
+# In the case of MNIST, we have test batch size 100 and 100 test iterations,
+# covering the full 10,000 testing images.
+test_iter: 100
+# Carry out testing every 500 training iterations.
+test_interval: 500
+# The base learning rate, momentum and the weight decay of the network.
+base_lr: 0.01
+momentum: 0.9
+weight_decay: 0.0005
+# The learning rate policy
+lr_policy: "inv"
+gamma: 0.0001
+power: 0.75
+# Display every 100 iterations
+display: 100
+# The maximum number of iterations
+max_iter: 10000
+# snapshot intermediate results
+snapshot: 5000
+snapshot_prefix: "examples/mnist/lenet"
+# solver mode: CPU or GPU
+solver_mode: CPU
+# create a solver trace too
+solver_trace_param {
+  save_interval: 2000
+  trace_interval: 20
+  num_traces: 20
+}
+

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -71,10 +71,12 @@ class Solver {
   virtual ~Solver() {}
   inline const SolverParameter& param() const { return param_; }
   inline shared_ptr<Net<Dtype> > net() { return net_; }
+  inline const shared_ptr<Net<Dtype> >& net() const { return net_; }
   inline const vector<shared_ptr<Net<Dtype> > >& test_nets() {
     return test_nets_;
   }
   int iter() const { return iter_; }
+  const TraceDigest& get_digest() const;
 
   // Invoked at specific points during an iteration
   class Callback {

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -9,6 +9,8 @@
 
 namespace caffe {
 
+template <typename Dtype> class SolverTrace;
+
 /**
   * @brief Enumeration of actions that a client of the Solver may request by
   * implementing the Solver's action request function, which a
@@ -72,7 +74,7 @@ class Solver {
   inline const vector<shared_ptr<Net<Dtype> > >& test_nets() {
     return test_nets_;
   }
-  int iter() { return iter_; }
+  int iter() const { return iter_; }
 
   // Invoked at specific points during an iteration
   class Callback {
@@ -125,6 +127,9 @@ class Solver {
 
   // True iff a request to stop early was received.
   bool requested_early_exit_;
+
+  // Maintains a history of the solver for analysis afterwards
+  shared_ptr<SolverTrace<Dtype> > solver_trace_;
 
   DISABLE_COPY_AND_ASSIGN(Solver);
 };

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -62,7 +62,7 @@ class Solver {
   // The Restore method simply dispatches to one of the
   // RestoreSolverStateFrom___ protected methods. You should implement these
   // methods to restore the state from the appropriate snapshot type.
-  void Restore(const char* resume_file);
+  void Restore(const char* resume_file, const char* trace_file = NULL);
   // The Solver::Snapshot function implements the basic snapshotting utility
   // that stores the learned net. You should implement the SnapshotSolverState()
   // function that produces a SolverState protocol buffer that needs to be

--- a/include/caffe/util/solver_trace.hpp
+++ b/include/caffe/util/solver_trace.hpp
@@ -29,18 +29,20 @@ class SolverTrace {
                        const Solver<Dtype>* solver);
   virtual ~SolverTrace() {}
   /** @brief Get a const reference to the history */
-  virtual const TraceDigest& get_digest() const;
+  const TraceDigest& get_digest() const;
   /** @brief Add trace of state the solver is in during training to digest */
-  virtual void update_trace_train(SolverAction::Enum request);
-  virtual void update_trace_train_loss(Dtype loss,
+  void update_trace_train(SolverAction::Enum request);
+  void update_trace_train_loss(Dtype loss,
                                        Dtype smoothed_loss);
-  virtual void update_trace_test_loss(int test_net_id, Dtype loss);
-  virtual void update_trace_test_score(int test_net_id,
+  void update_trace_test_loss(int test_net_id, Dtype loss);
+  void update_trace_test_score(int test_net_id,
                                        const string& output_name,
                                        Dtype loss_weight,
                                        Dtype mean_score);
   /** @brief Save the history of the solver to a proto file */
-  virtual void Save() const;
+  void Save() const;
+  /** @brief Restore the history of the solver from a proto file */
+  void Restore(const string& trace_filename);
 
  protected:
   void update_weight_trace();                  /// Add weight history to digest

--- a/include/caffe/util/solver_trace.hpp
+++ b/include/caffe/util/solver_trace.hpp
@@ -32,6 +32,8 @@ class SolverTrace {
   virtual const TraceDigest& get_digest() const;
   /** @brief Add trace of state the solver is in during training to digest */
   virtual void update_trace_train(SolverAction::Enum request);
+  virtual void update_trace_train_loss(Dtype loss,
+                                       Dtype smoothed_loss);
   virtual void update_trace_test_loss(int test_net_id, Dtype loss);
   virtual void update_trace_test_score(int test_net_id,
                                        const string& output_name,

--- a/include/caffe/util/solver_trace.hpp
+++ b/include/caffe/util/solver_trace.hpp
@@ -29,6 +29,7 @@ class SolverTrace {
   virtual ~SolverTrace() {}
   /** @brief Get a const reference to the history */
   virtual const TraceDigest& get_digest() const;
+  /** @brief Add trace of state the solver is in during training to digest */
   virtual void update_trace_train(SolverAction::Enum request);
   virtual void update_trace_test_loss(int test_net_id, Dtype loss);
   virtual void update_trace_test_score(int test_net_id,
@@ -37,12 +38,17 @@ class SolverTrace {
                                        Dtype mean_score);
   /** @brief Save the history of the solver to a proto file */
   virtual void Save() const;
+
  protected:
+  void update_weight_trace();                  /// Add weight history to digest
   SolverParameter param_;
   SolverTraceParameter trace_param_;
   shared_ptr<TraceDigest> trace_digest_;       /// History of the solver
   const Solver<Dtype>* solver_;                /// Solver to get history for
   int save_trace_;                             /// Interval when to save trace
+  int start_iter_;                             /// Iter where the solver starts
+  int last_iter_;                              /// The last iter we updated
+  string filename_;                            /// File for the solver trace
   DISABLE_COPY_AND_ASSIGN(SolverTrace);
 };
 

--- a/include/caffe/util/solver_trace.hpp
+++ b/include/caffe/util/solver_trace.hpp
@@ -43,8 +43,11 @@ class SolverTrace {
  protected:
   void update_weight_trace();                  /// Add weight history to digest
   void update_activation_trace();
+  void update_diff_trace();
+  void blob_trace(int trace_interval, int num_traces, bool use_data);
   void init_weight_trace();
   void init_activation_trace();
+  void init_diff_trace();
   SolverParameter param_;
   SolverTraceParameter trace_param_;
   shared_ptr<TraceDigest> trace_digest_;       /// History of the solver
@@ -57,6 +60,8 @@ class SolverTrace {
   int activation_trace_interval_;
   int num_weight_traces_;
   int weight_trace_interval_;
+  int num_diff_traces_;
+  int diff_trace_interval_;
   std::map<string, int> activation_name_to_index_;
   DISABLE_COPY_AND_ASSIGN(SolverTrace);
 };

--- a/include/caffe/util/solver_trace.hpp
+++ b/include/caffe/util/solver_trace.hpp
@@ -1,0 +1,51 @@
+#ifndef CAFFE_SOLVER_TRACE_HPP_
+#define CAFFE_SOLVER_TRACE_HPP_
+#include <string>
+#include <vector>
+
+#include "caffe/solver.hpp"
+
+namespace caffe {
+
+template <typename Dtype> class Solver;
+
+/**
+ * @brief Maintains a history of the Solver process so that the learning can
+ *        be analyzied
+ * 
+ * The solver trace stores the values over time of certain aspects of learning
+ * such as the weights, biases, activations, gradients and test and training
+ * errors. These are stored and then from time to time saved to disk.
+ * 
+ * @note Since every run has only one solver trace, and it continually extended
+ * with new values there is no real disadvantage to updating and saving often,
+ * only the memory used and the time writing to disk.
+ */
+template <typename Dtype>
+class SolverTrace {
+ public:
+  explicit SolverTrace(const SolverParameter& param,
+                       const Solver<Dtype>* solver);
+  virtual ~SolverTrace() {}
+  /** @brief Get a const reference to the history */
+  virtual const TraceDigest& get_digest() const;
+  virtual void update_trace_train(SolverAction::Enum request);
+  virtual void update_trace_test_loss(int test_net_id, Dtype loss);
+  virtual void update_trace_test_score(int test_net_id,
+                                       const string& output_name,
+                                       Dtype loss_weight,
+                                       Dtype mean_score);
+  /** @brief Save the history of the solver to a proto file */
+  virtual void Save() const;
+ protected:
+  SolverParameter param_;
+  SolverTraceParameter trace_param_;
+  shared_ptr<TraceDigest> trace_digest_;       /// History of the solver
+  const Solver<Dtype>* solver_;                /// Solver to get history for
+  int save_trace_;                             /// Interval when to save trace
+  DISABLE_COPY_AND_ASSIGN(SolverTrace);
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_SOLVER_TRACE_HPP_

--- a/include/caffe/util/solver_trace.hpp
+++ b/include/caffe/util/solver_trace.hpp
@@ -1,5 +1,6 @@
 #ifndef CAFFE_SOLVER_TRACE_HPP_
 #define CAFFE_SOLVER_TRACE_HPP_
+#include <map>
 #include <string>
 #include <vector>
 
@@ -41,6 +42,9 @@ class SolverTrace {
 
  protected:
   void update_weight_trace();                  /// Add weight history to digest
+  void update_activation_trace();
+  void init_weight_trace();
+  void init_activation_trace();
   SolverParameter param_;
   SolverTraceParameter trace_param_;
   shared_ptr<TraceDigest> trace_digest_;       /// History of the solver
@@ -49,6 +53,11 @@ class SolverTrace {
   int start_iter_;                             /// Iter where the solver starts
   int last_iter_;                              /// The last iter we updated
   string filename_;                            /// File for the solver trace
+  int num_activation_traces_;
+  int activation_trace_interval_;
+  int num_weight_traces_;
+  int weight_trace_interval_;
+  std::map<string, int> activation_name_to_index_;
   DISABLE_COPY_AND_ASSIGN(SolverTrace);
 };
 

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -283,9 +283,10 @@ BOOST_PYTHON_MODULE(_caffe) {
 
   bp::class_<LayerParameter>("LayerParameter", bp::no_init);
 
+  typedef shared_ptr<Net<Dtype> >(Solver<Dtype>::*MutableNetGetter)();
   bp::class_<Solver<Dtype>, shared_ptr<Solver<Dtype> >, boost::noncopyable>(
     "Solver", bp::no_init)
-    .add_property("net", &Solver<Dtype>::net)
+    .add_property("net", static_cast<MutableNetGetter>(&Solver<Dtype>::net))
     .add_property("test_nets", bp::make_function(&Solver<Dtype>::test_nets,
           bp::return_internal_reference<>()))
     .add_property("iter", &Solver<Dtype>::iter)

--- a/python/display_traces.py
+++ b/python/display_traces.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+"""
+display_traces.py Command line callable to display trace created while training
+"""
+
+import matplotlib.pyplot as plt 
+import numpy as np
+import os
+import sys
+import argparse
+
+from caffe.proto import caffe_pb2 as proto # run 'make pycaffe' in the caffe directory 
+
+def main(argv):
+    pycaffe_dir = os.path.dirname(__file__)
+
+    parser = argparse.ArgumentParser()
+    # Required argument: trace file
+    parser.add_argument(
+        "--trace_file",
+        help=".caffetrace file to visualize"
+    )
+    args = parser.parse_args()
+    with open(args.trace_file,'rb') as file_handle:
+        proto_string = file_handle.read()
+    trace_digest = proto.TraceDigest.FromString(proto_string)
+    
+    fig1 = plt.figure()
+    plot_weight_trace(trace_digest, fig=fig1)
+    fig1.suptitle("weight traces")
+    
+    fig2 = plt.figure()
+    plot_diff_trace(trace_digest, fig=fig2)
+    fig2.suptitle("diff traces")
+    
+    fig3 = plt.figure()
+    plot_activation_trace(trace_digest, fig=fig3)
+    fig3.suptitle("activation traces")
+    
+    plt.show()
+    
+def plot_activation_trace(trace_digest, fig=None, blobs=[]):
+    '''
+    Plot the activations from a proto buffer
+    '''
+    if fig==None:
+        fig = plt.figure()
+    else:
+        plt.clf()
+    count = 1
+    for at in trace_digest.activation_trace:
+        if blobs != []:
+            num_blobs = len(blobs)
+        else:
+            num_blobs = len(trace_digest.activation_trace)
+        if blobs != [] and at.blob_name not in blobs:
+            continue
+        num_activation_traces = len(at.activation_trace_point)
+        ax = fig.add_subplot(num_blobs, 1, count)
+        count += 1
+        x = np.empty(num_activation_traces, dtype=float)
+
+        num_traces = len(at.activation_trace_point[0].value)
+        if num_traces == 0:
+            break
+        y = np.empty((num_activation_traces, num_traces), dtype=float)
+        
+        for j, atp in enumerate(at.activation_trace_point):
+            x[j] = atp.iter
+            for k, value in enumerate(atp.value):
+                y[j,k] = value
+        
+        for j in range(num_traces):
+            ax.plot(x, y[:,j])
+        ax.set_title(at.blob_name)
+    
+def plot_weight_trace(trace_digest, fig=None, return_traces=False, traces={}):
+    return plot_trace(trace_digest.weight_trace_point, fig, return_traces, traces)
+    
+def plot_diff_trace(trace_digest, fig=None, return_traces=False, traces={}):
+    return plot_trace(trace_digest.diff_trace_point, fig, return_traces, traces)
+
+def plot_trace(weight_trace_digest, fig, return_traces, traces):
+    '''
+    Plot weight or diff traces of blobs of layers saved in a proto buffer
+    '''
+    if fig==None:
+        fig = plt.figure()
+    else:
+        plt.clf()
+    
+    # a lambda to append something to something other or nothing
+    append = lambda x,y: y if x is None else np.append(x,y,axis=0)
+
+    max_num_blobs = 0  
+    #figure out how many blobs we need to print
+    for wt in weight_trace_digest:
+        if wt.param_id >= max_num_blobs:
+            max_num_blobs = wt.param_id+1
+
+    layers = {}
+    x = {}
+    for i,wt in enumerate(weight_trace_digest):
+      
+        if not layers.has_key(wt.layer_name):
+            layers[wt.layer_name] = max_num_blobs * [ None ]
+        
+        layers[wt.layer_name][wt.param_id] = append( layers[wt.layer_name][wt.param_id], [np.array(wt.value)]);
+        x[wt.iter]=None
+    
+    x=np.sort(x.keys());
+
+    if traces=={}:
+        traces = layers.keys()
+    else:
+        traces = set(layers.keys()).intersection(traces)
+
+    i = 1
+    rows = len(traces)
+    for layer in np.sort(list(traces)):
+        for j in range(max_num_blobs):
+            if j < len(layers[layer]):
+                ax = fig.add_subplot(rows,max_num_blobs,i)
+                ax.plot(x,layers[layer][j])
+                ax.set_title(layer+"_"+str(j))
+            i+=1
+
+    if return_traces:
+        return layers, x
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/python/display_traces.py
+++ b/python/display_traces.py
@@ -37,11 +37,19 @@ def main(argv):
     plot_activation_trace(trace_digest, fig=fig3)
     fig3.suptitle("activation traces")
     
+    fig4 = plt.figure()
+    plot_test_score(trace_digest, fig=fig4)
+    plot_train_loss(trace_digest, fig=fig4, smoothing_window=10)
+    fig4.suptitle("test score")
+    
     plt.show()
     
 def plot_activation_trace(trace_digest, fig=None, blobs=[]):
     '''
     Plot the activations from a proto buffer
+    @param trace_digest protobuffer created by parsing the trace file
+    @param fig Optional figure that the traces should be plotted to
+    @param blobs If set, plot only the activation traces of these blobs
     '''
     if fig==None:
         fig = plt.figure()
@@ -74,10 +82,17 @@ def plot_activation_trace(trace_digest, fig=None, blobs=[]):
             ax.plot(x, y[:,j])
         ax.set_title(at.blob_name)
     
-def plot_weight_trace(trace_digest, fig=None, return_traces=False, traces={}):
+def plot_weight_trace(trace_digest, fig=None, return_traces=False, traces=set([])):
     return plot_trace(trace_digest.weight_trace_point, fig, return_traces, traces)
     
-def plot_diff_trace(trace_digest, fig=None, return_traces=False, traces={}):
+def plot_diff_trace(trace_digest, fig=None, return_traces=False, traces=set([])):
+    '''
+    Plot the trace of the diffs through training time
+    @param trace_digest protobuffer created by parsing the trace file
+    @param fig Optional figure that the traces should be plotted to
+    @param return_traces If set to true, values of the traces are returned
+    @param traces If set, plot only traces of layers in this set, otherwise everything
+    '''
     return plot_trace(trace_digest.diff_trace_point, fig, return_traces, traces)
 
 def plot_trace(weight_trace_digest, fig, return_traces, traces):
@@ -110,7 +125,7 @@ def plot_trace(weight_trace_digest, fig, return_traces, traces):
     
     x=np.sort(x.keys());
 
-    if traces=={}:
+    if len(traces) == 0:
         traces = layers.keys()
     else:
         traces = set(layers.keys()).intersection(traces)
@@ -127,6 +142,78 @@ def plot_trace(weight_trace_digest, fig, return_traces, traces):
 
     if return_traces:
         return layers, x
+
+def plot_test_loss(trace_digest, fig=None, target=None, return_traces=False):
+    x_test,y_test = {},{}
+
+    for tp in trace_digest.test_loss_trace_point:
+        if target is None or tp.test_net_id in target:
+            if tp.test_net_id in x_test:
+                x_test[tp.test_net_id].append(tp.iter)
+                y_test[tp.test_net_id].append(tp.test_loss)
+            else:
+                x_test[tp.test_net_id] = [tp.iter]
+                y_test[tp.test_net_id] = [tp.test_loss]
+    
+    for test_name in x_test.keys():
+        if fig == None:
+            plt.plot(x_test[test_name],y_test[test_name], label='test net id: ' + str(test_name))
+            plt.legend()
+        else:
+            ax = fig.add_subplot(111)
+            ax.plot(x_test[test_name],y_test[test_name], label='test net id: ' + str(test_name))
+            ax.legend()
+    if return_traces:
+        return x_test,y_test
+        
+def plot_test_score(trace_digest, fig=None, target=None, return_traces=False):
+    x_test,y_test = {},{}
+
+    for tp in trace_digest.test_score_trace_point:
+        if target is None or tp.test_net_id in target:
+            id_string = 'test net id, score name: '
+            id_string += str(tp.test_net_id) + ' ' + str(tp.score_name)
+            if id_string in x_test:
+                x_test[id_string].append(tp.iter)
+                y_test[id_string].append(tp.mean_score)
+            else:
+                x_test[id_string] = [tp.iter]
+                y_test[id_string] = [tp.mean_score]
+    if fig:
+        ax = fig.add_subplot(111)
+
+    for test_name in x_test.keys():
+        if fig == None:
+            plt.plot(x_test[test_name],y_test[test_name], label=test_name)
+            plt.legend()
+        else:
+            ax.plot(x_test[test_name],y_test[test_name], label=test_name)
+            ax.legend()
+    if return_traces:
+        return x_test,y_test
+
+def plot_train_loss(trace_digest, fig=None, return_traces=False, smoothing_window=1):
+    assert smoothing_window >= 0
+    x_test,y_test = [], []
+    moving_window = np.zeros(smoothing_window, dtype=float)
+    for i, tp in enumerate(trace_digest.train_trace_point):
+        x_test.append(tp.iter)
+        moving_window[i % smoothing_window] = tp.train_loss
+        if i >= smoothing_window:
+            y_test.append(np.mean(moving_window))
+        else:
+            y_test.append(np.sum(moving_window) / (i+1))
+    if fig:
+        ax = fig.add_subplot(111)
+
+    if fig == None:
+        plt.plot(x_test, y_test, label='training loss')
+        plt.legend()
+    else:
+        ax.plot(x_test,y_test, label='training loss')
+        ax.legend()
+    if return_traces:
+        return x_test,y_test
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -246,6 +246,7 @@ message SolverParameter {
 message TraceDigest {
   repeated WeightTracePoint weight_trace_point = 1;
   repeated ActivationTrace  activation_trace = 2;
+  repeated WeightTracePoint diff_trace_point = 3;
 }
 
 message SolverTraceParameter {
@@ -290,6 +291,17 @@ message SolverTraceParameter {
   // number of parameters to track from every layer
   // If this is not set, num_traces is used as a default
   optional int32 num_activation_traces = 9;
+  
+  // tells us how often we should take weight trace values.
+  // If this is not set, trace_interval is used as a default
+  // tells us how often we should take diff trace values.
+  // If this value is zero, no diff trace will be made
+  // determines how detailed the diff trace will be
+  optional int32 diff_trace_interval = 10;
+
+  // number of parameters to track from every layer
+  // If this is not set, num_traces is used as a default
+  optional int32 num_diff_traces = 11;
   
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -98,7 +98,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 41 (last added: type)
+// SolverParameter next available ID: 42 (last added: solver_trace_param)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -239,6 +239,23 @@ message SolverParameter {
   }
   // DEPRECATED: use type instead of solver_type
   optional SolverType solver_type = 30 [default = SGD];
+  
+  optional SolverTraceParameter solver_trace_param = 41;
+}
+
+message TraceDigest {
+  optional int32 dummy = 1;
+}
+
+message SolverTraceParameter {
+  // filename where the trace will be saved
+  optional string trace_filename = 1;
+  // save the trace in a human readable format too
+  optional bool human_readable_trace = 2;
+  // How often solver trace should be saved to disk
+  // determines the IO to disk load that the solver traces will create
+  // If not set, it is the same as SolverParameter.snapshot
+  optional int32 save_interval = 3;
 }
 
 // A message that stores the solver snapshots

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -247,6 +247,9 @@ message TraceDigest {
   repeated WeightTracePoint weight_trace_point = 1;
   repeated ActivationTrace  activation_trace = 2;
   repeated WeightTracePoint diff_trace_point = 3;
+  repeated TrainTracePoint  train_trace_point = 4;
+  repeated TestLossTracePoint   test_loss_trace_point = 5;
+  repeated TestScoreTracePoint   test_score_trace_point = 6;
 }
 
 message SolverTraceParameter {
@@ -302,6 +305,15 @@ message SolverTraceParameter {
   // number of parameters to track from every layer
   // If this is not set, num_traces is used as a default
   optional int32 num_diff_traces = 11;
+  
+  // during training phase, record training loss in the solver trace
+  optional bool create_train_trace = 12 [default = true];
+  
+  // during test phase, record the loss / accuracy in the solver trace
+  optional bool create_test_trace = 13 [default = true];
+  
+  // save the trace every time we train
+  optional bool save_after_test = 14 [default = true];
   
 }
 
@@ -1071,6 +1083,42 @@ message TileParameter {
 // Message that stores parameters used by ThresholdLayer
 message ThresholdParameter {
   optional float threshold = 1 [default = 0]; // Strictly positive values
+}
+
+message TestLossTracePoint {
+  //the id of the test net we test the loss of
+  optional int32 test_net_id = 1;
+
+  //number of training iterations up until this point
+  optional int32 iter = 2;
+
+  //the loss of this net at this point
+  optional float test_loss = 3;
+}
+
+//the test output of one forward pass of one net
+message TestScoreTracePoint {
+
+  //the id of the test net we test the loss of
+  optional int32 test_net_id = 1;
+  
+  //number of training iterations up until this point
+  optional int32 iter = 2;
+
+  //the index of the data blob we send through the net to test it
+  optional string score_name = 3;
+
+  //the mean score of the net on this test blob
+  optional float mean_score = 4;
+
+  //the weight given to this blob of test data
+  optional float loss_weight = 5;
+}
+
+message TrainTracePoint {
+  optional int32 iter = 1;
+  optional float train_loss = 2;
+  optional float train_smoothed_loss = 3;
 }
 
 // Stores a few weights from a blob of a layer. Used for solver trace.

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -245,6 +245,7 @@ message SolverParameter {
 
 message TraceDigest {
   repeated WeightTracePoint weight_trace_point = 1;
+  repeated ActivationTrace  activation_trace = 2;
 }
 
 message SolverTraceParameter {
@@ -259,13 +260,37 @@ message SolverTraceParameter {
   // If not set, it is the same as SolverParameter.snapshot
   optional int32 save_interval = 3;
   
+  // tells us how often we should take trace values.
+  // If this value is zero or not set, no trace will be made
+  // determines how detailed the trace will be
+  // values like weight_trace_interval override this
+  optional int32 trace_interval = 4 [default = 0];
+  
+  // number of parameters to track from every layer / blob
+  // values like num_weight_traces override this
+  optional int32 num_traces = 5 [default = 10];
+  
   // tells us how often we should take weight trace values.
-  // If this value is zero or not set, no weight trace will be made
+  // If this is not set, trace_interval is used as a default
+  // If this value is zero, no weight trace will be made
   // determines how detailed the weight trace will be
-  optional int32 weight_trace_interval = 4 [default = 0];
+  optional int32 weight_trace_interval = 6;
 
-  // number of parameters to track from every layer 
-  optional int32 num_weight_traces = 5 [default = 10];
+  // number of parameters to track from every layer
+  // If this is not set, num_traces is used as a default
+  optional int32 num_weight_traces = 7;
+  
+  // tells us how often we should take weight trace values.
+  // If this is not set, trace_interval is used as a default
+  // tells us how often we should take activation trace values.
+  // If this value is zero, no activation trace will be made
+  // determines how detailed the activation trace will be
+  optional int32 activation_trace_interval = 8;
+
+  // number of parameters to track from every layer
+  // If this is not set, num_traces is used as a default
+  optional int32 num_activation_traces = 9;
+  
 }
 
 // A message that stores the solver snapshots
@@ -1036,12 +1061,23 @@ message ThresholdParameter {
   optional float threshold = 1 [default = 0]; // Strictly positive values
 }
 
-// Stores a few weights from a blob of a layer. Used from solver trace.
+// Stores a few weights from a blob of a layer. Used for solver trace.
 message WeightTracePoint {
   optional int32  iter = 1;
   optional int32  param_id = 2;
   optional string layer_name = 3;
   repeated float  value = 4;
+}
+
+// Stores a few activations from a blob.  Used for solver trace.
+message ActivationTrace {
+  optional string blob_name = 1;
+  repeated ActivationTracePoint activation_trace_point = 2;
+}
+
+message ActivationTracePoint {
+  optional int32 iter  = 1;
+  repeated float value = 2;
 }
 
 message WindowDataParameter {

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -244,18 +244,28 @@ message SolverParameter {
 }
 
 message TraceDigest {
-  optional int32 dummy = 1;
+  repeated WeightTracePoint weight_trace_point = 1;
 }
 
 message SolverTraceParameter {
   // filename where the trace will be saved
   optional string trace_filename = 1;
+  
   // save the trace in a human readable format too
   optional bool human_readable_trace = 2;
+  
   // How often solver trace should be saved to disk
   // determines the IO to disk load that the solver traces will create
   // If not set, it is the same as SolverParameter.snapshot
   optional int32 save_interval = 3;
+  
+  // tells us how often we should take weight trace values.
+  // If this value is zero or not set, no weight trace will be made
+  // determines how detailed the weight trace will be
+  optional int32 weight_trace_interval = 4 [default = 0];
+
+  // number of parameters to track from every layer 
+  optional int32 num_weight_traces = 5 [default = 10];
 }
 
 // A message that stores the solver snapshots
@@ -1024,6 +1034,14 @@ message TileParameter {
 // Message that stores parameters used by ThresholdLayer
 message ThresholdParameter {
   optional float threshold = 1 [default = 0]; // Strictly positive values
+}
+
+// Stores a few weights from a blob of a layer. Used from solver trace.
+message WeightTracePoint {
+  optional int32  iter = 1;
+  optional int32  param_id = 2;
+  optional string layer_name = 3;
+  repeated float  value = 4;
 }
 
 message WindowDataParameter {

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -7,6 +7,7 @@
 #include "caffe/util/format.hpp"
 #include "caffe/util/hdf5.hpp"
 #include "caffe/util/io.hpp"
+#include "caffe/util/solver_trace.hpp"
 #include "caffe/util/upgrade_proto.hpp"
 
 namespace caffe {
@@ -58,6 +59,10 @@ void Solver<Dtype>::Init(const SolverParameter& param) {
   if (Caffe::root_solver()) {
     InitTestNets();
     LOG(INFO) << "Solver scaffolding done.";
+  }
+  // Add solver trace to root solver
+  if (Caffe::root_solver()) {
+    solver_trace_.reset(new SolverTrace<Dtype>(param, this));
   }
   iter_ = 0;
   current_step_ = 0;
@@ -267,6 +272,11 @@ void Solver<Dtype>::Step(int iters) {
 
     SolverAction::Enum request = GetRequestedAction();
 
+    // Add new information to weight trace
+    if (Caffe::root_solver()) {
+      solver_trace_->update_trace_train(request);
+    }
+
     // Save a snapshot if needed.
     if ((param_.snapshot()
          && iter_ % param_.snapshot() == 0
@@ -305,6 +315,9 @@ void Solver<Dtype>::Solve(const char* resume_file) {
       && (!param_.snapshot() || iter_ % param_.snapshot() != 0)) {
     Snapshot();
   }
+  // Force a solver trace update
+  solver_trace_->update_trace_train(SolverAction::SNAPSHOT);
+
   if (requested_early_exit_) {
     LOG(INFO) << "Optimization stopped early.";
     return;
@@ -394,6 +407,7 @@ void Solver<Dtype>::Test(const int test_net_id) {
   if (param_.test_compute_loss()) {
     loss /= param_.test_iter(test_net_id);
     LOG(INFO) << "Test loss: " << loss;
+    solver_trace_->update_trace_test_loss(test_net_id, loss);
   }
   for (int i = 0; i < test_score.size(); ++i) {
     const int output_blob_index =
@@ -408,7 +422,10 @@ void Solver<Dtype>::Test(const int test_net_id) {
     }
     LOG(INFO) << "    Test net output #" << i << ": " << output_name << " = "
               << mean_score << loss_msg_stream.str();
+    solver_trace_->update_trace_test_score(test_net_id, output_name,
+                                           loss_weight, mean_score);
   }
+  solver_trace_->Save();
 }
 
 template <typename Dtype>

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -243,6 +243,9 @@ void Solver<Dtype>::Step(int iters) {
       smoothed_loss += (loss - losses[idx]) / average_loss;
       losses[idx] = loss;
     }
+    if (Caffe::root_solver()) {
+      solver_trace_->update_trace_train_loss(loss, smoothed_loss);
+    }
     if (display) {
       LOG_IF(INFO, Caffe::root_solver()) << "Iteration " << iter_
           << ", loss = " << smoothed_loss;
@@ -412,10 +415,13 @@ void Solver<Dtype>::Test(const int test_net_id) {
     LOG(INFO)     << "Test interrupted.";
     return;
   }
+  if (param_.test_iter(test_net_id) > 0) {
+    Dtype l = loss / param_.test_iter(test_net_id);
+    solver_trace_->update_trace_test_loss(test_net_id, l);
+  }
   if (param_.test_compute_loss()) {
     loss /= param_.test_iter(test_net_id);
     LOG(INFO) << "Test loss: " << loss;
-    solver_trace_->update_trace_test_loss(test_net_id, loss);
   }
   for (int i = 0; i < test_score.size(); ++i) {
     const int output_blob_index =
@@ -433,7 +439,10 @@ void Solver<Dtype>::Test(const int test_net_id) {
     solver_trace_->update_trace_test_score(test_net_id, output_name,
                                            loss_weight, mean_score);
   }
-  solver_trace_->Save();
+  if (param_.has_solver_trace_param() &&
+      param_.solver_trace_param().save_after_test()) {
+    solver_trace_->Save();
+  }
 }
 
 template <typename Dtype>

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -506,7 +506,7 @@ string Solver<Dtype>::SnapshotToHDF5() {
 }
 
 template <typename Dtype>
-void Solver<Dtype>::Restore(const char* state_file) {
+void Solver<Dtype>::Restore(const char* state_file, const char* trace_file) {
   CHECK(Caffe::root_solver());
   string state_filename(state_file);
   if (state_filename.size() >= 3 &&
@@ -514,6 +514,10 @@ void Solver<Dtype>::Restore(const char* state_file) {
     RestoreSolverStateFromHDF5(state_filename);
   } else {
     RestoreSolverStateFromBinaryProto(state_filename);
+  }
+  if (trace_file) {
+    string trace_filename(trace_file);
+    solver_trace_->Restore(trace_file);
   }
 }
 

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -25,6 +25,10 @@ SolverAction::Enum Solver<Dtype>::GetRequestedAction() {
   }
   return SolverAction::NONE;
 }
+template<typename Dtype>
+const TraceDigest& Solver<Dtype>::get_digest() const {
+  return solver_trace_->get_digest();
+}
 
 template <typename Dtype>
 Solver<Dtype>::Solver(const SolverParameter& param, const Solver* root_solver)
@@ -60,12 +64,13 @@ void Solver<Dtype>::Init(const SolverParameter& param) {
     InitTestNets();
     LOG(INFO) << "Solver scaffolding done.";
   }
+  iter_ = 0;
+  current_step_ = 0;
+
   // Add solver trace to root solver
   if (Caffe::root_solver()) {
     solver_trace_.reset(new SolverTrace<Dtype>(param, this));
   }
-  iter_ = 0;
-  current_step_ = 0;
 }
 
 template <typename Dtype>
@@ -305,7 +310,10 @@ void Solver<Dtype>::Solve(const char* resume_file) {
     LOG(INFO) << "Restoring previous solver status from " << resume_file;
     Restore(resume_file);
   }
-
+  // record the trace at iteration == 0
+  if (iter_ == 0) {
+    solver_trace_->update_trace_train(SolverAction::NONE);
+  }
   // For a network that is trained by the solver, no bottom or top vecs
   // should be given, and we will just provide dummy vecs.
   Step(param_.max_iter() - iter_);

--- a/src/caffe/test/test_solver_trace.cpp
+++ b/src/caffe/test/test_solver_trace.cpp
@@ -1,0 +1,360 @@
+#include <algorithm>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "google/protobuf/text_format.h"
+
+#include "gtest/gtest.h"
+
+#include "caffe/common.hpp"
+#include "caffe/parallel.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/sgd_solvers.hpp"
+#include "caffe/util/io.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+using std::ostringstream;
+
+namespace caffe {
+
+using google::protobuf::TextFormat;
+
+template <typename TypeParam>
+class SolverTraceTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  SolverTraceTest() :
+      seed_(1701), num_(4), channels_(3), height_(10), width_(10),
+      share_(false) {
+        input_file_ = new string(
+        CMAKE_SOURCE_DIR "caffe/test/test_data/solver_data_list.txt" CMAKE_EXT);
+      }
+  ~SolverTraceTest() {
+    delete input_file_;
+  }
+
+  string snapshot_prefix_;
+  shared_ptr<SGDSolver<Dtype> > solver_;
+  shared_ptr<P2PSync<Dtype> > sync_;
+  int seed_;
+  // Dimensions are determined by generate_sample_data.py
+  // TODO this is brittle and the hdf5 file should be checked instead.
+  int num_, channels_, height_, width_;
+  bool share_;
+  Dtype delta_;  // Stability constant for RMSProp, AdaGrad, AdaDelta and Adam
+
+  // Test data: check out generate_sample_data.py in the same directory.
+  string* input_file_;
+
+  virtual void InitSolver(const SolverParameter& param) = 0;
+
+  virtual void InitSolverFromProtoString(const string& proto) {
+    SolverParameter param;
+    CHECK(google::protobuf::TextFormat::ParseFromString(proto, &param));
+    // Set the solver_mode according to current Caffe::mode.
+    switch (Caffe::mode()) {
+      case Caffe::CPU:
+        param.set_solver_mode(SolverParameter_SolverMode_CPU);
+        break;
+      case Caffe::GPU:
+        param.set_solver_mode(SolverParameter_SolverMode_GPU);
+        break;
+      default:
+        LOG(FATAL) << "Unknown Caffe mode: " << Caffe::mode();
+    }
+    InitSolver(param);
+    delta_ = param.delta();
+  }
+
+  std::pair<string, string> RunLeastSquaresSolver(const Dtype learning_rate,
+      const Dtype weight_decay, const Dtype momentum, const int num_iters,
+      const int iter_size = 1, const int devices = 1,
+      const bool snapshot = false, const char* from_snapshot = NULL,
+      const char* from_trace = NULL, string extra_proto="") {
+    ostringstream proto;
+    int device_id = 0;
+#ifndef CPU_ONLY
+    if (Caffe::mode() == Caffe::GPU) {
+      CUDA_CHECK(cudaGetDevice(&device_id));
+    }
+#endif
+    proto <<
+       "snapshot_after_train: " << snapshot << " "
+       "max_iter: " << num_iters << " "
+       "base_lr: " << learning_rate << " "
+       "lr_policy: 'fixed' "
+       "iter_size: " << iter_size << " "
+       "device_id: " << device_id << " "
+       "net_param { "
+       "  name: 'TestNetwork' "
+       "  layer { "
+       "    name: 'data' "
+       "    type: 'HDF5Data' "
+       "    hdf5_data_param { "
+       "      source: '" << *(this->input_file_) << "' "
+       "      batch_size: " << num_ / iter_size << " "
+       "    } "
+       "    top: 'data' "
+       "    top: 'targets' "
+       "  } ";
+    if (share_) {
+      proto <<
+         "  layer { "
+         "    name: 'slice' "
+         "    type: 'Slice' "
+         "    bottom: 'data' "
+         "    top: 'data1' "
+         "    top: 'data2' "
+         "    slice_param { "
+         "      axis: 0 "
+         "    } "
+         "  } ";
+    }
+    proto <<
+       "  layer { "
+       "    name: 'innerprod' "
+       "    type: 'InnerProduct' "
+       "    param { name: 'weights' } "
+       "    param { name: 'bias' } "
+       "    inner_product_param { "
+       "      num_output: 1 "
+       "      weight_filler { "
+       "        type: 'gaussian' "
+       "        std: 1.0 "
+       "      } "
+       "      bias_filler { "
+       "        type: 'gaussian' "
+       "        std: 1.0 "
+       "      } "
+       "    } "
+       "    bottom: '" << string(share_ ? "data1": "data") << "' "
+       "    top: '" << string(share_ ? "innerprod1": "innerprod") << "' "
+       "  } ";
+    if (share_) {
+      proto <<
+         "  layer { "
+         "    name: 'innerprod2' "
+         "    type: 'InnerProduct' "
+         "    param { name: 'weights' } "
+         "    param { name: 'bias' } "
+         "    inner_product_param { "
+         "      num_output: 1 "
+         "      weight_filler { "
+         "        type: 'gaussian' "
+         "        std: 1.0 "
+         "      } "
+         "      bias_filler { "
+         "        type: 'gaussian' "
+         "        std: 1.0 "
+         "      } "
+         "    } "
+         "    bottom: 'data2' "
+         "    top: 'innerprod2' "
+         "  } "
+         "  layer { "
+         "    name: 'concat' "
+         "    type: 'Concat' "
+         "    bottom: 'innerprod1' "
+         "    bottom: 'innerprod2' "
+         "    top: 'innerprod' "
+         "    concat_param { "
+         "      axis: 0 "
+         "    } "
+         "  } ";
+    }
+    proto <<
+       "  layer { "
+       "    name: 'loss' "
+       "    type: 'EuclideanLoss' "
+       "    bottom: 'innerprod' "
+       "    bottom: 'targets' "
+       "  } "
+       "} ";
+    if (weight_decay != 0) {
+      proto << "weight_decay: " << weight_decay << " ";
+    }
+    if (momentum != 0) {
+      proto << "momentum: " << momentum << " ";
+    }
+    proto << "snapshot_prefix: '" << snapshot_prefix_ << "/' ";
+    if (snapshot) {
+      proto << "snapshot: " << num_iters << " ";
+    }
+    proto << extra_proto;
+    Caffe::set_random_seed(this->seed_);
+    this->InitSolverFromProtoString(proto.str());
+    if (from_snapshot != NULL) {
+      this->solver_->Restore(from_snapshot);
+      vector<Blob<Dtype>*> empty_bottom_vec;
+      for (int i = 0; i < this->solver_->iter(); ++i) {
+        this->solver_->net()->Forward(empty_bottom_vec);
+      }
+    }
+    if (devices == 1) {
+      this->solver_->Solve();
+    } else {
+      LOG(INFO) << "Multi-GPU test on " << devices << " devices";
+      vector<int> gpus;
+      // put current device at the beginning
+      int device_id = solver_->param().device_id();
+      gpus.push_back(device_id);
+      for (int i = 0; gpus.size() < devices; ++i) {
+        if (i != device_id)
+          gpus.push_back(i);
+      }
+      Caffe::set_solver_count(gpus.size());
+      this->sync_.reset(new P2PSync<Dtype>(
+          this->solver_, NULL, this->solver_->param()));
+      this->sync_->run(gpus);
+      Caffe::set_solver_count(1);
+    }
+    if (snapshot) {
+      ostringstream resume_file, trace_file;
+      resume_file << snapshot_prefix_ << "/_iter_" << num_iters
+                  << ".solverstate";
+      string resume_filename = resume_file.str();
+      trace_file << snapshot_prefix_ << "/trace.caffetrace";
+      string trace_filename = trace_file.str();
+      return std::pair<string, string>(resume_filename, trace_filename);
+    }
+    return std::pair<string, string>(string(), string());
+  }
+
+  void TestSolverWeightTrace(const Dtype learning_rate = 1.0,
+      const Dtype weight_decay = 0.0, const Dtype momentum = 0.0,
+      const int num_iters = 1) {
+    // Run the solver for num_iters * 2 iterations.
+    const int total_num_iters = num_iters * 2;
+    bool snapshot = false;
+    const char* from_snapshot = NULL;
+    const char* trace_snapshot = NULL;
+    int weight_trace_interval = 1;
+    int num_traces = 5;
+    const int kIterSize = 1;
+    const int kDevices = 1;
+
+    MakeTempDir(&snapshot_prefix_);
+    ostringstream extra_proto;
+    extra_proto <<
+      "solver_trace_param { "
+      "  save_interval: 1 "
+      "  trace_filename: '" << snapshot_prefix_ << "/trace' "
+      "  weight_trace_interval: " << weight_trace_interval << " "
+      "  num_weight_traces: " << num_traces << " "
+      "} ";
+
+    RunLeastSquaresSolver(learning_rate, weight_decay, momentum,
+        total_num_iters, kIterSize, kDevices, snapshot, from_snapshot,
+        trace_snapshot, extra_proto.str());
+
+    string string_snapshot, string_no_snapshot;
+    const TraceDigest& digest = solver_->get_digest();
+    TextFormat::PrintToString(digest, &string_no_snapshot);
+
+    // map from a name to the weight
+    map<string, float> selected_weights;
+
+    vector<vector<int> > trace_per_blob_iter(0);
+    for (int i = 0; i < 2; ++i) {
+      trace_per_blob_iter.push_back(vector<int>(total_num_iters + 1));
+    }
+    int share_mult = share_ ? 2 : 1;
+    // We take a trace before we start and after we end and at every step
+    // and we save 1 traces for four blobs
+    EXPECT_EQ(digest.weight_trace_point_size(),
+              share_mult * 2 * (total_num_iters + 1));
+    for (int i = 0; i < digest.weight_trace_point_size(); ++i) {
+      string layer_name = digest.weight_trace_point(i).layer_name();
+      int param_id = digest.weight_trace_point(i).param_id();
+      ASSERT_GE(param_id, 0);
+      ASSERT_LE(param_id, 1);
+      int iter = digest.weight_trace_point(i).iter();
+      stringstream ss;
+      ss << param_id << "_" << iter;
+      float weight = digest.weight_trace_point(i).value(0);
+      if (share_ && layer_name == "innerprod") {
+        selected_weights[ss.str()] = weight;
+      }
+
+      // param_id == 0 means weights, otherwise bias of which there is only one
+      if (param_id == 0) {
+        ASSERT_EQ(digest.weight_trace_point(i).value_size(), num_traces);
+      } else {
+        ASSERT_EQ(digest.weight_trace_point(i).value_size(), 1);
+      }
+
+      // make sure the layer name is correct
+      if (share_) {
+        EXPECT_TRUE(layer_name == "innerprod" || layer_name == "innerprod2");
+      } else {
+        EXPECT_EQ(layer_name, "innerprod");
+      }
+      EXPECT_LE(weight, 100.);
+      EXPECT_GE(weight, -100.);
+      ASSERT_LE(iter, total_num_iters);
+      ASSERT_GE(iter, 0);
+      trace_per_blob_iter[param_id][iter]++;
+    }
+    // per layer / blob / iteration there should be exactly one weight trace
+    for (int i = 0; i < 2; ++i) {
+      for (int j = 0; j < total_num_iters + 1; ++j) {
+        EXPECT_EQ(trace_per_blob_iter[i][j], share_mult);
+      }
+    }
+    // make sure the weights of the shared blobs are the same
+    if (share_) {
+      for (int i = 0; i < digest.weight_trace_point_size(); ++i) {
+        string layer_name = digest.weight_trace_point(i).layer_name();
+        int param_id = digest.weight_trace_point(i).param_id();
+        int iter = digest.weight_trace_point(i).iter();
+        stringstream ss;
+        ss << param_id << "_" << iter;
+        float weight = digest.weight_trace_point(i).value(0);
+        if (layer_name == "innerprod2") {
+          EXPECT_FLOAT_EQ(selected_weights[ss.str()], weight);
+        }
+      }
+    }
+  }
+};
+
+template <typename TypeParam>
+class SGDSolverTraceTest : public SolverTraceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  virtual void InitSolver(const SolverParameter& param) {
+    this->solver_.reset(new SGDSolver<Dtype>(param));
+  }
+};
+
+TYPED_TEST_CASE(SGDSolverTraceTest, TestDtypesAndDevices);
+
+TYPED_TEST(SGDSolverTraceTest, TestSolverWeightTrace) {
+  typedef typename TypeParam::Dtype Dtype;
+  const Dtype kLearningRate = 0.01;
+  const Dtype kWeightDecay = 0.5;
+  const Dtype kMomentum = 0.9;
+  const int kNumIters = 4;
+  for (int i = 1; i <= kNumIters; ++i) {
+    this->TestSolverWeightTrace(kLearningRate, kWeightDecay, kMomentum, i);
+  }
+}
+
+TYPED_TEST(SGDSolverTraceTest, TestSolverWeightTraceShare) {
+  typedef typename TypeParam::Dtype Dtype;
+  const Dtype kLearningRate = 0.01;
+  const Dtype kWeightDecay = 0.5;
+  const Dtype kMomentum = 0.9;
+  const int kNumIters = 4;
+  this->share_ = true;
+  for (int i = 1; i <= kNumIters; ++i) {
+    this->TestSolverWeightTrace(kLearningRate, kWeightDecay, kMomentum, i);
+  }
+}
+
+}  // namespace caffe

--- a/src/caffe/util/solver_trace.cpp
+++ b/src/caffe/util/solver_trace.cpp
@@ -1,0 +1,83 @@
+#include <string>
+
+#include "caffe/util/io.hpp"
+#include "caffe/util/solver_trace.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+SolverTrace<Dtype>::SolverTrace(const SolverParameter& param,
+    const Solver<Dtype>* solver)
+  : trace_digest_(new TraceDigest()), solver_(solver) {
+  param_ = param;
+  if (param_.has_solver_trace_param()) {
+    trace_param_ = param_.solver_trace_param();
+    if (trace_param_.has_save_interval()) {
+      CHECK_GE(trace_param_.save_interval(), 0)
+        << "solver trace trace save_interval >= 0";
+      save_trace_ = trace_param_.save_interval();
+    } else {
+      save_trace_ = param_.snapshot();
+    }
+  }
+}
+
+template <typename Dtype>
+const TraceDigest& SolverTrace<Dtype>::get_digest() const {
+  return *trace_digest_;
+}
+
+template <typename Dtype>
+void SolverTrace<Dtype>::update_trace_train(SolverAction::Enum request) {
+  // Continue only if the trace params have been set
+  if (!param_.has_solver_trace_param()) {
+    return;
+  }
+  CHECK(Caffe::root_solver());
+  int iter = solver_->iter();
+  if (iter % save_trace_ == 0 || request == SolverAction::SNAPSHOT) {
+    Save();
+  }
+}
+
+template <typename Dtype>
+void SolverTrace<Dtype>::update_trace_test_loss(int test_net_id, Dtype loss) {
+  // Continue only if the trace params have been set
+  if (!param_.has_solver_trace_param()) {
+    return;
+  }
+  CHECK(Caffe::root_solver());
+}
+
+template <typename Dtype>
+void SolverTrace<Dtype>::update_trace_test_score(int test_net_id,
+                                                 const string& output_name,
+                                                 Dtype loss_weight,
+                                                 Dtype mean_score) {
+  // Continue only if the trace params have been set
+  if (!param_.has_solver_trace_param()) {
+    return;
+  }
+  CHECK(Caffe::root_solver());
+}
+
+template <typename Dtype>
+void SolverTrace<Dtype>::Save() const {
+  string filename;
+  if (trace_param_.has_trace_filename()) {
+    filename = trace_param_.trace_filename() + ".caffetrace";
+  } else {
+    filename = param_.snapshot_prefix() + ".caffetrace";
+  }
+  LOG(INFO) << "Snapshotting trace to " << filename;
+  WriteProtoToBinaryFile(*trace_digest_, filename.c_str());
+  if (trace_param_.human_readable_trace()) {
+    filename += "_txt";
+    LOG(INFO) << "Snapshotting human readable trace to " << filename;
+    WriteProtoToTextFile(*trace_digest_, filename.c_str());
+  }
+}
+
+INSTANTIATE_CLASS(SolverTrace);
+
+}  // namespace caffe

--- a/src/caffe/util/solver_trace.cpp
+++ b/src/caffe/util/solver_trace.cpp
@@ -1,5 +1,5 @@
 #include <string>
-
+#include <vector>
 #include "caffe/util/io.hpp"
 #include "caffe/util/solver_trace.hpp"
 
@@ -8,16 +8,30 @@ namespace caffe {
 template <typename Dtype>
 SolverTrace<Dtype>::SolverTrace(const SolverParameter& param,
     const Solver<Dtype>* solver)
-  : trace_digest_(new TraceDigest()), solver_(solver) {
+  : trace_digest_(new TraceDigest()), solver_(solver), last_iter_(-1) {
   param_ = param;
   if (param_.has_solver_trace_param()) {
     trace_param_ = param_.solver_trace_param();
     if (trace_param_.has_save_interval()) {
-      CHECK_GE(trace_param_.save_interval(), 0)
-        << "solver trace trace save_interval >= 0";
+      CHECK_GT(trace_param_.save_interval(), 0)
+        << "solver trace trace save_interval > 0";
       save_trace_ = trace_param_.save_interval();
     } else {
+      CHECK_GT(param_.snapshot(), 0)
+        << "param_.snapshot() must be > 0 "
+        << "or set a solver trace trace save_interval > 0";
       save_trace_ = param_.snapshot();
+    }
+    // TODO: update this when the load from historical trace works
+    start_iter_ = solver_->iter();
+
+    // Figure out filename where solver trace will be saved
+    if (trace_param_.has_trace_filename()) {
+      filename_ = trace_param_.trace_filename() + ".caffetrace";
+    } else {
+      CHECK(param_.has_snapshot_prefix()) <<
+          "either snapshot_prefix or trace_filename must be set";
+      filename_ = param_.snapshot_prefix() + ".caffetrace";
     }
   }
 }
@@ -35,7 +49,14 @@ void SolverTrace<Dtype>::update_trace_train(SolverAction::Enum request) {
   }
   CHECK(Caffe::root_solver());
   int iter = solver_->iter();
-  if (iter % save_trace_ == 0 || request == SolverAction::SNAPSHOT) {
+  // If we haven't already saved this iteration
+  if (iter != last_iter_) {
+    last_iter_ = iter;
+    update_weight_trace();
+  }
+  // this prevents saving the same iteration twice even if we are requested to
+  if (iter % save_trace_ == 0 ||
+      (request == SolverAction::SNAPSHOT && iter % save_trace_ != 0)) {
     Save();
   }
 }
@@ -63,18 +84,54 @@ void SolverTrace<Dtype>::update_trace_test_score(int test_net_id,
 
 template <typename Dtype>
 void SolverTrace<Dtype>::Save() const {
-  string filename;
-  if (trace_param_.has_trace_filename()) {
-    filename = trace_param_.trace_filename() + ".caffetrace";
-  } else {
-    filename = param_.snapshot_prefix() + ".caffetrace";
+  if (param_.has_solver_trace_param()) {
+    LOG(INFO) << "Snapshotting trace to " << filename_;
+    WriteProtoToBinaryFile(*trace_digest_, filename_.c_str());
+    if (trace_param_.human_readable_trace()) {
+      string hr_filename = filename_ + "_txt";
+      LOG(INFO) << "Snapshotting human readable trace to " << hr_filename;
+      WriteProtoToTextFile(*trace_digest_, hr_filename.c_str());
+    }
   }
-  LOG(INFO) << "Snapshotting trace to " << filename;
-  WriteProtoToBinaryFile(*trace_digest_, filename.c_str());
-  if (trace_param_.human_readable_trace()) {
-    filename += "_txt";
-    LOG(INFO) << "Snapshotting human readable trace to " << filename;
-    WriteProtoToTextFile(*trace_digest_, filename.c_str());
+}
+
+template <typename Dtype>
+void SolverTrace<Dtype>::update_weight_trace() {
+  int iter = solver_->iter();
+  // If we are at the very start or at a point where we want to create trace
+  if ((trace_param_.weight_trace_interval() > 0)
+      && ((iter + start_iter_) % trace_param_.weight_trace_interval() == 0)
+      && (start_iter_ == 0 || iter > start_iter_)) {
+    const vector<shared_ptr<Layer<Dtype> > >& layers= solver_->net()->layers();
+    const vector<string>& layer_names = solver_->net()->layer_names();
+
+    // for each layer in the net weight traces are created
+    for (int layer_id = 0; layer_id < layers.size(); ++layer_id) {
+      const vector<shared_ptr<Blob<Dtype> > >& blobs =
+          layers[layer_id]->blobs();
+      // for each blob in the layer weight traces are created
+      for (int param_id = 0; param_id  < blobs.size(); ++param_id) {
+        WeightTracePoint* new_point = trace_digest_->add_weight_trace_point();
+        new_point->set_iter(iter);
+        new_point->set_layer_name(layer_names[layer_id]);
+        new_point->set_param_id(param_id);
+        int count = blobs[param_id]->count();
+        const Dtype* data = blobs[param_id]->cpu_data();
+        // If the blob has a lot of values, add them to trace at even intervals
+        if (count > trace_param_.num_weight_traces()) {
+          int start = count / (trace_param_.num_weight_traces() * 2 + 2);
+          int step  = count / (trace_param_.num_weight_traces() + 1);
+          for (int i = 0; i < trace_param_.num_weight_traces(); ++i) {
+            new_point->add_value(data[start + i * step]);
+          }
+        } else {
+          // If there are not very many values, add them all to trace
+          for (int i = 0; i < count; ++i) {
+            new_point->add_value(data[i]);
+          }
+        }
+      }
+    }
   }
 }
 

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -38,6 +38,9 @@ DEFINE_string(snapshot, "",
 DEFINE_string(weights, "",
     "Optional; the pretrained weights to initialize finetuning, "
     "separated by ','. Cannot be set simultaneously with snapshot.");
+DEFINE_string(trace, "",
+    "Optional; the trace file to resume training, "
+    "can only be defined if snapshot is defined.");
 DEFINE_int32(iterations, 50,
     "The number of iterations to run.");
 DEFINE_string(sigint_effect, "stop",
@@ -155,7 +158,10 @@ int train() {
   CHECK(!FLAGS_snapshot.size() || !FLAGS_weights.size())
       << "Give a snapshot to resume training or weights to finetune "
       "but not both.";
-
+  if (FLAGS_trace.size()) {
+    CHECK(FLAGS_snapshot.size()) << "Can not restore a trace without also "
+    "defining a snapshot from which to restore";
+  }
   caffe::SolverParameter solver_param;
   caffe::ReadSolverParamsFromTextFileOrDie(FLAGS_solver, &solver_param);
 
@@ -200,7 +206,12 @@ int train() {
 
   if (FLAGS_snapshot.size()) {
     LOG(INFO) << "Resuming from " << FLAGS_snapshot;
-    solver->Restore(FLAGS_snapshot.c_str());
+    if (FLAGS_trace.size()) {
+      LOG(INFO) << "Resuming trace from " << FLAGS_trace;
+      solver->Restore(FLAGS_snapshot.c_str(), FLAGS_trace.c_str());
+    } else {
+      solver->Restore(FLAGS_snapshot.c_str());
+    }
   } else if (FLAGS_weights.size()) {
     CopyLayers(solver.get(), FLAGS_weights);
   }


### PR DESCRIPTION
This pull request allows a running history to be created of any solver.  Only a very small user selected subset of values are saved, but these are enough to visualize the progress of training.

With this pull request, plots tracing the progress of learning can be created that look like this:

![test_trace](https://cloud.githubusercontent.com/assets/4824567/12421248/8ca2947a-bec1-11e5-8ed2-97e8e28cfe60.png)

![weight_traces](https://cloud.githubusercontent.com/assets/4824567/12421249/8cbf59b6-bec1-11e5-8787-f21637171931.png)

The changes made were the following:
 * messages for saving solver history are added to caffe.proto
 * options for how solver history is saved (how often, how much) is added to caffe.proto
 * a SolverTrace class is created to manage solver history
 * Solver class is modified to save its pass its state to SolverTrace at appropriate times
 * caffe executable is updated to allow resumption of training with a solver trace file
 * mnist example that creates a solver trace added
 * python script to visualize a solver trace file added
