### PR TITLE
Confusion Matrix

### DIFF
--- a/include/caffe/layers/confusion_matrix_layer.hpp
+++ b/include/caffe/layers/confusion_matrix_layer.hpp
@@ -1,0 +1,69 @@
+#ifndef CAFFE_CONFUSION_MATRIX_LAYER_HPP_
+#define CAFFE_CONFUSION_MATRIX_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/loss_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Computes the confusion matrix for a one-of-many classification task.
+ */
+template <typename Dtype>
+class ConfusionMatrixLayer : public Layer<Dtype> {
+ public:
+  /**
+   * @param param provides ConfusionMatrixParameter confusion_matrix_param
+   */
+  explicit ConfusionMatrixLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "ConfusionMatrix"; }
+  virtual inline int ExactNumBottomBlobs() const { return 2; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  /**
+   * @param bottom input Blob vector (length 2)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the predictions @f$ x @f$, a Blob with values in
+   *      @f$ [-\infty, +\infty] @f$ indicating the predicted score for each of
+   *      the @f$ K = CHW @f$ classes. Each @f$ x_n @f$ is mapped to a predicted
+   *      label @f$ \hat{l}_n @f$ given by its maximal index:
+   *      @f$ \hat{l}_n = \arg\max\limits_k x_{nk} @f$
+   *   -# @f$ (N \times 1 \times 1 \times 1) @f$
+   *      the labels @f$ l @f$, an integer-valued Blob with values
+   *      @f$ l_n \in [0, 1, 2, ..., K - 1] @f$
+   *      indicating the correct class label among the @f$ K @f$ classes
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (K \times K \) @f$
+   *      
+   */
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  /// @brief Not implemented -- ConfusionMatrixLayer cannot be used as a loss.
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    for (int i = 0; i < propagate_down.size(); ++i) {
+      if (propagate_down[i]) { NOT_IMPLEMENTED; }
+    }
+  }
+
+  int label_axis_, outer_num_, inner_num_;
+  int num_classes_;
+  Blob<Dtype> confusion_matrix_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_CONFUSION_MATRIX_LAYER_HPP_

