### PR TITLE
there is a very very small mistake in the LeNet MNIST tutorial

### DIFF
--- a/examples/mnist/readme.md
+++ b/examples/mnist/readme.md
@@ -248,7 +248,7 @@ These messages tell you the details about each layer, its connections and its ou
     I1203 solver.cpp:36] Solver scaffolding done.
     I1203 solver.cpp:44] Solving LeNet
 
-Based on the solver setting, we will print the training loss function every 100 iterations, and test the network every 1000 iterations. You will see messages like this:
+Based on the solver setting, we will print the training loss function every 100 iterations, and test the network every 500 iterations. You will see messages like this:
 
     I1203 solver.cpp:204] Iteration 100, lr = 0.00992565
     I1203 solver.cpp:66] Iteration 100, loss = 0.26044


### PR DESCRIPTION
Hi,
In your caffe homepage, in the LeNet MNIST Tutorial, there is a sentence in the Training and Testing the Model section,

> Based on the solver setting, we will print the training loss function every 100 iterations, and test the network every 1000 iterations. You will see messages like this:

You said test the network every **1000** iterations, but actually you test the network every **500** iterations.

This is a very very small mistake, but I hope it is helpful for newer.