### PR TITLE
[WIP] Allow for pooling over the first blob axis based on a key

### DIFF
--- a/include/caffe/layers/key_pooling_layer.hpp
+++ b/include/caffe/layers/key_pooling_layer.hpp
@@ -52,10 +52,7 @@ class KeyPoolingLayer : public Layer<Dtype> {
   vector<Dtype> has_keys_;
   // Store the start and end indices for each key in the input array.
   vector<int> key_start_;
-  vector<int> key_end_;
-
-  int largest_key_set_;
-
+  vector<int> key_len_;
 
 };
 

--- a/include/caffe/layers/key_pooling_layer.hpp
+++ b/include/caffe/layers/key_pooling_layer.hpp
@@ -48,6 +48,7 @@ class KeyPoolingLayer : public Layer<Dtype> {
 
   // The following layer is used to perform the pooling per-key.
   PoolingLayer<Dtype> pooling_layer_;
+  Blob<Dtype> key_top_mask_;
   // Store the keys for each of the elements in the generated top.
   vector<Dtype> has_keys_;
   // Store the start and end indices for each key in the input array.

--- a/include/caffe/layers/key_pooling_layer.hpp
+++ b/include/caffe/layers/key_pooling_layer.hpp
@@ -1,0 +1,64 @@
+#ifndef CAFFE_KEY_POOLING_LAYER_HPP_
+#define CAFFE_KEY_POOLING_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/layers/pooling_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Pools the input image by taking the max, average, etc. within regions.
+ *
+ * TODO(dox): thorough documentation for Forward, Backward, and proto params.
+ */
+template <typename Dtype>
+class KeyPoolingLayer : public Layer<Dtype> {
+ public:
+  explicit KeyPoolingLayer(const LayerParameter& param)
+      : Layer<Dtype>(param), pooling_layer_(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "KeyPooling"; }
+  virtual inline int ExactNumBottomBlobs() const { return 2; }
+  virtual inline int MinTopBlobs() const { return 1; }
+  // MAX POOL layers can output an extra top blob for the mask;
+  // others can only output the pooled inputs.
+  // The list of keys can also be an output
+  virtual inline int MaxTopBlobs() const {
+    return (this->layer_param_.pooling_param().pool() ==
+            PoolingParameter_PoolMethod_MAX) ? 3 : 2;
+  }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  // virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+  //     const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  // virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+  //     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  // The following layer is used to perform the pooling per-key.
+  PoolingLayer<Dtype> pooling_layer_;
+  // Store the keys for each of the elements in the generated top.
+  vector<Dtype> has_keys_;
+  // Store the start and end indices for each key in the input array.
+  vector<int> key_start_;
+  vector<int> key_end_;
+
+  int largest_key_set_;
+
+
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_KEY_POOLING_LAYER_HPP_

--- a/src/caffe/layers/key_pooling_layer.cpp
+++ b/src/caffe/layers/key_pooling_layer.cpp
@@ -12,18 +12,16 @@ using std::max;
 
 template <typename Dtype>
 void KeyPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top) {
+                                        const vector<Blob<Dtype>*>& top) {
   CHECK_EQ(bottom[0]->shape(0), bottom[1]->shape(0))
       << "The number of keys must be equal to the size of the batch";
 
   pooling_layer_.LayerSetUp(bottom, top);
-
 }
 
 template <typename Dtype>
 void KeyPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top) {
-
+                                     const vector<Blob<Dtype>*>& top) {
   int num_keys = bottom[1]->shape(0);
   has_keys_.clear();
   key_start_.clear();
@@ -50,18 +48,18 @@ void KeyPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
         j++;
         key_end_.push_back(i);
 
-        largest_key_set_ = std::max(key_end_[j-1] - key_start_[j-1], largest_key_set_);
+        largest_key_set_ =
+            std::max(key_end_[j - 1] - key_start_[j - 1], largest_key_set_);
 
         current_key = keys[i];
         has_keys_.push_back(current_key);
         key_start_.push_back(i);
-
       }
     }
     key_end_.push_back(num_keys);
 
-
-    largest_key_set_ = std::max(key_end_[num_keys-1] - key_start_[num_keys-1], largest_key_set_);
+    largest_key_set_ = std::max(
+        key_end_[num_keys - 1] - key_start_[num_keys - 1], largest_key_set_);
   }
 
   CHECK_LE(has_keys_.size(), num_keys);
@@ -77,14 +75,11 @@ void KeyPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   if (top.size() > 2) {
     top[2]->Reshape(has_keys_.size(), 1, 1, 1);
   }
