### PR TITLE
Allow EuclideanLossLayer to ignore labels

### DIFF
--- a/include/caffe/layers/euclidean_loss_layer.hpp
+++ b/include/caffe/layers/euclidean_loss_layer.hpp
@@ -99,6 +99,10 @@ class EuclideanLossLayer : public LossLayer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
+  /// Whether to ignore instances with a certain label.
+  bool has_ignore_label_;
+  /// The label indicating that an instance should be ignored.
+  int ignore_label_;
   Blob<Dtype> diff_;
 };
 

--- a/src/caffe/layers/euclidean_loss_layer.cpp
+++ b/src/caffe/layers/euclidean_loss_layer.cpp
@@ -12,12 +12,28 @@ void EuclideanLossLayer<Dtype>::Reshape(
   CHECK_EQ(bottom[0]->count(1), bottom[1]->count(1))
       << "Inputs must have the same dimension.";
   diff_.ReshapeLike(*bottom[0]);
+
+  has_ignore_label_ =
+    this->layer_param_.loss_param().has_ignore_label();
+  if (has_ignore_label_) {
+    ignore_label_ = this->layer_param_.loss_param().ignore_label();
+  }
 }
 
 template <typename Dtype>
 void EuclideanLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   int count = bottom[0]->count();
+  if (has_ignore_label_) {
+    const Dtype* label_data = bottom[1]->cpu_data();
+    Dtype* bottom_data = bottom[0]->mutable_cpu_data();
+    for (int i = 0; i < count; ++i) {
+      const int label_value = static_cast<int>(label_data[i]);
+      if (label_value == ignore_label_) {
+        bottom_data[i] = label_data[i];
+      }
+    }
+  }
   caffe_sub(
       count,
       bottom[0]->cpu_data(),

--- a/src/caffe/layers/euclidean_loss_layer.cpp
+++ b/src/caffe/layers/euclidean_loss_layer.cpp
@@ -25,12 +25,13 @@ void EuclideanLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   int count = bottom[0]->count();
   if (has_ignore_label_) {
-    const Dtype* label_data = bottom[1]->cpu_data();
+    Dtype* label_data = bottom[1]->mutable_cpu_data();
     Dtype* bottom_data = bottom[0]->mutable_cpu_data();
     for (int i = 0; i < count; ++i) {
       const int label_value = static_cast<int>(label_data[i]);
       if (label_value == ignore_label_) {
-        bottom_data[i] = label_data[i];
+        label_data[i] = ignore_label_;
+        bottom_data[i] = ignore_label_;
       }
     }
   }

--- a/src/caffe/layers/euclidean_loss_layer.cpp
+++ b/src/caffe/layers/euclidean_loss_layer.cpp
@@ -24,22 +24,21 @@ template <typename Dtype>
 void EuclideanLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   int count = bottom[0]->count();
-  if (has_ignore_label_) {
-    Dtype* label_data = bottom[1]->mutable_cpu_data();
-    Dtype* bottom_data = bottom[0]->mutable_cpu_data();
-    for (int i = 0; i < count; ++i) {
-      const int label_value = static_cast<int>(label_data[i]);
-      if (label_value == ignore_label_) {
-        label_data[i] = ignore_label_;
-        bottom_data[i] = ignore_label_;
-      }
-    }
-  }
   caffe_sub(
       count,
       bottom[0]->cpu_data(),
       bottom[1]->cpu_data(),
       diff_.mutable_cpu_data());
+  if (has_ignore_label_) {
+    const Dtype* label_data = bottom[1]->cpu_data();
+    Dtype* diff__data = diff_.mutable_cpu_data();
+    for (int i = 0; i < count; ++i) {
+      const int label_value = static_cast<int>(label_data[i]);
+      if (label_value == ignore_label_) {
+        diff__data[i] = 0;
+      }
+    }
+  }
   Dtype dot = caffe_cpu_dot(count, diff_.cpu_data(), diff_.cpu_data());
   Dtype loss = dot / bottom[0]->num() / Dtype(2);
   top[0]->mutable_cpu_data()[0] = loss;

--- a/src/caffe/layers/euclidean_loss_layer.cu
+++ b/src/caffe/layers/euclidean_loss_layer.cu
@@ -7,12 +7,13 @@ namespace caffe {
 
 template <typename Dtype>
 __global__ void EuclideanLossForwardGPU(const int n,
-          const Dtype* label_data_, Dtype* bottom_data_,
+          Dtype* label_data_, Dtype* bottom_data_,
           const int ignore_label_) {
   CUDA_KERNEL_LOOP(index, n) {
     const int label_value = static_cast<int>(label_data_[index]);
     if (label_value == ignore_label_) {
-      bottom_data_[index] = label_data_[index];
+      label_data_[index] = ignore_label_;
+      bottom_data_[index] = ignore_label_;
     }
   }
 }
@@ -22,8 +23,9 @@ void EuclideanLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   int count = bottom[0]->count();
   if (has_ignore_label_) {
+    // NOLINT_NEXT_LINE(whitespace/operators)
     EuclideanLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(count),
-        CAFFE_CUDA_NUM_THREADS>>>(count, bottom[1]->gpu_data(),
+        CAFFE_CUDA_NUM_THREADS>>>(count, bottom[1]->mutable_gpu_data(),
                                   bottom[0]->mutable_gpu_data(),
                                   ignore_label_);
   }

--- a/src/caffe/layers/euclidean_loss_layer.cu
+++ b/src/caffe/layers/euclidean_loss_layer.cu
@@ -7,13 +7,12 @@ namespace caffe {
 
 template <typename Dtype>
 __global__ void EuclideanLossForwardGPU(const int n,
-          Dtype* label_data_, Dtype* bottom_data_,
+          const Dtype* label_data_, Dtype* diff__data_,
           const int ignore_label_) {
   CUDA_KERNEL_LOOP(index, n) {
     const int label_value = static_cast<int>(label_data_[index]);
     if (label_value == ignore_label_) {
-      label_data_[index] = ignore_label_;
-      bottom_data_[index] = ignore_label_;
+      diff__data_[index] = 0;
     }
   }
 }
@@ -22,18 +21,18 @@ template <typename Dtype>
 void EuclideanLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   int count = bottom[0]->count();
-  if (has_ignore_label_) {
-    // NOLINT_NEXT_LINE(whitespace/operators)
-    EuclideanLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(count),
-        CAFFE_CUDA_NUM_THREADS>>>(count, bottom[1]->mutable_gpu_data(),
-                                  bottom[0]->mutable_gpu_data(),
-                                  ignore_label_);
-  }
   caffe_gpu_sub(
       count,
       bottom[0]->gpu_data(),
       bottom[1]->gpu_data(),
       diff_.mutable_gpu_data());
+  if (has_ignore_label_) {
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    EuclideanLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(count),
+        CAFFE_CUDA_NUM_THREADS>>>(count, bottom[1]->gpu_data(),
+                                  diff_.mutable_gpu_data(),
+                                  ignore_label_);
+  }
   Dtype dot;
   caffe_gpu_dot(count, diff_.gpu_data(), diff_.gpu_data(), &dot);
   Dtype loss = dot / bottom[0]->num() / Dtype(2);

--- a/src/caffe/layers/euclidean_loss_layer.cu
+++ b/src/caffe/layers/euclidean_loss_layer.cu
@@ -6,9 +6,27 @@
 namespace caffe {
 
 template <typename Dtype>
+__global__ void EuclideanLossForwardGPU(const int n,
+          const Dtype* label_data_, Dtype* bottom_data_,
+          const int ignore_label_) {
+  CUDA_KERNEL_LOOP(index, n) {
+    const int label_value = static_cast<int>(label_data_[index]);
+    if (label_value == ignore_label_) {
+      bottom_data_[index] = label_data_[index];
+    }
+  }
+}
+
+template <typename Dtype>
 void EuclideanLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   int count = bottom[0]->count();
+  if (has_ignore_label_) {
+    EuclideanLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(count),
+        CAFFE_CUDA_NUM_THREADS>>>(count, bottom[1]->gpu_data(),
+                                  bottom[0]->mutable_gpu_data(),
+                                  ignore_label_);
+  }
   caffe_gpu_sub(
       count,
       bottom[0]->gpu_data(),

--- a/src/caffe/test/test_euclidean_loss_layer.cpp
+++ b/src/caffe/test/test_euclidean_loss_layer.cpp
@@ -86,4 +86,76 @@ TYPED_TEST(EuclideanLossLayerTest, TestGradient) {
       this->blob_top_vec_);
 }
 
+TYPED_TEST(EuclideanLossLayerTest, TestForwardIgnoreLabel) {
+  typedef typename TypeParam::Dtype Dtype;
+  // First, compute the loss with ignored labels
+  LayerParameter layer_param;
+  const Dtype kIgnoreLabelValue = -1;
+  layer_param.mutable_loss_param()->set_ignore_label(int(kIgnoreLabelValue));
+  this->blob_bottom_label_->mutable_cpu_data()[1] = kIgnoreLabelValue;
+  this->blob_bottom_label_->mutable_cpu_data()[5] = kIgnoreLabelValue;
+  this->blob_bottom_label_->mutable_cpu_data()[10] = kIgnoreLabelValue;
+  EuclideanLossLayer<Dtype> layer_ignore(layer_param);
+  layer_ignore.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  const Dtype loss_ignore =
+      layer_ignore.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // Then, manually compute the loss for known ignored indices
+  int count = this->blob_bottom_label_->count();
+  Dtype loss_manual = 0;
+  for(int i = 0; i < count; ++i) {
+    if (i == 1 || i == 5 || i == 10) {
+      continue;
+    }
+    const Dtype a = this->blob_bottom_label_->mutable_cpu_data()[i];
+    const Dtype b = this->blob_bottom_data_->mutable_cpu_data()[i];
+    Dtype dot = (a-b)*(a-b);
+    loss_manual += dot;
+  }
+  loss_manual = loss_manual / this->blob_bottom_data_->num() / Dtype(2);
+  // Finally, compare the two losses
+  EXPECT_NEAR(loss_ignore, loss_manual, 1e-4);
+}
+
+TYPED_TEST(EuclideanLossLayerTest, TestGradientIgnoreLabel) {
+  typedef typename TypeParam::Dtype Dtype;
+  // First, compute the diffs without ignored labels
+  LayerParameter layer_param;
+  const Dtype kIgnoreLabelValue = -1;
+  EuclideanLossLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  vector<bool> propagate_down(2);
+  propagate_down[0] = true;
+  propagate_down[1] = true;
+  layer.Backward(this->blob_top_vec_, propagate_down, this->blob_bottom_vec_);
+  int count = this->blob_bottom_label_->count();
+  // Next, sum up the diffs (except for ignored indices and label_value that gets ignored during typecasting)
+  Dtype accum_grad_a[2] = {0, 0};
+  for(int i = 0; i < count; ++i) {
+    const int label_value = static_cast<int>(this->blob_bottom_label_->cpu_data()[i]);
+    if (i == 2 || i == 6 || i == 11 || label_value == int(kIgnoreLabelValue)) {
+      continue;
+    }
+    accum_grad_a[0] += this->blob_bottom_data_->mutable_cpu_diff()[i];
+    accum_grad_a[1] += this->blob_bottom_label_->mutable_cpu_diff()[i];
+  }
+  // Compute the diffs with ignored labels and sum them up
+  layer_param.mutable_loss_param()->set_ignore_label(int(kIgnoreLabelValue));
+  this->blob_bottom_label_->mutable_cpu_data()[2] = kIgnoreLabelValue;
+  this->blob_bottom_label_->mutable_cpu_data()[6] = kIgnoreLabelValue;
+  this->blob_bottom_label_->mutable_cpu_data()[11] = kIgnoreLabelValue;
+  EuclideanLossLayer<Dtype> layer_ignore(layer_param);
+  layer_ignore.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer_ignore.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer_ignore.Backward(this->blob_top_vec_, propagate_down, this->blob_bottom_vec_);;
+  Dtype accum_grad_b[2] = {0, 0};
+  for(int i = 0; i < count; ++i) {
+    accum_grad_b[0] += this->blob_bottom_data_->mutable_cpu_diff()[i];
+    accum_grad_b[1] += this->blob_bottom_label_->mutable_cpu_diff()[i];
+  }
+  // Compare the diffs
+  EXPECT_NEAR(accum_grad_a[0], accum_grad_b[0], 1e-4);
+  EXPECT_NEAR(accum_grad_a[1], accum_grad_b[1], 1e-4);
+}
+
 }  // namespace caffe

--- a/src/caffe/test/test_euclidean_loss_layer.cpp
+++ b/src/caffe/test/test_euclidean_loss_layer.cpp
@@ -102,7 +102,7 @@ TYPED_TEST(EuclideanLossLayerTest, TestForwardIgnoreLabel) {
   // Then, manually compute the loss for known ignored indices
   int count = this->blob_bottom_label_->count();
   Dtype loss_manual = 0;
-  for(int i = 0; i < count; ++i) {
+  for (int i = 0; i < count; ++i) {
     if (i == 1 || i == 5 || i == 10) {
       continue;
     }

--- a/src/caffe/test/test_euclidean_loss_layer.cpp
+++ b/src/caffe/test/test_euclidean_loss_layer.cpp
@@ -91,7 +91,7 @@ TYPED_TEST(EuclideanLossLayerTest, TestForwardIgnoreLabel) {
   // First, compute the loss with ignored labels
   LayerParameter layer_param;
   const Dtype kIgnoreLabelValue = -1;
-  layer_param.mutable_loss_param()->set_ignore_label(int(kIgnoreLabelValue));
+  layer_param.mutable_loss_param()->set_ignore_label(kIgnoreLabelValue);
   this->blob_bottom_label_->mutable_cpu_data()[1] = kIgnoreLabelValue;
   this->blob_bottom_label_->mutable_cpu_data()[5] = kIgnoreLabelValue;
   this->blob_bottom_label_->mutable_cpu_data()[10] = kIgnoreLabelValue;
@@ -118,44 +118,17 @@ TYPED_TEST(EuclideanLossLayerTest, TestForwardIgnoreLabel) {
 
 TYPED_TEST(EuclideanLossLayerTest, TestGradientIgnoreLabel) {
   typedef typename TypeParam::Dtype Dtype;
-  // First, compute the diffs without ignored labels
+  // First, set some labels to the ignored label
   LayerParameter layer_param;
   const Dtype kIgnoreLabelValue = -1;
-  EuclideanLossLayer<Dtype> layer(layer_param);
-  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
-  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
-  vector<bool> propagate_down(2);
-  propagate_down[0] = true;
-  propagate_down[1] = true;
-  layer.Backward(this->blob_top_vec_, propagate_down, this->blob_bottom_vec_);
-  int count = this->blob_bottom_label_->count();
-  // Next, sum up the diffs (except for ignored indices and label_value that gets ignored during typecasting)
-  Dtype accum_grad_a[2] = {0, 0};
-  for(int i = 0; i < count; ++i) {
-    const int label_value = static_cast<int>(this->blob_bottom_label_->cpu_data()[i]);
-    if (i == 2 || i == 6 || i == 11 || label_value == int(kIgnoreLabelValue)) {
-      continue;
-    }
-    accum_grad_a[0] += this->blob_bottom_data_->mutable_cpu_diff()[i];
-    accum_grad_a[1] += this->blob_bottom_label_->mutable_cpu_diff()[i];
-  }
-  // Compute the diffs with ignored labels and sum them up
-  layer_param.mutable_loss_param()->set_ignore_label(int(kIgnoreLabelValue));
   this->blob_bottom_label_->mutable_cpu_data()[2] = kIgnoreLabelValue;
   this->blob_bottom_label_->mutable_cpu_data()[6] = kIgnoreLabelValue;
   this->blob_bottom_label_->mutable_cpu_data()[11] = kIgnoreLabelValue;
-  EuclideanLossLayer<Dtype> layer_ignore(layer_param);
-  layer_ignore.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
-  layer_ignore.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
-  layer_ignore.Backward(this->blob_top_vec_, propagate_down, this->blob_bottom_vec_);;
-  Dtype accum_grad_b[2] = {0, 0};
-  for(int i = 0; i < count; ++i) {
-    accum_grad_b[0] += this->blob_bottom_data_->mutable_cpu_diff()[i];
-    accum_grad_b[1] += this->blob_bottom_label_->mutable_cpu_diff()[i];
-  }
-  // Compare the diffs
-  EXPECT_NEAR(accum_grad_a[0], accum_grad_b[0], 1e-4);
-  EXPECT_NEAR(accum_grad_a[1], accum_grad_b[1], 1e-4);
+  EuclideanLossLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  GradientChecker<Dtype> checker(1e-2, 1e-2, 1701);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_);
 }
 
 }  // namespace caffe


### PR DESCRIPTION
Typecast the labels to `int` type and ignore the labels if they are equal to `ignore_label_`.
