### PR TITLE
make CaffeFreeHost thread safe

### DIFF
--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -6,7 +6,7 @@ namespace caffe {
 
 SyncedMemory::~SyncedMemory() {
   if (cpu_ptr_ && own_cpu_data_) {
-    CaffeFreeHost(cpu_ptr_, cpu_malloc_use_cuda_);
+    CaffeFreeHost(cpu_ptr_, cpu_malloc_use_cuda_, gpu_device_);
   }
 
 #ifndef CPU_ONLY
@@ -25,7 +25,7 @@ SyncedMemory::~SyncedMemory() {
 inline void SyncedMemory::to_cpu() {
   switch (head_) {
   case UNINITIALIZED:
-    CaffeMallocHost(&cpu_ptr_, size_, &cpu_malloc_use_cuda_);
+    CaffeMallocHost(&cpu_ptr_, size_, &cpu_malloc_use_cuda_, &gpu_device_);
     caffe_memset(size_, 0, cpu_ptr_);
     head_ = HEAD_AT_CPU;
     own_cpu_data_ = true;
@@ -33,7 +33,7 @@ inline void SyncedMemory::to_cpu() {
   case HEAD_AT_GPU:
 #ifndef CPU_ONLY
     if (cpu_ptr_ == NULL) {
-      CaffeMallocHost(&cpu_ptr_, size_, &cpu_malloc_use_cuda_);
+      CaffeMallocHost(&cpu_ptr_, size_, &cpu_malloc_use_cuda_, &gpu_device_);
       own_cpu_data_ = true;
     }
     caffe_gpu_memcpy(size_, gpu_ptr_, cpu_ptr_);
@@ -84,7 +84,7 @@ const void* SyncedMemory::cpu_data() {
 void SyncedMemory::set_cpu_data(void* data) {
   CHECK(data);
   if (own_cpu_data_) {
-    CaffeFreeHost(cpu_ptr_, cpu_malloc_use_cuda_);
+    CaffeFreeHost(cpu_ptr_, cpu_malloc_use_cuda_, gpu_device_);
   }
   cpu_ptr_ = data;
   head_ = HEAD_AT_CPU;


### PR DESCRIPTION
Current implementation of CaffeFreeHost() assumes that it's invoked by the same thread as CaffeMallocHost() caller. This PR remove that constraint. This is useful, for example, when Caffe blob is released by JVM GC.