### PR TITLE
fix CUDA version detection in Makefile to accomodate OS X's grep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ endif
 ifeq ($(OSX), 1)
 	CXX := /usr/bin/clang++
 	ifneq ($(CPU_ONLY), 1)
-		CUDA_VERSION := $(shell $(CUDA_DIR)/bin/nvcc -V | grep -o 'release \d' | grep -o '\d')
+		CUDA_VERSION := $(shell $(CUDA_DIR)/bin/nvcc -V | grep -o 'release [0-9.]*' | grep -o '[0-9.]*')
 		ifeq ($(shell echo | awk '{exit $(CUDA_VERSION) < 7.0;}'), 1)
 			CXXFLAGS += -stdlib=libstdc++
 			LINKFLAGS += -stdlib=libstdc++


### PR DESCRIPTION
OS X grep doesn't support \d by default (unfortunately). This causes the CUDA version detection to fail:
```
[~/caffe] make clean
awk: syntax error at source line 1
 context is
	{exit  >>>  < <<<  7.0;}
awk: illegal statement at source line 1
```
If you run the version check manually:
```
[~/caffe] echo $(/usr/local/cuda/bin/nvcc -V | grep -o 'release \d')

```
After the change
```
[~/caffe] echo $(/usr/local/cuda/bin/nvcc -V | grep -o 'release [0-9.]*' | grep -o '[0-9.]*')
7.5
```