### PR TITLE
Windows Python Layer Fix #3915

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ MANIFEST-*
 *.opensdf
 *.pdb
 *.props
+
+# Packages cache
+windows/packages/

--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -1,6 +1,14 @@
 from .pycaffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, RMSPropSolver, AdaDeltaSolver, AdamSolver
-from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver, layer_type_list
-from ._caffe import __version__
+# On Windows, evaluating python layers from the caffe executable tool
+# requires using an embedded _caffe module
+# so here we try to load the embedded (no dot) module first
+try:
+    from embedded_caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver, layer_type_list
+    from embedded_caffe import __version__
+except ImportError:
+    from ._caffe import set_mode_cpu, set_mode_gpu, set_device, Layer, get_solver, layer_type_list
+    from ._caffe import __version__
+
 from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -1,5 +1,3 @@
-#include <Python.h>  // NOLINT(build/include_alpha)
-
 // Produce deprecation warnings (needs to come before arrayobject.h inclusion).
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -1,3 +1,5 @@
+#ifdef WITH_PYTHON_LAYER
+
 // Produce deprecation warnings (needs to come before arrayobject.h inclusion).
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
@@ -393,3 +395,5 @@ void PythonInitEmbeddedCaffeModule() {
 #endif
 
 }  // namespace caffe
+
+#endif // WITH_PYTHON_LAYER

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -222,13 +222,13 @@ bp::object BlobVec_add_blob(bp::tuple args, bp::dict kwargs) {
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SolveOverloads, Solve, 0, 1);
 
-// Workaround a Boost.Python limitation on Windows where wrapped C++ 
-// objects can't cross over from the process embedding python 
+// Workaround a Boost.Python limitation on Windows where wrapped C++
+// objects can't cross over from the process embedding python
 // to the dynamic library implementing an extension module when
 // both the process and extension module use Boost.Python
 //
-// Change the Python module name when embedded 
-// pycaffe.py and __init__.py try importing from embedded_caffe first 
+// Change the Python module name when embedded
+// pycaffe.py and __init__.py try importing from embedded_caffe first
 // then fall back to _caffe
 #ifndef EMBED_PYTHON_MODULE
     #define PREFIXED_MODULE_NAME(module_name) module_name
@@ -236,12 +236,12 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SolveOverloads, Solve, 0, 1);
     #define PREFIXED_MODULE_NAME(module_name) embedded ## module_name
 #endif
 
-// Macro to get the module entry point function, in Python 2.x "init" is prefixed, 
-// for Python 3.x the prefix is "PyInit_"
+// Macro to get the module entry point function, in Python 2.x "init" is
+// prefixed,for Python 3.x the prefix is "PyInit_"
 #if PY_VERSION_HEX >= 0x03000000
-    #define PREFIXED_MODULE_INIT(name) BOOST_PP_CAT(PyInit_, PREFIXED_MODULE_NAME(name))
+#define MODULE_INIT(name) BOOST_PP_CAT(PyInit_, PREFIXED_MODULE_NAME(name))
 #else
-    #define PREFIXED_MODULE_INIT(name) BOOST_PP_CAT(init, PREFIXED_MODULE_NAME(name))
+#define MODULE_INIT(name) BOOST_PP_CAT(init, PREFIXED_MODULE_NAME(name))
 #endif
 
 
@@ -382,7 +382,8 @@ BOOST_PYTHON_MODULE(PREFIXED_MODULE_NAME(_caffe)) {
   // so call _import_array directly instead of using import_array macro
   if (_import_array() < 0) {
       PyErr_Print();
-      PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import");
+      PyErr_SetString(PyExc_ImportError,
+        "numpy.core.multiarray failed to import");
   }
 }
 
@@ -390,10 +391,10 @@ BOOST_PYTHON_MODULE(PREFIXED_MODULE_NAME(_caffe)) {
 // and set its entry point function
 #ifdef EMBED_PYTHON_MODULE
 void PythonInitEmbeddedCaffeModule() {
-    PyImport_AppendInittab("embedded_caffe", PREFIXED_MODULE_INIT(_caffe) );
+    PyImport_AppendInittab("embedded_caffe", MODULE_INIT(_caffe) );
 }
 #endif
 
 }  // namespace caffe
 
