### PR TITLE
mnist get data script bug fix

### DIFF
--- a/data/mnist/get_mnist.sh
+++ b/data/mnist/get_mnist.sh
@@ -9,7 +9,7 @@ echo "Downloading..."
 for fname in train-images-idx3-ubyte train-labels-idx1-ubyte t10k-images-idx3-ubyte t10k-labels-idx1-ubyte
 do
     if [ ! -e $fname ]; then
-        wget --no-check-certificate http://yann.lecun.com/exdb/mnist/${fname}.gz
+        wget --no-check-certificate http://yann.lecun.com/exdb/mnist/${fname}.gz -O ${fname}.gz
         gunzip ${fname}.gz
     fi
 done


### PR DESCRIPTION
In some instances,if we use ctrl+c to stop the downloading,the wget tool will automatically  append some string  like '.0','.1' which gunzip cannot open.

so,i add -O option to customize the download file name.