-
 }
 
 template <typename Dtype>
 void KeyPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-      const vector<Blob<Dtype>*>& top) {
-
-
+                                         const vector<Blob<Dtype>*>& top) {
   for (int i = 0; i < has_keys_.size(); ++i) {
     // Create a local copy of the blobs for the top and the bottom
     Blob<Dtype> key_bottom;
@@ -99,18 +94,19 @@ void KeyPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     bottom_shape[0] = key_end_[i] - key_start_[i];
     key_bottom.Reshape(bottom_shape);
 
-    const Dtype *bottom_data = bottom[0]->cpu_data();
+    const Dtype* bottom_data = bottom[0]->cpu_data();
     caffe_copy(key_bottom.count(),
                &bottom_data[bottom[0]->offset(key_start_[i])],
                key_bottom.mutable_cpu_data());
 
+    // Perform pooling on this key.
     pooling_layer_.Forward(pooling_bottoms, pooling_tops);
 
     key_top_mask.Reshape(key_top.shape());
+    Dtype* key_pool = key_top.mutable_cpu_data();
+    Dtype* key_mask = key_top_mask.mutable_cpu_data();
 
-    Dtype *key_pool = key_top.mutable_cpu_data();
-    Dtype *key_mask = key_top_mask.mutable_cpu_data();
-    caffe_set(key_top.count(), Dtype(key_start_[i]), key_mask);
+    caffe_set(key_mask.count(), Dtype(key_start_[i]), key_mask);
     for (int j = 1; j < key_top.shape(0); ++j) {
       int j_offset = key_top.offset(j);
       for (int k = 0; k < key_top.count(1); ++k) {
@@ -134,12 +130,12 @@ void KeyPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   if (top.size() > 2) {
     caffe_copy(has_keys_.size(), &has_keys_[0], top[2]->mutable_cpu_data());
   }
-
 }
 
 template <typename Dtype>
 void KeyPoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
-      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+                                          const vector<bool>& propagate_down,
+                                          const vector<Blob<Dtype>*>& bottom) {
   pooling_layer_.Backward(bottom, propagate_down, top);
 }
 

--- a/src/caffe/layers/key_pooling_layer.cpp
+++ b/src/caffe/layers/key_pooling_layer.cpp
@@ -1,0 +1,114 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/key_pooling_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+using std::min;
+using std::max;
+
+template <typename Dtype>
+void KeyPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  CHECK_EQ(bottom[0]->shape(0), bottom[1]->shape(0))
+      << "The number of keys must be equal to the size of the batch";
+
+  pooling_layer_.LayerSetUp(bottom, top);
+
+}
+
+template <typename Dtype>
+void KeyPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+
+  int num_keys = bottom[1]->shape(0);
+  has_keys_.clear();
+  key_start_.clear();
+  key_end_.clear();
+
+  vector<Blob<Dtype>*> pooling_top;
+  pooling_top.push_back(top[0]);
+
+  pooling_layer_.Reshape(bottom, pooling_top);
+
+  if (num_keys > 0) {
+    const Dtype* keys = bottom[1]->cpu_data();
+
+    Dtype current_key = keys[0];
+    has_keys_.push_back(current_key);
+    key_start_.push_back(0);
+
+    int j = 0;
+    for (int i = 1; i < num_keys; ++i) {
+      if (keys[i] != current_key) {
+        j++;
+        key_end_.push_back(i);
+
+        largest_key_set_ = std::max(key_end_[j-1] - key_start_[j-1], largest_key_set_);
+
+        current_key = keys[i];
+        has_keys_.push_back(current_key);
+        key_start_.push_back(i);
+
+      }
+    }
+    key_end_.push_back(num_keys);
+
+
+    largest_key_set_ = std::max(key_end_[num_keys-1] - key_start_[num_keys-1], largest_key_set_);
+  }
+
+  CHECK_LE(has_keys_.size(), num_keys);
+
+  // Resize the tops to match the keys.
+  vector<int> required_shape(top[0]->shape());
+  required_shape[0] = has_keys_.size();
+  top[0]->Reshape(required_shape);
+
+  if (top.size() > 1) {
+    top[1]->Reshape(has_keys_.size(), 1, 1, 1);
+  }
+
+}
+
+template <typename Dtype>
+void KeyPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+
+  vector<Blob<Dtype>*> pooling_top;
+  pooling_top.push_back(top[0]);
+
+  for (int i = 0; i < has_keys_.size(); ++i) {
+    // Create a local copy of the blobs for the top and the bottom
+    Blob<Dtype> key_bottom;
+    Blob<Dtype> key_top;
+
+
+
+
+
+    pooling_layer_.Forward(bottom, pooling_top);
+
+  }
+
+
+
+
+  if (top.size() > 1) {
+    caffe_copy(has_keys_.size(), &has_keys_[0], top[1]->mutable_cpu_data());
+  }
+
+}
+
+template <typename Dtype>
+void KeyPoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  pooling_layer_.Backward(bottom, propagate_down, top);
+}
+
+INSTANTIATE_CLASS(KeyPoolingLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/key_pooling_layer.cpp
+++ b/src/caffe/layers/key_pooling_layer.cpp
@@ -106,7 +106,7 @@ void KeyPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     Dtype* key_pool = key_top.mutable_cpu_data();
     Dtype* key_mask = key_top_mask.mutable_cpu_data();
 
-    caffe_set(key_mask.count(), Dtype(key_start_[i]), key_mask);
+    caffe_set(key_top_mask.count(), Dtype(key_start_[i]), key_mask);
     for (int j = 1; j < key_top.shape(0); ++j) {
       int j_offset = key_top.offset(j);
       for (int k = 0; k < key_top.count(1); ++k) {

--- a/src/caffe/layers/key_pooling_layer.cpp
+++ b/src/caffe/layers/key_pooling_layer.cpp
@@ -95,7 +95,7 @@ void KeyPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     per_key_bottom.Reshape(bottom_shape);
     per_key_top_mask.Reshape(top_shape);
 
-#if 0
+#ifdef USE_CPU_INPLACE
     // Set the bottom as a view into the alocated blob.
     per_key_bottom.set_cpu_data(
         &bottom[0]->mutable_cpu_data()[bottom[0]->offset(key_start_[i])]);
@@ -113,7 +113,7 @@ void KeyPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     // Perform pooling on this key.
     pooling_layer_.Forward(pooling_bottoms, pooling_tops);
 
-#if 0
+#ifdef USE_CPU_INPLACE
     // TODO: Currently the max pooling layer returns indices for each image
     // channel. Update these by adding the collection and channel offsets.
     Dtype* top_mask =
@@ -146,7 +146,7 @@ void KeyPoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       }
     }
 
-#if 0
+#ifdef USE_CPU_INPLACE
 #else
     caffe_copy(per_key_top_mask.count(),
            per_key_top_mask.cpu_data(),

--- a/src/caffe/layers/key_pooling_layer.cpp
+++ b/src/caffe/layers/key_pooling_layer.cpp
@@ -165,14 +165,14 @@ void KeyPoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
                                           const vector<bool>& propagate_down,
                                           const vector<Blob<Dtype>*>& bottom) {
 
-  Dtype *bottom_data = bottom[0]->mutable_cpu_data();
+  Dtype *bottom_diff = bottom[0]->mutable_cpu_diff();
   const Dtype *top_diff = top[0]->cpu_diff();
   const Dtype *mask = key_top_mask_.cpu_data();
   for (int i = 0; i < has_keys_.size(); ++i) {
     const int top_offset = top[0]->offset(i);
     for (int pi = 0; pi < key_top_mask_.count(1); ++pi) {
       const int bottom_index = mask[top_offset + pi];
-      bottom_data[bottom_index] += top_diff[top_offset + pi];
+      bottom_diff[bottom_index] += top_diff[top_offset + pi];
     }
   }
 }

--- a/src/caffe/test/test_key_pooling_layer.cpp
+++ b/src/caffe/test/test_key_pooling_layer.cpp
@@ -71,7 +71,8 @@ TYPED_TEST(KeyPoolingLayerTest, TestAllKeysDifferentIsStdPooling) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_global_pooling(true);
+  pooling_param->set_kernel_size(1);
+
   KeyPoolingLayer<Dtype> layer(layer_param);
   PoolingLayer<Dtype> ref_layer(layer_param);
 
@@ -110,7 +111,8 @@ TYPED_TEST(KeyPoolingLayerTest, TestKeySameReduces) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_global_pooling(true);
+  pooling_param->set_kernel_size(1);
+
   KeyPoolingLayer<Dtype> layer(layer_param);
   PoolingLayer<Dtype> ref_layer(layer_param);
 
@@ -138,10 +140,9 @@ TYPED_TEST(KeyPoolingLayerTest, TestKeySameReduces) {
   ref_layer.Forward(ref_bottom_vec, ref_top_vec);
 
   EXPECT_EQ(this->blob_top_keys_->count(), 1);
-  EXPECT_EQ(this->blob_top_->cpu_data()[0], this->blob_bottom_->count()-1);
-  // for (int i = 0; i < this->blob_top_->count(); ++i) {
-  //   EXPECT_EQ(this->blob_top_->cpu_data()[i], ref_top.cpu_data()[i]);
-  // }
+  for (int i = 0; i < this->blob_top_->count(); ++i) {
+    EXPECT_EQ(this->blob_top_->cpu_data()[i], i + 28);
+  }
 }
 
 
@@ -149,8 +150,7 @@ TYPED_TEST(KeyPoolingLayerTest, TestDifferentKeyGroups) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_h(1);
-  pooling_param->set_kernel_w(1);
+  pooling_param->set_global_pooling(true);
 
   KeyPoolingLayer<Dtype> layer(layer_param);
   PoolingLayer<Dtype> ref_layer(layer_param);
@@ -180,12 +180,159 @@ TYPED_TEST(KeyPoolingLayerTest, TestDifferentKeyGroups) {
   EXPECT_EQ(this->blob_top_keys_->count(), 2);
 
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
-  ref_layer.Forward(ref_bottom_vec, ref_top_vec);
 
   EXPECT_EQ(this->blob_top_keys_->count(), 2);
-  for (int i = 0; i < this->blob_top_->count(); ++i) {
-    EXPECT_EQ(this->blob_top_->cpu_data()[i], ref_top.cpu_data()[i]);
-  }
+
+  EXPECT_EQ(this->blob_top_->cpu_data()[0], 13);
+  EXPECT_EQ(this->blob_top_->cpu_data()[1], 34);
+
 }
+
+
+TYPED_TEST(KeyPoolingLayerTest, TestForwardMax) {
+  typedef typename TypeParam::Dtype Dtype;
+  const int num_collection = 3;
+  const int num_images = 6;
+  const int channels = 3;
+  const int height = 2;
+  const int width = 3;
+
+  LayerParameter layer_param;
+  PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
+  pooling_param->set_kernel_size(1);
+
+  KeyPoolingLayer<Dtype> layer(layer_param);
+
+  this->blob_bottom_keys_->Reshape(num_images, 1, 1, 1);
+  Dtype *key_data = this->blob_bottom_keys_->mutable_cpu_data();
+  key_data[0] = 0;
+  key_data[1] = 1; key_data[2] = 1; key_data[3] = 1;
+  key_data[4] = 2; key_data[5] = 2;
+
+  this->blob_bottom_->Reshape(num_images, channels, height, width);
+  // consider the following 3 collections, 6 images of format 3x2
+  // [1 0 1]  ||  [1 0 0]    [0 2 0]    [3 3 0]  ||  [1 0 2]    [ 2 1 5]
+  // [0 0 1]  ||  [0 0 1]    [0 2 0]    [3 0 0]  ||  [0 4 1]    [-1 2 1]
+  // where the channel index is added to each pixel
+  // in order to produce different arrays for different channels
+  Dtype* image = this->blob_bottom_->mutable_cpu_data();
+  for (int i = 0; i < channels; ++i) {
+    // image 0
+    image[this->blob_bottom_->offset(0, i) + 0] = 1 + i;
+    image[this->blob_bottom_->offset(0, i) + 1] = 0 + i;
+    image[this->blob_bottom_->offset(0, i) + 2] = 1 + i;
+    image[this->blob_bottom_->offset(0, i) + 3] = 0 + i;
+    image[this->blob_bottom_->offset(0, i) + 4] = 0 + i;
+    image[this->blob_bottom_->offset(0, i) + 5] = 1 + i;
+    // image 1
+    image[this->blob_bottom_->offset(1, i) + 0] = 1 + i;
+    image[this->blob_bottom_->offset(1, i) + 1] = 0 + i;
+    image[this->blob_bottom_->offset(1, i) + 2] = 0 + i;
+    image[this->blob_bottom_->offset(1, i) + 3] = 0 + i;
+    image[this->blob_bottom_->offset(1, i) + 4] = 0 + i;
+    image[this->blob_bottom_->offset(1, i) + 5] = 1 + i;
+    // image 2
+    image[this->blob_bottom_->offset(2, i) + 0] = 0 + i;
+    image[this->blob_bottom_->offset(2, i) + 1] = 2 + i;
+    image[this->blob_bottom_->offset(2, i) + 2] = 0 + i;
+    image[this->blob_bottom_->offset(2, i) + 3] = 0 + i;
+    image[this->blob_bottom_->offset(2, i) + 4] = 2 + i;
+    image[this->blob_bottom_->offset(2, i) + 5] = 0 + i;
+    // image 3
+    image[this->blob_bottom_->offset(3, i) + 0] = 3 + i;
+    image[this->blob_bottom_->offset(3, i) + 1] = 3 + i;
+    image[this->blob_bottom_->offset(3, i) + 2] = 0 + i;
+    image[this->blob_bottom_->offset(3, i) + 3] = 3 + i;
+    image[this->blob_bottom_->offset(3, i) + 4] = 0 + i;
+    image[this->blob_bottom_->offset(3, i) + 5] = 0 + i;
+    // image 4
+    image[this->blob_bottom_->offset(4, i) + 0] = 1 + i;
+    image[this->blob_bottom_->offset(4, i) + 1] = 0 + i;
+    image[this->blob_bottom_->offset(4, i) + 2] = 2 + i;
+    image[this->blob_bottom_->offset(4, i) + 3] = 0 + i;
+    image[this->blob_bottom_->offset(4, i) + 4] = 4 + i;
+    image[this->blob_bottom_->offset(4, i) + 5] = 1 + i;
+    // image 5
+    image[this->blob_bottom_->offset(5, i) + 0] = 2 + i;
+    image[this->blob_bottom_->offset(5, i) + 1] = 1 + i;
+    image[this->blob_bottom_->offset(5, i) + 2] = 5 + i;
+    image[this->blob_bottom_->offset(5, i) + 3] =-1 + i;
+    image[this->blob_bottom_->offset(5, i) + 4] = 2 + i;
+    image[this->blob_bottom_->offset(5, i) + 5] = 1 + i;
+  }
+
+
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+
+  EXPECT_EQ(this->blob_top_->num(), num_collection);
+  EXPECT_EQ(this->blob_top_->channels(), channels);
+  EXPECT_EQ(this->blob_top_->height(), height);
+  EXPECT_EQ(this->blob_top_->width(), width);
+  // if (blob_top_vec_.size() > 1) {
+  //   EXPECT_EQ(blob_top_mask_->num(), num_collection);
+  //   EXPECT_EQ(blob_top_mask_->channels(), channels);
+  //   EXPECT_EQ(blob_top_mask_->height(), height);
+  //   EXPECT_EQ(blob_top_mask_->width(), width);
+  // }
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // Expected output for channel = 0
+  // [1 0 1]  ||  [3 3 0]  ||  [2 1 5]
+  // [0 0 1]  ||  [3 2 1]  ||  [0 4 1]
+  // adding channel index per pixel gives output for channel != 0
+  const Dtype* pooled = this->blob_top_->cpu_data();
+  for (int i = 0; i < channels; ++i) {
+    // output 0
+    EXPECT_EQ(pooled[this->blob_top_->offset(0, i) + 0], 1 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(0, i) + 1], 0 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(0, i) + 2], 1 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(0, i) + 3], 0 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(0, i) + 4], 0 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(0, i) + 5], 1 + i);
+    // output 1
+    EXPECT_EQ(pooled[this->blob_top_->offset(1, i) + 0], 3 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(1, i) + 1], 3 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(1, i) + 2], 0 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(1, i) + 3], 3 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(1, i) + 4], 2 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(1, i) + 5], 1 + i);
+    // output 2
+    EXPECT_EQ(pooled[this->blob_top_->offset(2, i) + 0], 2 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(2, i) + 1], 1 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(2, i) + 2], 5 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(2, i) + 3], 0 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(2, i) + 4], 4 + i);
+    EXPECT_EQ(pooled[this->blob_top_->offset(2, i) + 5], 1 + i);
+  }
+  // if (blob_top_vec_.size() > 1) {
+  //   // test the mask
+  //   // Expected output for every channel
+  //   // [0 0 0]  ||  [3 3 1]  ||  [5 5 5]
+  //   // [0 0 0]  ||  [3 2 1]  ||  [4 4 4]
+  //   for (int i = 0; i < channels; ++i) {
+  //     // output 0
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(0 * channels  + i) * height * width  +  0], 0);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(0 * channels  + i) * height * width  +  1], 0);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(0 * channels  + i) * height * width  +  2], 0);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(0 * channels  + i) * height * width  +  3], 0);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(0 * channels  + i) * height * width  +  4], 0);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(0 * channels  + i) * height * width  +  5], 0);
+  //     // output 1
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(1 * channels  + i) * height * width  +  0], 3);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(1 * channels  + i) * height * width  +  1], 3);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(1 * channels  + i) * height * width  +  2], 1);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(1 * channels  + i) * height * width  +  3], 3);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(1 * channels  + i) * height * width  +  4], 2);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(1 * channels  + i) * height * width  +  5], 1);
+  //     // output 2
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(2 * channels  + i) * height * width  +  0], 5);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(2 * channels  + i) * height * width  +  1], 5);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(2 * channels  + i) * height * width  +  2], 5);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(2 * channels  + i) * height * width  +  3], 4);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(2 * channels  + i) * height * width  +  4], 4);
+  //     EXPECT_EQ(blob_top_mask_->mutable_cpu_data()[(2 * channels  + i) * height * width  +  5], 4);
+  //   }
+  // }
+}
+
 
 }

