### PR TITLE
Examples correction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -679,7 +679,6 @@ $(DISTRIBUTE_DIR): all py | $(DISTRIBUTE_SUBDIRS)
 	cp $(PROTO_GEN_HEADER_SRCS) $(DISTRIBUTE_DIR)/include/caffe/proto
 	# add tool and example binaries
 	cp $(TOOL_BINS) $(DISTRIBUTE_DIR)/bin
-	cp -P $(TOOL_BIN_LINKS) $(DISTRIBUTE_DIR)/bin
 	cp $(EXAMPLE_BINS) $(DISTRIBUTE_DIR)/bin
 	# add libraries
 	cp $(STATIC_NAME) $(DISTRIBUTE_DIR)/lib

--- a/Makefile
+++ b/Makefile
@@ -679,6 +679,7 @@ $(DISTRIBUTE_DIR): all py | $(DISTRIBUTE_SUBDIRS)
 	cp $(PROTO_GEN_HEADER_SRCS) $(DISTRIBUTE_DIR)/include/caffe/proto
 	# add tool and example binaries
 	cp $(TOOL_BINS) $(DISTRIBUTE_DIR)/bin
+	cp -P $(TOOL_BIN_LINKS) $(DISTRIBUTE_DIR)/bin
 	cp $(EXAMPLE_BINS) $(DISTRIBUTE_DIR)/bin
 	# add libraries
 	cp $(STATIC_NAME) $(DISTRIBUTE_DIR)/lib

--- a/examples/cifar10/create_cifar10.sh
+++ b/examples/cifar10/create_cifar10.sh
@@ -5,15 +5,26 @@ EXAMPLE=examples/cifar10
 DATA=data/cifar10
 DBTYPE=lmdb
 
+# Check if CAFFE_ROOT is set
+if [ -z ${CAFFE_ROOT+x} ]; 
+# if unset
+then
+  EXAMPLES_BIN=./build/$EXAMPLE
+  TOOLS_BIN=./build/tools
+else
+  EXAMPLES_BIN=$CAFFE_BIN
+  TOOLS_BIN=$CAFFE_BIN
+fi  
+
 echo "Creating $DBTYPE..."
 
 rm -rf $EXAMPLE/cifar10_train_$DBTYPE $EXAMPLE/cifar10_test_$DBTYPE
 
-./build/examples/cifar10/convert_cifar_data.bin $DATA $EXAMPLE $DBTYPE
+$EXAMPLES_BIN/convert_cifar_data.bin $DATA $EXAMPLE $DBTYPE
 
 echo "Computing image mean..."
 
-./build/tools/compute_image_mean -backend=$DBTYPE \
+$TOOLS_BIN/compute_image_mean -backend=$DBTYPE \
   $EXAMPLE/cifar10_train_$DBTYPE $EXAMPLE/mean.binaryproto
 
 echo "Done."

--- a/examples/cifar10/create_cifar10.sh
+++ b/examples/cifar10/create_cifar10.sh
@@ -5,26 +5,26 @@ EXAMPLE=examples/cifar10
 DATA=data/cifar10
 DBTYPE=lmdb
 
-# Check if CAFFE_ROOT is set
-if [ -z ${CAFFE_ROOT+x} ]; 
+# Check if CAFFE_BIN is set
+if [ -z ${CAFFE_BIN+x} ]; 
 # if unset
 then
-  EXAMPLES_BIN=./build/$EXAMPLE
-  TOOLS_BIN=./build/tools
+  EXAMPLES=./build/$EXAMPLE
+  TOOLS=./build/tools
 else
-  EXAMPLES_BIN=$CAFFE_BIN
-  TOOLS_BIN=$CAFFE_BIN
+  EXAMPLES=$CAFFE_BIN
+  TOOLS=$CAFFE_BIN
 fi  
 
 echo "Creating $DBTYPE..."
 
 rm -rf $EXAMPLE/cifar10_train_$DBTYPE $EXAMPLE/cifar10_test_$DBTYPE
 
