### PR TITLE
Resolve SIGSEGV error in image_data_layer.cpp

### DIFF
--- a/src/caffe/layers/image_data_layer.cpp
+++ b/src/caffe/layers/image_data_layer.cpp
@@ -46,6 +46,8 @@ void ImageDataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
     lines_.push_back(std::make_pair(line.substr(0, pos), label));
   }
 
+  CHECK(!lines_.empty()) << "File is empty";
+
   if (this->layer_param_.image_data_param().shuffle()) {
     // randomly shuffle data
     LOG(INFO) << "Shuffling data";


### PR DESCRIPTION
PR to resolve issue [#4186](https://github.com/BVLC/caffe/issues/4186).

Added check in image_data_layer.cpp to ensure that if an empty list is given as source to ImageData layer, segmentation fault won't occur.