### PR TITLE
Update ipython notebook to do better visualization of weights.

### DIFF
--- a/examples/00-classification.ipynb
+++ b/examples/00-classification.ipynb
@@ -530,7 +530,7 @@
     "    data = data.reshape((n, n) + data.shape[1:]).transpose((0, 2, 1, 3) + tuple(range(4, data.ndim + 1)))\n",
     "    data = data.reshape((n * data.shape[1], n * data.shape[3]) + data.shape[4:])\n",
     "    \n",
-    "    plt.imshow(data); plt.axis('off')"
+    "    plt.imshow(data, interpolation='nearest'); plt.axis('off')"
    ]
   },
   {
@@ -771,7 +771,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
   },
   "priority": 1
  },


### PR DESCRIPTION
I think that by making the visualization of weights using 'nearest' interpolation will make it better.

Example of current visualization:

![caffe_pull_before](https://cloud.githubusercontent.com/assets/2501383/14542230/e9647fd8-025b-11e6-96e7-8bcde2240569.png)

With 'nearest' interpolation:

![caffe_pull_after](https://cloud.githubusercontent.com/assets/2501383/14542234/ef42cd4c-025b-11e6-8e94-aed7ef95b8b3.png)