--- a/src/caffe/test/test_key_pooling_layer.cpp
+++ b/src/caffe/test/test_key_pooling_layer.cpp
@@ -80,30 +80,10 @@ class KeyPoolingLayerTest : public MultiDeviceTest<TypeParam> {
     // [1 0 1]  ||  [3 1 4]  ||  [-1 2 1]
     // where the channel index is added to each pixel
     // in order to produce different arrays for different channels
-    Dtype *top_diff = blob_top_->mutable_cpu_diff();
-    for (int i = 0; i < shape[1]; ++i) {
-      // diff 0
-      top_diff[blob_top_->offset(0,i,0,0)] = 1 + i;
-      top_diff[blob_top_->offset(0,i,0,1)] = 2 + i;
-      top_diff[blob_top_->offset(0,i,0,2)] = 1 + i;
-      top_diff[blob_top_->offset(0,i,1,0)] = 1 + i;
-      top_diff[blob_top_->offset(0,i,1,1)] = 0 + i;
-      top_diff[blob_top_->offset(0,i,1,2)] = 1 + i;
-      // diff 1
-      top_diff[blob_top_->offset(1,i,0,0)] = 3 + i;
-      top_diff[blob_top_->offset(1,i,0,1)] = 2 + i;
-      top_diff[blob_top_->offset(1,i,0,2)] = 6 + i;
-      top_diff[blob_top_->offset(1,i,1,0)] = 3 + i;
-      top_diff[blob_top_->offset(1,i,1,1)] = 1 + i;
-      top_diff[blob_top_->offset(1,i,1,2)] = 4 + i;
-      // diff 2
-      top_diff[blob_top_->offset(2,i,0,0)] = 2 + i;
-      top_diff[blob_top_->offset(2,i,0,1)] = 1 + i;
-      top_diff[blob_top_->offset(2,i,0,2)] = 5 + i;
-      top_diff[blob_top_->offset(2,i,1,0)] =-1 + i;
-      top_diff[blob_top_->offset(2,i,1,1)] = 2 + i;
-      top_diff[blob_top_->offset(2,i,1,2)] = 1 + i;
-    }
+    FillerParameter filler_param;
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_top_);
+
     // define top_mask, needed for MAX pooling tests
     blob_top_mask_->Reshape(shape);
     // channel 0,1
