### PR TITLE
nd convolution and pooling with cuDNN

### DIFF
--- a/include/caffe/filler.hpp
+++ b/include/caffe/filler.hpp
@@ -147,8 +147,8 @@ class XavierFiller : public Filler<Dtype> {
       : Filler<Dtype>(param) {}
   virtual void Fill(Blob<Dtype>* blob) {
     CHECK(blob->count());
-    int fan_in = blob->count() / blob->num();
-    int fan_out = blob->count() / blob->channels();
+    int fan_in = blob->count() / blob->shape(0);
+    int fan_out = blob->count() / blob->shape(1);
     Dtype n = fan_in;  // default to fan_in
     if (this->filler_param_.variance_norm() ==
         FillerParameter_VarianceNorm_AVERAGE) {

--- a/include/caffe/layers/pooling_layer.hpp
+++ b/include/caffe/layers/pooling_layer.hpp
@@ -52,15 +52,9 @@ class PoolingLayer : public Layer<Dtype> {
   std::vector<int> pad_;
 
   int num_spatial_axes_;
-
-  int kernel_h_, kernel_w_;
-  int stride_h_, stride_w_;
-  int pad_h_, pad_w_;
   int channels_;
   std::vector<int> input_shape_;
   std::vector<int> pooled_shape_;
-  int height_, width_;
-  int pooled_height_, pooled_width_;
   bool global_pooling_;
   Blob<Dtype> rand_idx_;
   Blob<int> max_idx_;

--- a/include/caffe/layers/pooling_layer.hpp
+++ b/include/caffe/layers/pooling_layer.hpp
@@ -44,10 +44,21 @@ class PoolingLayer : public Layer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
+  /// @brief The spatial dimensions of a filter kernel.
+  std::vector<int> kernel_shape_;
+  /// @brief The spatial dimensions of the stride.
+  std::vector<int> stride_;
+  /// @brief The spatial dimensions of the padding.
+  std::vector<int> pad_;
+
+  int num_spatial_axes_;
+
   int kernel_h_, kernel_w_;
   int stride_h_, stride_w_;
   int pad_h_, pad_w_;
   int channels_;
+  std::vector<int> input_shape_;
+  std::vector<int> pooled_shape_;
   int height_, width_;
   int pooled_height_, pooled_width_;
   bool global_pooling_;

--- a/include/caffe/util/cudnn.hpp
+++ b/include/caffe/util/cudnn.hpp
@@ -4,6 +4,8 @@
 
 #include <cudnn.h>
 
+#include <vector>
+
 #include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"
 
@@ -69,11 +71,26 @@ inline void createTensor4dDesc(cudnnTensorDescriptor_t* desc) {
 }
 
 template <typename Dtype>
+inline void createTensorDesc(cudnnTensorDescriptor_t* desc) {
+  CUDNN_CHECK(cudnnCreateTensorDescriptor(desc));
+}
+
+template <typename Dtype>
 inline void setTensor4dDesc(cudnnTensorDescriptor_t* desc,
     int n, int c, int h, int w,
     int stride_n, int stride_c, int stride_h, int stride_w) {
   CUDNN_CHECK(cudnnSetTensor4dDescriptorEx(*desc, dataType<Dtype>::type,
         n, c, h, w, stride_n, stride_c, stride_h, stride_w));
+}
+
+template <typename Dtype>
+inline void setTensorNdDesc(cudnnTensorDescriptor_t* desc,
+    std::vector<int> shape,
+    std::vector<int> stride) {
+  CHECK_EQ(shape.size(), stride.size())
+      << "Dimensions of shape and stride don't match !";
+  CUDNN_CHECK(cudnnSetTensorNdDescriptor(*desc, dataType<Dtype>::type,
+        shape.size(), shape.data(), stride.data()));
 }
 
 template <typename Dtype>
@@ -88,11 +105,30 @@ inline void setTensor4dDesc(cudnnTensorDescriptor_t* desc,
 }
 
 template <typename Dtype>
+inline void setTensorNdDesc(cudnnTensorDescriptor_t* desc,
+    std::vector<int> shape) {
+  // set up stride
+  std::vector<int> stride(shape.size(), 1);
+  for (int i = stride.size() - 2; i >= 0; --i) {
+    stride[i] = shape[i + 1] * stride[i + 1];
+  }
+  setTensorNdDesc<Dtype>(desc, shape, stride);
+}
+
+template <typename Dtype>
 inline void createFilterDesc(cudnnFilterDescriptor_t* desc,
     int n, int c, int h, int w) {
   CUDNN_CHECK(cudnnCreateFilterDescriptor(desc));
   CUDNN_CHECK(cudnnSetFilter4dDescriptor(*desc, dataType<Dtype>::type,
       n, c, h, w));
+}
+
+template <typename Dtype>
+inline void createNdFilterDesc(cudnnFilterDescriptor_t* desc,
+    std::vector<int> shape) {
+  CUDNN_CHECK(cudnnCreateFilterDescriptor(desc));
+  CUDNN_CHECK(cudnnSetFilterNdDescriptor(*desc, dataType<Dtype>::type,
+      shape.size(), shape.data()));
 }
 
 template <typename Dtype>
@@ -106,6 +142,25 @@ inline void setConvolutionDesc(cudnnConvolutionDescriptor_t* conv,
     int pad_h, int pad_w, int stride_h, int stride_w) {
   CUDNN_CHECK(cudnnSetConvolution2dDescriptor(*conv,
       pad_h, pad_w, stride_h, stride_w, 1, 1, CUDNN_CROSS_CORRELATION));
+}
+
+template <typename Dtype>
+inline void setNdConvolutionDesc(cudnnConvolutionDescriptor_t* conv,
+    cudnnTensorDescriptor_t bottom, cudnnFilterDescriptor_t filter,
+    std::vector<int> pad, std::vector<int> stride) {
+  int nbDims;
+  std::vector<int> shape(pad.size() + 2);
+  cudnnDataType_t cudnn_type;
+  cudnnGetFilterNdDescriptor(filter,
+      shape.size(), &cudnn_type, &nbDims, shape.data());
+  CHECK_EQ(nbDims, pad.size() + 2)
+      << "Dimensions of filters and pad don't match !";
+  CHECK_EQ(nbDims, stride.size() + 2)
+      << "Dimensions of filters and stride don't match !";
+  std::vector<int> upscale(pad.size(), 1);
+  CUDNN_CHECK(cudnnSetConvolutionNdDescriptor(*conv,
+      pad.size(), pad.data(), stride.data(), upscale.data(),
+      CUDNN_CROSS_CORRELATION, cudnn_type));
 }
 
 template <typename Dtype>
@@ -125,6 +180,30 @@ inline void createPoolingDesc(cudnnPoolingDescriptor_t* pool_desc,
   CUDNN_CHECK(cudnnCreatePoolingDescriptor(pool_desc));
   CUDNN_CHECK(cudnnSetPooling2dDescriptor(*pool_desc, *mode, h, w,
         pad_h, pad_w, stride_h, stride_w));
+}
+
+template <typename Dtype>
+inline void createNdPoolingDesc(cudnnPoolingDescriptor_t* pool_desc,
+    PoolingParameter_PoolMethod poolmethod, cudnnPoolingMode_t* mode,
+    std::vector<int> shape, std::vector<int> pad,
+    std::vector<int> stride) {
+  CHECK_EQ(shape.size(), pad.size())
+      << "Dimensions of shape and pad don't match !";
+  CHECK_EQ(shape.size(), stride.size())
+      << "Dimensions of shape and stride don't match !";
+  switch (poolmethod) {
+  case PoolingParameter_PoolMethod_MAX:
+    *mode = CUDNN_POOLING_MAX;
+    break;
+  case PoolingParameter_PoolMethod_AVE:
+    *mode = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
+    break;
+  default:
+    LOG(FATAL) << "Unknown pooling method.";
+  }
+  CUDNN_CHECK(cudnnCreatePoolingDescriptor(pool_desc));
+  CUDNN_CHECK(cudnnSetPoolingNdDescriptor(*pool_desc, *mode, shape.size(),
+        shape.data(), pad.data(), stride.data()));
 }
 
 }  // namespace cudnn

--- a/src/caffe/layers/cudnn_pooling_layer.cpp
+++ b/src/caffe/layers/cudnn_pooling_layer.cpp
@@ -10,12 +10,11 @@ void CuDNNPoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   PoolingLayer<Dtype>::LayerSetUp(bottom, top);
   CUDNN_CHECK(cudnnCreate(&handle_));
-  cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
-  cudnn::createTensor4dDesc<Dtype>(&top_desc_);
-  cudnn::createPoolingDesc<Dtype>(&pooling_desc_,
+  cudnn::createTensorDesc<Dtype>(&bottom_desc_);
+  cudnn::createTensorDesc<Dtype>(&top_desc_);
+  cudnn::createNdPoolingDesc<Dtype>(&pooling_desc_,
       this->layer_param_.pooling_param().pool(), &mode_,
-      this->kernel_h_, this->kernel_w_, this->pad_h_, this->pad_w_,
-      this->stride_h_, this->stride_w_);
+      this->kernel_shape_, this->pad_, this->stride_);
   handles_setup_ = true;
 }
 
@@ -23,10 +22,8 @@ template <typename Dtype>
 void CuDNNPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   PoolingLayer<Dtype>::Reshape(bottom, top);
-  cudnn::setTensor4dDesc<Dtype>(&bottom_desc_, bottom[0]->num(),
-      this->channels_, this->height_, this->width_);
-  cudnn::setTensor4dDesc<Dtype>(&top_desc_, bottom[0]->num(),
-      this->channels_, this->pooled_height_, this->pooled_width_);
+  cudnn::setTensorNdDesc<Dtype>(&bottom_desc_, this->input_shape_);
+  cudnn::setTensorNdDesc<Dtype>(&top_desc_, this->pooled_shape_);
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/cudnn_relu_layer.cpp
+++ b/src/caffe/layers/cudnn_relu_layer.cpp
@@ -11,8 +11,8 @@ void CuDNNReLULayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   ReLULayer<Dtype>::LayerSetUp(bottom, top);
   // initialize cuDNN
   CUDNN_CHECK(cudnnCreate(&handle_));
-  cudnn::createTensor4dDesc<Dtype>(&bottom_desc_);
-  cudnn::createTensor4dDesc<Dtype>(&top_desc_);
+  cudnn::createTensorDesc<Dtype>(&bottom_desc_);
+  cudnn::createTensorDesc<Dtype>(&top_desc_);
   handles_setup_ = true;
 }
 
@@ -20,12 +20,8 @@ template <typename Dtype>
 void CuDNNReLULayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   ReLULayer<Dtype>::Reshape(bottom, top);
-  const int N = bottom[0]->num();
-  const int K = bottom[0]->channels();
-  const int H = bottom[0]->height();
-  const int W = bottom[0]->width();
-  cudnn::setTensor4dDesc<Dtype>(&bottom_desc_, N, K, H, W);
-  cudnn::setTensor4dDesc<Dtype>(&top_desc_, N, K, H, W);
+  cudnn::setTensorNdDesc<Dtype>(&bottom_desc_, bottom[0]->shape());
+  cudnn::setTensorNdDesc<Dtype>(&top_desc_, bottom[0]->shape());
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/euclidean_loss_layer.cpp
+++ b/src/caffe/layers/euclidean_loss_layer.cpp
@@ -24,7 +24,7 @@ void EuclideanLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       bottom[1]->cpu_data(),
       diff_.mutable_cpu_data());
   Dtype dot = caffe_cpu_dot(count, diff_.cpu_data(), diff_.cpu_data());