-$EXAMPLES_BIN/convert_cifar_data.bin $DATA $EXAMPLE $DBTYPE
+$EXAMPLES/convert_cifar_data.bin $DATA $EXAMPLE $DBTYPE
 
 echo "Computing image mean..."
 
-$TOOLS_BIN/compute_image_mean -backend=$DBTYPE \
+$TOOLS/compute_image_mean -backend=$DBTYPE \
   $EXAMPLE/cifar10_train_$DBTYPE $EXAMPLE/mean.binaryproto
 
 echo "Done."

--- a/examples/cifar10/create_cifar10.sh
+++ b/examples/cifar10/create_cifar10.sh
@@ -6,9 +6,7 @@ DATA=data/cifar10
 DBTYPE=lmdb
 
 # Check if CAFFE_BIN is set
-if [ -z ${CAFFE_BIN+x} ]; 
-# if unset
-then
+if [ -z "$CAFFE_BIN" ]; then
   EXAMPLES=./build/$EXAMPLE
   TOOLS=./build/tools
 else

--- a/examples/cifar10/create_cifar10.sh
+++ b/examples/cifar10/create_cifar10.sh
@@ -5,7 +5,7 @@ EXAMPLE=examples/cifar10
 DATA=data/cifar10
 DBTYPE=lmdb
 
-# Check if CAFFE_BIN is set
+# Check if CAFFE_BIN is unset
 if [ -z "$CAFFE_BIN" ]; then
   EXAMPLES=./build/$EXAMPLE
   TOOLS=./build/tools

--- a/examples/cifar10/train_full.sh
+++ b/examples/cifar10/train_full.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is unset
-if [ -z ${TOOLS+x} ];
-then
+if [ -z "$TOOLS" ]; then
 TOOLS=./build/tools
 fi
 

--- a/examples/cifar10/train_full.sh
+++ b/examples/cifar10/train_full.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env sh
 
-# Check if CAFFE_BIN is unset
-if [ -z ${CAFFE_BIN+x} ];
+# Check if TOOLS is unset
+if [ -z ${TOOLS+x} ];
 then
 TOOLS=./build/tools
-else
-TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/cifar10/train_full.sh
+++ b/examples/cifar10/train_full.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is unset
-if [ -z "$TOOLS" ]; then
-TOOLS=./build/tools
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
+  TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/cifar10/train_full.sh
+++ b/examples/cifar10/train_full.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 
+# Check if CAFFE_BIN is unset
+if [ -z ${CAFFE_BIN+x} ];
+then
 TOOLS=./build/tools
+else
+TOOLS=$CAFFE_BIN
+fi
 
 $TOOLS/caffe train \
     --solver=examples/cifar10/cifar10_full_solver.prototxt

--- a/examples/cifar10/train_full_sigmoid.sh
+++ b/examples/cifar10/train_full_sigmoid.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is unset
-if [ -z ${TOOLS+x} ];
-then
+if [ -z "$TOOLS" ]; then
 TOOLS=./build/tools
 fi
 

--- a/examples/cifar10/train_full_sigmoid.sh
+++ b/examples/cifar10/train_full_sigmoid.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env sh
 
-# Check if CAFFE_BIN is unset
-if [ -z ${CAFFE_BIN+x} ];
+# Check if TOOLS is unset
+if [ -z ${TOOLS+x} ];
 then
 TOOLS=./build/tools
-else
-TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/cifar10/train_full_sigmoid.sh
+++ b/examples/cifar10/train_full_sigmoid.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is unset
-if [ -z "$TOOLS" ]; then
-TOOLS=./build/tools
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
+  TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/cifar10/train_full_sigmoid.sh
+++ b/examples/cifar10/train_full_sigmoid.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 
+# Check if CAFFE_BIN is unset
+if [ -z ${CAFFE_BIN+x} ];
+then
 TOOLS=./build/tools
+else
+TOOLS=$CAFFE_BIN
+fi
 
 $TOOLS/caffe train \
     --solver=examples/cifar10/cifar10_full_sigmoid_solver.prototxt

