### PR TITLE
avoid non-integer array indices

### DIFF
--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -79,6 +79,7 @@ class Classifier(caffe.Net):
                 -self.crop_dims / 2.0,
                 self.crop_dims / 2.0
             ])
+            crop = crop.astype(int)
             input_ = input_[:, crop[0]:crop[2], crop[1]:crop[3], :]
 
         # Classify


### PR DESCRIPTION
non-integer indices cause `VisibleDeprecationWarning` in recent versions of numpy