@@ -113,50 +93,26 @@ class KeyPoolingLayerTest : public MultiDeviceTest<TypeParam> {
     // [0 0 0]  ||  [1 2 1]  ||  [5 4 5]
     // [0 0 0]  ||  [3 1 3]  ||  [5 4 4]
     Dtype *top_mask = blob_top_mask_->mutable_cpu_data();
-    for (int i = 0; i < shape[1] - 1; ++i) {
-      // mask 0
-      top_mask[blob_top_mask_->offset(0,i) + 0] = 0;
-      top_mask[blob_top_mask_->offset(0,i) + 1] = 0;
-      top_mask[blob_top_mask_->offset(0,i) + 2] = 0;
-      top_mask[blob_top_mask_->offset(0,i) + 3] = 0;
-      top_mask[blob_top_mask_->offset(0,i) + 4] = 0;
-      top_mask[blob_top_mask_->offset(0,i) + 5] = 0;
-      // mask 1
-      top_mask[blob_top_mask_->offset(1,i) + 0] = 3;
-      top_mask[blob_top_mask_->offset(1,i) + 1] = 3;
-      top_mask[blob_top_mask_->offset(1,i) + 2] = 1;
-      top_mask[blob_top_mask_->offset(1,i) + 3] = 3;
-      top_mask[blob_top_mask_->offset(1,i) + 4] = 2;
-      top_mask[blob_top_mask_->offset(1,i) + 5] = 1;
-      // mask 2
-      top_mask[blob_top_mask_->offset(2,i) + 0] = 5;
-      top_mask[blob_top_mask_->offset(2,i) + 1] = 5;
-      top_mask[blob_top_mask_->offset(2,i) + 2] = 5;
-      top_mask[blob_top_mask_->offset(2,i) + 3] = 4;
-      top_mask[blob_top_mask_->offset(2,i) + 4] = 4;
-      top_mask[blob_top_mask_->offset(2,i) + 5] = 4;
+    // Collection 0
+    for (int i = 0; i < blob_top_mask_->count(1); ++i) {
+      top_mask[blob_top_mask_->offset(0) + i] = i;
     }
-    // mask 0
-    top_mask[blob_top_mask_->offset(0,2) + 0] = 0;
-    top_mask[blob_top_mask_->offset(0,2) + 1] = 0;
-    top_mask[blob_top_mask_->offset(0,2) + 2] = 0;
-    top_mask[blob_top_mask_->offset(0,2) + 3] = 0;
-    top_mask[blob_top_mask_->offset(0,2) + 4] = 0;
-    top_mask[blob_top_mask_->offset(0,2) + 5] = 0;
-    // mask 1
-    top_mask[blob_top_mask_->offset(1,2) + 0] = 1;
-    top_mask[blob_top_mask_->offset(1,2) + 1] = 2;
-    top_mask[blob_top_mask_->offset(1,2) + 2] = 1;
-    top_mask[blob_top_mask_->offset(1,2) + 3] = 3;
-    top_mask[blob_top_mask_->offset(1,2) + 4] = 1;
-    top_mask[blob_top_mask_->offset(1,2) + 5] = 3;
-    // mask 2
-    top_mask[blob_top_mask_->offset(2,2) + 0] = 5;
-    top_mask[blob_top_mask_->offset(2,2) + 1] = 4;
-    top_mask[blob_top_mask_->offset(2,2) + 2] = 5;
-    top_mask[blob_top_mask_->offset(2,2) + 3] = 5;
-    top_mask[blob_top_mask_->offset(2,2) + 4] = 4;
-    top_mask[blob_top_mask_->offset(2,2) + 5] = 4;
+    for (int i = 0; i < shape[1]; ++i) {
+      // Collection 1
+      top_mask[blob_top_mask_->offset(1,i,0,0)] = blob_bottom_->offset(1,i,0,0);
+      top_mask[blob_top_mask_->offset(1,i,0,1)] = blob_bottom_->offset(2,i,0,1);
+      top_mask[blob_top_mask_->offset(1,i,0,2)] = blob_bottom_->offset(3,i,0,2);
+      top_mask[blob_top_mask_->offset(1,i,1,0)] = blob_bottom_->offset(1,i,1,2);
+      top_mask[blob_top_mask_->offset(1,i,1,1)] = blob_bottom_->offset(2,i,1,1);
+      top_mask[blob_top_mask_->offset(1,i,1,2)] = blob_bottom_->offset(3,i,1,0);
+      // Collection 2
+      top_mask[blob_top_mask_->offset(2,i,0,0)] = blob_bottom_->offset(4,i,0,0);
+      top_mask[blob_top_mask_->offset(2,i,0,1)] = blob_bottom_->offset(5,i,0,1);
+      top_mask[blob_top_mask_->offset(2,i,0,2)] = blob_bottom_->offset(4,i,0,2);
+      top_mask[blob_top_mask_->offset(2,i,1,0)] = blob_bottom_->offset(5,i,1,2);
+      top_mask[blob_top_mask_->offset(2,i,1,1)] = blob_bottom_->offset(4,i,1,1);
+      top_mask[blob_top_mask_->offset(2,i,1,2)] = blob_bottom_->offset(5,i,1,0);
+    }
   }
   void TestBackwardMax() {
     LayerParameter layer_param;
@@ -188,121 +144,20 @@ class KeyPoolingLayerTest : public MultiDeviceTest<TypeParam> {
     shape.push_back(3);
     ASSERT_EQ(blob_bottom_->shape(), shape);
 
-    const Dtype *bottom_diff = blob_bottom_->cpu_diff();
-    for (int i = 0; i < shape[1]; ++i) {
-      // output 0
-      EXPECT_EQ(bottom_diff[blob_bottom_->offset(0,i,0,0)], 1 + i);
-      EXPECT_EQ(bottom_diff[blob_bottom_->offset(0,i,0,1)], 2 + i);
-      EXPECT_EQ(bottom_diff[blob_bottom_->offset(0,i,0,2)], 1 + i);
-      EXPECT_EQ(bottom_diff[blob_bottom_->offset(0,i,1,0)], 1 + i);
-      EXPECT_EQ(bottom_diff[blob_bottom_->offset(0,i,1,1)], 0 + i);
-      EXPECT_EQ(bottom_diff[blob_bottom_->offset(0,i,1,2)], 1 + i);
+    Blob<Dtype> store_diff;
+    store_diff.CopyFrom(*blob_bottom_, true, true);
+
+    Dtype *result = store_diff.mutable_cpu_data();
+    for (int i = 0; i < blob_top_mask_->count(); ++i) {
+      const int bottom_i = blob_top_mask_->cpu_data()[i];
+      const Dtype expected = blob_top_->cpu_data()[i];
+      EXPECT_EQ(result[bottom_i], expected);
+      result[bottom_i] = Dtype(0);
     }
-    // channel 0, output 1
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 0) + 0], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 0) + 1], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 0) + 2], 6);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 0) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 0) + 4], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 0) + 5], 4);
-    // channel 0, output 2
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 0) + 0], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 0) + 1], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 0) + 2], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 0) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 0) + 4], 1);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 0) + 5], 0);
-    // channel 0, output 3
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 0) + 0], 3);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 0) + 1], 2);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 0) + 2], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 0) + 3], 3);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 0) + 4], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 0) + 5], 0);
-    // channel 0, output 4
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 0) + 0], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 0) + 1], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 0) + 2], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 0) + 3],-1);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 0) + 4], 2);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 0) + 5], 1);
-    // channel 0, output 5
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 0) + 0], 2);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 0) + 1], 1);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 0) + 2], 5);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 0) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 0) + 4], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 0) + 5], 0);
-    // channel 1, output 1
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 1) + 0], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 1) + 1], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 1) + 2], 7);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 1) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 1) + 4], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 1) + 5], 5);
-    // channel 1, output 2
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 1) + 0], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 1) + 1], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 1) + 2], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 1) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 1) + 4], 2);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 1) + 5], 0);
-    // channel 1, output 3
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 1) + 0], 4);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 1) + 1], 3);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 1) + 2], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 1) + 3], 4);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 1) + 4], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 1) + 5], 0);
-    // channel 1, output 4
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 1) + 0], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 1) + 1], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 1) + 2], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 1) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 1) + 4], 3);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 1) + 5], 2);
-    // channel 1, output 5
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 1) + 0], 3);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 1) + 1], 2);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 1) + 2], 6);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 1) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 1) + 4], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 1) + 5], 0);
-    // channel 2, output 1
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 2) + 0], 5);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 2) + 1], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 2) + 2], 8);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 2) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 2) + 4], 3);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(1, 2) + 5], 0);
-    // channel 2, output 2
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 2) + 0], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 2) + 1], 4);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 2) + 2], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 2) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 2) + 4], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(2, 2) + 5], 0);
-    // channel 2, output 3
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 2) + 0], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 2) + 1], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 2) + 2], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 2) + 3], 5);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 2) + 4], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(3, 2) + 5], 6);
-    // channel 2, output 4
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 2) + 0], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 2) + 1], 3);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 2) + 2], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 2) + 3], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 2) + 4], 4);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(4, 2) + 5], 3);
-    // channel 2, output 5
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 2) + 0], 4);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 2) + 1], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 2) + 2], 7);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 2) + 3], 1);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 2) + 4], 0);
-    EXPECT_EQ(bottom_diff[blob_bottom_->offset(5, 2) + 5], 0);
+
+    for (int i = 0; i < store_diff.count(); ++i) {
+      EXPECT_EQ(result[i], Dtype(0));
+    }
   }
 
 };

