### PR TITLE
Bug fix for Concat layer in computing offsets for Crop

### DIFF
--- a/python/caffe/coord_map.py
+++ b/python/caffe/coord_map.py
@@ -12,7 +12,7 @@ from caffe import layers as L
 PASS_THROUGH_LAYERS = ['AbsVal', 'BatchNorm', 'Bias', 'BNLL', 'Dropout',
                        'Eltwise', 'ELU', 'Log', 'LRN', 'Exp', 'MVN', 'Power',
                        'ReLU', 'PReLU', 'Scale', 'Sigmoid', 'Split', 'TanH',
-                       'Threshold']
+                       'Threshold', 'Concat']
 
 
 def conv_params(fn):
@@ -76,6 +76,7 @@ def coord_map(fn):
         axis -= 1  # -1 for last non-coordinate dim.
         return axis, 1, - offset
     else:
+        print("Error: Encountered an unfamiliar layer: " + fn.type_name)
         raise UndefinedMapException
 
 


### PR DESCRIPTION
The coord_map function did not know how to treat Concatenation layers, and threw an UndefinedMapException when they were encountered without any warning to the user. I added Concat to the list of PASS_THROUGH_LAYERS, and added a warning in case other newer layers are encountered in the future. I am not 100% sure Concat should just be a PASS_THROUGH_LAYER, and does not require any special treatment, but from what I understood of how this code works I think this is correct, right?