### PR TITLE
command-line interface to modelzoo

### DIFF
--- a/scripts/modelzoo.py
+++ b/scripts/modelzoo.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+"""
+modelzoo is a CLI tool for listing
+
+TASKS
+
+[ ] integrate scripts/download_model_binary.py
+[ ] integrate scripts/upload_model_to_gist.sh
+"""
+
+import os
+import json
+import click
+import urllib2
+import subprocess
+import dateutil.parser
+
+
+URL = "http://www.modelzoo.co/models"
+
+
+@click.group()
+def cli():
+    "List and download publicly available Caffe models."
+    pass
+
+
+@cli.command()
+def list():
+    gists = json.load(urllib2.urlopen(URL + '.json'))
+    for gist in gists:
+        if gist is None:
+            click.secho("Could not retrieve info", fg='red')
+        else:
+            click.secho("\n[{}]".format(gist['id']), fg='green', nl=False)
+            click.echo("\t{}".format(gist['description']))
+            click.echo("\towner: {}\tcreated: {}\tupdated: {}".format(
+                gist['owner'],
+                dateutil.parser.parse(gist['created_at']).strftime('%Y-%m-%d'),
+                dateutil.parser.parse(gist['updated_at']).strftime('%Y-%m-%d')
+            ))
+            click.echo("\tgist: {}".format(gist['gist_id']))
+
+
+@cli.command()
+@click.argument('index_or_gist_id')
+@click.option('--dirname', default='./models', help='where to download model')
+def get(index_or_gist_id, dirname):
+    model_dirname = os.path.join(dirname, 'modelzoo_' + index_or_gist_id)
+    if os.path.exists(model_dirname):
+        print("{} already exists! Make sure you're not overwriting you don't mean to.".format(model_dirname))
+        exit(1)
+    os.makedirs(model_dirname)
+
+    print("Downloading model...")
+    resource = urllib2.urlopen('{}/{}/download'.format(URL, index_or_gist_id))
+
+    zip_filename = model_dirname + "/gist.zip"
+    with open(zip_filename, 'wb') as file:
+        file.write(resource.read())
+
+    subprocess.call(['unzip', '-j', zip_filename, '-d', model_dirname])
+    print("Extracted model to {}".format(model_dirname))
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
The Caffe Model Zoo has been effective for dissemination of research and other community-trained models, but the wiki format limits what can be achieved. Instead, a database-backed website could allow yet greater sharing and access.

Here, I propose http://modelzoo.co as such website, with an associated command-line utility `modelzoo`. It should act much like `pip`, the Python Package Index. It's currently seeded with every model gist listed on the wiki.

<img width="1007" alt="screenshot 2016-02-22 17 38 16" src="https://cloud.githubusercontent.com/assets/4881/13238913/2fd09c08-d98b-11e5-8a9a-bd634b9bb073.png">

<img width="879" alt="screenshot 2016-02-22 17 38 51" src="https://cloud.githubusercontent.com/assets/4881/13238915/317c35da-d98b-11e5-8450-81c97677319c.png">

<img width="450" alt="screenshot 2016-02-22 17 34 45" src="https://cloud.githubusercontent.com/assets/4881/13238821/9461aabe-d98a-11e5-80fd-d2d5c0d86663.png">
