### PR TITLE
show Caffe's version from MatCaffe

### DIFF
--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -504,6 +504,13 @@ static void write_mean(MEX_ARGS) {
   mxFree(mean_proto_file);
 }
 
+// Usage: caffe_('version')
+static void version(MEX_ARGS) {
+  mxCHECK(nrhs == 0, "Usage: caffe_('version')");
+  // Return version string
+  plhs[0] = mxCreateString(AS_STRING(CAFFE_VERSION));
+}
+
 /** -----------------------------------------------------------------
  ** Available commands.
  **/
@@ -542,6 +549,7 @@ static handler_registry handlers[] = {
   { "reset",              reset           },
   { "read_mean",          read_mean       },
   { "write_mean",         write_mean      },
+  { "version",            version         },
   // The end.
   { "END",                NULL            },
 };

--- a/matlab/+caffe/version.m
+++ b/matlab/+caffe/version.m
@@ -1,0 +1,7 @@
+function version_str = version()
+% version()
+%   show Caffe's version.
+
+version_str = caffe_('version');
+
+end


### PR DESCRIPTION
Add property `caffe.version` to Matcaffe (fix #3592).