-#endif // WITH_PYTHON_LAYER
+#endif  // WITH_PYTHON_LAYER

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -353,9 +353,16 @@ BOOST_PYTHON_MODULE(_caffe) {
   bp::class_<vector<bool> >("BoolVec")
     .def(bp::vector_indexing_suite<vector<bool> >());
 
-  // boost python expects a void (missing) return value, while import_array
-  // returns NULL for python3. import_array1() forces a void return value.
-  import_array1();
+  // boost python expects a void (missing) return value
+  // so call _import_array directly instead of using import_array macro
+  if (_import_array() < 0) {
+      PyErr_Print();
+      PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import");
+  }
+}
+
+void PythonInitEmbeddedCaffeModule() {
+    PyImport_AppendInittab("_caffe", caffe::init_caffe);
 }
 
 }  // namespace caffe

--- a/python/caffe/pycaffe.py
+++ b/python/caffe/pycaffe.py
@@ -10,8 +10,16 @@ except:
     from itertools import zip_longest as izip_longest
 import numpy as np
 
-from ._caffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, \
-        RMSPropSolver, AdaDeltaSolver, AdamSolver
+# On Windows, evaluating python layers from the caffe executable tool
+# requires using an embedded _caffe module
+# so here we try to load the embedded (no dot) module first
+try:
+    from embedded_caffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, \
+            RMSPropSolver, AdaDeltaSolver, AdamSolver
+except ImportError:
+    from ._caffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, \
+            RMSPropSolver, AdaDeltaSolver, AdamSolver
+
 import caffe.io
 
 import six

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -241,11 +241,12 @@ REGISTER_LAYER_CREATOR(TanH, GetTanHLayer);
 #ifdef WITH_PYTHON_LAYER
 
 template <typename Dtype>
