### PR TITLE
Added check before register ptr to python

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -255,7 +255,8 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("_set_input_arrays", &Net_SetInputArrays,
         bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >())
     .def("save", &Net_Save);
-  bp::register_ptr_to_python<shared_ptr<Net<Dtype> > >();
+  if (boost::python::converter::registry::query(boost::python::type_id <shared_ptr<Net<Dtype> > >()) == NULL)
+    bp::register_ptr_to_python<shared_ptr<Net<Dtype> > >();
 
   bp::class_<Blob<Dtype>, shared_ptr<Blob<Dtype> >, boost::noncopyable>(
     "Blob", bp::no_init)
@@ -275,7 +276,8 @@ BOOST_PYTHON_MODULE(_caffe) {
           NdarrayCallPolicies()))
     .add_property("diff",     bp::make_function(&Blob<Dtype>::mutable_cpu_diff,
           NdarrayCallPolicies()));
-  bp::register_ptr_to_python<shared_ptr<Blob<Dtype> > >();
+  if (boost::python::converter::registry::query(boost::python::type_id <shared_ptr<Blob<Dtype> > >()) == NULL)
+    bp::register_ptr_to_python<shared_ptr<Blob<Dtype> > >();
 
   bp::class_<Layer<Dtype>, shared_ptr<PythonLayer<Dtype> >,
     boost::noncopyable>("Layer", bp::init<const LayerParameter&>())
@@ -299,7 +301,8 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("step", &Solver<Dtype>::Step)
     .def("restore", &Solver<Dtype>::Restore)
     .def("snapshot", &Solver<Dtype>::Snapshot);
-  bp::register_ptr_to_python<shared_ptr<Solver<Dtype> > >();
+  if (boost::python::converter::registry::query(boost::python::type_id <shared_ptr<Solver<Dtype> > >()) == NULL)
+    bp::register_ptr_to_python<shared_ptr<Solver<Dtype> > >();
 
   bp::class_<SGDSolver<Dtype>, bp::bases<Solver<Dtype> >,
     shared_ptr<SGDSolver<Dtype> >, boost::noncopyable>(


### PR DESCRIPTION
add check before register ptr to python for Net,Blob,Layers. 
able to solve the warning related to: 
[https://github.com/BVLC/caffe/pull/3575](https://github.com/BVLC/caffe/pull/3575)
and 
[https://groups.google.com/forum/#!topic/caffe-users/C_air48cISU](https://groups.google.com/forum/#!topic/caffe-users/C_air48cISU)

On master branch, there are warnings when run pycaffe.
/home/ubuntu/caffe/python/caffe/pycaffe.py:13: RuntimeWarning: to-Python converter for boost::shared_ptr<caffe::Net<float> > already registered; second conversion method ignored.
  from ._caffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, \
/home/ubuntu/caffe/python/caffe/pycaffe.py:13: RuntimeWarning: to-Python converter for boost::shared_ptr<caffe::Blob<float> > already registered; second conversion method ignored.
  from ._caffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, \
/home/ubuntu/caffe/python/caffe/pycaffe.py:13: RuntimeWarning: to-Python converter for boost::shared_ptr<caffe::Solver<float> > already registered; second conversion method ignored.
  from ._caffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, \