--- a/examples/cifar10/train_full_sigmoid_bn.sh
+++ b/examples/cifar10/train_full_sigmoid_bn.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is unset
-if [ -z ${TOOLS+x} ];
-then
+if [ -z "$TOOLS" ]; then
 TOOLS=./build/tools
 fi
 

--- a/examples/cifar10/train_full_sigmoid_bn.sh
+++ b/examples/cifar10/train_full_sigmoid_bn.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env sh
 
-# Check if CAFFE_BIN is unset
-if [ -z ${CAFFE_BIN+x} ];
+# Check if TOOLS is unset
+if [ -z ${TOOLS+x} ];
 then
 TOOLS=./build/tools
-else
-TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/cifar10/train_full_sigmoid_bn.sh
+++ b/examples/cifar10/train_full_sigmoid_bn.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 
+# Check if CAFFE_BIN is unset
+if [ -z ${CAFFE_BIN+x} ];
+then
 TOOLS=./build/tools
+else
+TOOLS=$CAFFE_BIN
+fi
 
 $TOOLS/caffe train \
     --solver=examples/cifar10/cifar10_full_sigmoid_solver_bn.prototxt

--- a/examples/cifar10/train_full_sigmoid_bn.sh
+++ b/examples/cifar10/train_full_sigmoid_bn.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is unset
-if [ -z "$TOOLS" ]; then
-TOOLS=./build/tools
+# Check if $CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
+  TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/cifar10/train_quick.sh
+++ b/examples/cifar10/train_quick.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is unset
-if [ -z ${TOOLS+x} ];
-then
+if [ -z "$TOOLS" ]; then
 TOOLS=./build/tools
 fi
 

--- a/examples/cifar10/train_quick.sh
+++ b/examples/cifar10/train_quick.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 
+# Check if CAFFE_BIN is unset
+if [ -z ${CAFFE_BIN+x} ];
+then
 TOOLS=./build/tools
+else
+TOOLS=$CAFFE_BIN
+fi
 
 $TOOLS/caffe train \
   --solver=examples/cifar10/cifar10_quick_solver.prototxt

--- a/examples/cifar10/train_quick.sh
+++ b/examples/cifar10/train_quick.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env sh
 
-# Check if CAFFE_BIN is unset
-if [ -z ${CAFFE_BIN+x} ];
+# Check if TOOLS is unset
+if [ -z ${TOOLS+x} ];
 then
 TOOLS=./build/tools
-else
-TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/cifar10/train_quick.sh
+++ b/examples/cifar10/train_quick.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is unset
-if [ -z "$TOOLS" ]; then
-TOOLS=./build/tools
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
+  TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/imagenet/create_imagenet.sh
+++ b/examples/imagenet/create_imagenet.sh
@@ -41,6 +41,7 @@ fi
 
 echo "Creating train lmdb..."
 
+rm -rf $EXAMPLE/ilsvrc12_train_lmdb
 GLOG_logtostderr=1 $TOOLS/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \
@@ -51,6 +52,7 @@ GLOG_logtostderr=1 $TOOLS/convert_imageset \
 
 echo "Creating val lmdb..."
 
+rm -rf $EXAMPLE/ilsvrc12_val_lmdb
 GLOG_logtostderr=1 $TOOLS/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \

--- a/examples/imagenet/create_imagenet.sh
+++ b/examples/imagenet/create_imagenet.sh
@@ -4,7 +4,12 @@
 
 EXAMPLE=examples/imagenet
 DATA=data/ilsvrc12
-TOOLS=build/tools
+
+# Check if TOOLS is unset
+if [ -z ${TOOLS+x} ];
+then
+TOOLS=./build/tools
+fi
 
 TRAIN_DATA_ROOT=/path/to/imagenet/train/
 VAL_DATA_ROOT=/path/to/imagenet/val/

--- a/examples/imagenet/create_imagenet.sh
+++ b/examples/imagenet/create_imagenet.sh
@@ -5,9 +5,11 @@
 EXAMPLE=examples/imagenet
 DATA=data/ilsvrc12
 
