### PR TITLE
Remove Python.h include since Boost Python already does it 

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -1,5 +1,3 @@
-#include <Python.h>  // NOLINT(build/include_alpha)
-
 // Produce deprecation warnings (needs to come before arrayobject.h inclusion).
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 


### PR DESCRIPTION
This avoid adding the autolib for the debug version of Python.
This enables building in Debug without having the Python debug binaries.

See this file in Boost
boost\python\detail\wrap_python.hpp

specially the following line
`#undef _DEBUG // Don't let Python force the debug library just because we're debugging`.