### PR TITLE
Cache protobuf3 build in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,10 @@ env:
     - BUILD_NAME="cudnn-cmake" WITH_CMAKE=true WITH_CUDA=true WITH_CUDNN=true
 
 cache:
+  timeout: 604800  # 1 week
   apt: true
+  directories:
+    - ~/protobuf3
 
 before_install:
   - source ./scripts/travis/defaults.sh

--- a/scripts/travis/install-deps.sh
+++ b/scripts/travis/install-deps.sh
@@ -40,25 +40,30 @@ else
     python3-skimage
 
   # build Protobuf3 since it's needed for Python3
-  echo "Building protobuf3 from source ..."
+  PROTOBUF3_DIR=~/protobuf3
   pushd .
-  PROTOBUF3_DIR=~/protobuf3-build
-  rm -rf $PROTOBUF3_DIR
-  mkdir $PROTOBUF3_DIR
+  if [ -d "$PROTOBUF3_DIR" ] && [ -e "$PROTOBUF3_DIR/src/protoc" ]; then
+    echo "Using cached protobuf3 build ..."
+    cd $PROTOBUF3_DIR
+  else
+    echo "Building protobuf3 from source ..."
+    rm -rf $PROTOBUF3_DIR
+    mkdir $PROTOBUF3_DIR
 
-  # install some more dependencies required to build protobuf3
-  apt-get install -y --no-install-recommends \
-    curl \
-    dh-autoreconf \
-    unzip
+    # install some more dependencies required to build protobuf3
+    apt-get install -y --no-install-recommends \
+      curl \
+      dh-autoreconf \
+      unzip
 
-  wget https://github.com/google/protobuf/archive/v3.0.0-beta-3.tar.gz -O protobuf3.tar.gz
-  tar -xzf protobuf3.tar.gz -C $PROTOBUF3_DIR --strip 1
-  rm protobuf3.tar.gz
-  cd $PROTOBUF3_DIR
-  ./autogen.sh
-  ./configure --prefix=/usr
-  make --jobs=$NUM_THREADS
+    wget https://github.com/google/protobuf/archive/v3.0.0-beta-3.tar.gz -O protobuf3.tar.gz
+    tar -xzf protobuf3.tar.gz -C $PROTOBUF3_DIR --strip 1
+    rm protobuf3.tar.gz
+    cd $PROTOBUF3_DIR
+    ./autogen.sh
+    ./configure --prefix=/usr
+    make --jobs=$NUM_THREADS
+  fi
   make install
   popd
 fi


### PR DESCRIPTION
This should shave a few minutes off the "python3-cmake" build. It's a similar solution to https://github.com/NVIDIA/DIGITS/pull/788, which is working great.

I'm not actually sure how TravisCI will handle this since only one of the nine build targets is building protobuf3. Here's the relevant documentation:
https://docs.travis-ci.com/user/caching/#Caches-and-build-matrices

If I'm reading it correctly, each build target should have its own cache, so 8 of the targets should cache an empty directory, and the "python3-cmake" target should cache the build.

I can't really test this until it's merged, but it also can't break anything too seriously. Worst case is the python3 target stops working and we revert this commit.