### PR TITLE
Update versions for Travis build

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -255,7 +255,6 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("_set_input_arrays", &Net_SetInputArrays,
         bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >())
     .def("save", &Net_Save);
-  bp::register_ptr_to_python<shared_ptr<Net<Dtype> > >();
 
   bp::class_<Blob<Dtype>, shared_ptr<Blob<Dtype> >, boost::noncopyable>(
     "Blob", bp::no_init)
@@ -275,7 +274,6 @@ BOOST_PYTHON_MODULE(_caffe) {
           NdarrayCallPolicies()))
     .add_property("diff",     bp::make_function(&Blob<Dtype>::mutable_cpu_diff,
           NdarrayCallPolicies()));
-  bp::register_ptr_to_python<shared_ptr<Blob<Dtype> > >();
 
   bp::class_<Layer<Dtype>, shared_ptr<PythonLayer<Dtype> >,
     boost::noncopyable>("Layer", bp::init<const LayerParameter&>())
@@ -299,7 +297,6 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("step", &Solver<Dtype>::Step)
     .def("restore", &Solver<Dtype>::Restore)
     .def("snapshot", &Solver<Dtype>::Snapshot);
-  bp::register_ptr_to_python<shared_ptr<Solver<Dtype> > >();
 
   bp::class_<SGDSolver<Dtype>, bp::bases<Solver<Dtype> >,
     shared_ptr<SGDSolver<Dtype> >, boost::noncopyable>(

--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -92,8 +92,4 @@ if [ "$PYTHON_VERSION" -eq "3" ] && [ ! -e "$CONDA_DIR/bin/protoc" ]; then
   popd
 fi
 
-if [ "$PYTHON_VERSION" -eq "3" ]; then
-  pip install --pre protobuf
-else
-  pip install protobuf
-fi
+pip install protobuf

--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -72,17 +72,17 @@ if [ ! -d $CONDA_DIR ]; then
   conda update --yes conda
   # The version of boost we're using for Python 3 depends on 3.4 for now.
   if [ "$PYTHON_VERSION" -eq "3" ]; then
-    conda install --yes python=3.4
+    conda install --yes python=3.5
   fi
   conda install --yes numpy scipy matplotlib scikit-image pip
   # Let conda install boost (so that boost_python matches)
-  conda install --yes -c https://conda.binstar.org/menpo boost=1.56.0
+  conda install --yes -c https://conda.binstar.org/menpo boost=1.59.0
 fi
 
 # install protobuf 3 (just use the miniconda3 directory to avoid having to setup the path again)
 if [ "$PYTHON_VERSION" -eq "3" ] && [ ! -e "$CONDA_DIR/bin/protoc" ]; then
   pushd .
-  wget https://github.com/google/protobuf/archive/v3.0.0-alpha-3.1.tar.gz -O protobuf-3.tar.gz
+  wget https://github.com/google/protobuf/archive/v3.0.0-beta-2.tar.gz -O protobuf-3.tar.gz
   tar -C /tmp -xzvf protobuf-3.tar.gz
   cd /tmp/protobuf-3*/
   ./autogen.sh


### PR DESCRIPTION
There are new releases of Miniconda, boost, and protobuf.
I'm partly checking whether recent travis failures like #3613 are
due to a version issue or what.

It seems like Travis is out again due to some CMake or Python 3 issue.