### PR TITLE
supporting N-D Blobs in Dropout layer Reshape

### DIFF
--- a/src/caffe/layers/dropout_layer.cpp
+++ b/src/caffe/layers/dropout_layer.cpp
@@ -23,8 +23,8 @@ void DropoutLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   NeuronLayer<Dtype>::Reshape(bottom, top);
   // Set up the cache for random number generation
-  rand_vec_.Reshape(bottom[0]->num(), bottom[0]->channels(),
-      bottom[0]->height(), bottom[0]->width());
+  // ReshapeLike does not work because rand_vec_ is of Dtype uint
+  rand_vec_.Reshape(bottom[0]->shape());
 }
 
 template <typename Dtype>


### PR DESCRIPTION
`Reshape` method of Dropout layer `reshape`s `rand_vec_` using deprecated shape methods (`num()`, `channels()`, `height()` and `width()`). 
Replacing these methods with newer `shape()` allows Dorpout layer to work on Blobs with `num_axes()>4`.

**This PR is a small patch**

Thank you!