### PR TITLE
Fix OSX El Capitan incompatibility, by adding CUDA_LIB_DIR to @rpath of libcaffe.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,8 @@ ifeq ($(UNAME), Linux)
 	LINUX := 1
 else ifeq ($(UNAME), Darwin)
 	OSX := 1
+	OSX_MAJOR_VERSION := $(shell sw_vers -productVersion | cut -f 1 -d .)
+	OSX_MINOR_VERSION := $(shell sw_vers -productVersion | cut -f 2 -d .)
 endif
 
 # Linux
@@ -407,6 +409,16 @@ else
 endif
 LDFLAGS += $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir)) $(PKG_CONFIG) \
 		$(foreach library,$(LIBRARIES),-l$(library))
+
+ifeq ($(OSX), 1)
+	OSX_10_OR_LATER   := $(shell [ $(OSX_MAJOR_VERSION) -ge 10 ] && echo true)
+	OSX_10_5_OR_LATER := $(shell [ $(OSX_MINOR_VERSION) -ge 5 ] && echo true)
+	ifeq ($(OSX_10_OR_LATER),true)
+		ifeq ($(OSX_10_5_OR_LATER),true)
+			LDFLAGS += -Wl,-rpath,$(CUDA_LIB_DIR)
+		endif
+	endif
+endif
 PYTHON_LDFLAGS := $(LDFLAGS) $(foreach library,$(PYTHON_LIBRARIES),-l$(library))
 
 # 'superclean' target recursively* deletes all files ending with an extension


### PR DESCRIPTION
Fixing dynamic linking issue issues on OSX Elcapitan, reported in #3227 and #2720 