### PR TITLE
Fixed integer overflow issue with LMDB on 32bit systems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,12 +184,14 @@ LIBRARIES += glog gflags protobuf boost_system boost_filesystem m hdf5_hl hdf5
 USE_LEVELDB ?= 1
 USE_LMDB ?= 1
 USE_OPENCV ?= 1
+LMDB_MAP_SIZE ?= 1099511627776
 
 ifeq ($(USE_LEVELDB), 1)
 	LIBRARIES += leveldb snappy
 endif
 ifeq ($(USE_LMDB), 1)
 	LIBRARIES += lmdb
+    COMMON_FLAGS += -D_LMDB_MAP_SIZE=$(LMDB_MAP_SIZE)
 endif
 ifeq ($(USE_OPENCV), 1)
 	LIBRARIES += opencv_core opencv_highgui opencv_imgproc 

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ ifeq ($(USE_LEVELDB), 1)
 endif
 ifeq ($(USE_LMDB), 1)
 	LIBRARIES += lmdb
-    COMMON_FLAGS += -D_LMDB_MAP_SIZE=$(LMDB_MAP_SIZE)
+	COMMON_FLAGS += -D_LMDB_MAP_SIZE=$(LMDB_MAP_SIZE)
 endif
 ifeq ($(USE_OPENCV), 1)
 	LIBRARIES += opencv_core opencv_highgui opencv_imgproc 

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -16,6 +16,7 @@
 #	You should not set this flag if you will be reading LMDBs with any
 #	possibility of simultaneous read and write
 # ALLOW_LMDB_NOLOCK := 1
+# LMDB_MAP_SIZE := 4294967295 # 1TB is the default - uncomment this to avoid overflow on 32bit systems.
 
 # Uncomment if you're using OpenCV 3
 # OPENCV_VERSION := 3

--- a/examples/mnist/convert_mnist_data.cpp
+++ b/examples/mnist/convert_mnist_data.cpp
@@ -23,8 +23,8 @@
 #include <string>
 
 #include "caffe/proto/caffe.pb.h"
-#include "caffe/util/format.hpp"
 #include "caffe/util/db_lmdb.hpp"
+#include "caffe/util/format.hpp"
 
 #if defined(USE_LEVELDB) && defined(USE_LMDB)
 
