### PR TITLE
Precise accuracy calculation.

### DIFF
--- a/include/caffe/layers/accuracy_layer.hpp
+++ b/include/caffe/layers/accuracy_layer.hpp
@@ -86,6 +86,9 @@ class AccuracyLayer : public Layer<Dtype> {
   bool has_ignore_label_;
   /// The label indicating that an instance should be ignored.
   int ignore_label_;
+  /// Whether to return count of valid entries
+  bool return_count_;
+
   /// Keeps counts of the number of samples per class.
   Blob<Dtype> nums_buffer_;
 };

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -464,6 +464,9 @@ message AccuracyParameter {
 
   // If specified, ignore instances with the given label.
   optional int32 ignore_label = 3;
+
+  // return the count as well as the accuracy (second data element of first blob)
+  optional bool return_count = 4[default = false];
 }
 
 message ArgMaxParameter {


### PR DESCRIPTION
Add the option to return the counts that contribute to an accuracy score.

Why do we need this?
Together with PR #3631 this adds the options of precise accuracy calculations (e.g. over the entire test set.) It fixes the problem that during the test phase accuracies are averaged without respecting `counts` variable between batches, withing one test. An equivalent thing happens during train when `iter_size` is set.

This may only be needed in certain cases, e.g. a high number or ignore_labels in the dataset, different image sizes during segmentation, e.c.t. A minimal solution to the problem is to let the user do the accuracy accumulation ( respecting weighting ) using a simple layer. These two pull requests
add the necessary functionality to easily implement this layer.

Here is also a python layer that does the accumulation respecting counts.
```
# A layer that accumulates outputs and outputs weighted mean

# The use case is for this layer to accumulate values over epochs,
# hoever "epoch" can be an arbitrary number of iterations.
# To make sure that you see the ouput of this layer check that
# iter_per_epoch % display == 0
class OutputAccum(caffe.Layer):
    def setup(self, bottom, top):
        assert(len(top) == len(bottom))
        params = json.loads(self.param_str)

        # How many iteration to collect before printing output
        self.iter_per_epoch = params["iter_per_epoch"]

        # Offset self.iteration to -1 so that it starts with 1
        self.iteration = 0
        self.epoch = 0
        self.accum = ([]*len(bottom),)
        self.print_now = False

        self.top_shape = []
        for i in range(len(bottom)):
            blob_shape = list(bottom[i].data.shape)
            blob_shape[-1] -= 1
            self.top_shape.append(blob_shape)

    def reshape(self, bottom, top):
        # Reshape in forward, we need to do this since only here do we
        # know what the iteration number is, hence if we should output
        # This is quite off label use, but I don't know where this would cuase
        # truble
        pass

    def forward(self,bottom,top):

        # see reshape function
        for i in range(len(self.top_shape)):
            top[i].reshape(*self.top_shape[i])

        if self.iteration % self.iter_per_epoch == 0:
            self.print_now = True
        else:
            self.print_now = False
            top[0].reshape(0)
        # I'll behave now

        for i in range(len(bottom)):
            #Make sure to append a copy there
            self.accum[i].append(bottom[0].data.copy())

        if  self.print_now:
            #make sure we print exactly when we
            accum = np.array(self.accum)
            values = accum[:,:,:-1]
            weights = accum[:,:,-1]
            for i in range(accum.shape[0]):
                means = np.average(values[i],axis=0,weights=weights[i])
                top[i].data[...] = means

            self.print_now = False
            self.print_next = False
            self.accum = ([]*len(bottom),)

        self.iteration += 1
``` 

Example layer specification
```
layer {
  type: "Python"
  bottom: "acc"
  top: "epoch_acc"
  python_param {
    module: "pylayer"
    layer: "OutputAccum"
    param_str: '{"iter_per_epoch":18}'
  }
  #include {
  #  phase: TRAIN
  #}
}
```