--- a/src/caffe/layers/confusion_matrix_layer.cpp
+++ b/src/caffe/layers/confusion_matrix_layer.cpp
@@ -1,0 +1,90 @@
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "caffe/layers/confusion_matrix_layer.hpp"
+#include "caffe/util/io.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void ConfusionMatrixLayer<Dtype>::LayerSetUp(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+}
+
+template <typename Dtype>
+void ConfusionMatrixLayer<Dtype>::Reshape(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  label_axis_ = bottom[0]->CanonicalAxisIndex(
+                  this->layer_param_.confusion_matrix_param().axis());
+  outer_num_ = bottom[0]->count(0, label_axis_);
+  inner_num_ = bottom[0]->count(label_axis_ + 1);
+  num_classes_ = bottom[0]->shape(label_axis_);
+  CHECK_EQ(outer_num_ * inner_num_, bottom[1]->count())
+      << "Number of labels must match number of channels in bottom[0]";
+  vector<int> confusion_dim(2, num_classes_);
+  top[0]->Reshape(confusion_dim);
+  confusion_matrix_.Reshape(confusion_dim);
+}
+
+template <typename Dtype>
+void ConfusionMatrixLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  const Dtype* bottom_label = bottom[1]->cpu_data();
+  const int dim = bottom[0]->count() / outer_num_;
+
+  caffe_set(confusion_matrix_.count(), Dtype(0),
+            confusion_matrix_.mutable_cpu_data());
+  caffe_set(top[0]->count(), Dtype(0), top[0]->mutable_cpu_data());
+
+  Dtype max_val = -1.;
+  int max_id = 0;
+  int count = 0;
+  for (int i = 0; i < outer_num_; ++i) {
+    for (int j = 0; j < inner_num_; ++j) {
+      const int label_value =
+          static_cast<int>(bottom_label[i * inner_num_ + j]);
+      DCHECK_GE(label_value, 0);
+      DCHECK_LT(label_value, num_classes_);
+
+      max_id = 0;
+      max_val = -1.;
+      for (int k = 0; k < num_classes_; ++k) {
+        if (bottom_data[i * dim + k * inner_num_ + j] > max_val) {
+          max_val = bottom_data[i * dim + k * inner_num_ + j];
+          max_id = k;
+        }
+      }
+      int predicted_class = max_id;
+      DCHECK_GE(predicted_class, 0);
+      DCHECK_LT(predicted_class, num_classes_);
+      confusion_matrix_.mutable_cpu_data()[label_value * num_classes_
+                                           + predicted_class] += 1;
+      ++count;
+    }
+  }
+
+  int num_image_per_class = 0;
+  for (int i = 0; i < num_classes_; ++i) {
+    num_image_per_class = 0;
+    int base= i * num_classes_;
+    for (int j = 0; j < num_classes_; ++j) {
+      num_image_per_class = num_image_per_class
+                            + confusion_matrix_.cpu_data()[base +j];
+    }
+    for (int j = 0; j < num_classes_; ++j) {
+      Dtype value = confusion_matrix_.cpu_data()[base + j]
+                    / ((Dtype) num_image_per_class);
+      top[0]->mutable_cpu_data()[base + j] = value;
+    }
+  }
+}
+
+INSTANTIATE_CLASS(ConfusionMatrixLayer);
+REGISTER_LAYER_CLASS(ConfusionMatrix);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -358,6 +358,7 @@ message LayerParameter {
   optional BatchNormParameter batch_norm_param = 139;
   optional BiasParameter bias_param = 141;
   optional ConcatParameter concat_param = 104;
+  optional ConfusionMatrixParameter confusion_matrix_param = 145;
   optional ContrastiveLossParameter contrastive_loss_param = 105;
   optional ConvolutionParameter convolution_param = 106;
   optional CropParameter crop_param = 144;
@@ -532,6 +533,15 @@ message BiasParameter {
   // Default is the zero (0) initialization, resulting in the BiasLayer
   // initially performing the identity operation.
   optional FillerParameter filler = 3;
+}
+
+message ConfusionMatrixParameter {
+  // The "label" axis of the prediction blob, whose argmax corresponds to the
+  // predicted label -- may be negative to index from the end (e.g., -1 for the
+  // last axis).  For example, if axis == 1 and the predictions are
+  // (N x C x H x W), the label blob is expected to contain N*H*W ground truth
+  // labels with integer values in {0, 1, ..., C-1}.
+  optional int32 axis = 1 [default = 1];
 }
 
 message ContrastiveLossParameter {

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -338,10 +338,13 @@ void Solver<Dtype>::Test(const int test_net_id) {
             << ", Testing net (#" << test_net_id << ")";
   CHECK_NOTNULL(test_nets_[test_net_id].get())->
       ShareTrainedLayersWith(net_.get());
-  vector<Dtype> test_score;
+
+  vector<Blob<Dtype>* > test_score;
   vector<int> test_score_output_id;
+  vector<Blob<Dtype>*> bottom_vec;
   const shared_ptr<Net<Dtype> >& test_net = test_nets_[test_net_id];
   Dtype loss = 0;
+
   for (int i = 0; i < param_.test_iter(test_net_id); ++i) {
     SolverAction::Enum request = GetRequestedAction();
     // Check to see if stoppage of testing/training has been requested.
@@ -353,6 +356,7 @@ void Solver<Dtype>::Test(const int test_net_id) {
         }
         request = GetRequestedAction();
     }
+
     if (requested_early_exit_) {
       // break out of test loop.
       break;
@@ -360,51 +364,105 @@ void Solver<Dtype>::Test(const int test_net_id) {
 
     Dtype iter_loss;
     const vector<Blob<Dtype>*>& result =
-        test_net->Forward(&iter_loss);
+        test_net->Forward(bottom_vec, &iter_loss);
+
     if (param_.test_compute_loss()) {
       loss += iter_loss;
     }
+
+    int num_results = result.size();
+    test_score.resize(num_results);
     if (i == 0) {
       for (int j = 0; j < result.size(); ++j) {
         const Dtype* result_vec = result[j]->cpu_data();
+        test_score[j] = new Blob<Dtype>;
+        test_score[j]->Reshape(result[j]->shape());
+        const int output_blob_index = test_net->output_blob_indices()[j];
+        const string& output_name = test_net->blob_names()[output_blob_index];
+        DLOG(INFO) << "Test net " << test_net_id
+                  << " output: " << j << " " << output_name
+                  << " dim=" << result[j]-> shape().size()
+                  << " size="<< result[j]-> count();
         for (int k = 0; k < result[j]->count(); ++k) {
-          test_score.push_back(result_vec[k]);
-          test_score_output_id.push_back(j);
+          test_score[j]->mutable_cpu_data()[k]=result_vec[k];
         }
+        test_score_output_id.push_back(j);
       }
     } else {
-      int idx = 0;
       for (int j = 0; j < result.size(); ++j) {
         const Dtype* result_vec = result[j]->cpu_data();
         for (int k = 0; k < result[j]->count(); ++k) {
-          test_score[idx++] += result_vec[k];
+          test_score[j]->mutable_cpu_data()[k] += result_vec[k];
         }
       }
     }
   }
+
   if (requested_early_exit_) {
     LOG(INFO)     << "Test interrupted.";
     return;
   }
+
   if (param_.test_compute_loss()) {
     loss /= param_.test_iter(test_net_id);
     LOG(INFO) << "Test loss: " << loss;
   }
+
   for (int i = 0; i < test_score.size(); ++i) {
     const int output_blob_index =
         test_net->output_blob_indices()[test_score_output_id[i]];
     const string& output_name = test_net->blob_names()[output_blob_index];
     const Dtype loss_weight = test_net->blob_loss_weights()[output_blob_index];
     ostringstream loss_msg_stream;
-    const Dtype mean_score = test_score[i] / param_.test_iter(test_net_id);
-    if (loss_weight) {
-      loss_msg_stream << " (* " << loss_weight
-                      << " = " << loss_weight * mean_score << " loss)";
+    if (test_score[i]->count() == 1) {
+      const Dtype mean_score =
+                  test_score[i]->cpu_data()[0] / param_.test_iter(test_net_id);
+      if (loss_weight) {
+        loss_msg_stream << " (* " << loss_weight
+                        << " = " << loss_weight * mean_score << " loss)";
+      }
+      LOG(INFO) << "    Test net output #" << i << ": " << output_name << " = "
+                << mean_score << loss_msg_stream.str();
+    } else if (test_score[i]->shape().size() == 1) {    //  0- or 1-D-vector
+      for (int j = 0; j < test_score[i]->count(); ++j) {
+        Dtype mean_score =
+              test_score[i]->cpu_data()[j] / param_.test_iter(test_net_id);
+        if (loss_weight)
+           mean_score = mean_score * loss_weight;
+        loss_msg_stream <<  mean_score << " ";
+      }
+      LOG(INFO) << "    Test net output #" << i << ": "
+                << output_name << " = " << loss_msg_stream.str();
+    } else if (test_score[i]->shape().size() == 2) {    // 2D - array
+      LOG(INFO) << "    Test net output #" << i << ": " << output_name
+                << " [" << test_score[i]->shape()[0] << "x"
+                << test_score[i]->shape()[1] << "]";
+      int num_rows = test_score[i]->shape()[0];
+      int num_columns = test_score[i]->shape()[1];
+      for (int j = 0; j < num_rows; ++j) {
+        ostringstream line_msg_stream;
+        line_msg_stream << "      " << output_name << " ";
+        line_msg_stream.width(4);
+        line_msg_stream << j << ": ";
+        for (int k = 0; k < num_columns; ++k) {
+          line_msg_stream.width(6);
+          line_msg_stream.precision(4);
+          line_msg_stream.setf(ostringstream::fixed);
+          line_msg_stream.setf(ostringstream::showpoint);
+          Dtype prob = test_score[i]->cpu_data()[j*num_columns + k] /
+                          param_.test_iter(test_net_id);
+          line_msg_stream << prob << "  ";
+        }
+        LOG(INFO) << line_msg_stream.str();
+      }
+    } else {
+      LOG(INFO) << "    Test net output #" << i << ": " << output_name
+                << test_score[i]->shape().size()
+                << "-d shape is not supported ";
     }
-    LOG(INFO) << "    Test net output #" << i << ": " << output_name << " = "
-              << mean_score << loss_msg_stream.str();
   }
 }
+
 
 template <typename Dtype>
 void Solver<Dtype>::Snapshot() {

--- a/src/caffe/test/test_confusion_matrix.cpp
+++ b/src/caffe/test/test_confusion_matrix.cpp
@@ -1,0 +1,122 @@
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/confusion_matrix_layer.hpp"
+#include "caffe/util/rng.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+class ConfusionMatrixLayerTest : public CPUDeviceTest<Dtype> {
+ protected:
+  ConfusionMatrixLayerTest()
+      : blob_bottom_data_(new Blob<Dtype>()),
+        blob_bottom_label_(new Blob<Dtype>()),
+        blob_top_(new Blob<Dtype>()) {
+    vector<int> shape(2);
+    shape[0] = 100;
+    shape[1] = 10;
+    blob_bottom_data_->Reshape(shape);
+    shape.resize(1);
+    blob_bottom_label_->Reshape(shape);
+    FillBottoms();
+
+    blob_bottom_vec_.push_back(blob_bottom_data_);
+    blob_bottom_vec_.push_back(blob_bottom_label_);
+    blob_top_vec_.push_back(blob_top_);
+  }
+
+  virtual void FillBottoms() {
+    // fill the probability values
+    FillerParameter filler_param;
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_data_);
+
+    const unsigned int prefetch_rng_seed = caffe_rng_rand();
+    shared_ptr<Caffe::RNG> rng(new Caffe::RNG(prefetch_rng_seed));
+    caffe::rng_t* prefetch_rng =
+          static_cast<caffe::rng_t*>(rng->generator());
+    Dtype* label_data = blob_bottom_label_->mutable_cpu_data();
+    for (int i = 0; i < blob_bottom_label_->count(); ++i) {
+      label_data[i] = (*prefetch_rng)() % 10;
+    }
+  }
+
+  virtual ~ConfusionMatrixLayerTest() {
+    delete blob_bottom_data_;
+    delete blob_bottom_label_;
+    delete blob_top_;
+  }
+
+  Blob<Dtype>* const blob_bottom_data_;
+  Blob<Dtype>* const blob_bottom_label_;
+  Blob<Dtype>* const blob_top_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(ConfusionMatrixLayerTest, TestDtypes);
+
+TYPED_TEST(ConfusionMatrixLayerTest, TestSetup) {
+  LayerParameter layer_param;
+  ConfusionMatrixLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  int label_axis = 1;
+  int num_classes = this->blob_bottom_vec_[0]->shape(label_axis);
+  EXPECT_EQ(num_classes, 10);
+  EXPECT_EQ(this->blob_top_->shape().size(), 2);
+  EXPECT_EQ(this->blob_top_->shape(0), num_classes);
+  EXPECT_EQ(this->blob_top_->shape(1), num_classes);
+}
+
+
+TYPED_TEST(ConfusionMatrixLayerTest, TestForwardCPU) {
+  LayerParameter layer_param;
+  ConfusionMatrixLayer<TypeParam> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+
+  int num_classes = 10;
+  vector<int> shape(2, num_classes);
+  vector<float> confusion_matrix(num_classes*num_classes, 0.);
+  vector<int> num_tests_per_class(num_classes, 0);
+
+  TypeParam max_value;
+  int max_id;
+  for (int i = 0; i < 100; ++i) {
+    max_value = -FLT_MAX;
+    max_id = 0;
+    for (int j = 0; j < num_classes; ++j) {
+      if (this->blob_bottom_data_->data_at(i, j, 0, 0) > max_value) {
+        max_value = this->blob_bottom_data_->data_at(i, j, 0, 0);
+        max_id = j;
+      }
+    }
+    int label = this->blob_bottom_label_->data_at(i, 0, 0, 0);
+    num_tests_per_class[label]++;
+    confusion_matrix[label*num_classes + max_id] += 1.0;
+  }
+  for (int j = 0; j < num_classes; ++j)
+    if (num_tests_per_class[j] > 0) {
+      for (int k = 0; k < num_classes; ++k)
+        confusion_matrix[j*num_classes + k] =
+           confusion_matrix[j*num_classes + k] /
+           static_cast<float>(num_tests_per_class[j]);
+  }
+  // test output
+  for (int j = 0; j < num_classes; ++j)
+    for (int k = 0; k < num_classes; ++k) {
+      EXPECT_NEAR(this->blob_top_vec_[0]->cpu_data()[j*num_classes + k],
+        confusion_matrix[j*num_classes + k], 1e-4);
+    }
+}
+}  // namespace caffe


### PR DESCRIPTION
This PR is based on https://github.com/BVLC/caffe/pull/3052. I just updated it to work with the current master.
This layer was written by _Boris Ginsburg_

>  New layer, which produces Confusion Matrix (https://en.wikipedia.org/wiki/Confusion_matrix ):
> 
> input: the same as for accuracy layer
> output: 2D matrix ( Blob) [CxC], where C is number of classes
> I also modified Solver::Test() to print 2D outputs of test net into log file.
