### PR TITLE
[Python] Create solvers/nets without proto files.

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -24,7 +24,7 @@ template <typename Dtype>
 class Net {
  public:
   explicit Net(const NetParameter& param, const Net* root_net = NULL);
-  explicit Net(const string& param_file, Phase phase,
+  explicit Net(const string& param_str_or_file, Phase phase,
       const Net* root_net = NULL);
   virtual ~Net() {}
 

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -55,6 +55,8 @@ inline bool ReadProtoFromTextFile(const string& filename, Message* proto) {
   return ReadProtoFromTextFile(filename.c_str(), proto);
 }
 
+bool ReadProtoFromTextString(const string& input, Message* proto);
+
 inline void ReadProtoFromTextFileOrDie(const char* filename, Message* proto) {
   CHECK(ReadProtoFromTextFile(filename, proto));
 }

--- a/include/caffe/util/upgrade_proto.hpp
+++ b/include/caffe/util/upgrade_proto.hpp
@@ -19,6 +19,12 @@ void ReadNetParamsFromTextFileOrDie(const string& param_file,
 void ReadNetParamsFromBinaryFileOrDie(const string& param_file,
                                       NetParameter* param);
 
+bool ReadNetParamsFromTextFile(const string& param_file,
+                                    NetParameter* param);
+
+bool ReadNetParamsFromTextString(const string& param_file,
+                                    NetParameter* param);
+
 // Return true iff any layer contains parameters specified using
 // deprecated V0LayerParameter.
 bool NetNeedsV0ToV1Upgrade(const NetParameter& net_param);

--- a/include/caffe/util/upgrade_proto.hpp
+++ b/include/caffe/util/upgrade_proto.hpp
@@ -83,6 +83,9 @@ bool UpgradeSolverAsNeeded(const string& param_file, SolverParameter* param);
 void ReadSolverParamsFromTextFileOrDie(const string& param_file,
                                        SolverParameter* param);
 
+bool ReadSolverParamsFromTextString(const string& param_str,
+                                    SolverParameter* param);
+
 }  // namespace caffe
 
 #endif   // CAFFE_UTIL_UPGRADE_PROTO_H_

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,5 +1,5 @@
 from .pycaffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, RMSPropSolver, AdaDeltaSolver, AdamSolver
-from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver, layer_type_list
+from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver, get_solver_net, layer_type_list
 from ._caffe import __version__
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -88,10 +88,10 @@ void CheckContiguousArray(PyArrayObject* arr, string name,
 
 // Net constructor for passing phase as int
 shared_ptr<Net<Dtype> > Net_Init(
-    string param_file, int phase) {
-  CheckFile(param_file);
+    string param_str_or_file, int phase) {
+  //CheckFile(param_file);
 
-  shared_ptr<Net<Dtype> > net(new Net<Dtype>(param_file,
+  shared_ptr<Net<Dtype> > net(new Net<Dtype>(param_str_or_file,
       static_cast<Phase>(phase)));
   return net;
 }

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -89,8 +89,6 @@ void CheckContiguousArray(PyArrayObject* arr, string name,
 // Net constructor for passing phase as int
 shared_ptr<Net<Dtype> > Net_Init(
     string param_str_or_file, int phase) {
-  //CheckFile(param_file);
-
   shared_ptr<Net<Dtype> > net(new Net<Dtype>(param_str_or_file,
       static_cast<Phase>(phase)));
   return net;
@@ -158,6 +156,35 @@ Solver<Dtype>* GetSolverFromFile(const string& filename) {
   SolverParameter param;
   ReadSolverParamsFromTextFileOrDie(filename, &param);
   return SolverRegistry<Dtype>::CreateSolver(param);
+}
+
+// Why is this implemented in the following way?
+// To creat a solver we requrie a (proto) net specification. This cannot
+// be extracted from an existing network, so instead we initialize the solver
+// and net from two proto strings, one for the solver and one for the net.
+Solver<Dtype>* GetSolverFromSolverNetStrings(const string& solver_param_str,
+                                const string& net_param_str) {
+  NetParameter* net_param_p = new NetParameter();
+  CHECK(ReadNetParamsFromTextString(net_param_str, net_param_p))
+    << "Failer to parse Net param string";
+
+  SolverParameter solver_param;
+  CHECK(ReadSolverParamsFromTextString(solver_param_str, &solver_param))
+      << "Failed to parse Solver param string";
+
+  // Check that we haven't specified a net yet to avoid overwriting confusion
+  const int num_train_nets = solver_param.has_net() +
+      solver_param.has_net_param() + solver_param.has_train_net() +
+      solver_param.has_train_net_param();
+  const string& field_names = "net, net_param, train_net, train_net_param";
+  CHECK_LE(num_train_nets, 1)
+      << "string SolverParameter must not specify a train net "
+      << "using one of these fields: " << field_names;
+
+  // Is this safe, protobuf takes control of net_param*
+  solver_param.set_allocated_net_param(net_param_p);
+
+  return SolverRegistry<Dtype>::CreateSolver(solver_param);
 }
 
 struct NdarrayConverterGenerator {
@@ -366,6 +393,8 @@ BOOST_PYTHON_MODULE(_caffe) {
         "AdamSolver", bp::init<string>());
 
   bp::def("get_solver", &GetSolverFromFile,
+      bp::return_value_policy<bp::manage_new_object>());
+  bp::def("get_solver_net", &GetSolverFromSolverNetStrings,
       bp::return_value_policy<bp::manage_new_object>());
 
   // vector wrappers for all the vector types we use

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -28,10 +28,20 @@ Net<Dtype>::Net(const NetParameter& param, const Net* root_net)
 }
 
 template <typename Dtype>
-Net<Dtype>::Net(const string& param_file, Phase phase, const Net* root_net)
+Net<Dtype>::Net(const string& param_str_or_file, Phase phase,
+                const Net* root_net)
     : root_net_(root_net) {
   NetParameter param;
-  ReadNetParamsFromTextFileOrDie(param_file, &param);
+
+  // Net params are provided either as string or as a file
+  // Check if they are provided as a string first
+  if (ReadNetParamsFromTextString(param_str_or_file, &param)) {
+    // do nothing
+  } else if (ReadNetParamsFromTextString(param_str_or_file, &param)) {
+    // do nothing
+  } else {
+    CHECK(false) << "param_str_or_file was neither string nor file.";
+  }
   param.mutable_state()->set_phase(phase);
   Init(param);
 }

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -41,6 +41,11 @@ bool ReadProtoFromTextFile(const char* filename, Message* proto) {
   return success;
 }
 
+bool ReadProtoFromTextString(const string& input, Message* proto) {
+  bool success = google::protobuf::TextFormat::ParseFromString(input, proto);
+  return success;
+}
+
 void WriteProtoToTextFile(const Message& proto, const char* filename) {
   int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
   FileOutputStream* output = new FileOutputStream(fd);

--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -88,6 +88,24 @@ void ReadNetParamsFromBinaryFileOrDie(const string& param_file,
   UpgradeNetAsNeeded(param_file, param);
 }
 
+bool ReadNetParamsFromTextFile(const string& param_file,
+                                    NetParameter* param) {
+  if (ReadProtoFromTextFile(param_file, param)) {
+      UpgradeNetAsNeeded(param_file, param);
+      return true;
+  }
+  return false;
+}
+
+bool ReadNetParamsFromTextString(const string& param_file,
+                                    NetParameter* param) {
+  if (ReadProtoFromTextString(param_file, param)) {
+      UpgradeNetAsNeeded(param_file, param);
+      return true;
+  }
+  return false;
+}
+
 bool NetNeedsV0ToV1Upgrade(const NetParameter& net_param) {
   for (int i = 0; i < net_param.layers_size(); ++i) {
     if (net_param.layers(i).has_layer()) {

--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -1083,4 +1083,14 @@ void ReadSolverParamsFromTextFileOrDie(const string& param_file,
   UpgradeSolverAsNeeded(param_file, param);
 }
 
+// Read parameters from a string into a SolverParameter proto message.
+bool ReadSolverParamsFromTextString(const string& param_file,
+                                    SolverParameter* param) {
+  if (ReadProtoFromTextString(param_file, param)) {
+    UpgradeSolverAsNeeded(param_file, param);
+    return true;
+  }
+  return false;
+}
+
 }  // namespace caffe


### PR DESCRIPTION
This PR allows the creation of solver and net objects without requiring the creation of 
temporary files. 

1. The net interface was changes to allow initialization with a string protobuffer in text form. 
2. As the solver interface requires a network to be specified during creation, a net is needed when initializing the solver. To this end a helper function was added that copies a net specification into a solver specification and initializes the solver ( and thus the net ).

I originally wanted to pass a caffe_pb2.SolverParameter/NetParameter object directly to the c++ interface but I didn't find a way to convert between these and the boost c++ serialized SolverParameter/NetParameter, so I chose strings for everything.

This function can be called in the following way:
```
solver_proto = self.create_solver_proto() #from caffe_pb2.SolverParameter
netspec_proto = self.create_netspec().to_proto() #from netspec
self.solver = caffe.get_solver_net( str(solver_proto), str(netspec_proto))
```