### PR TITLE
Add external library data layer

### DIFF
--- a/include/caffe/layers/data_layer.hpp
+++ b/include/caffe/layers/data_layer.hpp
@@ -32,6 +32,7 @@ class DataLayer : public BasePrefetchingDataLayer<Dtype> {
   virtual void load_batch(Batch<Dtype>* batch);
 
   DataReader reader_;
+  bool output_labels_;
 };
 
 }  // namespace caffe

--- a/include/caffe/layers/external_lib_data_layer.hpp
+++ b/include/caffe/layers/external_lib_data_layer.hpp
@@ -1,0 +1,46 @@
+#ifndef CAFFE_EXTERNAL_LIB_DATA_LAYER_HPP_
+#define CAFFE_EXTERNAL_LIB_DATA_LAYER_HPP_
+
+#include <string>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layers/base_data_layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+class IExternalLib;
+class IExternalLibDataSource;
+
+namespace caffe {
+
+/**
+* @brief Provides data to the net from the external dynamically load library.
+*/
+template <typename Dtype>
+class ExternalLibDataLayer : public BasePrefetchingDataLayer<Dtype> {
+ public:
+  explicit ExternalLibDataLayer(const LayerParameter& param);
+  virtual ~ExternalLibDataLayer();
+  virtual void DataLayerSetUp(const std::vector<Blob<Dtype>*>& bottom,
+    const std::vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "ExternalLibData"; }
+
+ protected:
+  virtual void load_batch(Batch<Dtype>* batch);
+  virtual bool PrefetchToGpu(int index);
+
+  virtual boost::shared_ptr<IExternalLib> GetExternalLib(
+    const std::string& ext_lib_path,
+    const std::string& factory_name,
+    const std::string& ext_lib_param);
+
+ private:
+  shared_ptr<IExternalLib> external_lib_interface_;
+  IExternalLibDataSource* data_source_;
+  std::vector<int> gpu_prefetch_indices_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_DATA_LAYER_HPP_

--- a/include/caffe/util/external_lib_data_source.hpp
+++ b/include/caffe/util/external_lib_data_source.hpp
@@ -1,0 +1,51 @@
+/**
+* @brief    This file contains interface declarations that external data source
+*           needs to implement to be able to plug into caffe pipeline. External
+*           library needs to export the factory method with the signature
+*           defined below.
+*           To instruct caffe to use external lib as data source one needs to
+*           use external lib data layer.
+*/
+#ifndef EXTARNAL_LIB_DATA_SOURCE_H_
+#define EXTARNAL_LIB_DATA_SOURCE_H_
+
+class IExternalLibDataSource;
+
+// External library data source factory method signature.
+typedef IExternalLibDataSource* (*ExternalLibDataSourceFactoryMethod)(
+  const char* external_lib_params);
+
+enum BlobType { BlobTypeFLOAT, BlobTypeDOUBLE };
+
+/**
+* @brief    Defines interface for one data point.
+*/
+class IDatum {
+ public:
+  // Returns datum shape for the blob with the given name.
+  virtual void GetBlobShape(const char* blob_name, const int** shape,
+    int* shape_count) = 0;
+
+  // Returns data of the given type for the blob with the given name.
+  virtual void GetBlobData(const char* blob_name, void* blob_data,
+    BlobType type) = 0;
+};
+
+/**
+* @brief    Defines interface for data source.
+*/
+class IExternalLibDataSource {
+ public:
+  // Releases resources, data source should not be used after this call.
+  virtual void Release() = 0;
+
+  // Moves internal iterator to the next datum.
+  virtual void MoveToNext() = 0;
+
+  // Returns current datum. Returned object must be valid till the next
+  // MoveToNext call. This call does not advances internal iterator,
+  // MoveToNext needs to be called to advance.
+  virtual IDatum* GetCurrent() = 0;
+};
+
+#endif

--- a/include/caffe/util/external_lib_data_source_util.hpp
+++ b/include/caffe/util/external_lib_data_source_util.hpp
@@ -1,0 +1,30 @@
+/**
+* @brief    This file contains helper interface declarations for external
+*           library data source.
+*/
+#ifndef EXTERNAL_LIB_DATA_SOURCE_UTIL_H_
+#define EXTERNAL_LIB_DATA_SOURCE_UTIL_H_
+
+#include <boost/shared_ptr.hpp>
+#include <string>
+
+class IExternalLibDataSource;
+
+/**
+* @brief    Class that abstracts away platform dependent library handling.
+*/
+class IExternalLib {
+ public:
+  virtual ~IExternalLib() {}
+  virtual IExternalLibDataSource* GetDataSource() = 0;
+};
+
+/**
+* @brief   Returns library object that abstracts away library management
+*          dependent on platform.
+*/
+boost::shared_ptr<IExternalLib> GetDataSourceLibraryWrapper(
+  const std::string& ext_lib_path, const std::string& factory_name,
+  const std::string& ext_lib_param);
+
+#endif

--- a/scripts/cpp_lint.py
+++ b/scripts/cpp_lint.py
@@ -1623,7 +1623,8 @@ def CheckCaffeDataLayerSetUp(filename, clean_lines, linenum, error):
        line.find('void DataLayer<Dtype>::DataLayerSetUp') == -1 and
        line.find('void ImageDataLayer<Dtype>::DataLayerSetUp') == -1 and
        line.find('void MemoryDataLayer<Dtype>::DataLayerSetUp') == -1 and
-       line.find('void WindowDataLayer<Dtype>::DataLayerSetUp') == -1):
+       line.find('void WindowDataLayer<Dtype>::DataLayerSetUp') == -1 and
+       line.find('void ExternalLibDataLayer<Dtype>::DataLayerSetUp') == -1):
       error(filename, linenum, 'caffe/data_layer_setup', 2,
             'Except the base classes, Caffe DataLayer should define'
             + ' DataLayerSetUp instead of LayerSetUp. The base DataLayers'

--- a/src/caffe/layers/base_data_layer.cu
+++ b/src/caffe/layers/base_data_layer.cu
@@ -8,17 +8,12 @@ template <typename Dtype>
 void BasePrefetchingDataLayer<Dtype>::Forward_gpu(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   Batch<Dtype>* batch = prefetch_full_.pop("Data layer prefetch queue empty");
-  // Reshape to loaded data.
-  top[0]->ReshapeLike(batch->data_);
-  // Copy the data
-  caffe_copy(batch->data_.count(), batch->data_.gpu_data(),
-      top[0]->mutable_gpu_data());
-  if (this->output_labels_) {
-    // Reshape to loaded labels.
-    top[1]->ReshapeLike(batch->label_);
-    // Copy the labels.
-    caffe_copy(batch->label_.count(), batch->label_.gpu_data(),
-        top[1]->mutable_gpu_data());
+  for (size_t ib = 0; ib < batch->data_.size(); ib++) {
+    // Reshape to loaded data.
+    top[ib]->ReshapeLike(*batch->data_[ib].get());
+    // Copy the data
+    caffe_copy(batch->data_[ib]->count(), batch->data_[ib]->gpu_data(),
+      top[ib]->mutable_gpu_data());
   }
   // Ensure the copy is synchronous wrt the host, so that the next batch isn't
   // copied in meanwhile.

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -25,6 +25,11 @@ DataLayer<Dtype>::~DataLayer() {
 template <typename Dtype>
 void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+  if (top.size() == 1) {
+    output_labels_ = false;
+  } else {
+    output_labels_ = true;
+  }
   const int batch_size = this->layer_param_.data_param().batch_size();
   // Read a data point, and use it to initialize the top blob.
   Datum& datum = *(reader_.full().peek());
@@ -36,7 +41,7 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   top_shape[0] = batch_size;
   top[0]->Reshape(top_shape);
   for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
-    this->prefetch_[i].data_.Reshape(top_shape);
+    this->prefetch_[i].data_[0]->Reshape(top_shape);
   }
   LOG(INFO) << "output data size: " << top[0]->num() << ","
       << top[0]->channels() << "," << top[0]->height() << ","
@@ -46,7 +51,7 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
     vector<int> label_shape(1, batch_size);
     top[1]->Reshape(label_shape);
     for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
-      this->prefetch_[i].label_.Reshape(label_shape);
+      this->prefetch_[i].data_[1]->Reshape(label_shape);
     }
   }
 }
