### PR TITLE
Copy proto definition to distribute directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -651,6 +651,8 @@ superclean: clean supercleanfiles
 $(DIST_ALIASES): $(DISTRIBUTE_DIR)
 
 $(DISTRIBUTE_DIR): all py | $(DISTRIBUTE_SUBDIRS)
+	# add proto
+	cp -r src/caffe/proto $(DISTRIBUTE_DIR)/
 	# add include
 	cp -r include $(DISTRIBUTE_DIR)/
 	mkdir -p $(DISTRIBUTE_DIR)/include/caffe/proto


### PR DESCRIPTION
To ensure Caffe to be executable on JVM, caffe.prototxt is required by JVM layers to access solver and network configurations. For that purpose, we make caffe.prototxt available in distribute directory.