-# Check if TOOLS is unset
-if [ -z "$TOOLS" ]; then
-TOOLS=./build/tools
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
+  TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 TRAIN_DATA_ROOT=/path/to/imagenet/train/

--- a/examples/imagenet/create_imagenet.sh
+++ b/examples/imagenet/create_imagenet.sh
@@ -6,8 +6,7 @@ EXAMPLE=examples/imagenet
 DATA=data/ilsvrc12
 
 # Check if TOOLS is unset
-if [ -z ${TOOLS+x} ];
-then
+if [ -z "$TOOLS" ]; then
 TOOLS=./build/tools
 fi
 

--- a/examples/imagenet/make_imagenet_mean.sh
+++ b/examples/imagenet/make_imagenet_mean.sh
@@ -5,9 +5,11 @@
 EXAMPLE=examples/imagenet
 DATA=data/ilsvrc12
 
-# Check if TOOLS is unset
-if [ -z "$TOOLS" ]; then
-TOOLS=./build/tools
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
+  TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 

--- a/examples/imagenet/make_imagenet_mean.sh
+++ b/examples/imagenet/make_imagenet_mean.sh
@@ -4,7 +4,13 @@
 
 EXAMPLE=examples/imagenet
 DATA=data/ilsvrc12
-TOOLS=build/tools
+
+# Check if TOOLS is unset
+if [ -z ${TOOLS+x} ];
+then
+TOOLS=./build/tools
+fi
+
 
 $TOOLS/compute_image_mean $EXAMPLE/ilsvrc12_train_lmdb \
   $DATA/imagenet_mean.binaryproto

--- a/examples/imagenet/make_imagenet_mean.sh
+++ b/examples/imagenet/make_imagenet_mean.sh
@@ -6,8 +6,7 @@ EXAMPLE=examples/imagenet
 DATA=data/ilsvrc12
 
 # Check if TOOLS is unset
-if [ -z ${TOOLS+x} ];
-then
+if [ -z "$TOOLS" ]; then
 TOOLS=./build/tools
 fi
 

--- a/examples/imagenet/resume_training.sh
+++ b/examples/imagenet/resume_training.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
 
-./build/tools/caffe train \
+# Check if TOOLS is unset
+if [ -z ${TOOLS+x} ];
+then
+TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train \
     --solver=models/bvlc_reference_caffenet/solver.prototxt \
     --snapshot=models/bvlc_reference_caffenet/caffenet_train_10000.solverstate.h5

--- a/examples/imagenet/resume_training.sh
+++ b/examples/imagenet/resume_training.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is unset
-if [ -z ${TOOLS+x} ];
-then
+if [ -z "$TOOLS" ]; then
 TOOLS=./build/tools
 fi
 

--- a/examples/imagenet/resume_training.sh
+++ b/examples/imagenet/resume_training.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is unset
-if [ -z "$TOOLS" ]; then
-TOOLS=./build/tools
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
+  TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/imagenet/train_caffenet.sh
+++ b/examples/imagenet/train_caffenet.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env sh
 
-./build/tools/caffe train \
+# Check if TOOLS is unset
+if [ -z ${TOOLS+x} ];
+then
+TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train \
     --solver=models/bvlc_reference_caffenet/solver.prototxt

--- a/examples/imagenet/train_caffenet.sh
+++ b/examples/imagenet/train_caffenet.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is unset
-if [ -z ${TOOLS+x} ];
-then
+if [ -z "$TOOLS" ]; then
 TOOLS=./build/tools
 fi
 

--- a/examples/imagenet/train_caffenet.sh
+++ b/examples/imagenet/train_caffenet.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is unset
-if [ -z "$TOOLS" ]; then
-TOOLS=./build/tools
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
+  TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/mnist/create_mnist.sh
+++ b/examples/mnist/create_mnist.sh
@@ -6,9 +6,7 @@ EXAMPLE=examples/mnist
 DATA=data/mnist
 
 # Check if CAFFE_BIN is set
