### PR TITLE
Travis: force protobuf 3.0.0b2 for Python 3

### DIFF
--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -93,7 +93,7 @@ if [ "$PYTHON_VERSION" -eq "3" ] && [ ! -e "$CONDA_DIR/bin/protoc" ]; then
 fi
 
 if [ "$PYTHON_VERSION" -eq "3" ]; then
-  pip install --pre protobuf
+  pip install --pre protobuf==3.0.0b2
 else
   pip install protobuf
 fi


### PR DESCRIPTION
This is temporary measure to avoid the apparent upstream issue with protobuf 3.0.0b2.post1 which has broken Travis (previously, the most recent available version of the Python package was installed).

This needs to be tested against Travis; do not merge until passing.