### PR TITLE
Wrong calcuation of output dimension of deconvolutional layer

### DIFF
--- a/src/caffe/layers/deconv_layer.cpp
+++ b/src/caffe/layers/deconv_layer.cpp
@@ -15,8 +15,8 @@ void DeconvolutionLayer<Dtype>::compute_output_shape() {
     // i + 1 to skip channel axis
     const int input_dim = this->input_shape(i + 1);
     const int kernel_extent = dilation_data[i] * (kernel_shape_data[i] - 1) + 1;
-    const int output_dim = stride_data[i] * (input_dim - 1)
-        + kernel_extent - 2 * pad_data[i];
+    const int output_dim = stride_data[i] * input_dim
+        + kernel_extent - 1 - 2 * pad_data[i];
     this->output_shape_.push_back(output_dim);
   }
 }


### PR DESCRIPTION
EDIT:
Problem is not the formula. By the division by "stride" information gets lost and its not possible to evaluate the correct output size.

The reverse calculation of the output dimensions for a deconvolution network is wrong. For the following model with input size 24x24 an output size of 23x23 is calculated.
However it should have the same dimensions as the deconvolution should revert the convolution.

Tested with the following model and input size of 24x24.
...
layer {
  name: "conv1"
  type: "Convolution"
  bottom: "data"
  top: "conv1"
  convolution_param {
    num_output: 64
    kernel_size: 7
    stride: 2
    pad: 0
    weight_filler {
      type: "gaussian"
      std: 0.001
    }
    bias_filler {
      type: "constant"
      value: 0
    }
  }
}

layer {
  name: "deconv1"
  type: "Deconvolution"
  bottom: "conv1"
  top: "deconv1"
  convolution_param {
    num_output: 1
    kernel_size: 7
    stride: 2
    pad: 0
    weight_filler {
      type: "gaussian"
      std: 0.001
    }
    bias_filler {
      type: "constant"
      value: 0
    }
  }
}
...

0523 17:48:23.748564 32054 hdf5_data_layer.cpp:93] Number of HDF5 files: 1
I0523 17:48:23.749249 32054 hdf5.cpp:32] Datatype class: H5T_FLOAT
I0523 17:48:23.810364 32054 net.cpp:141] Setting up data
I0523 17:48:23.810400 32054 net.cpp:148] Top shape: 128 1 24 24 (73728)
I0523 17:48:23.810406 32054 net.cpp:148] Top shape: 128 1 24 24 (73728)
I0523 17:48:23.810410 32054 net.cpp:156] Memory required for data: 589824
I0523 17:48:23.810428 32054 layer_factory.hpp:77] Creating layer conv1
I0523 17:48:23.810458 32054 net.cpp:91] Creating Layer conv1
I0523 17:48:23.810464 32054 net.cpp:425] conv1 <- data
I0523 17:48:23.810475 32054 net.cpp:399] conv1 -> conv1
I0523 17:48:23.911188 32054 net.cpp:141] Setting up conv1
I0523 17:48:23.911218 32054 net.cpp:148] Top shape: 128 64 9 9 (663552)
I0523 17:48:23.911223 32054 net.cpp:156] Memory required for data: 3244032
I0523 17:48:23.911237 32054 layer_factory.hpp:77] Creating layer relu1
I0523 17:48:23.911248 32054 net.cpp:91] Creating Layer relu1
I0523 17:48:23.911255 32054 net.cpp:425] relu1 <- conv1
I0523 17:48:23.911260 32054 net.cpp:386] relu1 -> conv1 (in-place)
I0523 17:48:23.911367 32054 net.cpp:141] Setting up relu1
I0523 17:48:23.911375 32054 net.cpp:148] Top shape: 128 64 9 9 (663552)
I0523 17:48:23.911380 32054 net.cpp:156] Memory required for data: 5898240
I0523 17:48:23.911383 32054 layer_factory.hpp:77] Creating layer deconv1
I0523 17:48:23.911391 32054 net.cpp:91] Creating Layer deconv1
I0523 17:48:23.911396 32054 net.cpp:425] deconv1 <- conv1
I0523 17:48:23.911401 32054 net.cpp:399] deconv1 -> deconv1
I0523 17:48:23.911859 32054 net.cpp:141] Setting up deconv1
I0523 17:48:23.911869 32054 net.cpp:148] Top shape: 128 1 23 23 (67712)
I0523 17:48:23.911872 32054 net.cpp:156] Memory required for data: 6169088
I0523 17:48:23.911880 32054 layer_factory.hpp:77] Creating layer relu6
I0523 17:48:23.911900 32054 net.cpp:91] Creating Layer relu6
I0523 17:48:23.911905 32054 net.cpp:425] relu6 <- deconv1
I0523 17:48:23.911909 32054 net.cpp:386] relu6 -> deconv1 (in-place)
I0523 17:48:23.912127 32054 net.cpp:141] Setting up relu6
I0523 17:48:23.912147 32054 net.cpp:148] Top shape: 128 1 23 23 (67712)
I0523 17:48:23.912152 32054 net.cpp:156] Memory required for data: 6439936
I0523 17:48:23.912165 32054 layer_factory.hpp:77] Creating layer loss
I0523 17:48:23.912171 32054 net.cpp:91] Creating Layer loss
I0523 17:48:23.912184 32054 net.cpp:425] loss <- deconv1
I0523 17:48:23.912189 32054 net.cpp:425] loss <- label
I0523 17:48:23.912194 32054 net.cpp:399] loss -> loss
F0523 17:48:23.912209 32054 euclidean_loss_layer.cpp:12] Check failed: bottom[0]->count(1) == bottom[1]->count(1) (529 vs. 576) Inputs must have the same dimension.