### PR TITLE
Define preprocessing macro to properly report version on caffe comman…

### DIFF
--- a/windows/caffe/caffe.vcxproj
+++ b/windows/caffe/caffe.vcxproj
@@ -56,6 +56,9 @@
     <PostBuildEvent>
       <Command>"$(ScriptsDir)\FixGFlagsNaming.cmd" "$(OutDir)" $(Configuration)</Command>
     </PostBuildEvent>
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\tools\caffe.cpp" />


### PR DESCRIPTION
…d line option '-version'.

Adding this preprocessing definition macro to pass version number to 'CAFFE_VERSION' in caffe.cpp source.
DIGITS tries to find this information.  In Linux build, the version information is properly returned on command line option '-version.'

 