### PR TITLE
Changed mnist map size, paths, file extensions

### DIFF
--- a/examples/mnist/convert_mnist_data.cpp
+++ b/examples/mnist/convert_mnist_data.cpp
@@ -98,7 +98,7 @@ void convert_dataset(const char* image_filename, const char* label_filename,
     CHECK_EQ(mkdir(db_path, 0744), 0)
         << "mkdir " << db_path << "failed";
     CHECK_EQ(mdb_env_create(&mdb_env), MDB_SUCCESS) << "mdb_env_create failed";
-	CHECK_EQ(mdb_env_set_mapsize(mdb_env, 78643200), MDB_SUCCESS)  // 1TB
+    CHECK_EQ(mdb_env_set_mapsize(mdb_env, 78643200), MDB_SUCCESS)  // 75 MB
         << "mdb_env_set_mapsize failed";
     CHECK_EQ(mdb_env_open(mdb_env, db_path, 0, 0664), MDB_SUCCESS)
         << "mdb_env_open failed";

--- a/examples/mnist/convert_mnist_data.cpp
+++ b/examples/mnist/convert_mnist_data.cpp
@@ -98,7 +98,7 @@ void convert_dataset(const char* image_filename, const char* label_filename,
     CHECK_EQ(mkdir(db_path, 0744), 0)
         << "mkdir " << db_path << "failed";
     CHECK_EQ(mdb_env_create(&mdb_env), MDB_SUCCESS) << "mdb_env_create failed";
-    CHECK_EQ(mdb_env_set_mapsize(mdb_env, 1099511627776), MDB_SUCCESS)  // 1TB
+	CHECK_EQ(mdb_env_set_mapsize(mdb_env, 78643200), MDB_SUCCESS)  // 1TB
         << "mdb_env_set_mapsize failed";
     CHECK_EQ(mdb_env_open(mdb_env, db_path, 0, 0664), MDB_SUCCESS)
         << "mdb_env_open failed";

--- a/examples/mnist/create_mnist.sh
+++ b/examples/mnist/create_mnist.sh
@@ -4,7 +4,7 @@
 
 EXAMPLE=examples/mnist
 DATA=data/mnist
-BUILD=build/examples/mnist
+BUILD=Build/x64/Release
 
 BACKEND="lmdb"
 
@@ -13,9 +13,9 @@ echo "Creating ${BACKEND}..."
 rm -rf $EXAMPLE/mnist_train_${BACKEND}
 rm -rf $EXAMPLE/mnist_test_${BACKEND}
 
-$BUILD/convert_mnist_data.bin $DATA/train-images-idx3-ubyte \
+$BUILD/convert_mnist_data.exe $DATA/train-images-idx3-ubyte \
   $DATA/train-labels-idx1-ubyte $EXAMPLE/mnist_train_${BACKEND} --backend=${BACKEND}
-$BUILD/convert_mnist_data.bin $DATA/t10k-images-idx3-ubyte \
+$BUILD/convert_mnist_data.exe $DATA/t10k-images-idx3-ubyte \
   $DATA/t10k-labels-idx1-ubyte $EXAMPLE/mnist_test_${BACKEND} --backend=${BACKEND}
 
 echo "Done."

--- a/examples/mnist/train_lenet.sh
+++ b/examples/mnist/train_lenet.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-./build/tools/caffe train --solver=examples/mnist/lenet_solver.prototxt
+./Build/x64/Release/caffe.exe train --solver=examples/mnist/lenet_solver.prototxt


### PR DESCRIPTION
For the mnist example `convert_mnist_data.cpp` creates a 1 TB lmdb which fails if you don't have a terabyte to spare on your drive. I reduced it to 75 MB.

The scripts also assume that that executables will end with `bin` when on Windows they end with `exe` so I changed those too.

The location of binaries is different on Windows as well. I changed the path of the mnist examples to use the Windows path (the Release path, still won't work for Debug builds).