### PR TITLE
Workaround for inplace max pooling issue

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -91,11 +91,11 @@ shared_ptr<Layer<Dtype> > GetPoolingLayer(const LayerParameter& param) {
                 << "Using Caffe's own pooling layer.";
       return shared_ptr<Layer<Dtype> >(new PoolingLayer<Dtype>(param));
     }
-// CuDNN assumes layers are not being modified in place, thus breaking
-// our index tracking for updates in some cases in Caffe.  Until there
-// is a workaround in Caffe (index management) or cuDNN, use Caffe
-// layer to max pooling, or don't use in place layers after max
-// pooling layers
+    // CuDNN assumes layers are not being modified in place, thus
+    // breaking our index tracking for updates in some cases in Caffe.
+    // Until there is a workaround in Caffe (index management) or
+    // cuDNN, use Caffe layer to max pooling, or don't use in place
+    // layers after max pooling layers
     if (param.pooling_param().pool() == PoolingParameter_PoolMethod_MAX) {
         return shared_ptr<Layer<Dtype> >(new PoolingLayer<Dtype>(param));
     } else {

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -91,7 +91,16 @@ shared_ptr<Layer<Dtype> > GetPoolingLayer(const LayerParameter& param) {
                 << "Using Caffe's own pooling layer.";
       return shared_ptr<Layer<Dtype> >(new PoolingLayer<Dtype>(param));
     }
-    return shared_ptr<Layer<Dtype> >(new CuDNNPoolingLayer<Dtype>(param));
+// CuDNN assumes layers are not being modified in place, thus breaking
+// our index tracking for updates in some cases in Caffe.  Until there
+// is a workaround in Caffe (index management) or cuDNN, use Caffe
+// layer to max pooling, or don't use in place layers after max
+// pooling layers
+    if (param.pooling_param().pool() == PoolingParameter_PoolMethod_MAX) {
+        return shared_ptr<Layer<Dtype> >(new PoolingLayer<Dtype>(param));
+    } else {
+        return shared_ptr<Layer<Dtype> >(new CuDNNPoolingLayer<Dtype>(param));
+    }
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";


### PR DESCRIPTION
CuDNN assumes layers are not being modified in place, thus breaking our index tracking for updates in some cases in Caffe.  Until there is a workaround in Caffe (index management) or cuDNN, use Caffe
engine for max pooling, or don't use in place layers after max pooling layers