### PR TITLE
Fix for EmbedLayerTest failure

### DIFF
--- a/src/caffe/test/test_embed_layer.cpp
+++ b/src/caffe/test/test_embed_layer.cpp
@@ -124,7 +124,7 @@ TYPED_TEST(EmbedLayerTest, TestForwardWithBias) {
     top_offset[4] = 0;
     bias_offset[0] = 0;
     for (int j = 0; j < kNumOutput; ++j) {
-      EXPECT_EQ(layer->blobs()[0]->data_at(weight_offset) +
+      EXPECT_FLOAT_EQ(layer->blobs()[0]->data_at(weight_offset) +
                 layer->blobs()[1]->data_at(bias_offset),
                 this->blob_top_->data_at(top_offset));
       ++top_offset[4];


### PR DESCRIPTION
This test had a random failure due to floating point comparison. So, instead of a macro that does exact match, used EXPECT_FLOAT_EQ that tolerates some precision while comparing two float or double values.