### PR TITLE
Fix glog upstream autoconf for Ubuntu 16.04

### DIFF
--- a/cmake/External/glog.cmake
+++ b/cmake/External/glog.cmake
@@ -37,6 +37,7 @@ if (NOT __GLOG_INCLUDED)
       GIT_TAG "v0.3.4"
       UPDATE_COMMAND ""
       INSTALL_DIR ${gflags_INSTALL}
+      PATCH_COMMAND autoreconf -i ${glog_PREFIX}/src/glog
       CONFIGURE_COMMAND env "CFLAGS=${GLOG_C_FLAGS}" "CXXFLAGS=${GLOG_CXX_FLAGS}" ${glog_PREFIX}/src/glog/configure --prefix=${glog_INSTALL} --enable-shared=no --enable-static=yes --with-gflags=${GFLAGS_LIBRARY_DIRS}/..
       LOG_DOWNLOAD 1
       LOG_CONFIGURE 1


### PR DESCRIPTION
On Ubuntu 16.04, the autoconf tools of glog are not working as they depend on autoconf 1.14 while only 1.15 is available.

The error is

```
[ 75%] Building CXX object CMakeFiles/gflags_nothreads-static.dir/src/gflags_reporting.cc.o                                                                      
[ 87%] Building CXX object CMakeFiles/gflags_nothreads-static.dir/src/gflags_completions.cc.o                                                                    
[100%] Linking CXX static library lib/libgflags_nothreads.a                                                                                                      
[100%] Built target gflags_nothreads-static                                                                                                                      
[  2%] Performing install step for 'gflags'                                                                                                                      
-- gflags install command succeeded.  See also /media/renficiaud/linux-data/Code/sandbox/caffe/build/external/gflags-prefix/src/gflags-stamp/gflags-install-*.log
[  4%] Completed 'gflags'                                                                                                                                        
[  4%] Built target gflags                                                                                                                                       
Scanning dependencies of target glog                                                                                                                             
[  4%] Creating directories for 'glog'                                                                                                                           
[  5%] Performing download step (git clone) for 'glog'                                                                                                           
-- glog download command succeeded.  See also /media/renficiaud/linux-data/Code/sandbox/caffe/build/external/glog-prefix/src/glog-stamp/glog-download-*.log      
[  5%] No patch step for 'glog'                                                                                                                                  
[  5%] No update step for 'glog'                                                                                                                                 
[  6%] Performing configure step for 'glog'                                                                                                                      
-- glog configure command succeeded.  See also /media/renficiaud/linux-data/Code/sandbox/caffe/build/external/glog-prefix/src/glog-stamp/glog-configure-*.log    
[  6%] Performing build step for 'glog'                                                                                                                          
/bin/bash: aclocal-1.14: command not found                                                                                                                       
Makefile:957: recipe for target '/media/renficiaud/linux-data/Code/sandbox/caffe/build/external/glog-prefix/src/glog/aclocal.m4' failed                          
make[3]: *** [/media/renficiaud/linux-data/Code/sandbox/caffe/build/external/glog-prefix/src/glog/aclocal.m4] Error 127                                          
CMakeFiles/glog.dir/build.make:112: recipe for target 'external/glog-prefix/src/glog-stamp/glog-build' failed                                                    
make[2]: *** [external/glog-prefix/src/glog-stamp/glog-build] Error 2                                                                                            
CMakeFiles/Makefile2:131: recipe for target 'CMakeFiles/glog.dir/all' failed                                                                                     
make[1]: *** [CMakeFiles/glog.dir/all] Error 2                                                                                                                   
Makefile:127: recipe for target 'all' failed                                                                                                                     
```

The attached patch solves the issue by running `autoreconf`after the clone using the `PATCH_COMMAND` of cmake `ExternalProject_Add` command. I tried to use only one `CONFIGURE_COMMAND` but it does not work. 

After the patch is applied, the project compiles properly:

```
--   Doxygen           :   /usr/bin/doxygen (1.8.11)                                                                                                                              
--   config_file       :   /media/renficiaud/linux-data/Code/sandbox/caffe/.Doxyfile                                                                                              
--                                                                                                                                                                                
-- Install:                                                                                                                                                                       
--   Install path      :   /media/renficiaud/linux-data/Code/sandbox/caffe/build/install                                                                                          
--                                                                                                                                                                                
-- Configuring done                                                                                                                                                               
-- Generating done                                                                                                                                                                
-- Build files have been written to: /media/renficiaud/linux-data/Code/sandbox/caffe/build                                                                                        
[  4%] Built target gflags                                                                                                                                                        
[  4%] Performing patch step for 'glog'                                                                                                                                           
libtoolize: putting auxiliary files in '.'.                                                                                                                                       
libtoolize: copying file './ltmain.sh'                                                                                                                                            
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.                                                                                                                         
libtoolize: copying file 'm4/libtool.m4'                                                                                                                                          
libtoolize: copying file 'm4/ltoptions.m4'                                                                                                                                        
libtoolize: copying file 'm4/ltversion.m4'                                                                                                                                        
parallel-tests: installing './test-driver'                                                                                                                                        
[  5%] Performing configure step for 'glog'                                                                                                                                       
-- glog configure command succeeded.  See also /media/renficiaud/linux-data/Code/sandbox/caffe/build/external/glog-prefix/src/glog-stamp/glog-configure-*.log                     
[  5%] Performing build step for 'glog'                                                                                                                                           
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I/media/renficiaud/linux-data/Code/sandbox/caffe/build/external/glog-prefix/src/glog -I./src -I/media/renficiaud/linux-data/Code/sandb
ox/caffe/build/external/glog-prefix/src/glog/src -I/media/renficiaud/linux-data/Code/sandbox/caffe/build/external/gflags-install/lib/../include -Wall -Wwrite-strings -Woverloaded
-virtual -Wno-sign-compare -DNO_FRAME_POINTER -DNDEBUG -fPIC -MT src/libglog_la-logging.lo -MD -MP -MF src/.deps/libglog_la-logging.Tpo -c /media/renficiaud/linux-data/Code/sandb
ox/caffe/build/external/glog-prefix/src/glog/src/logging.cc -o src/libglog_la-logging.o                                                                                           
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I/media/renficiaud/linux-data/Code/sandbox/caffe/build/external/glog-prefix/src/glog -I./src -I/media/renficiaud/linux-data/Code/sandb
ox/caffe/build/external/glog-prefix/src/glog/src -I/media/renficiaud/linux-data/Code/sandbox/caffe/build/external/gflags-install/lib/../include -Wall -Wwrite-strings -Woverloaded
-virtual -Wno-sign-compare -DNO_FRAME_POINTER -DNDEBUG -fPIC -MT src/libglog_la-raw_logging.lo -MD -MP -MF src/.deps/libglog_la-raw_logging.Tpo -c /media/renficiaud/linux-data/Co
de/sandbox/caffe/build/external/glog-prefix/src/glog/src/raw_logging.cc -o src/libglog_la-raw_logging.o                                                                           
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I/media/renficiaud/linux-data/Code/sandbox/caffe/build/external/glog-prefix/src/glog -I./src -I/media/renficiaud/linux-data/Code/sandb

```
