### PR TITLE
fix parse_log.py

### DIFF
--- a/tools/extra/parse_log.py
+++ b/tools/extra/parse_log.py
@@ -86,7 +86,12 @@ def parse_line_for_net_output(regex_obj, row, row_dict_list,
 
     output_match = regex_obj.search(line)
     if output_match:
-        if not row or row['NumIters'] != iteration:
+        # output_num is not used; may be used in the future
+        # output_num = output_match.group(1)
+        output_name = output_match.group(2)
+        output_val = output_match.group(3)
+
+        if not row or output_name in row:
             # Push the last row and start a new one
             if row:
                 # If we're on a new iteration, push the last row
@@ -101,10 +106,6 @@ def parse_line_for_net_output(regex_obj, row, row_dict_list,
                 ('LearningRate', learning_rate)
             ])
 
-        # output_num is not used; may be used in the future
-        # output_num = output_match.group(1)
-        output_name = output_match.group(2)
-        output_val = output_match.group(3)
         row[output_name] = float(output_val)
 
     if row and len(row_dict_list) >= 1 and len(row) == len(row_dict_list[0]):


### PR DESCRIPTION
@dgolden1 Please have a look
 
In case of multiple testing nets, the following log snippets are generated. In the original version, the parse_log.py will skip the first output of the first net, i.e., `0.0787267`

The original version uses `row['NumIters'] != iteration` to check if the first record has finished. The new version uses `output_name in row`, which is robust to the multi net case.

```
I0623 07:11:38.172642  3432 solver.cpp:337] Iteration 5000, Testing net (#0)
I0623 07:11:38.988617  3432 net.cpp:685] Ignoring source layer loss
I0623 07:11:39.567838  3432 blocking_queue.cpp:50] Data layer prefetch queue empty
I0623 07:11:56.906494  3438 blocking_queue.cpp:50] Waiting for data
I0623 07:14:23.305070  3432 solver.cpp:405]     Test net output #0: accuracy = 0.0787267
I0623 07:14:23.305119  3432 solver.cpp:337] Iteration 5000, Testing net (#1)
I0623 07:14:23.360119  3432 net.cpp:685] Ignoring source layer loss
I0623 07:15:18.412569  3432 solver.cpp:405]     Test net output #0: accuracy = 0.0755807
```