### PR TITLE
Nicely prints gpu names

### DIFF
--- a/src/caffe/test/test_caffe_main.cpp
+++ b/src/caffe/test/test_caffe_main.cpp
@@ -34,6 +34,7 @@ int main(int argc, char** argv) {
   cudaGetDevice(&device);
   cout << "Current device id: " << device << endl;
   cudaGetDeviceProperties(&CAFFE_TEST_CUDA_PROP, device);
+  cout << "Current device name: " << CAFFE_TEST_CUDA_PROP.name << endl;
 #endif
   // invoke the test.
   return RUN_ALL_TESTS();

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -183,7 +183,13 @@ int train() {
       s << (i ? ", " : "") << gpus[i];
     }
     LOG(INFO) << "Using GPUs " << s.str();
-
+#ifndef CPU_ONLY
+    cudaDeviceProp device_prop;
+    for (int i = 0; i < gpus.size(); ++i) {
+      cudaGetDeviceProperties(&device_prop, gpus[i]);
+      LOG(INFO) << "GPU " << gpus[i] << ": " << device_prop.name;
+    }
+#endif
     solver_param.set_device_id(gpus[0]);
     Caffe::SetDevice(gpus[0]);
     Caffe::set_mode(Caffe::GPU);
@@ -229,6 +235,11 @@ int test() {
   get_gpus(&gpus);
   if (gpus.size() != 0) {
     LOG(INFO) << "Use GPU with device ID " << gpus[0];
+#ifndef CPU_ONLY
+    cudaDeviceProp device_prop;
+    cudaGetDeviceProperties(&device_prop, gpus[0]);
+    LOG(INFO) << "GPU device name: " << device_prop.name;
+#endif
     Caffe::SetDevice(gpus[0]);
     Caffe::set_mode(Caffe::GPU);
   } else {


### PR DESCRIPTION
Examples:

```
$ build/test/test_batch_norm_layer.testbin 
Cuda number of devices: 2
Current device id: 0
Current device name: GeForce GTX TITAN X
[==========] Running 16 tests from 6 test cases.
...

$ ./build/tools/caffe train --solver=examples/cifar10/cifar10_full_sigmoid_solver.prototxt --gpu=0,1 2>&1
I0202 13:37:35.839033 21978 caffe.cpp:192] Using GPUs 0, 1
I0202 13:37:35.839428 21978 caffe.cpp:197] GPU 0: GeForce GTX TITAN X
I0202 13:37:35.839630 21978 caffe.cpp:197] GPU 1: GeForce GTX 980
I0202 13:37:36.029009 21978 solver.cpp:54] Initializing solver from parameters: 
...
