### PR TITLE
Enable caffe works on system without GPU

### DIFF
--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -7,7 +7,14 @@
 
 // Stub out GPU calls as unavailable.
 
-#define NO_GPU LOG(FATAL) << "Cannot use GPU in CPU-only Caffe: check mode."
+#define NO_GPU                                                          \
+    do {                                                                \
+        static bool logged = false;                                     \
+        if ( !logged ) {                                                \
+            LOG(ERROR) << "Cannot use GPU in CPU-only Caffe: check mode." ; \
+            logged = true;                                              \
+        }                                                               \
+    } while (0)
 
 #define STUB_GPU(classname) \
 template <typename Dtype> \

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -260,7 +260,7 @@ template <> int Blob<int>::sumsq_data() const {
 
 template <typename Dtype>
 Dtype Blob<Dtype>::sumsq_data() const {
-  Dtype sumsq;
+  Dtype sumsq = 0;
   const Dtype* data;
   if (!data_) { return 0; }
   switch (data_->head()) {


### PR DESCRIPTION
when caffe run on system without GPU, it will raise fatal error to abort

Rongsong