### PR TITLE
Generalize bilinear interpolation filler to N-D multilinear/multicubic/lanczos filler

### DIFF
--- a/include/caffe/filler.hpp
+++ b/include/caffe/filler.hpp
@@ -207,58 +207,92 @@ class MSRAFiller : public Filler<Dtype> {
   }
 };
 
-/*!
-@brief Fills a Blob with coefficients for bilinear interpolation.
-
-A common use case is with the DeconvolutionLayer acting as upsampling.
-You can upsample a feature map with shape of (B, C, H, W) by any integer factor
-using the following proto.
-\code
-layer {
-  name: "upsample", type: "Deconvolution"
-  bottom: "{{bottom_name}}" top: "{{top_name}}"
-  convolution_param {
-    kernel_size: {{2 * factor - factor % 2}} stride: {{factor}}
-    num_output: {{C}} group: {{C}}
-    pad: {{ceil((factor - 1) / 2.)}}
-    weight_filler: { type: "bilinear" } bias_term: false
-  }
-  param { lr_mult: 0 decay_mult: 0 }
-}
-\endcode
-Please use this by replacing `{{}}` with your values. By specifying
-`num_output: {{C}} group: {{C}}`, it behaves as
-channel-wise convolution. The filter shape of this deconvolution layer will be
-(C, 1, K, K) where K is `kernel_size`, and this filler will set a (K, K)
-interpolation kernel for every channel of the filter identically. The resulting
-shape of the top feature map will be (B, C, factor * H, factor * W).
-Note that the learning rate and the
-weight decay are set to 0 in order to keep coefficient values of bilinear
-interpolation unchanged during training. If you apply this to an image, this
-operation is equivalent to the following call in Python with Scikit.Image.
-\code{.py}
-out = skimage.transform.rescale(img, factor, mode='constant', cval=0)
-\endcode
+/**
+ * @brief Base class for windowed interpolation fillers.
+ *
+ * A common use case is with the DeconvolutionLayer acting as upsampling. The
+ * derived classes need to implement the interpolation function f() and the size
+ * of the support, i.e. the absolute value, when f reaches 0.
+ * You can upsample a feature map with shape of (B, C, S_n,..., S_1) by any
+ * integer factor using the following proto.
+ * \code
+ * layer {
+ *   name: "upsample", type: "Deconvolution"
+ *   bottom: "{{bottom_name}}" top: "{{top_name}}"
+ *   convolution_param {
+ *     num_output: {{C}} group: {{C}}
+ *     kernel_size: {{2 * support * factor - factor % 2}}
+ *     stride: {{factor}}
+ *     pad: {{((2 * support - 1) * factor - factor % 2) / 2}}
+ *     weight_filler: { type: {{type}} }
+ *     bias_term: false
+ *   }
+ *   param { lr_mult: 0 decay_mult: 0 }
+ * }
+ * \endcode
+ * Please use this by replacing `{{}}` with your values. By specifying
+ * `num_output: {{C}} group: {{C}}`, it behaves as
+ * channel-wise convolution. The filter shape of this deconvolution layer will
+ * be (C, 1, K_n,..., K_1) where K_i is `kernel_size` in dimension i, and this
+ * filler will set a (K_n,..., K_1) interpolation kernel for every channel of
+ * the filter identically. The resulting shape of the top feature map will be
+ * (B, C, factor_n * S_n,..., factor_1 * S_1).
+ * Note that the learning rate and the weight decay are set to 0 in order to
+ * keep coefficient values of interpolation unchanged during training.
  */
 template <typename Dtype>
