### PR TITLE
Generalize bilinear filler to for N-D multilinear filler

### DIFF
--- a/include/caffe/util/upgrade_proto.hpp
+++ b/include/caffe/util/upgrade_proto.hpp
@@ -65,6 +65,12 @@ bool NetNeedsInputUpgrade(const NetParameter& net_param);
 // Perform all necessary transformations to upgrade input fields into layers.
 void UpgradeNetInput(NetParameter* net_param);
 
+// Return true iff the Net contains any deprecated weight fillers.
+bool NetNeedsWeightFillerUpgrade(const NetParameter& net_param);
+
+// Perform all necessary transformations to upgrade deprecated weight fillers.
+void UpgradeNetWeightFiller(NetParameter* net_param);
+
 // Return true iff the solver contains any old solver_type specified as enums
 bool SolverNeedsTypeUpgrade(const SolverParameter& solver_param);
 


### PR DESCRIPTION
This branch changes the bilinear filler (#2213) to support an arbitrary number of dimensions. Also, different scaling factors for each dimension are supported. I changed the name of the filler from "bilinear" to "linear", as it suits better for its multi-dimensional functionality.

The usage of this filler is the same as before (see comments, or #2213). Tests are not included, but I plan to write some using python scikit-image.