-if [ -z ${CAFFE_BIN+x} ];
-# if unset
-then
+if [ -z "$CAFFE_BIN" ]; then
   BUILD=build/examples/mnist
 else
   BUILD=$CAFFE_BIN

--- a/examples/mnist/create_mnist.sh
+++ b/examples/mnist/create_mnist.sh
@@ -5,7 +5,7 @@
 EXAMPLE=examples/mnist
 DATA=data/mnist
 
-# Check if CAFFE_BIN is set
+# Check if CAFFE_BIN is unset
 if [ -z "$CAFFE_BIN" ]; then
   BUILD=build/examples/mnist
 else

--- a/examples/mnist/create_mnist.sh
+++ b/examples/mnist/create_mnist.sh
@@ -4,7 +4,15 @@
 
 EXAMPLE=examples/mnist
 DATA=data/mnist
-BUILD=build/examples/mnist
+
+# Check if CAFFE_BIN is set
+if [ -z ${CAFFE_BIN+x} ];
+# if unset
+then
+  BUILD=build/examples/mnist
+else
+  BUILD=$CAFFE_BIN
+fi
 
 BACKEND="lmdb"
 

--- a/examples/mnist/train_lenet.sh
+++ b/examples/mnist/train_lenet.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env sh
 
-./build/tools/caffe train --solver=examples/mnist/lenet_solver.prototxt
+# Check if TOOLS is set
+if [ -z ${TOOLS+x} ];
+# if unset
+then
+  TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train --solver=examples/mnist/lenet_solver.prototxt

--- a/examples/mnist/train_lenet.sh
+++ b/examples/mnist/train_lenet.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is set
-if [ -z "$TOOLS" ]; then
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
   TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train --solver=examples/mnist/lenet_solver.prototxt

--- a/examples/mnist/train_lenet.sh
+++ b/examples/mnist/train_lenet.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is set
-if [ -z ${TOOLS+x} ];
-# if unset
-then
+if [ -z "$TOOLS" ]; then
   TOOLS=./build/tools
 fi
 

--- a/examples/mnist/train_lenet_adam.sh
+++ b/examples/mnist/train_lenet_adam.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env sh
 
-./build/tools/caffe train --solver=examples/mnist/lenet_solver_adam.prototxt
+# Check if TOOLS is set
+if [ -z ${TOOLS+x} ];
+# if unset
+then
+  TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train --solver=examples/mnist/lenet_solver_adam.prototxt

--- a/examples/mnist/train_lenet_adam.sh
+++ b/examples/mnist/train_lenet_adam.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is set
-if [ -z "$TOOLS" ]; then
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
   TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
+
 
 $TOOLS/caffe train --solver=examples/mnist/lenet_solver_adam.prototxt

--- a/examples/mnist/train_lenet_adam.sh
+++ b/examples/mnist/train_lenet_adam.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is set
-if [ -z ${TOOLS+x} ];
-# if unset
-then
+if [ -z "$TOOLS" ]; then
   TOOLS=./build/tools
 fi
 

--- a/examples/mnist/train_lenet_consolidated.sh
+++ b/examples/mnist/train_lenet_consolidated.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
 
-./build/tools/caffe train \
+# Check if TOOLS is set
+if [ -z ${TOOLS+x} ];
+# if unset
+then
+  TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train \
   --solver=examples/mnist/lenet_consolidated_solver.prototxt

--- a/examples/mnist/train_lenet_consolidated.sh
+++ b/examples/mnist/train_lenet_consolidated.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is set
-if [ -z "$TOOLS" ]; then
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
   TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/mnist/train_lenet_consolidated.sh
+++ b/examples/mnist/train_lenet_consolidated.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is set
-if [ -z ${TOOLS+x} ];
-# if unset
-then
+if [ -z "$TOOLS" ]; then
   TOOLS=./build/tools
 fi
 

