### PR TITLE
Fix for MemoryDataLayer memory leak (PyCaffe flow)

### DIFF
--- a/include/caffe/layers/memory_data_layer.hpp
+++ b/include/caffe/layers/memory_data_layer.hpp
@@ -49,8 +49,8 @@ class MemoryDataLayer : public BaseDataLayer<Dtype> {
       const vector<Blob<Dtype>*>& top);
 
   int batch_size_, channels_, height_, width_, size_;
-  Dtype* data_;
-  Dtype* labels_;
+  Blob<Dtype> data_;
+  Blob<Dtype> labels_;
   int n_;
   size_t pos_;
   Blob<Dtype> added_data_;


### PR DESCRIPTION
See https://github.com/NVIDIA/caffe/issues/154 to reproduce this leak. Problem: MemoryDataLayer<Dtype>::Reset makes a shallow copy. As a result, Python is unable to collect its garbage. This fix makes deep copy but it might defeat the MemoryDataLayer purpose.