### PR TITLE
Pin the base image version for the GPU Dockerfile

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -22,7 +22,7 @@ docker_files: standalone_files
 
 standalone_files: standalone/cpu/Dockerfile standalone/gpu/Dockerfile
 
-FROM_GPU = "nvidia/cuda:cudnn"
+FROM_GPU = "nvidia/cuda:7.5-cudnn4-devel-ubuntu14.04"
 FROM_CPU = "ubuntu:14.04"
 GPU_CMAKE_ARGS = -DUSE_CUDNN=1
 CPU_CMAKE_ARGS = -DCPU_ONLY=1

--- a/docker/standalone/gpu/Dockerfile
+++ b/docker/standalone/gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:cudnn
+FROM nvidia/cuda:7.5-cudnn4-devel-ubuntu14.04
 MAINTAINER caffe-maint@googlegroups.com
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
The previous Dockerfile can break if image nvidia/cuda:cudnn is updated to any of the following:
- Ubuntu 16.04 LTS (already released)
- cuDNN v5 (soon)
- CUDA 8.0 (soon)