--- a/examples/mnist/train_lenet_rmsprop.sh
+++ b/examples/mnist/train_lenet_rmsprop.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env sh
 
-./build/tools/caffe train --solver=examples/mnist/lenet_solver_rmsprop.prototxt
+# Check if TOOLS is set
+if [ -z ${TOOLS+x} ];
+# if unset
+then
+  TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train --solver=examples/mnist/lenet_solver_rmsprop.prototxt

--- a/examples/mnist/train_lenet_rmsprop.sh
+++ b/examples/mnist/train_lenet_rmsprop.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is set
-if [ -z "$TOOLS" ]; then
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
   TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train --solver=examples/mnist/lenet_solver_rmsprop.prototxt

--- a/examples/mnist/train_lenet_rmsprop.sh
+++ b/examples/mnist/train_lenet_rmsprop.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is set
-if [ -z ${TOOLS+x} ];
-# if unset
-then
+if [ -z "$TOOLS" ]; then
   TOOLS=./build/tools
 fi
 

--- a/examples/mnist/train_mnist_autoencoder.sh
+++ b/examples/mnist/train_mnist_autoencoder.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env sh
 
-./build/tools/caffe train \
+# Check if TOOLS is set
+if [ -z ${TOOLS+x} ];
+# if unset
+then
+  TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train \
   --solver=examples/mnist/mnist_autoencoder_solver.prototxt

--- a/examples/mnist/train_mnist_autoencoder.sh
+++ b/examples/mnist/train_mnist_autoencoder.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is set
-if [ -z "$TOOLS" ]; then
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
   TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/mnist/train_mnist_autoencoder.sh
+++ b/examples/mnist/train_mnist_autoencoder.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is set
-if [ -z ${TOOLS+x} ];
-# if unset
-then
+if [ -z "$TOOLS" ]; then
   TOOLS=./build/tools
 fi
 

--- a/examples/mnist/train_mnist_autoencoder_adadelta.sh
+++ b/examples/mnist/train_mnist_autoencoder_adadelta.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-./build/tools/caffe train \
+# Check if TOOLS is set
+if [ -z ${TOOLS+x} ];
+# if unset
+then
+  TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train \
   --solver=examples/mnist/mnist_autoencoder_solver_adadelta.prototxt

--- a/examples/mnist/train_mnist_autoencoder_adadelta.sh
+++ b/examples/mnist/train_mnist_autoencoder_adadelta.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # Check if TOOLS is set
-if [ -z ${TOOLS+x} ];
-# if unset
-then
+if [ -z "$TOOLS" ]; then
   TOOLS=./build/tools
 fi
 

--- a/examples/mnist/train_mnist_autoencoder_adadelta.sh
+++ b/examples/mnist/train_mnist_autoencoder_adadelta.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# Check if TOOLS is set
-if [ -z "$TOOLS" ]; then
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
   TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/mnist/train_mnist_autoencoder_adagrad.sh
+++ b/examples/mnist/train_mnist_autoencoder_adagrad.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-./build/tools/caffe train \
+# Check if TOOLS is set
+if [ -z ${TOOLS+x} ];
+# if unset
+then
+  TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train \
   --solver=examples/mnist/mnist_autoencoder_solver_adagrad.prototxt

--- a/examples/mnist/train_mnist_autoencoder_adagrad.sh
+++ b/examples/mnist/train_mnist_autoencoder_adagrad.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # Check if TOOLS is set
-if [ -z ${TOOLS+x} ];
-# if unset
-then
+if [ -z "$TOOLS" ]; then
   TOOLS=./build/tools
 fi
 

--- a/examples/mnist/train_mnist_autoencoder_adagrad.sh
+++ b/examples/mnist/train_mnist_autoencoder_adagrad.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# Check if TOOLS is set
-if [ -z "$TOOLS" ]; then
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
   TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/mnist/train_mnist_autoencoder_nesterov.sh