@@ -59,7 +64,7 @@ void DataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
   double read_time = 0;
   double trans_time = 0;
   CPUTimer timer;
-  CHECK(batch->data_.count());
+  CHECK(batch->data_[0]->count());
   CHECK(this->transformed_data_.count());
 
   // Reshape according to the first datum of each batch
@@ -71,13 +76,13 @@ void DataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
   this->transformed_data_.Reshape(top_shape);
   // Reshape batch according to the batch_size.
   top_shape[0] = batch_size;
-  batch->data_.Reshape(top_shape);
+  batch->data_[0]->Reshape(top_shape);
 
-  Dtype* top_data = batch->data_.mutable_cpu_data();
+  Dtype* top_data = batch->data_[0]->mutable_cpu_data();
   Dtype* top_label = NULL;  // suppress warnings about uninitialized variables
 
   if (this->output_labels_) {
-    top_label = batch->label_.mutable_cpu_data();
+    top_label = batch->data_[1]->mutable_cpu_data();
   }
   for (int item_id = 0; item_id < batch_size; ++item_id) {
     timer.Start();
@@ -86,7 +91,7 @@ void DataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
     read_time += timer.MicroSeconds();
     timer.Start();
     // Apply data transformations (mirror, scale, crop...)
-    int offset = batch->data_.offset(item_id);
+    int offset = batch->data_[0]->offset(item_id);
     this->transformed_data_.set_cpu_data(top_data + offset);
     this->data_transformer_->Transform(datum, &(this->transformed_data_));
     // Copy label.

--- a/src/caffe/layers/external_lib_data_layer.cpp
+++ b/src/caffe/layers/external_lib_data_layer.cpp
@@ -1,0 +1,175 @@
+#include <string>
+#include <vector>
+
+#include "caffe/layers/external_lib_data_layer.hpp"
+#include "caffe/util/external_lib_data_source.hpp"
+#include "caffe/util/external_lib_data_source_util.hpp"
+#include "glog/logging.h"
+
+namespace caffe {
+
+  // Helper structs to map actual blob type to BlobType.
+  template <typename T>
+  struct BlobTypeMap {
+    static BlobType GetType() {
+      LOG(FATAL) << "Blob type mapping not implemented.";
+      return BlobTypeFLOAT;
+    }
+  };
+  // Explicit instantiation for float.
+  template <>
+  struct BlobTypeMap<float> {
+    static BlobType GetType() {
+      return BlobTypeFLOAT;
+    }
+  };
+  // Explicit instantiation for double.
+  template <>
+  struct BlobTypeMap<double> {
+    static BlobType GetType() {
+      return BlobTypeDOUBLE;
+    }
+  };
+
+  template <typename Dtype>
+  ExternalLibDataLayer<Dtype>::ExternalLibDataLayer(
+    const LayerParameter& param)
+    : BasePrefetchingDataLayer<Dtype>(param) {
+    }
+
+  template <typename Dtype>
+  ExternalLibDataLayer<Dtype>::~ExternalLibDataLayer<Dtype>() {
+    this->StopInternalThread();
+  }
+
+  template <typename Dtype>
+  void ExternalLibDataLayer<Dtype>::DataLayerSetUp(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+    // Get data source object.
+    ExternalLibDataParameter ext_lib_data_param =
+      this->layer_param_.external_lib_data_param();
+    external_lib_interface_ = GetExternalLib(
+      ext_lib_data_param.external_lib_path(),
+      ext_lib_data_param.factory_method_name(),
+      ext_lib_data_param.external_lib_param());
+    data_source_ = external_lib_interface_->GetDataSource();
+
+    // Convert names of tops to be fetched to GPU to corresponding indices.
+    if (ext_lib_data_param.gpu_prefetch_top_size() == 0) {
+      // In case nothing is defined we default to prefetching just first top
+      // like in other data layers.
+      gpu_prefetch_indices_.push_back(0);
+    } else {
+      for (int it = 0; it < this->layer_param_.top_size(); it++) {
+        const string& top_name = this->layer_param_.top(it);
+        bool found = false;
+        for (int in = 0; in < ext_lib_data_param.gpu_prefetch_top_size();
+          in++) {
+          if (top_name == ext_lib_data_param.gpu_prefetch_top(in)) {
+            gpu_prefetch_indices_.push_back(it);
+            found = true;
+            break;
+          }
+        }
+        CHECK(found);
+      }
+    }
+
+    // Make sure we have number of blobs equal to number of tops.
+    for (int ip = 0; ip < this->PREFETCH_COUNT; ip++) {
+      CHECK(this->prefetch_[ip].data_.size() <= this->layer_param_.top_size());
+      for (int il = this->prefetch_[ip].data_.size();
+        il < this->layer_param_.top_size(); il++) {
+        this->prefetch_[ip].data_.push_back(
+          shared_ptr<Blob<Dtype> >(new Blob<Dtype>()));
+      }
+    }
+
+    // Now we need to reshape.
+    const int batch_size = ext_lib_data_param.batch_size();
+    IDatum* example = data_source_->GetCurrent();
+    for (int it = 0; it < this->layer_param_.top_size(); it++) {
+      const string& top_name = this->layer_param_.top(it);
+      const int* shape = NULL;
+      int shape_count = 0;
+      example->GetBlobShape(top_name.c_str(), &shape, &shape_count);
+      vector<int> shape_vec(shape, shape + shape_count);
+      shape_vec.insert(shape_vec.begin(), batch_size);
+      top[it]->Reshape(shape_vec);
+      for (int ip = 0; ip < this->PREFETCH_COUNT; ip++) {
+        this->prefetch_[ip].data_[it]->Reshape(shape_vec);
+      }
+    }
+  }
+
+  // This function is called on prefetch thread.
+  template <typename Dtype>
+  void ExternalLibDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
+    ExternalLibDataParameter external_lib_data_param =
+      this->layer_param_.external_lib_data_param();
+
+    // Take one example to be able to take shapes.
+    IDatum* example = data_source_->GetCurrent();
+
+    // Go over all batch blobs and reshape them accordingly.
+    const int batch_size = external_lib_data_param.batch_size();
+    for (int il = 0; il < this->layer_param_.top_size(); il++) {
+      // Take blob data from example for blob with the given name.
+      const string& top_name = this->layer_param_.top(il);
+      const int* shape = NULL;
+      int shape_count = 0;
+      example->GetBlobShape(top_name.c_str(), &shape, &shape_count);
+
+      vector<int> top_shape(shape, shape + shape_count);
+      top_shape.insert(top_shape.begin(), batch_size);
+      batch->data_[il]->Reshape(top_shape);
+    }
+
+    // Go over the batch and load data.
+    for (int item_id = 0; item_id < batch_size; ++item_id) {
+      // Take current batch example.
+      example = data_source_->GetCurrent();
+
+      // Go over all top blobs.
+      for (int il = 0; il < this->layer_param_.top_size(); il++) {
+        // Take blob shape from example for blob with the given name.
+        const string& top_name = this->layer_param_.top(il);
+        const int* shape = NULL;
+        int shape_count = 0;
+        example->GetBlobShape(top_name.c_str(), &shape, &shape_count);
+        vector<int> top_shape(shape, shape + shape_count);
+        top_shape.insert(top_shape.begin(), batch_size);
+        // Make sure we have example shaped appropriately.
+        CHECK(batch->data_[il]->shape() == top_shape);
+
+        // Load example data into memory.
+        int datum_size = batch->data_[il]->count(1);
+        example->GetBlobData(top_name.c_str(),
+          batch->data_[il]->mutable_cpu_data() + item_id * datum_size,
+          BlobTypeMap<Dtype>::GetType());
+      }
+
+      // Move to the next example.
+      data_source_->MoveToNext();
+    }
+  }
+
+  template <typename Dtype>
+  bool ExternalLibDataLayer<Dtype>::PrefetchToGpu(int index) {
+    return find(gpu_prefetch_indices_.begin(), gpu_prefetch_indices_.end(),
+      index) != gpu_prefetch_indices_.end();
+  }
+
+  template <typename Dtype>
+  shared_ptr<IExternalLib> ExternalLibDataLayer<Dtype>::GetExternalLib(
+    const string& ext_lib_path,
+    const string& factory_name,
+    const string& ext_lib_param) {
+    return GetDataSourceLibraryWrapper(ext_lib_path, factory_name,
+      ext_lib_param);
+  }
+
+  INSTANTIATE_CLASS(ExternalLibDataLayer);
+  REGISTER_LAYER_CLASS(ExternalLibData);
+
+}  // namespace caffe

