### PR TITLE
improve top_names and bottom_names in pycaffe

### DIFF
--- a/python/caffe/test/test_net.py
+++ b/python/caffe/test/test_net.py
@@ -3,6 +3,7 @@ import tempfile
 import os
 import numpy as np
 import six
+from collections import OrderedDict
 
 import caffe
 
@@ -66,6 +67,18 @@ class TestNet(unittest.TestCase):
     def test_inputs_outputs(self):
         self.assertEqual(self.net.inputs, [])
         self.assertEqual(self.net.outputs, ['loss'])
+
+    def test_top_bottom_names(self):
+        self.assertEqual(self.net.top_names,
+                         OrderedDict([('data', ['data', 'label']),
+                                      ('conv', ['conv']),
+                                      ('ip', ['ip']),
+                                      ('loss', ['loss'])]))
+        self.assertEqual(self.net.bottom_names,
+                         OrderedDict([('data', []),
+                                      ('conv', ['data']),
+                                      ('ip', ['conv']),
+                                      ('loss', ['ip', 'label'])]))
 
     def test_save_and_read(self):
         f = tempfile.NamedTemporaryFile(mode='w+', delete=False)


### PR DESCRIPTION
By rewriting these properties to proper OrderedDict, a lot of functionalities like iterations are added to the field. Plus, it gets computed only once, instead of partially at every element access.