### PR TITLE
Python LMDB Creator

### DIFF
--- a/python/caffe/lmdb_creator.py
+++ b/python/caffe/lmdb_creator.py
@@ -1,0 +1,281 @@
+import os
+import shutil
+import logging
+
+import numpy as np
+import lmdb
+import caffe.io
+
+class LMDBCreator(object):
+    def __init__(self):
+        '''
+        The LMDB creator class can create a single LMDB for single label 
+        classification or two LMDBs where each element in the database_images 
+        has a corresponding counterpart in database_additional with the same 
+        key. This is useful for creating e.g. LMDBs for semantic-segmentation.
+        '''
+        self.logger = logging.getLogger('LMDBCreator')
+        self.database_images = None
+        self.database_additional = None
+        self.txn_images = None
+        self.txn_additional = None
+        self.label_map = None
+        self.internal_counter = 0
+        
+        self.logger.debug('Using LMDB version %d.%d.%d' % lmdb.version())
+    
+    def open_single_lmdb_for_write(self, lmdb_path, max_lmdb_size=1024**4, 
+				   create=True, label_map=None):
+        '''
+        Opens a single LMDB for inserting ndarrays (i.e. images)
+        @param lmdb_path: str
+            Where to save the LMDB
+        @param max_lmdb_size: int
+            The maximum size in bytes of the LMDB (default: 1TB)
+        @param create: bool
+            If this flag is set, a potentially previously created LMDB at 
+            lmdb_path is deleted and overwritten by this new LMDB
+        @param label_map: dictionary
+            If you supply a dictionary mapping string labels to integer indices
+            you can later call put_single with string labels instead of int 
+            labels
+        '''
+        # delete existing LMDB if necessary
+        if os.path.exists(lmdb_path) and create:
+            self.logger.info('Erasing LMDB at %s', lmdb_path)
+            shutil.rmtree(lmdb_path)
+        self.logger.info('Opening single LMDB at %s for writing', lmdb_path)
+        self.database_images = lmdb.open(path=lmdb_path, 
+					 map_size=max_lmdb_size)
+        self.txn_images = self.database_images.begin(write=True)
+        self.label_map = label_map
+    
+    def open_dual_lmdb_for_write(self, image_lmdb_path, additional_lmdb_path, 
+				 max_lmdb_size=1024**4, create=True, label_map=None):
+        '''
+        Opens two LMDBs for writing where each element in the first has a 
+        counterpart with the same key in the second 
+        @param image_lmdb_path: str
+            Where to save the image LMDB
+        @param additional_lmdb_path: str
+            Where to save the additional LMDB
+        @param max_lmdb_size: int
+            The maximum size in bytes of each LMDB (default: 1TB)
+        @param create: bool
+            If this flag is set, potentially previously created LMDBs at 
+            lmdb_path and additional_lmdb_path are deleted and overwritten by 
+            new LMDBs
+        @param label_map: dictionary
+            If you supply a dictionary mapping string labels to integer indices
+            you can later call put_dual with string labels instead of int 
+            labels
+        '''
+        # delete existing LMDBs if necessary
+        if os.path.exists(image_lmdb_path) and create:
+            self.logger.info('Erasing LMDB at %s', image_lmdb_path)
+            shutil.rmtree(image_lmdb_path)
+        if os.path.exists(additional_lmdb_path) and create:
+            self.logger.info('Erasing LMDB at %s', additional_lmdb_path)
+            shutil.rmtree(additional_lmdb_path)            
+        self.logger.info('Opening LMDBs at %s and %s for writing', 
+			 image_lmdb_path, additional_lmdb_path)
+        self.database_images = lmdb.open(path=image_lmdb_path, 
+					 map_size=max_lmdb_size)
+        self.txn_images = self.database_images.begin(write=True)
+        self.database_additional = lmdb.open(path=additional_lmdb_path, 
+					     map_size=max_lmdb_size)
+        self.txn_additional = self.database_additional.begin(write=True)
+        self.label_map = label_map
+    
+    def put_single(self, img_mat, label, key=None):
+        '''
+        Puts an ndarray into the previously opened single LMDB        
+        @param img_mat: ndarray
+            The image data to be inserted in the LMDB
+        @param label: str or int
+            The label for the image
+        @param key: str
+            The key under which to save the data in the LMDB
+            If key is None, a generic key is generated
+        '''
+        # some checks
+        if self.database_images is None:
+            raise ValueError('No LMDB to write to. \
+	      Did you call open_single_lmdb_for_write?')
+        if self.database_additional is not None:
+            raise ValueError('Cannot execute put_single as \
+	      open_dual_lmdb_for_write has been chosen for LMDB creation')
+        if img_mat.dtype != np.uint8 or img_mat.ndim != 3:
+            raise ValueError('img_mat must be a 3d-ndarray of type np.uint8')
+        
+        # label may be a string if a label map was supplied
+        datum_label = None
+        if type(label) == str: 
+            if self.label_map is None:
+                raise ValueError('You may only supply a label of type str if \
+		  you called open_single_lmdb_for_write with a valid label_map')
+            else:
+                datum_label = self.label_map[label]
+        elif type(label) == int:
+            datum_label = label
+        else:
+            raise ValueError('label must be of type str or int')
+        
+        # convert img_mat to Caffe Datum
+        datum = caffe.io.array_to_datum(arr=img_mat, label=datum_label)
+        if key is None:
+            key = '%s_%s' % (str(self.internal_counter).zfill(8), str(label))
+        # push Datum into the LMDB
+        self.txn_images.put(key=key, value=datum.SerializeToString())
+        self.internal_counter += 1
+        if self.internal_counter % 1000 == 0:
+            self.txn_images.commit()
+            self.logger.debug('   Finished %*d ndarrays', 
+			      8, self.internal_counter)
+            # after a commit the txn object becomes invalid, so we need to get 
+            # a new one
+            self.txn_images = self.database_images.begin(write=True)
+    
+    def put_dual(self, img_mat, additional_mat, label, key=None):
+        '''
+        Puts an image and its corresponding additional information ndarray into
+        the previously opened LMDBs
+        
+        @param img_mat: ndarray
+            The image data to be inserted in the LMDB
+        @param additional_mat: ndarray
+            The label matrix (attributes, PHOC, ...) to be inserted
+        @param label: str or int
+            The label for the image
+        @param key: str
+            The key under which to save the data in the LMDB
+            If key is None, a generic key is generated
+        '''
+        # some checks
+        if self.database_images is None:
+            raise ValueError('No LMDB to write to. \
+	      Did you call open_dual_lmdb_for_write?')
+        if self.database_additional is None:
+            raise ValueError('Cannot execute put_dual as \
+	      open_single_lmdb_for_write has been chosen for LMDB creation')
+        if img_mat.dtype != np.uint8 or img_mat.ndim != 3:
+            raise ValueError('img_mat must be a 3d-ndarray of type np.uint8')
+        if additional_mat.dtype != np.uint8 or additional_mat.ndim != 3:
+            raise ValueError('additional_mat must be a 3d-ndarray of \
+	      type np.uint8')
+        
+        # label may be a string if a label map was supplied
+        datum_label = None
+        if type(label) == str: 
+            if self.label_map is None:
+                raise ValueError('You may only supply a label of type str if \
+		  you called open_dual_lmdb_for_write with a valid label_map')
+            elif not label in self.label_map.keys():
+                self.logger.warn('Warning, unknown key - skipping this entry')
+                return
+            else:
+                datum_label = self.label_map[label]
+        elif type(label) == int:
+            datum_label = label
+        else:
+            raise ValueError('label must be of type str or int')
+        
+        # convert img_mat and additional_mat to Caffe Data
+        datum_img = caffe.io.array_to_datum(arr=img_mat, label=datum_label)
+        datum_additional = caffe.io.array_to_datum(arr=additional_mat, 
+						   label=datum_label)
+        if key is None:
+            key = '%s_%s' % (str(self.internal_counter).zfill(8), str(label))
+        # push Data in the current LMDBs 
+        self.txn_images.put(key=key, value=datum_img.SerializeToString())
+        self.txn_additional.put(key=key, 
+				value=datum_additional.SerializeToString())
+        self.internal_counter += 1
+        if self.internal_counter % 10000 == 0:
+            self.txn_images.commit()
+            self.txn_additional.commit()
+            self.logger.debug('   Finished %*d ndarrays', 
+			      8, self.internal_counter)
+            # after a commit the txn objects becomes invalid, so we need to get
+            # new ones
+            self.txn_images = self.database_images.begin(write=True)
+            self.txn_additional = self.database_additional.begin(write=True)
+        return
+    
+    def finish_creation(self):
+        '''
+        Wraps up LMDB creation and resets all internal variables
+        '''
+        self.txn_images.commit()
+        self.database_images.sync()
+        self.database_images.close()
+        if self.database_additional is not None:
+            self.txn_additional.commit()
+            self.database_additional.sync()
+            self.database_additional.close()
+        self.logger.info('Finished after writing %d ndarrays', 
+			 self.internal_counter)
+        self.database_images = None
+        self.database_additional = None
+        self.txn_images = None
+        self.txn_additional = None
+        self.label_map = None
+        self.internal_counter = 0
+    
+    def create_single_lmdb_from_ndarray_batch(self, array_list, labels_list, 
+					      lmdb_path, max_lmdb_size=1024**4, 
+					      create=True):
+        '''
+        Creates an LMDB from a list of ndarrays
+        @param mats: list of 3d-ndarrays
+        @param labels: list of str or int
+        @param lmdb_path: str
+        '''
+        # some checks
+        if type(labels_list[0]) != str and type(labels_list[0]) != int:
+            raise ValueError('Labels must be of type string or int32')
+        if len(labels_list) != len(array_list):
+            raise ValueError('Number of labels and number of ndarrays must \
+	      match')
+        if array_list[0].dtype != np.uint8 or array_list[0].ndim != 3:
+            raise ValueError('array_list must contain 3d-ndarray of type \
+	      np.uint8')
+        
+        # delete previously created database
+        if create and os.path.exists(lmdb_path):
+            self.logger.info('Removing previously generated LMDB at %s', 
+			     lmdb_path)
+            shutil.rmtree(path=lmdb_path)
+        
+        self.logger.info('Creating LMDB from list of ndarrays')
+        label_to_idx_dict = None
+        if type(labels_list[0]) == str:
+            self.logger.info('Found labels to be strings, creating label \
+	      map...')
+            unique_labels = sorted(list(set(labels_list)))
+            label_to_idx_dict = dict((label, idx) 
+				     for idx, label in enumerate(unique_labels))
+            labels_list = [label_to_idx_dict[label] for label in labels_list]
+        
+        # open LMDB
+        self.logger.info('Writing LMDB...')
+        self.database = lmdb.open(lmdb_path, map_size=max_lmdb_size)
+        txn = self.database.begin(write=True)
+        # put the datums in the LMDB
+        for mat_idx, (mat, label) in enumerate(zip(array_list, labels_list)):
+            datum = caffe.io.array_to_datum(arr=mat, label=label)
+            key = '%s_%s' % (str(mat_idx).zfill(8), label)
+            txn.put(key=key, value=datum.SerializeToString())
+            # write every 1000 transactions
+            if (mat_idx+1) % 1000 == 0 or (mat_idx+1) == len(array_list):                    
+                txn.commit()
+                txn = self.database.begin(write=True)
+                self.logger.debug('   [ %*d / %d ]', len(str(len(array_list))), 
+				  mat_idx+1, len(array_list))
+	# finish LMDB creation
+        self.database.sync()
+        self.database.close()
+        
+        self.logger.info('Wrote %s ndarrays to the LMDB at %s', 
+			 len(array_list), lmdb_path)
+                

