### PR TITLE
(CMake) customisable version/soversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ endif()
 project(Caffe C CXX)
 
 # ---[ Caffe version
-set(CAFFE_TARGET_VERSION "1.0.0-rc3")
-set(CAFFE_TARGET_SOVERSION "1.0.0-rc3")
+set(CAFFE_TARGET_VERSION "1.0.0-rc3" CACHE STRING "Caffe logical version")
+set(CAFFE_TARGET_SOVERSION "1.0.0-rc3" CACHE STRING "Caffe soname version")
 add_definitions(-DCAFFE_VERSION=${CAFFE_TARGET_VERSION})
 
 # ---[ Using cmake scripts and modules


### PR DESCRIPTION
In the CMake configuration, the `libcaffe.so` soname, derived from the `CAFFE_TARGET_SOVERSION` variable [here] (https://github.com/BVLC/caffe/blob/master/CMakeLists.txt#L14), contains the `0-rc3` patch/revision information.

AFAIK this is against the general convention (described [here](http://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html) and other places), and has caused me a few issues, e.g. with CMake (when creating the symlink-chain through `cmake build . --target install`) and Bazel (when including Caffe as a pre-built external project) both of which prefer the more canonical soname form: `lib{name}.so.{number}`. 

This complicates the scenario when I want to maintain multiple versions of Caffe on the same machine, as shared libraries. Rather than changing the soname itself, I suggest the relevant variable is made customisable at the command line, which regardless I think is more generally useful.