### PR TITLE
IP layer (GPU): use gpu_data() instead of cpu_data() for bias_mul

### DIFF
--- a/src/caffe/layers/inner_product_layer.cu
+++ b/src/caffe/layers/inner_product_layer.cu
@@ -16,7 +16,7 @@ void InnerProductLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     caffe_gpu_gemv<Dtype>(CblasNoTrans, N_, K_, (Dtype)1.,
                          weight, bottom_data, (Dtype)0., top_data);
     if (bias_term_)
-      caffe_gpu_axpy<Dtype>(N_, bias_multiplier_.cpu_data()[0],
+      caffe_gpu_axpy<Dtype>(N_, bias_multiplier_.gpu_data()[0],
                             this->blobs_[1]->gpu_data(), top_data);
   } else {
     caffe_gpu_gemm<Dtype>(CblasNoTrans, CblasTrans, M_, N_, K_, (Dtype)1.,


### PR DESCRIPTION
The cuda code for IP layer's Forward_gpu() was calling bias_multiplier_.cpu_data() instead of calling gpu_data(). Switched it to gpu_data().