-shared_ptr<Layer<Dtype> > GetPythonLayer(const LayerParameter& param) {  
+shared_ptr<Layer<Dtype> > GetPythonLayer(const LayerParameter& param) {
   Py_Initialize();
   try {
     bp::object module = bp::import(param.python_param().module().c_str());
-    bp::object layer = module.attr(param.python_param().layer().c_str())(boost::ref(param));
+    bp::object layer = module.attr(param.python_param().layer().c_str())(
+      boost::ref(param));
     return bp::extract<shared_ptr<PythonLayer<Dtype> > >(layer)();
   } catch (bp::error_already_set) {
     PyErr_Print();

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -239,12 +239,13 @@ shared_ptr<Layer<Dtype> > GetTanHLayer(const LayerParameter& param) {
 REGISTER_LAYER_CREATOR(TanH, GetTanHLayer);
 
 #ifdef WITH_PYTHON_LAYER
+
 template <typename Dtype>
-shared_ptr<Layer<Dtype> > GetPythonLayer(const LayerParameter& param) {
+shared_ptr<Layer<Dtype> > GetPythonLayer(const LayerParameter& param) {  
   Py_Initialize();
   try {
     bp::object module = bp::import(param.python_param().module().c_str());
-    bp::object layer = module.attr(param.python_param().layer().c_str())(param);
+    bp::object layer = module.attr(param.python_param().layer().c_str())(boost::ref(param));
     return bp::extract<shared_ptr<PythonLayer<Dtype> > >(layer)();
   } catch (bp::error_already_set) {
     PyErr_Print();

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -1,6 +1,10 @@
 #ifdef WITH_PYTHON_LAYER
-#include "boost/python.hpp"
+#include <boost/python.hpp>
 namespace bp = boost::python;
+namespace caffe
+{
+    extern void PythonInitEmbeddedCaffeModule();
+}
 #endif
 
 #include <gflags/gflags.h>
@@ -400,6 +404,11 @@ int main(int argc, char** argv) {
       "  test            score a model\n"
       "  device_query    show GPU diagnostic information\n"
       "  time            benchmark model execution time");
+
+#ifdef WITH_PYTHON_LAYER
+  caffe::PythonInitEmbeddedCaffeModule();
+#endif
+
   // Run tool or show usage.
   caffe::GlobalInit(&argc, &argv);
   if (argc == 2) {

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -1,10 +1,12 @@
 #ifdef WITH_PYTHON_LAYER
 #include <boost/python.hpp>
 namespace bp = boost::python;
+#ifdef _MSC_VER
 namespace caffe
 {
     extern void PythonInitEmbeddedCaffeModule();
 }
+#endif
 #endif
 
 #include <gflags/gflags.h>
@@ -405,7 +407,7 @@ int main(int argc, char** argv) {
       "  device_query    show GPU diagnostic information\n"
       "  time            benchmark model execution time");
 
-#ifdef WITH_PYTHON_LAYER
+#if defined(WITH_PYTHON_LAYER) && defined(_MSC_VER)
   caffe::PythonInitEmbeddedCaffeModule();
 #endif
 

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -2,8 +2,7 @@
 #include <boost/python.hpp>
 namespace bp = boost::python;
 #ifdef _MSC_VER
-namespace caffe
-{
+namespace caffe {
     extern void PythonInitEmbeddedCaffeModule();
 }
 #endif

--- a/windows/caffe/caffe.vcxproj
+++ b/windows/caffe/caffe.vcxproj
@@ -53,6 +53,9 @@
     <PostBuildEvent>
       <Command>"$(ScriptsDir)\FixGFlagsNaming.cmd" "$(OutDir)" $(Configuration)</Command>
     </PostBuildEvent>
+    <ClCompile>
+      <PreprocessorDefinitions>EMBED_PYTHON_MODULE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
@@ -63,7 +66,7 @@
       <Command>"$(ScriptsDir)\FixGFlagsNaming.cmd" "$(OutDir)" $(Configuration)</Command>
     </PostBuildEvent>
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
+      <PreprocessorDefinitions>EMBED_PYTHON_MODULE;NDEBUG;%(PreprocessorDefinitions);CAFFE_VERSION=1.0.0-rc3</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/windows/caffe/caffe.vcxproj
+++ b/windows/caffe/caffe.vcxproj
@@ -39,6 +39,12 @@
   <ImportGroup Label="PropertySheets" Condition="Exists('$(SolutionDir)\CommonSettings.props')">
     <Import Project="..\CommonSettings.props" />
   </ImportGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>$(PythonDir)\Lib\site-packages\numpy\core\include\;$(PythonDir)\include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(PythonDir)\Lib\site-packages\numpy\core\include\;$(PythonDir)\include;$(IncludePath)</IncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
       <AdditionalDependencies>libcaffe.lib;$(CudaDependencies);%(AdditionalDependencies)</AdditionalDependencies>
@@ -61,6 +67,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\python\caffe\_caffe.cpp" />
     <ClCompile Include="..\..\tools\caffe.cpp" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This is a fix for the issue load python layer error on windows #3915

The changes are limited but they are not trivial. I don't expect this PR to get merged quickly. There might be a simpler more clever way to do this. Also, I'm not 100% Appveyor and Travis will pass because I tested this only on Windows. 

The issue is that on Windows networks with Python layers can't be trained with the caffe command line tool. This error is returned:
`'TypeError: No to_python (by-value) converter found for C++ type: class caffe::LayerParameter'`

It seems that on Windows, the embedded interpreter can't convert C++ class that are wrapped in the _caffe module (DLL). I didn't find the root cause for this which is most likely in Boost.Python. 

The fix is to embed the _caffe module inside the caffe command line application and to use the embedded module when it's present in pycaffe.py and __init__.py. 

Embedding the _caffe module requires simple changes to _caffe.cpp, caffe.cpp and the project file (caffe.vcxproj)

The changes to pycaffe.py and __init__.py are simple but may feel a bit intrusive for a Windows-only fix.  

