### PR TITLE
net_spec: handle deconvolution layers

### DIFF
--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -37,7 +37,9 @@ def param_name_dict():
     # strip the final '_param' or 'Parameter'
     param_names = [s[:-len('_param')] for s in param_names]
     param_type_names = [s[:-len('Parameter')] for s in param_type_names]
-    return dict(zip(param_type_names, param_names))
+    res = dict(zip(param_type_names, param_names))
+    res["Deconvolution"] = "convolution"
+    return res
 
 
 def to_proto(*tops):


### PR DESCRIPTION
Deconvolution shares parameters with Convolution, which wasn't properly handled up to now.