### PR TITLE
Note that `make clean` clears build and distribute dirs

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -98,6 +98,7 @@ LIBRARY_DIRS := $(PYTHON_LIB) /usr/local/lib /usr/lib
 # (Usually not necessary -- OpenCV libraries are normally installed in one of the above $LIBRARY_DIRS.)
 # USE_PKG_CONFIG := 1
 
+# N.B. both build and distribute dirs are cleared on `make clean`
 BUILD_DIR := build
 DISTRIBUTE_DIR := distribute
 


### PR DESCRIPTION
`make clean` forcibly clears `BUILD_DIR` and `DISTRIBUTE_DIR`.
I recently heard this was confusing, since `make distribute` is not the standard that `make install` is, so there is now a comment to help set expectations.