### PR TITLE
Remove unnecessary CAFFE_TEST_CUDA_PROP declarations

### DIFF
--- a/src/caffe/test/test_embed_layer.cpp
+++ b/src/caffe/test/test_embed_layer.cpp
@@ -12,10 +12,6 @@
 
 namespace caffe {
 
-#ifndef CPU_ONLY
-extern cudaDeviceProp CAFFE_TEST_CUDA_PROP;
-#endif
-
 template <typename TypeParam>
 class EmbedLayerTest : public MultiDeviceTest<TypeParam> {
   typedef typename TypeParam::Dtype Dtype;

--- a/src/caffe/test/test_im2col_kernel.cu
+++ b/src/caffe/test/test_im2col_kernel.cu
@@ -28,8 +28,6 @@ __global__ void im2col_nd_gpu_kernel(const int n, const Dtype* data_im,
     const int* kernel_shape, const int* pad, const int* stride,
     const int* dilation, Dtype* data_col);
 
-extern cudaDeviceProp CAFFE_TEST_CUDA_PROP;
-
 template <typename Dtype>
 class Im2colKernelTest : public GPUDeviceTest<Dtype> {
  protected:


### PR DESCRIPTION
This just removes a couple unneeded declarations in the unit tests, likely originally included due to copy-pasting of other tests.  (The other instances of this throughout the codebase are actually used.)