### PR TITLE
Update db_lmdb.cpp

### DIFF
--- a/src/caffe/util/db_lmdb.cpp
+++ b/src/caffe/util/db_lmdb.cpp
@@ -7,7 +7,9 @@
 
 namespace caffe { namespace db {
 
-const size_t LMDB_MAP_SIZE = 1099511627776;  // 1 TB
+//const size_t LMDB_MAP_SIZE = 1099511627776;  // 1 TB
+
+const size_t LMDB_MAP_SIZE = 536870912;
 
 void LMDB::Open(const string& source, Mode mode) {
   MDB_CHECK(mdb_env_create(&mdb_env_));


### PR DESCRIPTION
The huge value of map size is causing problem for ARMv7 processors. Suggesting appropriately small value for the map size.