--- a/src/caffe/test/test_key_pooling_layer.cpp
+++ b/src/caffe/test/test_key_pooling_layer.cpp
@@ -1,0 +1,191 @@
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/pooling_layer.hpp"
+#include "caffe/layers/key_pooling_layer.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+
+namespace caffe {
+
+template <typename TypeParam>
+class KeyPoolingLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  KeyPoolingLayerTest()
+      : num_(5),
+        blob_bottom_(new Blob<Dtype>()),
+      	blob_bottom_keys_(new Blob<Dtype>()),
+        blob_top_(new Blob<Dtype>()),
+        blob_top_keys_(new Blob<Dtype>()) {}
+  virtual void SetUp() {
+    Caffe::set_random_seed(1701);
+    // Fill the values.
+    // Simply use the linear index of the array element to make things
+    // easier to reason about.
+    blob_bottom_->Reshape(num_, 1, 7, 1);
+    // This should result in the following matrix:
+    // [ 0  1  2  3  4  5  6]
+    //   7  8  9 10 11 12 13]
+    //  14 15 16 17 18 19 20]
+    //  21 22 23 24 25 26 27]
+    //  28 29 30 31 32 33 34]
+    for (int i = 0; i < this->blob_bottom_->count(); ++i) {
+      this->blob_bottom_->mutable_cpu_data()[i] = i;
+    }
+    blob_bottom_keys_->Reshape(num_, 1, 1, 1);
+
+    blob_bottom_vec_.push_back(blob_bottom_);
+    blob_bottom_vec_.push_back(blob_bottom_keys_);
+    blob_top_vec_.push_back(blob_top_);
+    blob_top_vec_.push_back(blob_top_keys_);
+  }
+  virtual ~KeyPoolingLayerTest() {
+    delete blob_bottom_;
+    delete blob_bottom_keys_;
+    delete blob_top_;
+    delete blob_top_keys_;
+  }
+
+  int num_;
+  Blob<Dtype>* const blob_bottom_;
+  Blob<Dtype>* const blob_bottom_keys_;
+  Blob<Dtype>* const blob_top_;
+  Blob<Dtype>* const blob_top_keys_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+
+};
+
+TYPED_TEST_CASE(KeyPoolingLayerTest, TestDtypesAndDevices);
+
+
+TYPED_TEST(KeyPoolingLayerTest, TestAllKeysDifferentIsStdPooling) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
+  pooling_param->set_global_pooling(true);
+  KeyPoolingLayer<Dtype> layer(layer_param);
+  PoolingLayer<Dtype> ref_layer(layer_param);
+
+  for (int i = 0; i < this->num_; ++i) {
+    this->blob_bottom_keys_->mutable_cpu_data()[i] = i;
+  }
+
+
+  Blob<Dtype> ref_top;
+  vector<Blob<Dtype>*> ref_top_vec;
+  vector<Blob<Dtype>*> ref_bottom_vec;
+  ref_top_vec.push_back(&ref_top);
+  ref_bottom_vec.push_back(this->blob_bottom_);
+
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  ref_layer.SetUp(ref_bottom_vec, ref_top_vec);
+
+  EXPECT_EQ(this->blob_top_->shape(), ref_top.shape());
+  EXPECT_EQ(this->blob_top_keys_->count(), this->num_);
+
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  ref_layer.Forward(ref_bottom_vec, ref_top_vec);
+
+  EXPECT_EQ(this->blob_top_keys_->count(), this->num_);
+  for (int i = 0; i < this->num_; ++i) {
+    EXPECT_EQ(this->blob_top_keys_->cpu_data()[i], i);
+  }
+
+  for (int i = 0; i < ref_top.count(); ++i) {
+    EXPECT_EQ(this->blob_top_->cpu_data()[i], ref_top.cpu_data()[i]);
+  }
+}
+
+
+TYPED_TEST(KeyPoolingLayerTest, TestKeySameReduces) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
+  pooling_param->set_global_pooling(true);
+  KeyPoolingLayer<Dtype> layer(layer_param);
+  PoolingLayer<Dtype> ref_layer(layer_param);
+
+  for (int i = 0; i < this->num_; ++i) {
+    this->blob_bottom_keys_->mutable_cpu_data()[i] = 0;
+  }
+
+
+  Blob<Dtype> ref_top;
+  vector<Blob<Dtype>*> ref_top_vec;
+  vector<Blob<Dtype>*> ref_bottom_vec;
+  ref_top_vec.push_back(&ref_top);
+  ref_bottom_vec.push_back(this->blob_bottom_);
+
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  ref_layer.SetUp(ref_bottom_vec, ref_top_vec);
+
+  std::vector<int> expected_shape(ref_top.shape());
+  expected_shape[0] = 1;
+
+  EXPECT_EQ(this->blob_top_->shape(), expected_shape);
+  EXPECT_EQ(this->blob_top_keys_->count(), 1);
+
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  ref_layer.Forward(ref_bottom_vec, ref_top_vec);
+
+  EXPECT_EQ(this->blob_top_keys_->count(), 1);
+  EXPECT_EQ(this->blob_top_->cpu_data()[0], this->blob_bottom_->count()-1);
+  // for (int i = 0; i < this->blob_top_->count(); ++i) {
+  //   EXPECT_EQ(this->blob_top_->cpu_data()[i], ref_top.cpu_data()[i]);
+  // }
+}
+
+
+TYPED_TEST(KeyPoolingLayerTest, TestDifferentKeyGroups) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
+  pooling_param->set_kernel_h(1);
+  pooling_param->set_kernel_w(1);
+
+  KeyPoolingLayer<Dtype> layer(layer_param);
+  PoolingLayer<Dtype> ref_layer(layer_param);
+
+  for (int i = 0; i < this->num_; ++i) {
+    if (i < this->num_/2) {
+      this->blob_bottom_keys_->mutable_cpu_data()[i] = 0;
+    } else {
+      this->blob_bottom_keys_->mutable_cpu_data()[i] = 1;
+    }
+  }
+
+
+  Blob<Dtype> ref_top;
+  vector<Blob<Dtype>*> ref_top_vec;
+  vector<Blob<Dtype>*> ref_bottom_vec;
+  ref_top_vec.push_back(&ref_top);
+  ref_bottom_vec.push_back(this->blob_bottom_);
+
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  ref_layer.SetUp(ref_bottom_vec, ref_top_vec);
+
+  std::vector<int> expected_shape(ref_top.shape());
+  expected_shape[0] = 2;
+
+  EXPECT_EQ(this->blob_top_->shape(), expected_shape);
+  EXPECT_EQ(this->blob_top_keys_->count(), 2);
+
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  ref_layer.Forward(ref_bottom_vec, ref_top_vec);
+
+  EXPECT_EQ(this->blob_top_keys_->count(), 2);
+  for (int i = 0; i < this->blob_top_->count(); ++i) {
+    EXPECT_EQ(this->blob_top_->cpu_data()[i], ref_top.cpu_data()[i]);
+  }
+}
+
+}