--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -174,7 +174,7 @@ void WindowDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   const int batch_size = this->layer_param_.window_data_param().batch_size();
   top[0]->Reshape(batch_size, channels, crop_size, crop_size);
   for (int i = 0; i < this->PREFETCH_COUNT; ++i)
-    this->prefetch_[i].data_.Reshape(
+    this->prefetch_[i].data_[0]->Reshape(
         batch_size, channels, crop_size, crop_size);
 
   LOG(INFO) << "output data size: " << top[0]->num() << ","
@@ -184,7 +184,7 @@ void WindowDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   vector<int> label_shape(1, batch_size);
   top[1]->Reshape(label_shape);
   for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
-    this->prefetch_[i].label_.Reshape(label_shape);
+    this->prefetch_[i].data_[1]->Reshape(label_shape);
   }
 
   // data mean
@@ -233,8 +233,8 @@ void WindowDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
   double read_time = 0;
   double trans_time = 0;
   CPUTimer timer;
-  Dtype* top_data = batch->data_.mutable_cpu_data();
-  Dtype* top_label = batch->label_.mutable_cpu_data();
+  Dtype* top_data = batch->data_[0]->mutable_cpu_data();
+  Dtype* top_label = batch->data_[1]->mutable_cpu_data();
   const Dtype scale = this->layer_param_.window_data_param().scale();
   const int batch_size = this->layer_param_.window_data_param().batch_size();
   const int context_pad = this->layer_param_.window_data_param().context_pad();
