### PR TITLE
NetSpec for reshape layer

### DIFF
--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -76,7 +76,10 @@ def assign_proto(proto, name, val):
         for k, v in six.iteritems(val):
             assign_proto(getattr(proto, name), k, v)
     else:
-        setattr(proto, name, val)
+        try:
+            setattr(proto, name, val)
+        except:
+            getattr(proto, name).CopyFrom(val)
 
 
 class Top(object):


### PR DESCRIPTION
Currently, the test would fail with following error message:

```
Traceback (most recent call last):
    return n.to_proto()
  File "caffe/net_spec.py", line 192, in to_proto
    top._to_proto(layers, names, autonames)
  File "caffe/net_spec.py", line 100, in _to_proto
    return self.fn._to_proto(layers, names, autonames)
  File "caffe/net_spec.py", line 161, in _to_proto
    assign_proto(layer, k, v)
  File "caffe/net_spec.py", line 64, in assign_proto
    is_repeated_field = hasattr(getattr(proto, name), 'extend')
AttributeError: 'LayerParameter' object has no attribute 'shape'
```

The actual error (overrode by the try .. except) is:

```
    return n.to_proto()
  File "caffe/net_spec.py", line 192, in to_proto
    top._to_proto(layers, names, autonames)
  File "caffe/net_spec.py", line 100, in _to_proto
    return self.fn._to_proto(layers, names, autonames)
  File "caffe/net_spec.py", line 159, in _to_proto
    _param_names[self.type_name] + '_param'), k, v)
  File "caffe/net_spec.py", line 80, in assign_proto
    setattr(proto, name, val)
  File ".../google/protobuf/internal/python_message.py", line 539, in setter
    '"%s" in protocol message object.' % proto_field_name)
AttributeError: Assignment not allowed to composite field "shape" in protocol message object.
```

This PR include 
1. improvement for `assign_proto` to try `CopyFrom` on errors
2. the test case relying on the improvement.