--- a/src/caffe/test/test_key_pooling_layer.cpp
+++ b/src/caffe/test/test_key_pooling_layer.cpp
@@ -337,6 +337,15 @@ TYPED_TEST(KeyPoolingLayerTest, TestForwardMax) {
       EXPECT_EQ(mask[this->blob_top_mask_->offset(2, i) + 5], 4);
     }
   }
+  if (this->blob_top_vec_.size() > 2) {
+    // test the key map
+    // Expected output for every channel
+    // [0] ||  [1]  ||  [2]
+    const Dtype *key = this->blob_top_keys_->cpu_data();
+    EXPECT_EQ(key[0], 0);
+    EXPECT_EQ(key[1], 1);
+    EXPECT_EQ(key[2], 2);
+  }
 }
 
 


### PR DESCRIPTION
Internally, we have found that treating images as a collection and pooling over them results in improved performance for some tasks.

In an attempt to generalize this, I have started work on a key-based pooling layer. The idea is that in addition to the bottom blob representing the input data, a second blob is provided that indicates the keys associated with each of the entries in the batch (first dimension). An additional pooling step is then used to pool over all images withe the same key.

This can be seen as something similar to a reduce-by-key operation.

Although I am implementing this as an additional layer (which has a pooling layer member), there are some open questions which may indicate that it would be worth it to extend the pooling layer itself. As the initial proof of concept, I am performing the MAX pooling over the keys as a hard-coded step. Ideally, this should be handled by the pooling layer itself. Does it make sense to add further parameters to the pooling layer that handles these options? Is it feasible to pool over color channels, for example?