--- a/python/caffe/test/test_lmdb_creator.py
+++ b/python/caffe/test/test_lmdb_creator.py
@@ -1,0 +1,227 @@
+import unittest
+import shutil
+import logging
+from itertools import izip
+
+import lmdb
+import numpy as np
+import caffe.io
+from caffe.proto.caffe_pb2 import Datum
+
+from caffe.lmdb_creator import LMDBCreator
+
+class TestCaffeLMDBCreator(unittest.TestCase):
+    
+    def setUp(self):
+        logging_format = '[%(asctime)-19s, %(name)s] %(message)s'
+        logging.basicConfig(level=logging.DEBUG,
+                            format=logging_format)
+        self.logger = logging.getLogger('UnitTest CaffeLMDBCreator')        
+    
+    def tearDown(self):
+        pass
+
+    def testBatchCreate(self):
+        self.logger.info('Testing Batch Create')
+        lmdb_path = os.path.join(os.path.dirname(__file__), 'test_lmdb')
+        n_dummy_images = 10000
+           
+        dummy_data = [np.random.randint(0,256, (1, 224,224)).astype(np.uint8)
+                      for _ in xrange(n_dummy_images)]
+        labels = list(xrange(n_dummy_images))
+           
+        self.logger.info('Creating test LMDB')
+        lmdb_creator = LMDBCreator()
+        lmdb_creator.create_single_lmdb_from_ndarray_batch(array_list=dummy_data, labels_list=labels, 
+                                                           lmdb_path=lmdb_path, max_lmdb_size=1024**3)
+        self.logger.info('Testing previously created LMDB')
+        database = lmdb.open(lmdb_path)
+        self.assertEquals(first=database.stat()['entries'], second=n_dummy_images)
+        with database.begin() as txn:
+            cursor = txn.cursor()
+            datum = Datum()
+            for item_idx, (key, serialized_datum) in enumerate(cursor.iternext()):
+                datum.ParseFromString(serialized_datum)
+                mat = caffe.io.datum_to_array(datum=datum)
+                # check if the key is correct
+                self.assertEquals(first=key, second='%s_%d' % (str(item_idx).zfill(8), datum.label))
+                # check if the ndarray is correct
+                np.testing.assert_equal(actual=mat, desired=dummy_data[item_idx])
+                   
+        # clean up 
+        database.close()        
+        if os.path.exists(lmdb_path):
+            shutil.rmtree(path=lmdb_path)
+      
+    def testSingleCreate(self):
+        self.logger.info('Testing Single Create')
+        lmdb_path = os.path.join(os.path.dirname(__file__), 'test_lmdb')
+        n_dummy_images = 10000
+          
+        # create dummy data and dummy labels
+        dummy_data = [np.random.randint(0,256, (1, 224,224)).astype(np.uint8)
+                      for _ in xrange(n_dummy_images)]
+        labels = np.array(('label1', 'label2', 'label3', 'label4'))
+        label_map = dict((label, idx) for idx, label in enumerate(labels))
+        inds = np.random.randint(0,4, n_dummy_images)        
+        labels = labels[inds]
+          
+        self.logger.info('Creating test LMDB')
+        lmdb_creator = LMDBCreator()
+        lmdb_creator.open_single_lmdb_for_write(lmdb_path=lmdb_path, max_lmdb_size=1024**3, 
+                                                create=True, label_map=label_map)
+        for dummy_datum, label in zip(dummy_data, labels):
+            lmdb_creator.put_single(img_mat=dummy_datum, label=str(label))
+        lmdb_creator.finish_creation()
+          
+        self.logger.info('Testing previously created LMDB')
+        # build the reverse label map
+        idx_to_label_map = dict((v, k) for k,v in label_map.items())
+        database = lmdb.open(lmdb_path)
+        self.assertEquals(first=database.stat()['entries'], second=n_dummy_images)
+        with database.begin() as txn:
+            cursor = txn.cursor()
+            datum = Datum()
+            for item_idx, (key, serialized_datum) in enumerate(cursor.iternext()):
+                datum.ParseFromString(serialized_datum)
+                mat = caffe.io.datum_to_array(datum=datum)
+                # check if the key is correct
+                self.assertEquals(first=key, second='%s_%s' % (str(item_idx).zfill(8), idx_to_label_map[datum.label]))
+                # check if the ndarray is correct
+                np.testing.assert_equal(actual=mat, desired=dummy_data[item_idx])
+                if (item_idx+1) % 1000 == 0 or (item_idx+1) == n_dummy_images:
+                    self.logger.debug('   [ %*d / %d ] matrices passed test', len(str(n_dummy_images)), item_idx+1, n_dummy_images) 
+                  
+        # clean up
+        database.close()
+        if os.path.exists(lmdb_path):
+            shutil.rmtree(path=lmdb_path)
+    
+    def testDualCreate(self):
+        self.logger.info('Testing Dual Create')
+        img_lmdb_path = os.path.join(os.path.dirname(__file__), 'img_test_lmdb')
+        additional_lmdb_path = os.path.join(os.path.dirname(__file__), 'additional_test_lmdb')
+        n_dummy_images = 9235
+        
+        # create dummy data and dummy labels
+        img_dummy_data = [np.random.randint(0,256, (1,224,224)).astype(np.uint8)
+                          for _ in xrange(n_dummy_images)]
+        additional_dummy_data = [np.random.randint(0,256, (1,1,604)).astype(np.uint8)
+                                 for _ in xrange(n_dummy_images)]
+        labels = np.array(('label1', 'label2', 'label3', 'label4'))
+        label_map = dict((label, idx) for idx, label in enumerate(labels))
+        inds = np.random.randint(0,4, n_dummy_images)        
+        labels = labels[inds]
+
+        self.logger.info('Creating test LMDB')
+        lmdb_creator = LMDBCreator()
+        lmdb_creator.open_dual_lmdb_for_write(image_lmdb_path=img_lmdb_path, additional_lmdb_path=additional_lmdb_path, 
+                                              max_lmdb_size=1024**3, create=True, label_map=label_map)
+        for img_dummy_datum, additional_dummy_datum, label in zip(img_dummy_data,
+                                                                  additional_dummy_data,
+                                                                  labels):
+            lmdb_creator.put_dual(img_mat=img_dummy_datum, additional_mat=additional_dummy_datum, label=str(label))
+        lmdb_creator.finish_creation()
+        
+        self.logger.info('Testing previously created LMDB')
+        # build the reverse label map
+        idx_to_label_map = dict((v, k) for k,v in label_map.items())
+        img_database = lmdb.open(img_lmdb_path)
+        additional_database = lmdb.open(additional_lmdb_path)
+        self.assertEquals(first=img_database.stat()['entries'], second=n_dummy_images)
+        self.assertEquals(first=additional_database.stat()['entries'], second=n_dummy_images)
+        with img_database.begin() as img_txn, additional_database.begin() as additional_txn:
+            img_cursor = img_txn.cursor()
+            additional_cursor = additional_txn.cursor()
+            img_datum = Datum()
+            additional_datum = Datum()
+            for item_idx, ((img_key, img_serialized_datum), (additional_key, additional_serialized_datum)) in enumerate(izip(img_cursor.iternext(), additional_cursor.iternext())):
+                img_datum.ParseFromString(img_serialized_datum)
+                additional_datum.ParseFromString(additional_serialized_datum)
+                img_mat = caffe.io.datum_to_array(img_datum)
+                additional_mat = caffe.io.datum_to_array(additional_datum)
+                # check the key
+                self.assertEquals(first=img_key, second=additional_key)
+                self.assertEquals(first=img_key, second='%s_%s' % (str(item_idx).zfill(8), idx_to_label_map[img_datum.label]))
+                # check if the ndarray is correct
+                np.testing.assert_equal(actual=img_mat, desired=img_dummy_data[item_idx])
+                np.testing.assert_equal(actual=additional_mat, desired=additional_dummy_data[item_idx])
+                if (item_idx+1) % 1000 == 0 or (item_idx+1) == n_dummy_images:
+                    self.logger.debug('   [ %*d / %d ] matrices passed test', len(str(n_dummy_images)), item_idx+1, n_dummy_images)
+        # clean up
+        img_database.close()
+        additional_database.close()
+        if os.path.exists(img_lmdb_path):
+            shutil.rmtree(path=img_lmdb_path)
+        if os.path.exists(additional_lmdb_path):
+            shutil.rmtree(path=additional_lmdb_path)
+    
+    def testShuffle(self):
+        self.logger.info('Testing Data Shuffling')
+        img_lmdb_path = os.path.join(os.path.dirname(__file__), 'img_test_lmdb')
+        additional_lmdb_path = os.path.join(os.path.dirname(__file__), 'additional_test_lmdb')
+        n_dummy_images = 9235
+        
+        # create dummy data and dummy labels
+        img_dummy_data = [np.random.randint(0,256, (1,224,224)).astype(np.uint8)
+                          for _ in xrange(n_dummy_images)]
+        additional_dummy_data = [np.random.randint(0,256, (1,1,604)).astype(np.uint8)
+                                 for _ in xrange(n_dummy_images)]
+        labels = np.array(('label1', 'label2', 'label3', 'label4'))
+        label_map = dict((label, idx) for idx, label in enumerate(labels))
+        inds = np.random.randint(0,4, n_dummy_images)        
+        labels = labels[inds]
+        
+        # create random order to insert
+        rand_indices = np.arange(n_dummy_images)
+        np.random.shuffle(rand_indices)
+        
+        # create the LMDB
+        self.logger.info('Creating test LMDB')
+        lmdb_creator = LMDBCreator()
+        lmdb_creator.open_dual_lmdb_for_write(image_lmdb_path=img_lmdb_path, additional_lmdb_path=additional_lmdb_path, 
+                                              max_lmdb_size=1024**3, create=True, label_map=label_map)
+        for idx, (img_dummy_datum, additional_dummy_datum, label) in enumerate(zip(img_dummy_data,
+                                                                                   additional_dummy_data,
+                                                                                   labels)):
+            lmdb_creator.put_dual(img_mat=img_dummy_datum, additional_mat=additional_dummy_datum, 
+                                  label=str(label), key='%s_%s' % (str(rand_indices[idx]).zfill(8), str(label)))
+        lmdb_creator.finish_creation()
+            
+        self.logger.info('Testing previously created LMDB')
+        # build the reverse label map
+        idx_to_label_map = dict((v, k) for k,v in label_map.items())
+        img_database = lmdb.open(img_lmdb_path)
+        additional_database = lmdb.open(additional_lmdb_path)
+        self.assertEquals(first=img_database.stat()['entries'], second=n_dummy_images)
+        self.assertEquals(first=additional_database.stat()['entries'], second=n_dummy_images)
+        with img_database.begin() as img_txn, additional_database.begin() as additional_txn:
+            img_cursor = img_txn.cursor()
+            additional_cursor = additional_txn.cursor()
+            img_datum = Datum()
+            additional_datum = Datum()
+            for item_idx, ((img_key, img_serialized_datum), (additional_key, additional_serialized_datum)) in enumerate(izip(img_cursor.iternext(), additional_cursor.iternext())):
+                img_datum.ParseFromString(img_serialized_datum)
+                additional_datum.ParseFromString(additional_serialized_datum)
+                img_mat = caffe.io.datum_to_array(img_datum)
+                additional_mat = caffe.io.datum_to_array(additional_datum)
+                # check the key
+                self.assertEquals(first=img_key, second=additional_key)
+                self.assertEquals(first=img_key, second='%s_%s' % (str(item_idx).zfill(8), idx_to_label_map[img_datum.label]))
+                # check if the ndarray is correct
+                np.testing.assert_equal(actual=img_mat, desired=img_dummy_data[np.where(rand_indices == item_idx)[0][0]])
+                np.testing.assert_equal(actual=additional_mat, desired=additional_dummy_data[np.where(rand_indices == item_idx)[0][0]])
+                if (item_idx+1) % 1000 == 0 or (item_idx+1) == n_dummy_images:
+                    self.logger.debug('   [ %*d / %d ] matrices passed test', len(str(n_dummy_images)), item_idx+1, n_dummy_images)
+        # clean up
+        img_database.close()
+        additional_database.close()
+        if os.path.exists(img_lmdb_path):
+            shutil.rmtree(path=img_lmdb_path)
+        if os.path.exists(additional_lmdb_path):
+            shutil.rmtree(path=additional_lmdb_path)
+            
+                
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testCreateCaffeLMDB']
+    unittest.main()


### PR DESCRIPTION
This PR adds a LMDB creation class in python. This allows for (almost) arbitrary Numpy arrays to be inserted in this lightweight database, bypassing the need to first save the arrays as images and then creating a LMDB by calling convert_imageset.

For tasks in which multi-dimensional labels are needed (e.g. multi-label classification, semantic segmentation,...), the LMDBCreator offers the possibility to create a dual LMDB. Internally, this wraps creating two LMDBs and inserting corresponding elements with identical keys. These two LMDBs can then be included in standard proto files.

The PR calls for an additional dependency in pylmdb which can be easily installed by pip.