-class BilinearFiller : public Filler<Dtype> {
+class InterpolationFillerBase : public Filler<Dtype> {
  public:
-  explicit BilinearFiller(const FillerParameter& param)
+  explicit InterpolationFillerBase(const FillerParameter& param)
       : Filler<Dtype>(param) {}
   virtual void Fill(Blob<Dtype>* blob) {
-    CHECK_EQ(blob->num_axes(), 4) << "Blob must be 4 dim.";
-    CHECK_EQ(blob->width(), blob->height()) << "Filter must be square";
+    CHECK_GE(blob->num_axes(), 3) << "Blob must have at least 3 dimensions.";
     Dtype* data = blob->mutable_cpu_data();
-    int f = ceil(blob->width() / 2.);
-    float c = (2 * f - 1 - f % 2) / (2. * f);
     for (int i = 0; i < blob->count(); ++i) {
-      float x = i % blob->width();
-      float y = (i / blob->width()) % blob->height();
-      data[i] = (1 - fabs(x / f - c)) * (1 - fabs(y / f - c));
+      unsigned int stride = 1;
+      Dtype weight = 1;
+      for (int axis = blob->num_axes() - 1; axis >= 2; --axis) {
+        unsigned int shape = blob->shape(axis);
+        unsigned int factor =
+            std::ceil(static_cast<Dtype>(shape) / (2 * support()));
+        Dtype center = (2 * support() * factor - 1 - factor % 2) * 0.5;
+        Dtype coordinate = ((i / stride) % shape);
+        weight *= f((coordinate - center) / factor);
+        stride *= shape;
+      }
+      data[i] = weight;
     }
     CHECK_EQ(this->filler_param_.sparse(), -1)
          << "Sparsity not supported by this Filler.";
   }
+
+ protected:
+  virtual Dtype f(Dtype x) = 0;
+  virtual int support() = 0;
+};
+
+/**
+ * @brief Fills a Blob with coefficients for multilinear interpolation.
+ *
+ * Set type of weight_filler to 'multilinear'. Support is set to 1. See
+ * InterpolationFillerBase for a detailed explanation of how to set kernel_size,
+ * stride and pad.
+ * If you apply this to an image, this operation is equivalent to the following
+ * call in Python with Scikit.Image.
+ * \code{.py}
+ * out = skimage.transform.rescale(img, (factor_y, factor_x), mode='constant', cval=0)
+ * \endcode
+ */
+template <typename Dtype>
+class MultilinearFiller : public InterpolationFillerBase<Dtype> {
+ public:
+  explicit MultilinearFiller(const FillerParameter& param)
+      : InterpolationFillerBase<Dtype>(param) {}
+ protected:
+  virtual Dtype f(Dtype x) {
+    return std::abs(x) <= 1 ? 1 - std::abs(x) : 0;
+  }
+  virtual int support() { return 1; }
 };
 
 /**
@@ -282,8 +316,8 @@ Filler<Dtype>* GetFiller(const FillerParameter& param) {
     return new XavierFiller<Dtype>(param);
   } else if (type == "msra") {
     return new MSRAFiller<Dtype>(param);
-  } else if (type == "bilinear") {
-    return new BilinearFiller<Dtype>(param);
+  } else if (type == "multilinear") {
+    return new MultilinearFiller<Dtype>(param);
   } else {
     CHECK(false) << "Unknown filler name: " << param.type();
   }

--- a/include/caffe/util/upgrade_proto.hpp
+++ b/include/caffe/util/upgrade_proto.hpp
@@ -65,6 +65,12 @@ bool NetNeedsInputUpgrade(const NetParameter& net_param);
 // Perform all necessary transformations to upgrade input fields into layers.
 void UpgradeNetInput(NetParameter* net_param);
 
+// Return true iff the Net contains any deprecated weight fillers.
+bool NetNeedsWeightFillerUpgrade(const NetParameter& net_param);
+
+// Perform all necessary transformations to upgrade deprecated weight fillers.
+void UpgradeNetWeightFiller(NetParameter* net_param);
+
 // Return true iff the solver contains any old solver_type specified as enums
 bool SolverNeedsTypeUpgrade(const SolverParameter& solver_param);
 


### PR DESCRIPTION
This branch implements an n-dimensional generalization of the bilinear filler (#2213) and adds cubic and lanczos fillers.

It makes #3984 obsolete, as it uses a new common base class for all interpolation fillers. The base class InterpolationFillerBase calculates the weight values by calling the virtual interpolation functions of its derived classes. This PR implements linear, cubic and lanczos interpolation fillers, while additional interpolation functions (e.g. Hermite, Mitchell, Gaussian) may be implemented easily by deriving the class InterpolationFillerBase and implementing the virtual functions f() and support().

I have written a simple test script in python, which tests the fillers with various scaling factors in x and y. I will upload it after some cleanup.

If you have comments/suggestions, let me know!