### PR TITLE
Allow reshaping blobs to size 0.

### DIFF
--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -30,7 +30,9 @@ void Blob<Dtype>::Reshape(const vector<int>& shape) {
   int* shape_data = static_cast<int*>(shape_data_->mutable_cpu_data());
   for (int i = 0; i < shape.size(); ++i) {
     CHECK_GE(shape[i], 0);
-    CHECK_LE(shape[i], INT_MAX / count_) << "blob size exceeds INT_MAX";
+    if (count_ != 0) {
+      CHECK_LE(shape[i], INT_MAX / count_) << "blob size exceeds INT_MAX";
+    }
     count_ *= shape[i];
     shape_[i] = shape[i];
     shape_data[i] = shape[i];

--- a/src/caffe/test/test_blob.cpp
+++ b/src/caffe/test/test_blob.cpp
@@ -51,6 +51,14 @@ TYPED_TEST(BlobSimpleTest, TestReshape) {
   EXPECT_EQ(this->blob_->count(), 120);
 }
 
+TYPED_TEST(BlobSimpleTest, TestReshapeZero) {
+  vector<int> shape(2);
+  shape[0] = 0;
+  shape[1] = 5;
+  this->blob_->Reshape(shape);
+  EXPECT_EQ(this->blob_->count(), 0);
+}
+
 TYPED_TEST(BlobSimpleTest, TestLegacyBlobProtoShapeEquals) {
   BlobProto blob_proto;
 


### PR DESCRIPTION
The current implementation of `Blob::Reshape` has a check to ensure that Blob sizes do not exceed `INT_MAX` that goes awry whenever the size of the Blob is 0. (More precisely, the check causes a floating point exception if a 0 appears in the shape anywhere except for the last element.) This PR disables that check if `count_ == 0`.

While this seems a little silly upon first glance, I think there is a very real use case for supporting this behavior. I'm training a detection network that uses ground truth boxes, which are typically represented by 5 values, but some images have no ground truth boxes at all. In this case, having a ground truth blob of shape (0, 5) seems perfectly sensible to me.

This PR also includes a simple test that reshapes a Blob to shape (0, 5), which would have failed prior to the fix.