@@ -258,7 +258,7 @@ void WindowDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
   bool use_square = (crop_mode == "square") ? true : false;
 
   // zero out batch
-  caffe_set(batch->data_.count(), Dtype(0), top_data);
+  caffe_set(batch->data_[0]->count(), Dtype(0), top_data);
 
   const int num_fg = static_cast<int>(static_cast<float>(batch_size)
       * fg_fraction);

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -367,6 +367,7 @@ message LayerParameter {
   optional ConvolutionParameter convolution_param = 106;
   optional CropParameter crop_param = 144;
   optional DataParameter data_param = 107;
+  optional ExternalLibDataParameter external_lib_data_param = 10001;
   optional DropoutParameter dropout_param = 108;
   optional DummyDataParameter dummy_data_param = 109;
   optional EltwiseParameter eltwise_param = 110;
@@ -654,6 +655,19 @@ message DataParameter {
   // Prefetch queue (Number of batches to prefetch to host memory, increase if
   // data access bandwidth varies).
   optional uint32 prefetch = 10 [default = 4];
+}
+
+message ExternalLibDataParameter {
+  // Specify the external library path.
+  required string external_lib_path = 1;
+  // Specify the data source object factory method name.
+  required string factory_method_name = 2;
+  // Specify the parameter string to be passed to external library.
+  required string external_lib_param = 3;
+  // Specify the batch size.
+  required uint32 batch_size = 4;
+  // Indicates if blob with given name needs to be prefetched to GPU.
+  repeated string gpu_prefetch_top = 5;
 }
 
 message DropoutParameter {

--- a/src/caffe/test/test_external_lib_data_layer.cpp
+++ b/src/caffe/test/test_external_lib_data_layer.cpp
@@ -1,0 +1,207 @@
+#include <string>
+#include <vector>
+
+#include "caffe/layers/external_lib_data_layer.hpp"
+#include "caffe/util/external_lib_data_source.hpp"
+#include "caffe/util/external_lib_data_source_util.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+
+namespace caffe {
+
+// Names of the top blobs.
+const char* top_input_name = "input";
+const char* top_label_name = "label";
+
+// Dimension properties of the top blobs.
+static const int batch_size = 2;
+static const int input_dims = 3;
+static const int channels = 3;
+static const int height = 30;
+static const int width = 40;
+static const int input_count = channels * height * width;
+static const int target_dims = 1;
+
+// Dummy IDatum implementation. Sets same (given) value for input and target.
+template <typename Dtype>
+class DatumTest : public IDatum {
+ public:
+  explicit DatumTest(Dtype value) {
+    target_ = value;
+
+    input_ = shared_ptr<Dtype[]>(new Dtype[input_count]);
+    for (int i = 0; i < input_count; i++) {
+      input_[i] = value;
+    }
+  }
+
+  virtual void GetBlobShape(const char* blob_name, const int** shape,
+    int* shape_count) {
+    if (strcmp(blob_name, top_input_name) == 0) {
+      *shape = input_shape;
+      *shape_count = input_dims;
+    } else if (strcmp(blob_name, top_label_name) == 0) {
+      *shape = &target_shape_;
+      *shape_count = target_dims;
+    } else {
+      LOG(FATAL) << "Invalid blob name";
+    }
+  }
+
+  virtual void GetBlobData(const char* blob_name, void* blob_data,
+    BlobType type) {
+    if (strcmp(blob_name, top_input_name) == 0) {
+      // NOLINT_NEXT_LINE(caffe/alt_fn)
+      memcpy(blob_data, input_.get(), input_count * sizeof(Dtype));
+    } else if (strcmp(blob_name, top_label_name) == 0) {
+      // NOLINT_NEXT_LINE(caffe/alt_fn)
+      memcpy(blob_data, &target_, sizeof(Dtype));
+    } else {
+      LOG(FATAL) << "Invalid blob name";
+    }
+  }
+
+ private:
+  static const int input_shape[input_dims];
+  boost::shared_ptr<Dtype[]> input_;
+
+  static const int target_shape_;
+  Dtype target_;
+};
+
+template <typename Dtype>
+const int DatumTest<Dtype>::input_shape[input_dims] = { channels, height,
+  width };
+
+template <typename Dtype>
+const int DatumTest<Dtype>::target_shape_ = 1;
+
+// Dummy IExternalLibDataSource implementation. Creates two examples and
+// cycles through them.
+template <typename Dtype>
+class ExternalLibDataSourceTest : public IExternalLibDataSource {
+ public:
+  ExternalLibDataSourceTest() : datum_1_(Dtype(1)), datum_2_(Dtype(2)),
+    curr_datum_(&datum_1_) {}
+
+  virtual ~ExternalLibDataSourceTest() {}
+
+  virtual void Release() {
+    delete this;
+  }
+
+  virtual void MoveToNext() {
+    if (curr_datum_ == &datum_1_) {
+      curr_datum_ = &datum_2_;
+    } else if (curr_datum_ == &datum_2_) {
+      curr_datum_ = &datum_1_;
+    } else {
+      LOG(FATAL) << "Invalid datum test value";
+    }
+  }
+
+  virtual IDatum* GetCurrent() {
+    return curr_datum_;
+  }
+
+ private:
+  DatumTest<Dtype> datum_1_;
+  DatumTest<Dtype> datum_2_;
+  DatumTest<Dtype>* curr_datum_;
+};
+
+// Dummy implementation of the external lib. Does not load any external library
+// but fakes implementation in memory.
+template <typename Dtype>
+class ExternalLibTest : public IExternalLib {
+ public:
+  virtual IExternalLibDataSource* GetDataSource() {
+    return new ExternalLibDataSourceTest<Dtype>();
+  }
+};
+
+// Extends original external lib data layer to override external lib getting
+// (and to provide test implementation instead of original one).
+template <typename Dtype>
+class ExternalLibDataLayerEx : public ExternalLibDataLayer<Dtype> {
+ public:
+  explicit ExternalLibDataLayerEx(const LayerParameter& param) :
+    ExternalLibDataLayer<Dtype>(param) {}
+
+  // Override get library function.
+  virtual boost::shared_ptr<IExternalLib> GetExternalLib(
+    const std::string& ext_lib_path,
+    const std::string& factory_name,
+    const std::string& ext_lib_param) {
+    return shared_ptr<IExternalLib>(new ExternalLibTest<Dtype>());
+  }
+};
+
+// Test object.
+template <typename TypeParam>
+class ExternalLibDataLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  ExternalLibDataLayerTest() {
+    blob_top_vec_.push_back(&blob_top_data_);
+    blob_top_vec_.push_back(&blob_top_label_);
+  }
+
+  virtual ~ExternalLibDataLayerTest() {}
+
+  Blob<Dtype> blob_top_data_;
+  Blob<Dtype> blob_top_label_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(ExternalLibDataLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(ExternalLibDataLayerTest, TestRead) {
+  typedef typename TypeParam::Dtype Dtype;
+
+  // Create layer parameters.
+  LayerParameter param;
+  param.add_top(top_input_name);
+  param.add_top(top_label_name);
+  ExternalLibDataParameter* ext_lib_data_param =
+    param.mutable_external_lib_data_param();
+  ext_lib_data_param->set_batch_size(batch_size);
+
+  // Create layer based on layer parameters.
+  ExternalLibDataLayerEx<Dtype> layer(param);
+
+  // Test layer setup.
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  // Make sure we reshaped input accordingly.
+  ASSERT_EQ(this->blob_top_data_.num(), batch_size);
+  ASSERT_EQ(this->blob_top_data_.channels(), channels);
+  ASSERT_EQ(this->blob_top_data_.height(), height);
+  ASSERT_EQ(this->blob_top_data_.width(), width);
+  // Make sure we reshaped target accordingly.
+  ASSERT_EQ(this->blob_top_label_.num(), batch_size);
+  ASSERT_EQ(this->blob_top_label_.channels(), 1);
+  ASSERT_EQ(this->blob_top_label_.height(), 1);
+  ASSERT_EQ(this->blob_top_label_.width(), 1);
+
+  // Test forward pass.
+  const int iter_count = 2;
+  for (int i = 0; i < iter_count; i++) {
+    layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+    // Make sure we have expected values (all input equal to target).
+    const Dtype* input_data = this->blob_top_data_.cpu_data();
+    const Dtype* label_data = this->blob_top_label_.cpu_data();
+    int count = this->blob_top_data_.count(1);
+    for (int ib = 0; ib < batch_size; ib++) {
+      int data_offset = this->blob_top_data_.offset(ib);
+      int label_offset = this->blob_top_label_.offset(ib);
+
+      for (int ic = 0; ic < count; ic++) {
+        ASSERT_EQ(input_data[data_offset + ic], label_data[label_offset]);
+      }
+    }
+  }
+}
+
+}  // namespace caffe

--- a/src/caffe/util/external_lib_data_source_util.cpp
+++ b/src/caffe/util/external_lib_data_source_util.cpp
@@ -1,0 +1,128 @@
+#include <string>
+
+#include "caffe/util/external_lib_data_source.hpp"
+#include "caffe/util/external_lib_data_source_util.hpp"
+#include "glog/logging.h"
+
+using boost::shared_ptr;
+using std::string;
+
+#if defined(_MSC_VER)
+#include <windows.h>  // NOLINT(build/include_order)
+
+// Windows specific implementation of external library management (dll).
+class WindowsDll : public IExternalLib {
+ public:
+  WindowsDll(const string& ext_lib_path,
+    const string& factory_name, const string& ext_lib_param) {
+    // Load dynamic link library.
+    dll_module_ = LoadLibraryA(ext_lib_path.c_str());
+    if (dll_module_ == nullptr) {
+      LOG(FATAL) << "Error occurred while loading data source dll";
+    }
+
+    // Obtain pointer to factory method.
+    ExternalLibDataSourceFactoryMethod factory_method =
+      reinterpret_cast<ExternalLibDataSourceFactoryMethod>(
+      GetProcAddress(dll_module_, factory_name.c_str()));
+    if (factory_method == nullptr) {
+      LOG(FATAL) << "Error occurred while accessing factory method in data "
+        "source dll";
+    }
+
+    // Finally, use factory method to get data source object.
+    data_source_ = factory_method(ext_lib_param.c_str());
+    if (data_source_ == nullptr) {
+      LOG(FATAL) << "Error occurred while creating data source object";
+    }
+  }
+
+  virtual ~WindowsDll() override {
+    // Release data source object.
+    if (data_source_ != nullptr) {
+      data_source_->Release();
+    }
+
+    // Free library handle.
+    if (dll_module_ != nullptr) {
+      FreeLibrary(dll_module_);
+    }
+  }
+
+  virtual IExternalLibDataSource* GetDataSource() override {
+    return data_source_;
+  }
+
+ private:
+  HMODULE dll_module_;
+  IExternalLibDataSource* data_source_;
+};
+
+#elif __linux__
+#include <dlfcn.h>  // NOLINT(build/include_order)
+
+// Linux specific implementation of external library management (so).
+class LinuxSo : public IExternalLib {
+ public:
+  LinuxSo(const string& ext_lib_path,
+    const string& factory_name, const string& ext_lib_param) {
+    // Load dynamic load library.
+    handle_ = dlopen(ext_lib_path.c_str(), RTLD_LAZY);
+    if (handle_ == NULL) {
+      LOG(FATAL) << "Error occurred while loading data source so";
+    }
+
+    // Obtain pointer to factory method.
+    ExternalLibDataSourceFactoryMethod factory_method =
+      reinterpret_cast<ExternalLibDataSourceFactoryMethod>(
+      dlsym(handle_, factory_name.c_str()));
+    if (factory_method == NULL) {
+      LOG(FATAL) << "Error occurred while accessing factory method in data"
+        "source so";
+    }
+
+    // Finally, use factory method to get data source object.
+    data_source_ = factory_method(ext_lib_param.c_str());
+    if (data_source_ == NULL) {
+      LOG(FATAL) << "Error occurred while creating data source object";
+    }
+  }
+
+  virtual ~LinuxSo() {
+    // Release data source object.
+    if (data_source_ != NULL) {
+      data_source_->Release();
+    }
+
+    // Free library handle.
+    if (handle_ != NULL) {
+      dlclose(handle_);
+    }
+  }
+
+  virtual IExternalLibDataSource* GetDataSource() {
+    return data_source_;
+  }
+
+ private:
+  void* handle_;
+  IExternalLibDataSource* data_source_;
+};
+
+#endif
+
+shared_ptr<IExternalLib> GetDataSourceLibraryWrapper(
+  const string& ext_lib_path, const string& factory_name,
+  const string& ext_lib_param) {
+#if defined(_MSC_VER)
+  return shared_ptr<IExternalLib>(new WindowsDll(ext_lib_path, factory_name,
+    ext_lib_param));
+#elif __linux__
+  return shared_ptr<IExternalLib>(new LinuxSo(ext_lib_path, factory_name,
+    ext_lib_param));
+#else
+  LOG(FATAL) << "External library management is not implemented for "
+    "current platform!";
+  return nullptr;
+#endif
+}


### PR DESCRIPTION
Currently there are a number of data layers available in Caffe supporting different input formats. However, there is always one more format which is optimal for the given training.  
One cannot expect Caffe to support all the formats, but fairly close solution would be to implement extensible architecture which enables easy integration of external formats with Caffe.  
In this change external library data layer is implemented. This data layer expects external library (Shared Object on Linux or DLL on Windows) to provide data for Caffe network.  
Using this data layer has several benefits:
- Decouples data source from Caffe. New formats are easily consumable and do not require changes in Caffe codebase
- Enables in-memory synthetic data generation
- Enables multiple top blobs (current prefetching data layers only support 2 tops, which is a limitation for some trainings)
- Opens possibility to implement some of the existing data layers (LMDB, LevelDB etc.) as external libraries to reduce number of dependencies Caffe has

This change is implemented with compatibility in mind. All existing data layers maintain the same behaviour. External library adapters are provided for Windows and Linux to localize platform specific code.
