### PR TITLE
explicit install of libgfortran via conda

### DIFF
--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -74,7 +74,7 @@ if [ ! -d $CONDA_DIR ]; then
   if [ "$PYTHON_VERSION" -eq "3" ]; then
     conda install --yes python=3.4
   fi
-  conda install --yes numpy scipy matplotlib scikit-image pip
+  conda install --yes numpy scipy matplotlib scikit-image pip libgfortran
   # Let conda install boost (so that boost_python matches)
   conda install --yes -c https://conda.binstar.org/menpo boost=1.56.0
 fi


### PR DESCRIPTION
Nose tests have been failing with import errors due to not linking to gfortran libs.
This is strange because travis installs gfortran via apt-get.
Having conda install libgfortran resolves the problem.