### PR TITLE
Feat transformation scale

### DIFF
--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -146,6 +146,7 @@ class DataTransformer {
   shared_ptr<Caffe::RNG> rng_;
   Phase phase_;
   Blob<Dtype> data_mean_;
+  Blob<Dtype> data_scale_;
   vector<Dtype> mean_values_;
 };
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -403,6 +403,8 @@ message TransformationParameter {
   // data mean, if provided. Note that the mean subtraction is always carried
   // out before scaling.
   optional float scale = 1 [default = 1];
+  // scale_file and scale cannot be specified at the same time
+  optional string scale_file = 8;
   // Specify if we want to randomly mirror data.
   optional bool mirror = 2 [default = false];
   // Specify if we would like to randomly crop an image.

--- a/src/caffe/test/test_data_transformer.cpp
+++ b/src/caffe/test/test_data_transformer.cpp
@@ -341,5 +341,42 @@ TYPED_TEST(DataTransformTest, TestMeanFile) {
   }
 }
 
+TYPED_TEST(DataTransformTest, TestScaleFile) {
+  TransformationParameter transform_param;
+  const bool unique_pixels = true;  // pixels are consecutive ints [0,size]
+  const int label = 0;
+  const int channels = 3;
+  const int height = 4;
+  const int width = 5;
+  const int size = channels * height * width;
+
+  // Create a scale file
+  string scale_file;
+  MakeTempFilename(&scale_file);
+  BlobProto blob_scale;
+  blob_scale.set_num(1);
+  blob_scale.set_channels(channels);
+  blob_scale.set_height(height);
+  blob_scale.set_width(width);
+
+  for (int j = 0; j < size; ++j) {
+      blob_scale.add_data(j);
+  }
+
+  LOG(INFO) << "Using temporary scale_file " << scale_file;
+  WriteProtoToBinaryFile(blob_scale, scale_file);
+
+  transform_param.set_scale_file(scale_file);
+  Datum datum;
+  FillDatum(label, channels, height, width, unique_pixels, &datum);
+  Blob<TypeParam> blob(1, channels, height, width);
+  DataTransformer<TypeParam> transformer(transform_param, TEST);
+  transformer.InitRand();
+  transformer.Transform(datum, &blob);
+  for (int j = 0; j < blob.count(); ++j) {
+    EXPECT_EQ(blob.cpu_data()[j], j * j);
+  }
+}
+
 }  // namespace caffe
 #endif  // USE_OPENCV


### PR DESCRIPTION
This pull request allows every pixel / color of input blobs to be scaled individually in the data transformation layer in the same way that the mean can be subtracted individually.

Scaling individually allows for input data to have zero mean and unit variance, which is a handy trick used to train neural networks (see for example [Visin 2015](http://arxiv.org/pdf/1505.00393.pdf)).

Usage is straight forward:  The user specifies a scale file with the same format as the mean file, and each pixel is scaled accordingly.

```
transform_param {
  mean_file: "mean.prototxt"
  scale_file: "scale.prototxt"
  mirror: true
}
```