@@ -94,7 +94,9 @@ void convert_dataset(const char* image_filename, const char* label_filename,
     CHECK_EQ(mkdir(db_path, 0744), 0)
         << "mkdir " << db_path << "failed";
     CHECK_EQ(mdb_env_create(&mdb_env), MDB_SUCCESS) << "mdb_env_create failed";
-    CHECK_EQ(mdb_env_set_mapsize(mdb_env, BIGNUM_OR_MAX(_LMDB_MAP_SIZE)), MDB_SUCCESS) // 1TB or the maximum size of size_t.
+    // Check that the db size is the user specified one, or the max of size_t.
+    CHECK_EQ(mdb_env_set_mapsize(mdb_env, BIGNUM_OR_MAX(_LMDB_MAP_SIZE)), \
+                                MDB_SUCCESS)
         << "mdb_env_set_mapsize failed";
     CHECK_EQ(mdb_env_open(mdb_env, db_path, 0, 0664), MDB_SUCCESS)
         << "mdb_env_open failed";

--- a/examples/mnist/convert_mnist_data.cpp
+++ b/examples/mnist/convert_mnist_data.cpp
@@ -94,7 +94,7 @@ void convert_dataset(const char* image_filename, const char* label_filename,
     CHECK_EQ(mkdir(db_path, 0744), 0)
         << "mkdir " << db_path << "failed";
     CHECK_EQ(mdb_env_create(&mdb_env), MDB_SUCCESS) << "mdb_env_create failed";
-    CHECK_EQ(mdb_env_set_mapsize(mdb_env, BIGNUM_OR_MAX(1099511627776)), MDB_SUCCESS) // 1TB or the maximum size of size_t.
+    CHECK_EQ(mdb_env_set_mapsize(mdb_env, BIGNUM_OR_MAX(_LMDB_MAP_SIZE)), MDB_SUCCESS) // 1TB or the maximum size of size_t.
         << "mdb_env_set_mapsize failed";
     CHECK_EQ(mdb_env_open(mdb_env, db_path, 0, 0664), MDB_SUCCESS)
         << "mdb_env_open failed";

--- a/examples/mnist/convert_mnist_data.cpp
+++ b/examples/mnist/convert_mnist_data.cpp
@@ -24,6 +24,7 @@
 
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/format.hpp"
+#include "caffe/util/db_lmdb.hpp"
 
 #if defined(USE_LEVELDB) && defined(USE_LMDB)
 
@@ -93,7 +94,7 @@ void convert_dataset(const char* image_filename, const char* label_filename,
     CHECK_EQ(mkdir(db_path, 0744), 0)
         << "mkdir " << db_path << "failed";
     CHECK_EQ(mdb_env_create(&mdb_env), MDB_SUCCESS) << "mdb_env_create failed";
-    CHECK_EQ(mdb_env_set_mapsize(mdb_env, 1099511627776), MDB_SUCCESS)  // 1TB
+    CHECK_EQ(mdb_env_set_mapsize(mdb_env, BIGNUM_OR_MAX(1099511627776)), MDB_SUCCESS) // 1TB or the maximum size of size_t.
         << "mdb_env_set_mapsize failed";
     CHECK_EQ(mdb_env_open(mdb_env, db_path, 0, 0664), MDB_SUCCESS)
         << "mdb_env_open failed";

--- a/include/caffe/util/db_lmdb.hpp
+++ b/include/caffe/util/db_lmdb.hpp
@@ -11,6 +11,9 @@
 #include <limits>
 
 #define BIGNUM_OR_MAX(A) ((A) > (std::numeric_limits<size_t>::max()) ? (std::numeric_limits<size_t>::max()) : (A))
+#ifndef _LMDB_MAP_SIZE
+#define _LMDB_MAP_SIZE 1099511627776
+#endif
 
 namespace caffe { namespace db {
 

--- a/include/caffe/util/db_lmdb.hpp
+++ b/include/caffe/util/db_lmdb.hpp
@@ -2,15 +2,15 @@
 #ifndef CAFFE_UTIL_DB_LMDB_HPP
 #define CAFFE_UTIL_DB_LMDB_HPP
 
+#include <limits>
 #include <string>
 
 #include "lmdb.h"
 
 #include "caffe/util/db.hpp"
 
-#include <limits>
-
-#define BIGNUM_OR_MAX(A) ((A) > (std::numeric_limits<size_t>::max()) ? (std::numeric_limits<size_t>::max()) : (A))
+#define BIGNUM_OR_MAX(A) ((A) > (std::numeric_limits<size_t>::max()) ?\
+                         (std::numeric_limits<size_t>::max()) : (A))
 #ifndef _LMDB_MAP_SIZE
 #define _LMDB_MAP_SIZE 1099511627776
 #endif

--- a/include/caffe/util/db_lmdb.hpp
+++ b/include/caffe/util/db_lmdb.hpp
@@ -8,6 +8,10 @@
 
 #include "caffe/util/db.hpp"
 
+#include <limits>
+
+#define BIGNUM_OR_MAX(A) ((A) > (std::numeric_limits<size_t>::max()) ? (std::numeric_limits<size_t>::max()) : (A))
+
 namespace caffe { namespace db {
 
 inline void MDB_CHECK(int mdb_status) {

--- a/src/caffe/util/db_lmdb.cpp
+++ b/src/caffe/util/db_lmdb.cpp
@@ -7,7 +7,7 @@
 
 namespace caffe { namespace db {
 
-const size_t LMDB_MAP_SIZE = BIGNUM_OR_MAX(1099511627776);  // 1 TB or maximum number for size_t type.
+const size_t LMDB_MAP_SIZE = BIGNUM_OR_MAX(_LMDB_MAP_SIZE);  // 1 TB or maximum number for size_t type.
 
 void LMDB::Open(const string& source, Mode mode) {
   MDB_CHECK(mdb_env_create(&mdb_env_));

--- a/src/caffe/util/db_lmdb.cpp
+++ b/src/caffe/util/db_lmdb.cpp
@@ -7,7 +7,7 @@
 
 namespace caffe { namespace db {
 
-const size_t LMDB_MAP_SIZE = 1099511627776;  // 1 TB
+const size_t LMDB_MAP_SIZE = BIGNUM_OR_MAX(1099511627776);  // 1 TB or maximum number for size_t type.
 
 void LMDB::Open(const string& source, Mode mode) {
   MDB_CHECK(mdb_env_create(&mdb_env_));

--- a/src/caffe/util/db_lmdb.cpp
+++ b/src/caffe/util/db_lmdb.cpp
@@ -7,7 +7,8 @@
 
 namespace caffe { namespace db {
 
-const size_t LMDB_MAP_SIZE = BIGNUM_OR_MAX(_LMDB_MAP_SIZE);  // 1 TB or maximum number for size_t type.
+// User specified size or max value of size_t.
+const size_t LMDB_MAP_SIZE = BIGNUM_OR_MAX(_LMDB_MAP_SIZE);
 
 void LMDB::Open(const string& source, Mode mode) {
   MDB_CHECK(mdb_env_create(&mdb_env_));


### PR DESCRIPTION
I tried compiling Caffe on the Xilinx ZC706 evaluation board and noticed it wouldn't pass all of the tests. I then noticed that I have the same error when compiling Caffe on a 32bit Ubuntu 14.04 system (x86). It occurs with and without debugging enabled. It's likely this bug occurs in any system which uses an address size less than 41bits. I traced back the 1TB LMDB map size allocation in a few files. This 1TB allocation assumes that the underlying size_t parameter needed by LMDB is at least 41bits - this is not true on 32bit systems.

In order to address (if you'll excuse the pun) this, I did the following:
1) I created a macro to saturate the DB allocation size to the largest value available on the current system, if the user specifies a larger value. (Perhaps this should also include a warning? Either way, this is more desirable than overflow in my opinion...)
2) I added an extra variable in Makefile.config.example to allow the user to specify the desired allocation size. I added the definition of this symbol to the COMMON_FLAGS parameter in the Makefile.

The code should be self-explanatory, but let me know if you want any more information.

Also, if you have any suggestions on how I can improve my code - please let me know. Even if it's just a style preference - I'd like to hear about it.

Cheers,
Nick