### PR TITLE
Little fix for NetSpec: allow setting top blob names using string

### DIFF
--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -175,6 +175,12 @@ class NetSpec(object):
     def __getattr__(self, name):
         return self.tops[name]
 
+    def __setitem__(self, key, value):
+        self.__setattr__(key, value)
+
+    def __getitem__(self, item):
+        return self.__getattr__(item)
+
     def to_proto(self):
         names = {v: k for k, v in six.iteritems(self.tops)}
         autonames = Counter()


### PR DESCRIPTION
Some top blob names (ex. in GoogleNet) contain symbols that can't be used as python variable name. 

```python
n = caffe.NetSpec()
n.conv1/7x7_s2 = L.Convolution(n.data, name='conv1/7x7_s2', ...) 
```
This patch allows the following:
```python
n = caffe.NetSpec()
n['conv1/7x7_s2'] = L.Convolution(n.data, name='conv1/7x7_s2', ...) 
```
The patch is just a simple workaround that doesn't break original NetSpec style to specify top names

