### PR TITLE
Expand the net.input list to all input layers

### DIFF
--- a/python/caffe/test/test_net.py
+++ b/python/caffe/test/test_net.py
@@ -64,7 +64,7 @@ class TestNet(unittest.TestCase):
         self.net.backward()
 
     def test_inputs_outputs(self):
-        self.assertEqual(self.net.inputs, [])
+        self.assertEqual(self.net.inputs, ['data', 'label'])
         self.assertEqual(self.net.outputs, ['loss'])
 
     def test_save_and_read(self):

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -104,7 +104,7 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
     for (int top_id = 0; top_id < num_top; ++top_id) {
       AppendTop(param, layer_id, top_id, &available_blobs, &blob_name_to_idx);
       // Collect Input layer tops as Net inputs.
-      if (layer_param.type() == "Input") {
+      if (num_top && !layer_param.bottom_size()) {
         const int blob_id = blobs_.size() - 1;
         net_input_blob_indices_.push_back(blob_id);
         net_input_blobs_.push_back(blobs_[blob_id].get());


### PR DESCRIPTION
Currently, the input list of a network is only used (AFAIK) to provide a nice interface in python/caffe. However, it only includes the layers of type "Input", not all the input layers.

I understand that the idea was that the list is only the layers that need to be set by hand, but when manipulating a network by hand, having those layers in the input list is usually easier.

For instance, the `forward` method in python can only set the input data if the layer is in the input list.

Moreover, it mirrors more closely the behaviour of the output list.
