### PR TITLE
Fix vecLib search order

### DIFF
--- a/cmake/Modules/FindvecLib.cmake
+++ b/cmake/Modules/FindvecLib.cmake
@@ -14,9 +14,10 @@ set(__veclib_include_suffix "Frameworks/vecLib.framework/Versions/Current/Header
 
 find_path(vecLib_INCLUDE_DIR vecLib.h
           DOC "vecLib include directory"
-          PATHS /System/Library/${__veclib_include_suffix}
-                /System/Library/Frameworks/Accelerate.framework/Versions/Current/${__veclib_include_suffix}
-                /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/)
+          PATHS /System/Library/Frameworks/Accelerate.framework/Versions/Current/${__veclib_include_suffix}
+                /System/Library/${__veclib_include_suffix}
+                /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
+          NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(vecLib DEFAULT_MSG vecLib_INCLUDE_DIR)


### PR DESCRIPTION
@CheeseWiz @shelhamer

Clients that have gone through OS X upgrades may have both the old `/System/Library/${__veclib_include_suffix}` and the new `/System/Library/Frameworks/Accelerate.framework/Versions/Current/${__veclib_include_suffix}`. The current behavior is to find `/System/Library/${__veclib_include_suffix}` first, resulting in two errors:

1. Compile time error missing `cblas.h` header file. It no longer lives alongside `vecLib.h` in `/System/Library/${__veclib_include_suffix}`.
2. Link time error no such framework `vecLib`. Should be using `Accelerate` framework.

Changing the order of the search paths allows Accelerate to be found first if it exists. I had to add `NO_DEFAULT_PATH` as otherwise `/System/Library/${__veclib_include_suffix}` is still found first, as CMake's default paths are checked before user-specified paths.

I believe this is the proper fix for [this Stack Overflow question](http://stackoverflow.com/questions/35544356/install-caffe-on-mac-error-fatal-error-cblas-h-file-not-found).