### PR TITLE
Fix a crash when running caffe time utility

### DIFF
--- a/src/caffe/util/benchmark.cpp
+++ b/src/caffe/util/benchmark.cpp
@@ -6,7 +6,7 @@
 
 namespace caffe {
 
-static std::string benchmark_float = "__kernel void null() {\n}";  // NOLINT
+static std::string benchmark_float = "__kernel void null(void) {\n}";  // NOLINT
 Timer::Timer()
     : initted_(false), running_(false), has_run_at_least_once_(false) {
   Init();


### PR DESCRIPTION
No kernels or only kernel prototypes found when build executable

This fixes naibaf7/caffe#23

@naibaf7 ?
