### PR TITLE
Expose all netstate options (for all-in-one nets)

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -25,6 +25,7 @@ class Net {
  public:
   explicit Net(const NetParameter& param, const Net* root_net = NULL);
   explicit Net(const string& param_file, Phase phase,
+      const int level = 0, const vector<string>* stages = NULL,
       const Net* root_net = NULL);
   virtual ~Net() {}
 

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -86,19 +86,42 @@ void CheckContiguousArray(PyArrayObject* arr, string name,
   }
 }
 
-// Net constructor for passing phase as int
-shared_ptr<Net<Dtype> > Net_Init(
-    string param_file, int phase) {
-  CheckFile(param_file);
+// Net constructor
+shared_ptr<Net<Dtype> > Net_Init(string network_file, int phase,
+    const int level, const bp::object& stages,
+    const bp::object& weights) {
+  CheckFile(network_file);
 
-  shared_ptr<Net<Dtype> > net(new Net<Dtype>(param_file,
-      static_cast<Phase>(phase)));
+  // Convert stages from list to vector
+  vector<string> stages_vector;
+  if (!stages.is_none()) {
+    for (int i = 0; i < len(stages); i++) {
+      stages_vector.push_back(bp::extract<string>(stages[i]));
+    }
+  }
+
+  // Initialize net
+  shared_ptr<Net<Dtype> > net(new Net<Dtype>(network_file,
+        static_cast<Phase>(phase), level, &stages_vector));
+
+  // Load weights
+  if (!weights.is_none()) {
+    std::string weights_file_str = bp::extract<std::string>(weights);
+    CheckFile(weights_file_str);
+    net->CopyTrainedLayersFrom(weights_file_str);
+  }
+
   return net;
 }
 
-// Net construct-and-load convenience constructor
+// Legacy Net construct-and-load convenience constructor
 shared_ptr<Net<Dtype> > Net_Init_Load(
     string param_file, string pretrained_param_file, int phase) {
+  LOG(WARNING) << "DEPRECATION WARNING - deprecated use of Python interface";
+  LOG(WARNING) << "Use this instead (with the named \"weights\""
+    << " parameter):";
+  LOG(WARNING) << "Net('" << param_file << "', " << phase
+    << ", weights='" << pretrained_param_file << "')";
   CheckFile(param_file);
   CheckFile(pretrained_param_file);
 
@@ -245,7 +268,12 @@ BOOST_PYTHON_MODULE(_caffe) {
 
   bp::class_<Net<Dtype>, shared_ptr<Net<Dtype> >, boost::noncopyable >("Net",
     bp::no_init)
-    .def("__init__", bp::make_constructor(&Net_Init))
+    // Constructor
+    .def("__init__", bp::make_constructor(&Net_Init,
+          bp::default_call_policies(), (bp::arg("network_file"), "phase",
+            bp::arg("level")=0, bp::arg("stages")=bp::object(),
+            bp::arg("weights")=bp::object())))
+    // Legacy constructor
     .def("__init__", bp::make_constructor(&Net_Init_Load))
     .def("_forward", &Net<Dtype>::ForwardFromTo)
     .def("_backward", &Net<Dtype>::BackwardFromTo)

--- a/python/caffe/test/test_net.py
+++ b/python/caffe/test/test_net.py
@@ -72,7 +72,11 @@ class TestNet(unittest.TestCase):
         f.close()
         self.net.save(f.name)
         net_file = simple_net_file(self.num_output)
-        net2 = caffe.Net(net_file, f.name, caffe.TRAIN)
+        # Test legacy constructor
+        #   should print deprecation warning
+        caffe.Net(net_file, f.name, caffe.TRAIN)
+        # Test named constructor
+        net2 = caffe.Net(net_file, caffe.TRAIN, weights=f.name)
         os.remove(net_file)
         os.remove(f.name)
         for name in self.net.params:
@@ -93,3 +97,225 @@ class TestNet(unittest.TestCase):
             for i in range(len(self.net.params[name])):
                 self.assertEqual(abs(self.net.params[name][i].data
                     - net2.params[name][i].data).sum(), 0)
+
+class TestLevels(unittest.TestCase):
+
+    TEST_NET = """
+layer {
+  name: "data"
+  type: "DummyData"
+  top: "data"
+  dummy_data_param { shape { dim: 1 dim: 1 dim: 10 dim: 10 } }
+}
+layer {
+  name: "NoLevel"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "NoLevel"
+  inner_product_param { num_output: 1 }
+}
+layer {
+  name: "Level0Only"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "Level0Only"
+  include { min_level: 0 max_level: 0 }
+  inner_product_param { num_output: 1 }
+}
+layer {
+  name: "Level1Only"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "Level1Only"
+  include { min_level: 1 max_level: 1 }
+  inner_product_param { num_output: 1 }
+}
+layer {
+  name: "Level>=0"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "Level>=0"
+  include { min_level: 0 }
+  inner_product_param { num_output: 1 }
+}
+layer {
+  name: "Level>=1"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "Level>=1"
+  include { min_level: 1 }
+  inner_product_param { num_output: 1 }
+}
+"""
+
+    def setUp(self):
+        self.f = tempfile.NamedTemporaryFile(mode='w+')
+        self.f.write(self.TEST_NET)
+        self.f.flush()
+
+    def tearDown(self):
+        self.f.close()
+
+    def check_net(self, net, blobs):
+        net_blobs = [b for b in net.blobs.keys() if 'data' not in b]
+        self.assertEqual(net_blobs, blobs)
+
+    def test_0(self):
+        net = caffe.Net(self.f.name, caffe.TEST)
+        self.check_net(net, ['NoLevel', 'Level0Only', 'Level>=0'])
+
+    def test_1(self):
+        net = caffe.Net(self.f.name, caffe.TEST, level=1)
+        self.check_net(net, ['NoLevel', 'Level1Only', 'Level>=0', 'Level>=1'])
+
+
+class TestStages(unittest.TestCase):
+
+    TEST_NET = """
+layer {
+  name: "data"
+  type: "DummyData"
+  top: "data"
+  dummy_data_param { shape { dim: 1 dim: 1 dim: 10 dim: 10 } }
+}
+layer {
+  name: "A"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "A"
+  include { stage: "A" }
+  inner_product_param { num_output: 1 }
+}
+layer {
+  name: "B"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "B"
+  include { stage: "B" }
+  inner_product_param { num_output: 1 }
+}
+layer {
+  name: "AorB"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "AorB"
+  include { stage: "A" }
+  include { stage: "B" }
+  inner_product_param { num_output: 1 }
+}
+layer {
+  name: "AandB"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "AandB"
+  include { stage: "A" stage: "B" }
+  inner_product_param { num_output: 1 }
+}
+"""
+
+    def setUp(self):
+        self.f = tempfile.NamedTemporaryFile(mode='w+')
+        self.f.write(self.TEST_NET)
+        self.f.flush()
+
+    def tearDown(self):
+        self.f.close()
+
+    def check_net(self, net, blobs):
+        net_blobs = [b for b in net.blobs.keys() if 'data' not in b]
+        self.assertEqual(net_blobs, blobs)
+
+    def test_A(self):
+        net = caffe.Net(self.f.name, caffe.TEST, stages=['A'])
+        self.check_net(net, ['A', 'AorB'])
+
+    def test_B(self):
+        net = caffe.Net(self.f.name, caffe.TEST, stages=['B'])
+        self.check_net(net, ['B', 'AorB'])
+
+    def test_AandB(self):
+        net = caffe.Net(self.f.name, caffe.TEST, stages=['A', 'B'])
+        self.check_net(net, ['A', 'B', 'AorB', 'AandB'])
+
+
+class TestAllInOne(unittest.TestCase):
+
+    TEST_NET = """
+layer {
+  name: "train_data"
+  type: "DummyData"
+  top: "data"
+  top: "label"
+  dummy_data_param {
+    shape { dim: 1 dim: 1 dim: 10 dim: 10 }
+    shape { dim: 1 dim: 1 dim: 1 dim: 1 }
+  }
+  include { phase: TRAIN stage: "train" }
+}
+layer {
+  name: "val_data"
+  type: "DummyData"
+  top: "data"
+  top: "label"
+  dummy_data_param {
+    shape { dim: 1 dim: 1 dim: 10 dim: 10 }
+    shape { dim: 1 dim: 1 dim: 1 dim: 1 }
+  }
+  include { phase: TEST stage: "val" }
+}
+layer {
+  name: "deploy_data"
+  type: "Input"
+  top: "data"
+  input_param { shape { dim: 1 dim: 1 dim: 10 dim: 10 } }
+  include { phase: TEST stage: "deploy" }
+}
+layer {
+  name: "ip"
+  type: "InnerProduct"
+  bottom: "data"
+  top: "ip"
+  inner_product_param { num_output: 2 }
+}
+layer {
+  name: "loss"
+  type: "SoftmaxWithLoss"
+  bottom: "ip"
+  bottom: "label"
+  top: "loss"
+  include: { phase: TRAIN stage: "train" }
+  include: { phase: TEST stage: "val" }
+}
+layer {
+  name: "pred"
+  type: "Softmax"
+  bottom: "ip"
+  top: "pred"
+  include: { phase: TEST stage: "deploy" }
+}
+"""
+
+    def setUp(self):
+        self.f = tempfile.NamedTemporaryFile(mode='w+')
+        self.f.write(self.TEST_NET)
+        self.f.flush()
+
+    def tearDown(self):
+        self.f.close()
+
+    def check_net(self, net, outputs):
+        self.assertEqual(list(net.blobs['data'].shape), [1,1,10,10])
+        self.assertEqual(net.outputs, outputs)
+
+    def test_train(self):
+        net = caffe.Net(self.f.name, caffe.TRAIN, stages=['train'])
+        self.check_net(net, ['loss'])
+
+    def test_val(self):
+        net = caffe.Net(self.f.name, caffe.TEST, stages=['val'])
+        self.check_net(net, ['loss'])
+
+    def test_deploy(self):
+        net = caffe.Net(self.f.name, caffe.TEST, stages=['deploy'])
+        self.check_net(net, ['pred'])
+

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -28,11 +28,20 @@ Net<Dtype>::Net(const NetParameter& param, const Net* root_net)
 }
 
 template <typename Dtype>
-Net<Dtype>::Net(const string& param_file, Phase phase, const Net* root_net)
+Net<Dtype>::Net(const string& param_file, Phase phase,
+    const int level, const vector<string>* stages,
+    const Net* root_net)
     : root_net_(root_net) {
   NetParameter param;
   ReadNetParamsFromTextFileOrDie(param_file, &param);
+  // Set phase, stages and level
   param.mutable_state()->set_phase(phase);
+  if (stages != NULL) {
+    for (int i = 0; i < stages->size(); i++) {
+      param.mutable_state()->add_stage((*stages)[i]);
+    }
+  }
+  param.mutable_state()->set_level(level);
   Init(param);
 }
 

--- a/src/caffe/test/test_net.cpp
+++ b/src/caffe/test/test_net.cpp
@@ -9,6 +9,7 @@
 #include "caffe/common.hpp"
 #include "caffe/filler.hpp"
 #include "caffe/net.hpp"
+#include "caffe/util/io.hpp"
 #include "caffe/util/math_functions.hpp"
 
 #include "caffe/test/test_caffe_main.hpp"
@@ -27,6 +28,17 @@ class NetTest : public MultiDeviceTest<TypeParam> {
     NetParameter param;
     CHECK(google::protobuf::TextFormat::ParseFromString(proto, &param));
     net_.reset(new Net<Dtype>(param));
+  }
+
+  virtual void InitNetFromProtoFileWithState(const string& proto,
+      Phase phase = caffe::TRAIN, const int level = 0,
+      const vector<string>* stages = NULL) {
+    NetParameter param;
+    CHECK(google::protobuf::TextFormat::ParseFromString(proto, &param));
+    string param_file;
+    MakeTempFilename(&param_file);
+    WriteProtoToTextFile(param, param_file);
+    net_.reset(new Net<Dtype>(param_file, phase, level, stages));
   }
 
   virtual void CopyNetBlobs(const bool copy_diff,
@@ -769,6 +781,62 @@ class NetTest : public MultiDeviceTest<TypeParam> {
       "  type: 'SigmoidCrossEntropyLoss' "
       "} ";
     InitNetFromProtoString(proto);
+  }
+
+  virtual void InitAllInOneNet(Phase phase = caffe::TRAIN,
+      const int level = 0, const vector<string>* stages = NULL) {
+    string proto =
+      "name: 'All-in-one Network'"
+      "layer { "
+      "  name: 'train-data' "
+      "  type: 'DummyData' "
+      "  top: 'data' "
+      "  top: 'label' "
+      "  dummy_data_param { "
+      "    shape { dim: 1 dim: 10 } "
+      "    shape { dim: 1 dim: 1 } "
+      "  } "
+      "  include { phase: TRAIN stage: 'train' } "
+      "} "
+      "layer { "
+      "  name: 'val-data' "
+      "  type: 'DummyData' "
+      "  top: 'data' "
+      "  top: 'label' "
+      "  dummy_data_param { "
+      "    shape { dim: 1 dim: 10 } "
+      "    shape { dim: 1 dim: 1 } "
+      "  } "
+      "  include { phase: TEST stage: 'val' } "
+      "} "
+      "layer { "
+      "  name: 'deploy-data' "
+      "  type: 'Input' "
+      "  top: 'data' "
+      "  input_param { "
+      "    shape { dim: 1 dim: 10 } "
+      "  } "
+      "  include { phase: TEST stage: 'deploy' } "
+      "} "
+      "layer { "
+      "  name: 'ip' "
+      "  type: 'InnerProduct' "
+      "  bottom: 'data' "
+      "  top: 'ip' "
+      "  inner_product_param { "
+      "    num_output: 2 "
+      "  } "
+      "} "
+      "layer { "
+      "  name: 'loss' "
+      "  type: 'SoftmaxWithLoss' "
+      "  bottom: 'ip' "
+      "  bottom: 'label' "
+      "  top: 'loss' "
+      "  include { phase: TRAIN stage: 'train' } "
+      "  include { phase: TEST stage: 'val' } "
+      "} ";
+    InitNetFromProtoFileWithState(proto, phase, level, stages);
   }
 
   int seed_;
@@ -2471,6 +2539,66 @@ TYPED_TEST(NetTest, TestForcePropagateDown) {
       LOG(FATAL) << "Unknown layer: " << layer_name;
     }
   }
+}
+
+TYPED_TEST(NetTest, TestAllInOneNetTrain) {
+  vector<string> stages;
+  stages.push_back("train");
+  this->InitAllInOneNet(caffe::TRAIN, 0, &stages);
+  bool found_data = false;
+  bool found_loss = false;
+  for (int i = 0; i < this->net_->layers().size(); ++i) {
+    const string& layer_name = this->net_->layer_names()[i];
+    if (layer_name == "train-data") {
+      found_data = true;
+    } else if (layer_name == "loss") {
+      found_loss = true;
+    } else {
+      ASSERT_NE(layer_name, "val-data");
+      ASSERT_NE(layer_name, "deploy-data");
+    }
+  }
+  ASSERT_TRUE(found_data);
+  ASSERT_TRUE(found_loss);
+}
+
+TYPED_TEST(NetTest, TestAllInOneNetVal) {
+  vector<string> stages;
+  stages.push_back("val");
+  this->InitAllInOneNet(caffe::TEST, 0, &stages);
+  bool found_data = false;
+  bool found_loss = false;
+  for (int i = 0; i < this->net_->layers().size(); ++i) {
+    const string& layer_name = this->net_->layer_names()[i];
+    if (layer_name == "val-data") {
+      found_data = true;
+    } else if (layer_name == "loss") {
+      found_loss = true;
+    } else {
+      ASSERT_NE(layer_name, "train-data");
+      ASSERT_NE(layer_name, "deploy-data");
+    }
+  }
+  ASSERT_TRUE(found_data);
+  ASSERT_TRUE(found_loss);
+}
+
+TYPED_TEST(NetTest, TestAllInOneNetDeploy) {
+  vector<string> stages;
+  stages.push_back("deploy");
+  this->InitAllInOneNet(caffe::TEST, 0, &stages);
+  bool found_data = false;
+  for (int i = 0; i < this->net_->layers().size(); ++i) {
+    const string& layer_name = this->net_->layer_names()[i];
+    if (layer_name == "deploy-data") {
+      found_data = true;
+    } else {
+      ASSERT_NE(layer_name, "train-data");
+      ASSERT_NE(layer_name, "val-data");
+      ASSERT_NE(layer_name, "loss");
+    }
+  }
+  ASSERT_TRUE(found_data);
 }
 
 }  // namespace caffe

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -34,6 +34,13 @@ DEFINE_string(solver, "",
     "The solver definition protocol buffer text file.");
 DEFINE_string(model, "",
     "The model definition protocol buffer text file.");