+++ b/examples/mnist/train_mnist_autoencoder_nesterov.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-./build/tools/caffe train \
+# Check if TOOLS is set
+if [ -z ${TOOLS+x} ];
+# if unset
+then
+  TOOLS=./build/tools
+fi
+
+$TOOLS/caffe train \
   --solver=examples/mnist/mnist_autoencoder_solver_nesterov.prototxt

--- a/examples/mnist/train_mnist_autoencoder_nesterov.sh
+++ b/examples/mnist/train_mnist_autoencoder_nesterov.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # Check if TOOLS is set
-if [ -z ${TOOLS+x} ];
-# if unset
-then
+if [ -z "$TOOLS" ]; then
   TOOLS=./build/tools
 fi
 

--- a/examples/mnist/train_mnist_autoencoder_nesterov.sh
+++ b/examples/mnist/train_mnist_autoencoder_nesterov.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# Check if TOOLS is set
-if [ -z "$TOOLS" ]; then
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
   TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train \

--- a/examples/siamese/create_mnist_siamese.sh
+++ b/examples/siamese/create_mnist_siamese.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env sh
 # This script converts the mnist data into leveldb format.
 
-EXAMPLES=./build/examples/siamese
 DATA=./data/mnist
+
+# Check if CAFFE_BIN is set
+if [ -z ${CAFFE_BIN+x} ];
+# if unset
+then
+  EXAMPLES=./build/examples/siamese
+else
+  EXAMPLES=$CAFFE_BIN
+fi
 
 echo "Creating leveldb..."
 

--- a/examples/siamese/create_mnist_siamese.sh
+++ b/examples/siamese/create_mnist_siamese.sh
@@ -4,9 +4,7 @@
 DATA=./data/mnist
 
 # Check if CAFFE_BIN is set
-if [ -z ${CAFFE_BIN+x} ];
-# if unset
-then
+if [ -z "$CAFFE_BIN" ]; then
   EXAMPLES=./build/examples/siamese
 else
   EXAMPLES=$CAFFE_BIN

--- a/examples/siamese/create_mnist_siamese.sh
+++ b/examples/siamese/create_mnist_siamese.sh
@@ -3,7 +3,7 @@
 
 DATA=./data/mnist
 
-# Check if CAFFE_BIN is set
+# Check if CAFFE_BIN is unset
 if [ -z "$CAFFE_BIN" ]; then
   EXAMPLES=./build/examples/siamese
 else

--- a/examples/siamese/train_mnist_siamese.sh
+++ b/examples/siamese/train_mnist_siamese.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env sh
 
 # Check if TOOLS is set
-if [ -z ${TOOLS+x} ];
-# if unset
-then
+if [ -z "$TOOLS" ]; then
   TOOLS=./build/tools  
 fi
 

--- a/examples/siamese/train_mnist_siamese.sh
+++ b/examples/siamese/train_mnist_siamese.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env sh
 
-# Check if TOOLS is set
-if [ -z "$TOOLS" ]; then
-  TOOLS=./build/tools  
+# Check if CAFFE_BIN is unset
+if [ -z "$CAFFE_BIN" ]; then
+  TOOLS=./build/tools
+else
+  TOOLS=$CAFFE_BIN
 fi
 
 $TOOLS/caffe train --solver=examples/siamese/mnist_siamese_solver.prototxt

--- a/examples/siamese/train_mnist_siamese.sh
+++ b/examples/siamese/train_mnist_siamese.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env sh
 
-TOOLS=./build/tools
+# Check if TOOLS is set
+if [ -z ${TOOLS+x} ];
+# if unset
+then
+  TOOLS=./build/tools  
+fi
 
 $TOOLS/caffe train --solver=examples/siamese/mnist_siamese_solver.prototxt


### PR DESCRIPTION
This pull request contains changes so that examples scripts can also run in distribution mode.  In build environment, there will not be any impact. However, if the scripts are to be run in distribution mode, one would need to set variables CAFFE_BIN and TOOLS to the path where caffe and test executable resides.  
Currently, symbolic links of tools binaries and some more directories like models and data are not shipped into distribution. This pull request will need that as well. A different PR for this change is on the way.