### PR TITLE
Fix Makefile CUDA_VERSION extraction on OSX Yosemite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ endif
 ifeq ($(OSX), 1)
 	CXX := /usr/bin/clang++
 	ifneq ($(CPU_ONLY), 1)
-		CUDA_VERSION := $(shell $(CUDA_DIR)/bin/nvcc -V | grep -o 'release [0-9.]*' | grep -o '[0-9.]*')
+		CUDA_VERSION := $(shell $(CUDA_DIR)/bin/nvcc -V | grep -o 'release [0-9.]*' | tr -d '[a-z ]')
 		ifeq ($(shell echo | awk '{exit $(CUDA_VERSION) < 7.0;}'), 1)
 			CXXFLAGS += -stdlib=libstdc++
 			LINKFLAGS += -stdlib=libstdc++


### PR DESCRIPTION
The current way of extracting CUDA_VERSION causes problem on OSX Yosemite
```
$ make
awk: syntax error at source line 1
 context is
	{exit  >>>  < <<<  7.0;}
awk: illegal statement at source line 1

$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.10.5
BuildVersion:	14F27

$ uname -prs
Darwin 14.5.0 i386
```

Looks like the change suggested in #4075 wasn't helpful in my case: grep after the second pipe doesn't work as expected:
```
$ echo "nvcc: ... release 7.5, V7.5.19" | grep -o 'release [0-9.]*'
release 7.5
$ echo "nvcc: ... release 7.5, V7.5.19" | grep -o 'release [0-9.]*' | grep -o '[0-9.]*'

```

The following did work for me:
```
$ echo "nvcc: ... release 7.5, V7.5.19" | grep -o 'release [0-9.]*' | grep -o '[0-9].*'
7.5
$ echo "nvcc: ... release 7.5, V7.5.19" | grep -o 'release [0-9.]*' | tr -d '[a-z ]'
7.5
$ echo "nvcc: ... release 7.5, V7.5.19" | grep -o 'release [0-9.]*' | sed 's/[a-z ]//g'
7.5
```