+DEFINE_string(phase, "",
+    "Optional; network phase (TRAIN or TEST). Only used for 'time'.");
+DEFINE_int32(level, 0,
+    "Optional; network level.");
+DEFINE_string(stage, "",
+    "Optional; network stages (not to be confused with phase), "
+    "separated by ','.");
 DEFINE_string(snapshot, "",
     "Optional; the snapshot solver state to resume training.");
 DEFINE_string(weights, "",
@@ -101,6 +108,25 @@ static void get_gpus(vector<int>* gpus) {
   }
 }
 
+// Parse phase from flags
+caffe::Phase get_phase_from_flags(caffe::Phase default_value) {
+  if (FLAGS_phase == "")
+    return default_value;
+  if (FLAGS_phase == "TRAIN")
+    return caffe::TRAIN;
+  if (FLAGS_phase == "TEST")
+    return caffe::TEST;
+  LOG(FATAL) << "phase must be \"TRAIN\" or \"TEST\"";
+  return caffe::TRAIN;  // Avoid warning
+}
+
+// Parse stages from flags
+vector<string> get_stages_from_flags() {
+  vector<string> stages;
+  boost::split(stages, FLAGS_stage, boost::is_any_of(","));
+  return stages;
+}
+
 // caffe commands to call by
 //     caffe <command> <args>
 //
