### PR TITLE
Remove useless LevelDB include

### DIFF
--- a/src/caffe/test/test_data_transformer.cpp
+++ b/src/caffe/test/test_data_transformer.cpp
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "leveldb/db.h"
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"


### PR DESCRIPTION
The tests could not compile with USE_LEVELDB=0 and LevelDB missing from the system