### PR TITLE
CMake: Do not include "${PROJECT_BINARY_DIR}/include" with SYSTEM option

### DIFF
--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -23,7 +23,7 @@ endif()
 
 # place where to generate protobuf sources
 set(proto_gen_folder "${PROJECT_BINARY_DIR}/include/caffe/proto")
-include_directories(SYSTEM "${PROJECT_BINARY_DIR}/include")
+include_directories("${PROJECT_BINARY_DIR}/include")
 
 set(PROTOBUF_GENERATE_CPP_APPEND_PATH TRUE)
 


### PR DESCRIPTION
This is important for the include order. Without this patch, a
previously installed caffe.pb.h might be included instead of the one
that is generated during the build.