-  Dtype loss = dot / bottom[0]->num() / Dtype(2);
+  Dtype loss = dot / bottom[0]->shape(0) / Dtype(2);
   top[0]->mutable_cpu_data()[0] = loss;
 }
 
@@ -34,7 +34,7 @@ void EuclideanLossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
   for (int i = 0; i < 2; ++i) {
     if (propagate_down[i]) {
       const Dtype sign = (i == 0) ? 1 : -1;
-      const Dtype alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->num();
+      const Dtype alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->shape(0);
       caffe_cpu_axpby(
           bottom[i]->count(),              // count
           alpha,                              // alpha

--- a/src/caffe/layers/euclidean_loss_layer.cu
+++ b/src/caffe/layers/euclidean_loss_layer.cu
@@ -16,7 +16,7 @@ void EuclideanLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       diff_.mutable_gpu_data());
   Dtype dot;
   caffe_gpu_dot(count, diff_.gpu_data(), diff_.gpu_data(), &dot);
-  Dtype loss = dot / bottom[0]->num() / Dtype(2);
+  Dtype loss = dot / bottom[0]->shape(0) / Dtype(2);
   top[0]->mutable_cpu_data()[0] = loss;
 }
 
@@ -26,7 +26,7 @@ void EuclideanLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   for (int i = 0; i < 2; ++i) {
     if (propagate_down[i]) {
       const Dtype sign = (i == 0) ? 1 : -1;
-      const Dtype alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->num();
+      const Dtype alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->shape(0);
       caffe_gpu_axpby(
           bottom[i]->count(),              // count
           alpha,                              // alpha

--- a/src/caffe/layers/loss_layer.cpp
+++ b/src/caffe/layers/loss_layer.cpp
@@ -16,7 +16,7 @@ void LossLayer<Dtype>::LayerSetUp(
 template <typename Dtype>
 void LossLayer<Dtype>::Reshape(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
-  CHECK_EQ(bottom[0]->num(), bottom[1]->num())
+  CHECK_EQ(bottom[0]->shape(0), bottom[1]->shape(0))
       << "The data and label should have the same number.";
   vector<int> loss_shape(0);  // Loss layers output a scalar; 0 axes.
   top[0]->Reshape(loss_shape);

--- a/src/caffe/layers/lrn_layer.cpp
+++ b/src/caffe/layers/lrn_layer.cpp
@@ -38,8 +38,8 @@ void LRNLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     LayerParameter pool_param;
     pool_param.mutable_pooling_param()->set_pool(
         PoolingParameter_PoolMethod_AVE);
-    pool_param.mutable_pooling_param()->set_pad(pre_pad_);
-    pool_param.mutable_pooling_param()->set_kernel_size(size_);
+    pool_param.mutable_pooling_param()->add_pad(pre_pad_);
+    pool_param.mutable_pooling_param()->add_kernel_size(size_);
     pool_layer_.reset(new PoolingLayer<Dtype>(pool_param));
     pool_layer_->SetUp(square_top_vec_, pool_top_vec_);
     // Set up power_layer_ to compute (1 + alpha_/N^2 s)^-beta_, where s is

--- a/src/caffe/layers/pooling_layer.cpp
+++ b/src/caffe/layers/pooling_layer.cpp
@@ -14,111 +14,147 @@ template <typename Dtype>
 void PoolingLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   PoolingParameter pool_param = this->layer_param_.pooling_param();
-  if (pool_param.global_pooling()) {
-    CHECK(!(pool_param.has_kernel_size() ||
+  global_pooling_ = pool_param.global_pooling();
+  num_spatial_axes_ = bottom[0]->num_axes() - 2;
+  // Setup filter kernel dimensions (kernel_shape_).
+  kernel_shape_ = std::vector<int>(num_spatial_axes_, 0);
+  if (global_pooling_) {
+    CHECK(!((pool_param.kernel_size_size() > 0) ||
       pool_param.has_kernel_h() || pool_param.has_kernel_w()))
       << "With Global_pooling: true Filter size cannot specified";
+    for (int i = 0; i < num_spatial_axes_; ++i)
+      kernel_shape_[i] = bottom[0]->shape(i + 2);
   } else {
-    CHECK(!pool_param.has_kernel_size() !=
-      !(pool_param.has_kernel_h() && pool_param.has_kernel_w()))
-      << "Filter size is kernel_size OR kernel_h and kernel_w; not both";
-    CHECK(pool_param.has_kernel_size() ||
-      (pool_param.has_kernel_h() && pool_param.has_kernel_w()))
-      << "For non-square filters both kernel_h and kernel_w are required.";
-  }
-  CHECK((!pool_param.has_pad() && pool_param.has_pad_h()
-      && pool_param.has_pad_w())
-      || (!pool_param.has_pad_h() && !pool_param.has_pad_w()))
-      << "pad is pad OR pad_h and pad_w are required.";
-  CHECK((!pool_param.has_stride() && pool_param.has_stride_h()
-      && pool_param.has_stride_w())
-      || (!pool_param.has_stride_h() && !pool_param.has_stride_w()))
-      << "Stride is stride OR stride_h and stride_w are required.";
-  global_pooling_ = pool_param.global_pooling();
-  if (global_pooling_) {
-    kernel_h_ = bottom[0]->height();
-    kernel_w_ = bottom[0]->width();
-  } else {
-    if (pool_param.has_kernel_size()) {
-      kernel_h_ = kernel_w_ = pool_param.kernel_size();
+    if (pool_param.has_kernel_h() || pool_param.has_kernel_w()) {
+      CHECK_EQ(num_spatial_axes_, 2)
+          << "kernel_h & kernel_w can only be used for 2D pooling.";
+      CHECK_EQ(0, pool_param.kernel_size_size())
+          << "Either kernel_size or kernel_h/w should be specified; not both.";
+      kernel_shape_[0] = pool_param.kernel_h();
+      kernel_shape_[1] = pool_param.kernel_w();
     } else {
-      kernel_h_ = pool_param.kernel_h();
-      kernel_w_ = pool_param.kernel_w();
+      const int num_kernel_dims = pool_param.kernel_size_size();
+      CHECK(num_kernel_dims == 1 || num_kernel_dims == num_spatial_axes_)
+          << "kernel_size must be specified once, or once per spatial "
+          << "dimension (kernel_size specified " << num_kernel_dims
+          << " times; " << num_spatial_axes_ << " spatial dims).";
+        for (int i = 0; i < num_spatial_axes_; ++i) {
+          kernel_shape_[i] =
+              pool_param.kernel_size((num_kernel_dims == 1) ? 0 : i);
+        }
+    }
+    for (int i = 0; i < num_spatial_axes_; ++i) {
+      CHECK_GT(kernel_shape_[i], 0) << "Filter dimensions must be nonzero.";
     }
   }
-  CHECK_GT(kernel_h_, 0) << "Filter dimensions cannot be zero.";
-  CHECK_GT(kernel_w_, 0) << "Filter dimensions cannot be zero.";
-  if (!pool_param.has_pad_h()) {
-    pad_h_ = pad_w_ = pool_param.pad();
+  // Setup stride dimensions (stride_).
+  stride_ = std::vector<int>(num_spatial_axes_, 0);
+  if (pool_param.has_stride_h() || pool_param.has_stride_w()) {
+    CHECK_EQ(num_spatial_axes_, 2)
+        << "stride_h & stride_w can only be used for 2D pooling.";
+    CHECK_EQ(0, pool_param.stride_size())
+        << "Either stride or stride_h/w should be specified; not both.";
+    stride_[0] = pool_param.stride_h();
+    stride_[1] = pool_param.stride_w();
   } else {
-    pad_h_ = pool_param.pad_h();
-    pad_w_ = pool_param.pad_w();
+    const int num_stride_dims = pool_param.stride_size();
+    CHECK(num_stride_dims == 0 || num_stride_dims == 1 ||
+          num_stride_dims == num_spatial_axes_)
+        << "stride must be specified once, or once per spatial dimension "
+        << "(stride specified " << num_stride_dims << " times; "
+        << num_spatial_axes_ << " spatial dims).";
+    const int kDefaultStride = 1;
+    for (int i = 0; i < num_spatial_axes_; ++i) {
+      stride_[i] = (num_stride_dims == 0) ? kDefaultStride :
+          pool_param.stride((num_stride_dims == 1) ? 0 : i);
+      CHECK_GT(stride_[i], 0) << "Stride dimensions must be nonzero.";
+    }
   }
-  if (!pool_param.has_stride_h()) {
-    stride_h_ = stride_w_ = pool_param.stride();
+  // Setup pad dimensions (pad_).
+  pad_ = std::vector<int>(num_spatial_axes_, 0);
+  if (pool_param.has_pad_h() || pool_param.has_pad_w()) {
+    CHECK_EQ(num_spatial_axes_, 2)
+        << "pad_h & pad_w can only be used for 2D pooling.";
+    CHECK_EQ(0, pool_param.pad_size())
+        << "Either pad or pad_h/w should be specified; not both.";
+    pad_[0] = pool_param.pad_h();
+    pad_[1] = pool_param.pad_w();
   } else {
-    stride_h_ = pool_param.stride_h();
-    stride_w_ = pool_param.stride_w();
+    const int num_pad_dims = pool_param.pad_size();
+    CHECK(num_pad_dims == 0 || num_pad_dims == 1 ||
+          num_pad_dims == num_spatial_axes_)
+        << "pad must be specified once, or once per spatial dimension "
+        << "(pad specified " << num_pad_dims << " times; "
+        << num_spatial_axes_ << " spatial dims).";
+    const int kDefaultPad = 0;
+    for (int i = 0; i < num_spatial_axes_; ++i) {
+      pad_[i] = (num_pad_dims == 0) ? kDefaultPad :
+          pool_param.pad((num_pad_dims == 1) ? 0 : i);
+    }
   }
-  if (global_pooling_) {
-    CHECK(pad_h_ == 0 && pad_w_ == 0 && stride_h_ == 1 && stride_w_ == 1)
-      << "With Global_pooling: true; only pad = 0 and stride = 1";
-  }
-  if (pad_h_ != 0 || pad_w_ != 0) {
-    CHECK(this->layer_param_.pooling_param().pool()
-        == PoolingParameter_PoolMethod_AVE
-        || this->layer_param_.pooling_param().pool()
-        == PoolingParameter_PoolMethod_MAX)
-        << "Padding implemented only for average and max pooling.";
-    CHECK_LT(pad_h_, kernel_h_);
-    CHECK_LT(pad_w_, kernel_w_);
+  // remaining pooling sanity checks
+  for (int i = 0; i < num_spatial_axes_; ++i) {
+    if (global_pooling_) {
+      CHECK(pad_[i] == 0 && stride_[i] == 1)
+        << "With Global_pooling: true; only pad = 0 and stride = 1";
+    }
+    if (pad_[i] != 0) {
+      CHECK(this->layer_param_.pooling_param().pool()
+          == PoolingParameter_PoolMethod_AVE
+          || this->layer_param_.pooling_param().pool()
+          == PoolingParameter_PoolMethod_MAX)
+          << "Padding implemented only for average and max pooling.";
+    }
+    CHECK_LT(pad_[i], kernel_shape_[i]);
   }
 }
 
 template <typename Dtype>
 void PoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
-  CHECK_EQ(4, bottom[0]->num_axes()) << "Input must have 4 axes, "
-      << "corresponding to (num, channels, height, width)";
-  channels_ = bottom[0]->channels();
-  height_ = bottom[0]->height();
-  width_ = bottom[0]->width();
+  CHECK_EQ(bottom[0]->num_axes() - 2, num_spatial_axes_)
+      << "bottom num_axes may not change.";
+  channels_ = bottom[0]->shape(1);
+  input_shape_ = bottom[0]->shape();
   if (global_pooling_) {
-    kernel_h_ = bottom[0]->height();
-    kernel_w_ = bottom[0]->width();
+    for (int i = 0; i < num_spatial_axes_; ++i)
+      kernel_shape_[i] = input_shape_[i + 2];
   }
-  pooled_height_ = static_cast<int>(ceil(static_cast<float>(
-      height_ + 2 * pad_h_ - kernel_h_) / stride_h_)) + 1;
-  pooled_width_ = static_cast<int>(ceil(static_cast<float>(
-      width_ + 2 * pad_w_ - kernel_w_) / stride_w_)) + 1;
-  if (pad_h_ || pad_w_) {
-    // If we have padding, ensure that the last pooling starts strictly
-    // inside the image (instead of at the padding); otherwise clip the last.
-    if ((pooled_height_ - 1) * stride_h_ >= height_ + pad_h_) {
-      --pooled_height_;
-    }
-    if ((pooled_width_ - 1) * stride_w_ >= width_ + pad_w_) {
-      --pooled_width_;
-    }
-    CHECK_LT((pooled_height_ - 1) * stride_h_, height_ + pad_h_);
-    CHECK_LT((pooled_width_ - 1) * stride_w_, width_ + pad_w_);
+  // setup pooled shape
+  pooled_shape_ = std::vector<int>(input_shape_.size());
+  pooled_shape_[0] = input_shape_[0];
+  pooled_shape_[1] = input_shape_[1];
+  for (unsigned int i = 0; i < num_spatial_axes_; ++i) {
+    pooled_shape_[i + 2] = static_cast<int>(std::ceil(static_cast<float>(
+        input_shape_[i + 2] + 2 * pad_[i] - kernel_shape_[i]) /
+        stride_[i])) + 1;
   }
-  top[0]->Reshape(bottom[0]->num(), channels_, pooled_height_,
-      pooled_width_);
+  for (unsigned int i = 0; i < num_spatial_axes_; ++i) {
+    if (pad_[i]) {
+      // If we have padding, ensure that the last pooling starts strictly
+      // inside the image (instead of at the padding); otherwise clip the last.
+      if ((pooled_shape_[i + 2] - 1) * stride_[i] >=
+          input_shape_[i + 2] + pad_[i]) {
+        --pooled_shape_[i + 2];
+      }
+      CHECK_LT((pooled_shape_[i + 2] - 1) * stride_[i],
+          input_shape_[i + 2] + pad_[i]);
+    }
+  }
+  // reshape outputs
+  top[0]->Reshape(pooled_shape_);
   if (top.size() > 1) {
     top[1]->ReshapeLike(*top[0]);
   }
   // If max pooling, we will initialize the vector index part.
   if (this->layer_param_.pooling_param().pool() ==
       PoolingParameter_PoolMethod_MAX && top.size() == 1) {
-    max_idx_.Reshape(bottom[0]->num(), channels_, pooled_height_,
-        pooled_width_);
+    max_idx_.Reshape(pooled_shape_);
   }
   // If stochastic pooling, we will initialize the random index part.
   if (this->layer_param_.pooling_param().pool() ==
       PoolingParameter_PoolMethod_STOCHASTIC) {
-    rand_idx_.Reshape(bottom[0]->num(), channels_, pooled_height_,
-      pooled_width_);
+    rand_idx_.Reshape(pooled_shape_);
   }
 }
 

--- a/src/caffe/layers/pooling_layer.cpp
+++ b/src/caffe/layers/pooling_layer.cpp
@@ -170,6 +170,16 @@ void PoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   const bool use_top_mask = top.size() > 1;
   int* mask = NULL;  // suppress warnings about uninitalized variables
   Dtype* top_mask = NULL;
+  const int height_ = input_shape_[2];
+  const int width_ = input_shape_[3];
+  const int pooled_height_ = pooled_shape_[2];
+  const int pooled_width_ = pooled_shape_[3];
+  const int kernel_h_ = kernel_shape_[0];
+  const int kernel_w_ = kernel_shape_[1];
+  const int pad_h_ = pad_[0];
+  const int pad_w_ = pad_[1];
+  const int stride_h_ = stride_[0];
+  const int stride_w_ = stride_[1];
   // Different pooling methods. We explicitly do the switch outside the for
   // loop to save time, although this results in more code.
   switch (this->layer_param_.pooling_param().pool()) {
@@ -277,6 +287,16 @@ void PoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
   const bool use_top_mask = top.size() > 1;
   const int* mask = NULL;  // suppress warnings about uninitialized variables
   const Dtype* top_mask = NULL;
+  const int height_ = input_shape_[2];
+  const int width_ = input_shape_[3];
+  const int pooled_height_ = pooled_shape_[2];
+  const int pooled_width_ = pooled_shape_[3];
+  const int kernel_h_ = kernel_shape_[0];
+  const int kernel_w_ = kernel_shape_[1];
+  const int pad_h_ = pad_[0];
+  const int pad_w_ = pad_[1];
+  const int stride_h_ = stride_[0];
+  const int stride_w_ = stride_[1];
   switch (this->layer_param_.pooling_param().pool()) {
   case PoolingParameter_PoolMethod_MAX:
     // The main loop

--- a/src/caffe/layers/pooling_layer.cu
+++ b/src/caffe/layers/pooling_layer.cu
@@ -164,6 +164,16 @@ void PoolingLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   const bool use_top_mask = top.size() > 1;
   int* mask = NULL;
   Dtype* top_mask = NULL;
+  const int height_ = input_shape_[2];
+  const int width_ = input_shape_[3];
+  const int pooled_height_ = pooled_shape_[2];
+  const int pooled_width_ = pooled_shape_[3];
+  const int kernel_h_ = kernel_shape_[0];
+  const int kernel_w_ = kernel_shape_[1];
+  const int pad_h_ = pad_[0];
+  const int pad_w_ = pad_[1];
+  const int stride_h_ = stride_[0];
+  const int stride_w_ = stride_[1];
   switch (this->layer_param_.pooling_param().pool()) {
   case PoolingParameter_PoolMethod_MAX:
     if (use_top_mask) {
@@ -344,6 +354,16 @@ void PoolingLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   const bool use_top_mask = top.size() > 1;
   const int* mask = NULL;
   const Dtype* top_mask = NULL;
+  const int height_ = input_shape_[2];
+  const int width_ = input_shape_[3];
+  const int pooled_height_ = pooled_shape_[2];
+  const int pooled_width_ = pooled_shape_[3];
+  const int kernel_h_ = kernel_shape_[0];
+  const int kernel_w_ = kernel_shape_[1];
+  const int pad_h_ = pad_[0];
+  const int pad_w_ = pad_[1];
+  const int stride_h_ = stride_[0];
+  const int stride_w_ = stride_[1];
   switch (this->layer_param_.pooling_param().pool()) {
   case PoolingParameter_PoolMethod_MAX:
     if (use_top_mask) {

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -881,24 +881,28 @@ message PoolingParameter {
   }
   optional PoolMethod pool = 1 [default = MAX]; // The pooling method
   // Pad, kernel size, and stride are all given as a single value for equal
-  // dimensions in height and width or as Y, X pairs.
-  optional uint32 pad = 4 [default = 0]; // The padding size (equal in Y, X)
-  optional uint32 pad_h = 9 [default = 0]; // The padding height
-  optional uint32 pad_w = 10 [default = 0]; // The padding width
-  optional uint32 kernel_size = 2; // The kernel size (square)
-  optional uint32 kernel_h = 5; // The kernel height
-  optional uint32 kernel_w = 6; // The kernel width
-  optional uint32 stride = 3 [default = 1]; // The stride (equal in Y, X)
-  optional uint32 stride_h = 7; // The stride height
-  optional uint32 stride_w = 8; // The stride width
+  // dimensions in all spatial dimensions, or once per spatial dimension.
+  repeated uint32 pad = 4; // The padding size; defaults to 0
+  repeated uint32 kernel_size = 2; // The kernel size
+  repeated uint32 stride = 3; // The stride; defaults to 1
+
+  // For 2D padding only, the *_h and *_w versions may also be used to
+  // specify both spatial dimensions.
+  optional uint32 pad_h = 9 [default = 0]; // The padding height (2D only)
+  optional uint32 pad_w = 10 [default = 0]; // The padding width (2D only)
+  optional uint32 kernel_h = 5; // The kernel height (2D only)
+  optional uint32 kernel_w = 6; // The kernel width (2D only)
+  optional uint32 stride_h = 7; // The stride height (2D only)
+  optional uint32 stride_w = 8; // The stride width (2D only)
+
   enum Engine {
     DEFAULT = 0;
     CAFFE = 1;
     CUDNN = 2;
   }
   optional Engine engine = 11 [default = DEFAULT];
-  // If global_pooling then it will pool over the size of the bottom by doing
-  // kernel_h = bottom->height and kernel_w = bottom->width
+  // If global_pooling then it will pool over the size of the bottom by setting
+  // the size of the kernel to the size of the input image
   optional bool global_pooling = 12 [default = false];
 }
 

--- a/src/caffe/test/test_maxpool_dropout_layers.cpp
+++ b/src/caffe/test/test_maxpool_dropout_layers.cpp
@@ -44,8 +44,8 @@ TYPED_TEST(MaxPoolingDropoutTest, TestSetup) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
   PoolingLayer<Dtype> max_layer(layer_param);
   max_layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   DropoutLayer<Dtype> dropout_layer(layer_param);
@@ -61,8 +61,8 @@ TYPED_TEST(MaxPoolingDropoutTest, TestForward) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
   PoolingLayer<Dtype> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -91,8 +91,8 @@ TYPED_TEST(MaxPoolingDropoutTest, TestBackward) {
   LayerParameter layer_param;
   layer_param.set_phase(TRAIN);
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
   PoolingLayer<Dtype> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);

--- a/src/caffe/test/test_pooling_layer.cpp
+++ b/src/caffe/test/test_pooling_layer.cpp
@@ -49,7 +49,7 @@ class PoolingLayerTest : public MultiDeviceTest<TypeParam> {
   void TestForwardSquare() {
     LayerParameter layer_param;
     PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-    pooling_param->set_kernel_size(2);
+    pooling_param->add_kernel_size(2);
     pooling_param->set_pool(PoolingParameter_PoolMethod_MAX);
     const int num = 2;
     const int channels = 2;
@@ -377,8 +377,8 @@ TYPED_TEST(PoolingLayerTest, TestSetup) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
   PoolingLayer<Dtype> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   EXPECT_EQ(this->blob_top_->num(), this->blob_bottom_->num());
@@ -391,9 +391,9 @@ TYPED_TEST(PoolingLayerTest, TestSetupPadded) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
-  pooling_param->set_pad(1);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
+  pooling_param->add_pad(1);
   pooling_param->set_pool(PoolingParameter_PoolMethod_AVE);
   PoolingLayer<Dtype> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -421,7 +421,7 @@ TYPED_TEST(PoolingLayerTest, TestSetupGlobalPooling) {
 TYPED_TEST(PoolingLayerTest, PrintBackward) {
   LayerParameter layer_param;
   layer_param.set_kernelsize(3);
-  layer_param.set_stride(2);
+  layer_param.add_stride(2);
   layer_param.set_pool(LayerParameter_PoolMethod_MAX);
   PoolingLayer<TypeParam> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -464,8 +464,8 @@ TYPED_TEST(PoolingLayerTest, TestGradientMax) {
       PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
       pooling_param->set_kernel_h(kernel_h);
       pooling_param->set_kernel_w(kernel_w);
-      pooling_param->set_stride(2);
-      pooling_param->set_pad(1);
+      pooling_param->add_stride(2);
+      pooling_param->add_pad(1);
       pooling_param->set_pool(PoolingParameter_PoolMethod_MAX);
       PoolingLayer<Dtype> layer(layer_param);
       GradientChecker<Dtype> checker(1e-4, 1e-2);
@@ -479,9 +479,9 @@ TYPED_TEST(PoolingLayerTest, TestForwardMaxPadded) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
-  pooling_param->set_pad(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
+  pooling_param->add_pad(2);
   pooling_param->set_pool(PoolingParameter_PoolMethod_MAX);
   this->blob_bottom_->Reshape(1, 1, 3, 3);
   // Input:
@@ -528,7 +528,7 @@ TYPED_TEST(PoolingLayerTest, TestGradientMaxTopMask) {
       PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
       pooling_param->set_kernel_h(kernel_h);
       pooling_param->set_kernel_w(kernel_w);
-      pooling_param->set_stride(2);
+      pooling_param->add_stride(2);
       pooling_param->set_pool(PoolingParameter_PoolMethod_MAX);
       this->blob_top_vec_.push_back(this->blob_top_mask_);
       PoolingLayer<Dtype> layer(layer_param);
@@ -544,9 +544,9 @@ TYPED_TEST(PoolingLayerTest, TestForwardAve) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(1);
-  pooling_param->set_pad(1);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(1);
+  pooling_param->add_pad(1);
   pooling_param->set_pool(PoolingParameter_PoolMethod_AVE);
   this->blob_bottom_->Reshape(1, 1, 3, 3);
   FillerParameter filler_param;
@@ -580,7 +580,7 @@ TYPED_TEST(PoolingLayerTest, TestGradientAve) {
       PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
       pooling_param->set_kernel_h(kernel_h);
       pooling_param->set_kernel_w(kernel_w);
-      pooling_param->set_stride(2);
+      pooling_param->add_stride(2);
       pooling_param->set_pool(PoolingParameter_PoolMethod_AVE);
       PoolingLayer<Dtype> layer(layer_param);
       GradientChecker<Dtype> checker(1e-2, 1e-2);
@@ -598,8 +598,8 @@ TYPED_TEST(PoolingLayerTest, TestGradientAvePadded) {
       PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
       pooling_param->set_kernel_h(kernel_h);
       pooling_param->set_kernel_w(kernel_w);
-      pooling_param->set_stride(2);
-      pooling_param->set_pad(2);
+      pooling_param->add_stride(2);
+      pooling_param->add_pad(2);
       pooling_param->set_pool(PoolingParameter_PoolMethod_AVE);
       PoolingLayer<Dtype> layer(layer_param);
       GradientChecker<Dtype> checker(1e-2, 1e-2);
@@ -641,7 +641,7 @@ class CuDNNPoolingLayerTest : public GPUDeviceTest<Dtype> {
   void TestForwardSquare() {
     LayerParameter layer_param;
     PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-    pooling_param->set_kernel_size(2);
+    pooling_param->add_kernel_size(2);
     pooling_param->set_pool(PoolingParameter_PoolMethod_MAX);
     const int num = 2;
     const int channels = 2;
@@ -968,8 +968,8 @@ TYPED_TEST_CASE(CuDNNPoolingLayerTest, TestDtypes);
 TYPED_TEST(CuDNNPoolingLayerTest, TestSetupCuDNN) {
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
   CuDNNPoolingLayer<TypeParam> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   EXPECT_EQ(this->blob_top_->num(), this->blob_bottom_->num());
@@ -981,9 +981,9 @@ TYPED_TEST(CuDNNPoolingLayerTest, TestSetupCuDNN) {
 TYPED_TEST(CuDNNPoolingLayerTest, TestSetupPaddedCuDNN) {
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
-  pooling_param->set_pad(1);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
+  pooling_param->add_pad(1);
   pooling_param->set_pool(PoolingParameter_PoolMethod_AVE);
   CuDNNPoolingLayer<TypeParam> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -997,7 +997,7 @@ TYPED_TEST(CuDNNPoolingLayerTest, TestSetupPaddedCuDNN) {
 TYPED_TEST(CuDNNPoolingLayerTest, PrintBackwardCuDNN) {
   LayerParameter layer_param;
   layer_param.set_kernelsize(3);
-  layer_param.set_stride(2);
+  layer_param.add_stride(2);
   layer_param.set_pool(LayerParameter_PoolMethod_MAX);
   CuDNNPoolingLayer<TypeParam> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -1043,9 +1043,9 @@ TYPED_TEST(CuDNNPoolingLayerTest, TestGradientMaxCuDNN) {
       PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
       pooling_param->set_kernel_h(kernel_h);
       pooling_param->set_kernel_w(kernel_w);
-      pooling_param->set_stride(2);
+      pooling_param->add_stride(2);
       // currenty, cuDNN pooling does not support padding
-      pooling_param->set_pad(0);
+      pooling_param->add_pad(0);
       pooling_param->set_pool(PoolingParameter_PoolMethod_MAX);
       CuDNNPoolingLayer<TypeParam> layer(layer_param);
       GradientChecker<TypeParam> checker(1e-4, 1e-2);
@@ -1058,9 +1058,9 @@ TYPED_TEST(CuDNNPoolingLayerTest, TestGradientMaxCuDNN) {
 TYPED_TEST(CuDNNPoolingLayerTest, TestForwardMaxPaddedCuDNN) {
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
-  pooling_param->set_pad(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
+  pooling_param->add_pad(2);
   pooling_param->set_pool(PoolingParameter_PoolMethod_MAX);
   this->blob_bottom_->Reshape(1, 1, 3, 3);
   // Input:
@@ -1107,7 +1107,7 @@ TYPED_TEST(CuDNNPoolingLayerTest, TestGradientMaxTopMaskCuDNN) {
       PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
       pooling_param->set_kernel_h(kernel_h);
       pooling_param->set_kernel_w(kernel_w);
-      pooling_param->set_stride(2);
+      pooling_param->add_stride(2);
       pooling_param->set_pool(PoolingParameter_PoolMethod_MAX);
       this->blob_top_vec_.push_back(this->blob_top_mask_);
       CuDNNPoolingLayer<TypeParam> layer(layer_param);
@@ -1123,11 +1123,11 @@ TYPED_TEST(CuDNNPoolingLayerTest, TestGradientMaxTopMaskCuDNN) {
 TYPED_TEST(CuDNNPoolingLayerTest, TestForwardAveCuDNN) {
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(1);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(1);
   // Currently, cuDNN pooling does not support padding, so we use
   // a simplified version of this test.
-  pooling_param->set_pad(0);
+  pooling_param->add_pad(0);
   pooling_param->set_pool(PoolingParameter_PoolMethod_AVE);
   this->blob_bottom_->Reshape(1, 1, 3, 3);
   FillerParameter filler_param;
@@ -1152,7 +1152,7 @@ TYPED_TEST(CuDNNPoolingLayerTest, TestGradientAveCuDNN) {
       PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
       pooling_param->set_kernel_h(kernel_h);
       pooling_param->set_kernel_w(kernel_w);
-      pooling_param->set_stride(2);
+      pooling_param->add_stride(2);
       pooling_param->set_pool(PoolingParameter_PoolMethod_AVE);
       CuDNNPoolingLayer<TypeParam> layer(layer_param);
       GradientChecker<TypeParam> checker(1e-2, 1e-2);
@@ -1169,8 +1169,8 @@ TYPED_TEST(CuDNNPoolingLayerTest, TestGradientAvePaddedCuDNN) {
       PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
       pooling_param->set_kernel_h(kernel_h);
       pooling_param->set_kernel_w(kernel_w);
-      pooling_param->set_stride(2);
-      pooling_param->set_pad(2);
+      pooling_param->add_stride(2);
+      pooling_param->add_pad(2);
       pooling_param->set_pool(PoolingParameter_PoolMethod_AVE);
       CuDNNPoolingLayer<TypeParam> layer(layer_param);
       GradientChecker<TypeParam> checker(1e-2, 1e-2);

--- a/src/caffe/test/test_stochastic_pooling.cpp
+++ b/src/caffe/test/test_stochastic_pooling.cpp
@@ -56,8 +56,8 @@ TYPED_TEST_CASE(CPUStochasticPoolingLayerTest, TestDtypes);
 TYPED_TEST(CPUStochasticPoolingLayerTest, TestSetup) {
   LayerParameter layer_param;
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
   PoolingLayer<TypeParam> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   EXPECT_EQ(this->blob_top_->num(), this->blob_bottom_->num());
@@ -79,8 +79,8 @@ TYPED_TEST(GPUStochasticPoolingLayerTest, TestStochastic) {
   LayerParameter layer_param;
   layer_param.set_phase(TRAIN);
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
   pooling_param->set_pool(PoolingParameter_PoolMethod_STOCHASTIC);
   PoolingLayer<TypeParam> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -122,8 +122,8 @@ TYPED_TEST(GPUStochasticPoolingLayerTest, TestStochasticTestPhase) {
   LayerParameter layer_param;
   layer_param.set_phase(TEST);
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
   pooling_param->set_pool(PoolingParameter_PoolMethod_STOCHASTIC);
   PoolingLayer<TypeParam> layer(layer_param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -159,8 +159,8 @@ TYPED_TEST(GPUStochasticPoolingLayerTest, TestGradient) {
   LayerParameter layer_param;
   layer_param.set_phase(TRAIN);
   PoolingParameter* pooling_param = layer_param.mutable_pooling_param();
-  pooling_param->set_kernel_size(3);
-  pooling_param->set_stride(2);
+  pooling_param->add_kernel_size(3);
+  pooling_param->add_stride(2);
   pooling_param->set_pool(PoolingParameter_PoolMethod_STOCHASTIC);
   PoolingLayer<TypeParam> layer(layer_param);
   GradientChecker<TypeParam> checker(1e-4, 1e-2);

--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -267,7 +267,7 @@ bool UpgradeV0LayerParameter(const V1LayerParameter& v0_layer_connection,
       if (type == "conv") {
         layer_param->mutable_convolution_param()->add_pad(v0_layer_param.pad());
       } else if (type == "pool") {
-        layer_param->mutable_pooling_param()->set_pad(v0_layer_param.pad());
+        layer_param->mutable_pooling_param()->add_pad(v0_layer_param.pad());
       } else {
         LOG(ERROR) << "Unknown parameter pad for layer type " << type;
         is_fully_compatible = false;
@@ -278,7 +278,7 @@ bool UpgradeV0LayerParameter(const V1LayerParameter& v0_layer_connection,
         layer_param->mutable_convolution_param()->add_kernel_size(
             v0_layer_param.kernelsize());
       } else if (type == "pool") {
-        layer_param->mutable_pooling_param()->set_kernel_size(
+        layer_param->mutable_pooling_param()->add_kernel_size(
             v0_layer_param.kernelsize());
       } else {
         LOG(ERROR) << "Unknown parameter kernelsize for layer type " << type;
@@ -299,7 +299,7 @@ bool UpgradeV0LayerParameter(const V1LayerParameter& v0_layer_connection,
         layer_param->mutable_convolution_param()->add_stride(
             v0_layer_param.stride());
       } else if (type == "pool") {
-        layer_param->mutable_pooling_param()->set_stride(
+        layer_param->mutable_pooling_param()->add_stride(
             v0_layer_param.stride());
       } else {
         LOG(ERROR) << "Unknown parameter stride for layer type " << type;


### PR DESCRIPTION
This branch implements n-dimensional convolution and pooling with cudnn, similar to #2824 and  #3515. In contrast to #2824 and  #3515 this PR does not create new layers, but is built on top of the existing convolution and pooling layers.

The convolution layer already has an interface for nd convolutions (#2049), but the pooling layer has not. I changed the interface of the pooling layer to support nd pooling similar to #2049. This new interface made changes in the caffe internal pooling and some test files necessary, but I did not change the caffe CPU and GPU pooling to support nd pooling. Nd pooling (2d, 3d and possibly more) is **only** working for average pooling using cudnn.

I also changed some calls to legacy shape accessors (num(), channels(), etc.) when I needed them. There are still many layers that do not support the new shape() accessors. So if you encounter errors from blob.hpp saying "Cannot use legacy accessors on Blobs with > 4 axes.", check the layer for the legacy accessors and make the necessary changes.

I tested the code with cudnn v4 for 2d and 3d convolutions and poolings. I am not sure, if older/other versions of cudnn would work.
All test cases pass with the new pooling interface. Currently, I did not create any new cases that test nd convolution and pooling, but I'm planning to implement some.