### PR TITLE
bugfix for incorrect behaviour in `caffe_parse_linker_libs`

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -346,10 +346,11 @@ function(caffe_parse_linker_libs Caffe_LINKER_LIBS_variable folders_var flags_va
     elseif(lib MATCHES "^-l.*")
       list(APPEND libflags ${lib})
     elseif(IS_ABSOLUTE ${lib})
-      get_filename_component(name_we ${lib} NAME_WE)
       get_filename_component(folder  ${lib} PATH)
+      get_filename_component(filename ${lib} NAME)
+      string(REGEX REPLACE "\\.[^.]*$" "" filename_without_shortest_ext ${filename})
 
-      string(REGEX MATCH "^lib(.*)" __match ${name_we})
+      string(REGEX MATCH "^lib(.*)" __match ${filename_without_shortest_ext})
       list(APPEND libflags -l${CMAKE_MATCH_1})
       list(APPEND folders    ${folder})
     else()


### PR DESCRIPTION
bugfix for incorrect behaviour in `caffe_parse_linker_libs` function while extracting libflags from absolute library path with multiple (dots)

On Ubuntu (both on 14.04 and 15.10) using cmake to build matlab wrapper gives a `Cannot find -lpython2` error. See [here](http://stackoverflow.com/questions/31365592/cannot-find-lpython2-matcaffe-installation-error).

This is because `caffe_parse_linker_libs` converts an absolute library path like `/usr/lib/x86_64-linux-gnu/libpython2.7.so` to `-lpython2`

The attached change will correctly convert `/usr/lib/x86_64-linux-gnu/libpython2.7.so` to `-lpython2.7`