### PR TITLE
Fix initialization of deconvolution layer parameters in python net_spec interface

### DIFF
--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -37,7 +37,10 @@ def param_name_dict():
     # strip the final '_param' or 'Parameter'
     param_names = [s[:-len('_param')] for s in param_names]
     param_type_names = [s[:-len('Parameter')] for s in param_type_names]
-    return dict(zip(param_type_names, param_names))
+    result = dict(zip(param_type_names, param_names))
+    # convolution param is re-used in deconvolution layer
+    result['Deconvolution'] = 'convolution'
+    return result
 
 
 def to_proto(*tops):


### PR DESCRIPTION
Currently, you cannot initialize deconvolution layer parameters in the same way you can for a convolution layer, because the associated _param structure is called convolution_param instead of deconvolution_param.

E.g. the following throws an unknown attribute error:
deconv_layer = L.Deconvolution(bottom_layer, kernel_size=4, stride=2, num_output=25)

Solve the problem by adding the special case to the dictionary mapping layer types to parameters in param_name_dict().
