### PR TITLE
MKL support improvments

### DIFF
--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -20,7 +20,7 @@ caffe_option(MKL_MULTI_THREADED  "Use multi-threading"   ON IF NOT MKL_USE_SINGL
 
 # ---[ Root folders
 set(INTEL_ROOT "/opt/intel" CACHE PATH "Folder contains intel libs")
-find_path(MKL_ROOT include/mkl.h PATHS $ENV{MKL_ROOT} ${INTEL_ROOT}/mkl
+find_path(MKL_ROOT include/mkl.h PATHS $ENV{MKLROOT} ${INTEL_ROOT}/mkl
                                    DOC "Folder contains MKL")
 
 # ---[ Find include dir

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,8 @@ There are several implementations of this library. The choice is yours:
 * [ATLAS](http://math-atlas.sourceforge.net/): free, open source, and so the default for Caffe.
 * [Intel MKL](http://software.intel.com/en-us/intel-mkl): commercial and optimized for Intel CPUs, with a free trial and [student](http://software.intel.com/en-us/intel-education-offerings) licenses.
     1. Install MKL.
-    2. Set `BLAS := mkl` in `Makefile.config`
+    2. Set up MKL environment (Details: [Linux](https://software.intel.com/en-us/node/528499), [OS X](https://software.intel.com/en-us/node/528659)). Example: *source /opt/intel/mkl/bin/mklvars.sh intel64*
+    3. Set `BLAS := mkl` in `Makefile.config`
 * [OpenBLAS](http://www.openblas.net/): free and open source; this optimized and parallel BLAS could require more effort to install, although it might offer a speedup.
     1. Install OpenBLAS
     2. Set `BLAS := open` in `Makefile.config`


### PR DESCRIPTION
- Update in documentation on how to use MKL with caffe
- Fix to cmake based Linux build of caffe using MKL eg. cmake *\<path to CMakeLists.txt\> -DBLAS=mkl*
