### PR TITLE
Add support for specifying a separator in the image data layer

### DIFF
--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -33,6 +33,11 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   CHECK((new_height == 0 && new_width == 0) ||
       (new_height > 0 && new_width > 0)) << "Current implementation requires "
       "new_height and new_width to be set at the same time.";
+
+  CHECK_EQ(1, this->layer_param_.image_data_param().separator().length())
+      << "A separator must be a single character";
+  char separator = this->layer_param_.image_data_param().separator().at(0);
+
   // Read the file with filenames and labels
   const string& source = this->layer_param_.image_data_param().source();
   LOG(INFO) << "Opening file " << source;
@@ -41,7 +46,7 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
   size_t pos;
   int label;
   while (std::getline(infile, line)) {
-    pos = line.find_last_of(' ');
+    pos = line.find_last_of(separator);
     label = atoi(line.substr(pos + 1).c_str());
     lines_.push_back(std::make_pair(line.substr(0, pos), label));
   }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -795,6 +795,8 @@ message ImageDataParameter {
   // data.
   optional bool mirror = 6 [default = false];
   optional string root_folder = 12 [default = ""];
+  // Use the following separator. The default is a space.
+  optional string separator = 13 [default = " "];
 }
 
 message InfogainLossParameter {

--- a/src/caffe/test/test_image_data_layer.cpp
+++ b/src/caffe/test/test_image_data_layer.cpp
@@ -252,23 +252,24 @@ TYPED_TEST(ImageDataLayerTest, TestCommaSeparated) {
   image_data_param->set_separator(sep);
   ImageDataLayer<Dtype> layer(param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
-  EXPECT_EQ(this->blob_top_label_->num(), 1);
-  EXPECT_EQ(this->blob_top_label_->channels(), 1);
-  EXPECT_EQ(this->blob_top_label_->height(), 1);
-  EXPECT_EQ(this->blob_top_label_->width(), 1);
+
+  vector<int> label_shape;
+  label_shape.push_back(1);
+
+  vector<int> data_shape;
+  data_shape.push_back(1);
+  data_shape.push_back(3);
+  data_shape.push_back(360);
+  data_shape.push_back(480);
+
+  EXPECT_EQ(this->blob_top_label_->shape(), label_shape);
   // cat.jpg
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
-  EXPECT_EQ(this->blob_top_data_->num(), 1);
-  EXPECT_EQ(this->blob_top_data_->channels(), 3);
-  EXPECT_EQ(this->blob_top_data_->height(), 360);
-  EXPECT_EQ(this->blob_top_data_->width(), 480);
+  EXPECT_EQ(this->blob_top_data_->shape(), data_shape);
   EXPECT_EQ(this->blob_top_label_->cpu_data()[0], 0);
   // cat gray.jpg
   layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
-  EXPECT_EQ(this->blob_top_data_->num(), 1);
-  EXPECT_EQ(this->blob_top_data_->channels(), 3);
-  EXPECT_EQ(this->blob_top_data_->height(), 360);
-  EXPECT_EQ(this->blob_top_data_->width(), 480);
+  EXPECT_EQ(this->blob_top_data_->shape(), data_shape);
   EXPECT_EQ(this->blob_top_label_->cpu_data()[0], 1);
 }
 

--- a/src/caffe/test/test_image_data_layer.cpp
+++ b/src/caffe/test/test_image_data_layer.cpp
@@ -31,27 +31,7 @@ class ImageDataLayerTest : public MultiDeviceTest<TypeParam> {
     Caffe::set_random_seed(seed_);
     // Create test input file.
     MakeTempFilename(&filename_);
-    std::ofstream outfile(filename_.c_str(), std::ofstream::out);
     LOG(INFO) << "Using temporary file " << filename_;
-    for (int i = 0; i < 5; ++i) {
-      outfile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << i << std::endl;
-    }
-    outfile.close();
-    // Create test input file for images of distinct sizes.
-    MakeTempFilename(&filename_reshape_);
-    std::ofstream reshapefile(filename_reshape_.c_str(), std::ofstream::out);
-    LOG(INFO) << "Using temporary file " << filename_reshape_;
-    reshapefile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << 0 << std::endl;
-    reshapefile << EXAMPLES_SOURCE_DIR "images/fish-bike.jpg " << 1
-                << std::endl;
-    reshapefile.close();
-    // Create test input file for images with space in names
-    MakeTempFilename(&filename_space_);
-    std::ofstream spacefile(filename_space_.c_str(), std::ofstream::out);
-    LOG(INFO) << "Using temporary file " << filename_space_;
-    spacefile << EXAMPLES_SOURCE_DIR "images/cat.jpg " << 0 << std::endl;
-    spacefile << EXAMPLES_SOURCE_DIR "images/cat gray.jpg " << 1 << std::endl;
-    spacefile.close();
   }
 
   virtual ~ImageDataLayerTest() {
@@ -59,10 +39,16 @@ class ImageDataLayerTest : public MultiDeviceTest<TypeParam> {
     delete blob_top_label_;
   }
 
+  std::ofstream& stream() {
+    if (!stream_.is_open()) {
+      stream_.open(filename_.c_str(), std::ofstream::out);
+    }
+    return stream_;
+  }
+
   int seed_;
   string filename_;
-  string filename_reshape_;
-  string filename_space_;
+  std::ofstream stream_;
   Blob<Dtype>* const blob_top_data_;
   Blob<Dtype>* const blob_top_label_;
   vector<Blob<Dtype>*> blob_bottom_vec_;
@@ -73,6 +59,13 @@ TYPED_TEST_CASE(ImageDataLayerTest, TestDtypesAndDevices);
 
 TYPED_TEST(ImageDataLayerTest, TestRead) {
   typedef typename TypeParam::Dtype Dtype;
+
+  std::ofstream& output = this->stream();
+  for (int i = 0; i < 5; ++i) {
+    output << EXAMPLES_SOURCE_DIR "images/cat.jpg " << i << std::endl;
+  }
+  output.close();
+
   LayerParameter param;
   ImageDataParameter* image_data_param = param.mutable_image_data_param();
   image_data_param->set_batch_size(5);
@@ -99,6 +92,13 @@ TYPED_TEST(ImageDataLayerTest, TestRead) {
 
 TYPED_TEST(ImageDataLayerTest, TestResize) {
   typedef typename TypeParam::Dtype Dtype;
+
+  std::ofstream& output = this->stream();
+  for (int i = 0; i < 5; ++i) {
+    output << EXAMPLES_SOURCE_DIR "images/cat.jpg " << i << std::endl;
+  }
+  output.close();
+
   LayerParameter param;
   ImageDataParameter* image_data_param = param.mutable_image_data_param();
   image_data_param->set_batch_size(5);
@@ -127,10 +127,16 @@ TYPED_TEST(ImageDataLayerTest, TestResize) {
 
 TYPED_TEST(ImageDataLayerTest, TestReshape) {
   typedef typename TypeParam::Dtype Dtype;
+
+  std::ofstream& output = this->stream();
+  output << EXAMPLES_SOURCE_DIR "images/cat.jpg " << 0 << std::endl;
+  output << EXAMPLES_SOURCE_DIR "images/fish-bike.jpg " << 1 << std::endl;
+  output.close();
+
   LayerParameter param;
   ImageDataParameter* image_data_param = param.mutable_image_data_param();
   image_data_param->set_batch_size(1);
-  image_data_param->set_source(this->filename_reshape_.c_str());
+  image_data_param->set_source(this->filename_.c_str());
   image_data_param->set_shuffle(false);
   ImageDataLayer<Dtype> layer(param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
@@ -154,6 +160,13 @@ TYPED_TEST(ImageDataLayerTest, TestReshape) {
 
 TYPED_TEST(ImageDataLayerTest, TestShuffle) {
   typedef typename TypeParam::Dtype Dtype;
+
+  std::ofstream& output = this->stream();
+  for (int i = 0; i < 5; ++i) {
+    output << EXAMPLES_SOURCE_DIR "images/cat.jpg " << i << std::endl;
+  }
+  output.close();
+
   LayerParameter param;
   ImageDataParameter* image_data_param = param.mutable_image_data_param();
   image_data_param->set_batch_size(5);
@@ -188,10 +201,16 @@ TYPED_TEST(ImageDataLayerTest, TestShuffle) {
 
 TYPED_TEST(ImageDataLayerTest, TestSpace) {
   typedef typename TypeParam::Dtype Dtype;
+
+  std::ofstream& output = this->stream();
+  output << EXAMPLES_SOURCE_DIR "images/cat.jpg " << 0 << std::endl;
+  output << EXAMPLES_SOURCE_DIR "images/cat gray.jpg " << 1 << std::endl;
+  output.close();
+
   LayerParameter param;
   ImageDataParameter* image_data_param = param.mutable_image_data_param();
   image_data_param->set_batch_size(1);
-  image_data_param->set_source(this->filename_space_.c_str());
+  image_data_param->set_source(this->filename_.c_str());
   image_data_param->set_shuffle(false);
   ImageDataLayer<Dtype> layer(param);
   layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);


### PR DESCRIPTION
Although #3653 has been open for a while now, I noticed that #4059 (which adds support for file names with spaces in) means that my implementation may require a little more work. I therefore thought that I would break things up into multiple PRs so that I can get a better grip on the changes required.

This PR will add support for a specifying a separator (e.g. a comma) instead of assuming a space-separated list. This was also mentioned in https://github.com/BVLC/caffe/pull/3433#issuecomment-166772986.

I have also restructured the test class somewhat to make it easier to write tests for the image data layer.
