### PR TITLE
Remove misleading comment from a test file

### DIFF
--- a/src/caffe/test/test_caffe_main.cpp
+++ b/src/caffe/test/test_caffe_main.cpp
@@ -1,6 +1,3 @@
-// The main caffe test code. Your test cpp code should include this hpp
-// to allow a main function to be compiled into the binary.
-
 #include "caffe/caffe.hpp"
 #include "caffe/test/test_caffe_main.hpp"
 


### PR DESCRIPTION
Looks like it was accidentally copy+pasted from here:
https://github.com/BVLC/caffe/blob/rc3/include/caffe/test/test_caffe_main.hpp#L1-L2