### PR TITLE
Fix the bug of incorrect gradient when loss_weight set to zero

### DIFF
--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -24,7 +24,8 @@ template <typename Dtype>
 class Blob {
  public:
   Blob()
-       : data_(), diff_(), count_(0), capacity_(0) {}
+       : data_(), diff_(), count_(0), capacity_(0),
+         data_written_(false), diff_written_(false) {}
 
   /// @brief Deprecated; use <code>Blob(const vector<int>& shape)</code>.
   explicit Blob(const int num, const int channels, const int height,
@@ -265,6 +266,12 @@ class Blob {
 
   bool ShapeEquals(const BlobProto& other);
 
+  void ClearData();
+  void ClearDiff();
+
+  inline bool has_written_data() const { return data_written_; }
+  inline bool has_written_diff() const { return diff_written_; }
+
  protected:
   shared_ptr<SyncedMemory> data_;
   shared_ptr<SyncedMemory> diff_;
@@ -272,6 +279,8 @@ class Blob {
   vector<int> shape_;
   int count_;
   int capacity_;
+  bool data_written_;
+  bool diff_written_;
 
   DISABLE_COPY_AND_ASSIGN(Blob);
 };  // class Blob

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -24,8 +24,7 @@ template <typename Dtype>
 class Blob {
  public:
   Blob()
-       : data_(), diff_(), count_(0), capacity_(0),
-         data_written_(false), diff_written_(false) {}
+       : data_(), diff_(), count_(0), capacity_(0), diff_written_(false) {}
 
   /// @brief Deprecated; use <code>Blob(const vector<int>& shape)</code>.
   explicit Blob(const int num, const int channels, const int height,
@@ -266,10 +265,8 @@ class Blob {
 
   bool ShapeEquals(const BlobProto& other);
 
-  void ClearData();
   void ClearDiff();
 
-  inline bool has_written_data() const { return data_written_; }
   inline bool has_written_diff() const { return diff_written_; }
 
  protected:
@@ -279,7 +276,6 @@ class Blob {
   vector<int> shape_;
   int count_;
   int capacity_;
-  bool data_written_;
   bool diff_written_;
 
   DISABLE_COPY_AND_ASSIGN(Blob);

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -148,6 +148,12 @@ void Blob<Dtype>::ShareDiff(const Blob& other) {
   diff_written_ = other.has_written_diff();
 }
 
+// The "ClearDiff" method is used for parameter blobs in a Net, which are stored
+// as Blob<float> or Blob<double> -- hence we do not define it for
+// Blob<int> or Blob<unsigned int>.
+template <> void Blob<unsigned int>::ClearDiff() { NOT_IMPLEMENTED; }
+template <> void Blob<int>::ClearDiff() { NOT_IMPLEMENTED; }
+
 template <typename Dtype>
 void Blob<Dtype>::ClearDiff() {
   switch (diff_->head()) {

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -587,6 +587,11 @@ void Net<Dtype>::BackwardFromTo(int start, int end) {
       layers_[i]->Backward(
           top_vecs_[i], bottom_need_backward_[i], bottom_vecs_[i]);
       if (debug_info_) { BackwardDebugInfo(i); }
+    } else {
+      const vector<Blob<Dtype>*>& bottoms = bottom_vecs_[i];
+      for (int j = 0; j < bottoms.size(); ++j) {
+        if (bottoms[j]->has_written_diff()) { bottoms[j]->ClearDiff(); }
+      }
     }
   }
 }
@@ -923,21 +928,7 @@ void Net<Dtype>::Update() {
 template <typename Dtype>
 void Net<Dtype>::ClearParamDiffs() {
   for (int i = 0; i < learnable_params_.size(); ++i) {
-    Blob<Dtype>* blob = learnable_params_[i];
-    switch (Caffe::mode()) {
-    case Caffe::CPU:
-      caffe_set(blob->count(), static_cast<Dtype>(0),
-                blob->mutable_cpu_diff());
-      break;
-    case Caffe::GPU:
-#ifndef CPU_ONLY
-      caffe_gpu_set(blob->count(), static_cast<Dtype>(0),
-                    blob->mutable_gpu_diff());
-#else
-      NO_GPU;
-#endif
-      break;
-    }
+    learnable_params_[i]->ClearDiff();
   }
 }
 


### PR DESCRIPTION
This PR aims at fixing the bug raised in #2895.

A flag (diff_written_) is added to the Blob class to indicate whether its diff has been used. When BP, clear the bottom diffs (if necessary) of the layers that do not propagate down. The computation and memory overhead are negligible.
