### PR TITLE
Allow the python layer have attribute "phase"

### DIFF
--- a/include/caffe/layers/python_layer.hpp
+++ b/include/caffe/layers/python_layer.hpp
@@ -26,6 +26,7 @@ class PythonLayer : public Layer<Dtype> {
     }
     self_.attr("param_str") = bp::str(
         this->layer_param_.python_param().param_str());
+    self_.attr("phase") = static_cast<int>(this->phase_);
     self_.attr("setup")(bottom, top);
   }
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,


### PR DESCRIPTION
I noticed that the python layer cannot tell whether the phase is TRAIN or TEST. This change may bring convenience in some cases. e.g. to me.

    class MyLayer(caffe.Layer):
        ... ...
        def forward(self, bottom, top):
            if (self.phase == caffe.TRAIN):
                # do sth.
            else:
                # do sth. else
        ... ...