@@ -156,9 +182,15 @@ int train() {
   CHECK(!FLAGS_snapshot.size() || !FLAGS_weights.size())
       << "Give a snapshot to resume training or weights to finetune "
       "but not both.";
+  vector<string> stages = get_stages_from_flags();
 
   caffe::SolverParameter solver_param;
   caffe::ReadSolverParamsFromTextFileOrDie(FLAGS_solver, &solver_param);
+
+  solver_param.mutable_train_state()->set_level(FLAGS_level);
+  for (int i = 0; i < stages.size(); i++) {
+    solver_param.mutable_train_state()->add_stage(stages[i]);
+  }
 
   // If the gpus flag is not provided, allow the mode and device to be set
   // in the solver prototxt.
@@ -229,6 +261,7 @@ RegisterBrewFunction(train);
 int test() {
   CHECK_GT(FLAGS_model.size(), 0) << "Need a model definition to score.";
   CHECK_GT(FLAGS_weights.size(), 0) << "Need model weights to score.";
+  vector<string> stages = get_stages_from_flags();
 
   // Set device id and mode
   vector<int> gpus;
@@ -247,7 +280,7 @@ int test() {
     Caffe::set_mode(Caffe::CPU);
   }
   // Instantiate the caffe net.
-  Net<float> caffe_net(FLAGS_model, caffe::TEST);
+  Net<float> caffe_net(FLAGS_model, caffe::TEST, FLAGS_level, &stages);
   caffe_net.CopyTrainedLayersFrom(FLAGS_weights);
   LOG(INFO) << "Running for " << FLAGS_iterations << " iterations.";
 
@@ -300,6 +333,8 @@ RegisterBrewFunction(test);
 // Time: benchmark the execution time of a model.
 int time() {
   CHECK_GT(FLAGS_model.size(), 0) << "Need a model definition to time.";
+  caffe::Phase phase = get_phase_from_flags(caffe::TRAIN);
+  vector<string> stages = get_stages_from_flags();
 
   // Set device id and mode
   vector<int> gpus;
@@ -313,7 +348,7 @@ int time() {
     Caffe::set_mode(Caffe::CPU);
   }
   // Instantiate the caffe net.
-  Net<float> caffe_net(FLAGS_model, caffe::TRAIN);
+  Net<float> caffe_net(FLAGS_model, phase, FLAGS_level, &stages);
 
   // Do a clean forward and backward pass, so that memory allocation are done
   // and future iterations will be more stable.


### PR DESCRIPTION
*Was #3736*

There are 3 configurable dimensions to a network's [NetState](https://github.com/BVLC/caffe/blob/rc3/src/caffe/proto/caffe.proto#L257-L261): **phase** (TRAIN or TEST), **level** and **stage**. Currently, only **phase** is exposed through common interfaces. This PR exposes **level** and **stage** to the user, further enabling all-in-one nets (#1245)

New CLI:
```
build/tools/caffe time -model network.prototxt -level 1 -stage deploy
```
New pycaffe interface:
```python
net = caffe.Net('network.prototxt', weights='weights.caffemodel',
  phase=caffe.TEST, level=1, stages=['deploy'])
```

---

*EDIT: PR has been updated not to break old code*

~~This is a **breaking change** (see https://github.com/BVLC/caffe/pull/1790#issuecomment-199420059 for an explanation). Users will need to transform pycaffe code like:~~
```python
# old
net = caffe.Net('network.prototxt', 'weights.caffemodel', caffe.TEST)
```
~~to:~~
```python
# new
net = caffe.Net('network.prototxt', weights='weights.caffemodel', phase=caffe.TEST)
# or
net = caffe.Net('network.prototxt', caffe.TEST, weights='weights.caffemodel')
```
~~With some effort, this could probably be done without breaking the interface (but I'd need some help with the Boost.Python code). However, I am actually in favor of breaking the interface in order to make it simpler and more "Pythonic".~~