### PR TITLE
[windows] Fix missing %(DisableSpecificWarnings) in extract_features.vcxproj

### DIFF
--- a/windows/extract_features/extract_features.vcxproj
+++ b/windows/extract_features/extract_features.vcxproj
@@ -45,7 +45,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <ClCompile>
-      <DisableSpecificWarnings>4005</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4005;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -54,7 +54,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <ClCompile>
-      <DisableSpecificWarnings>4005</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4005;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
In a Japanese version of Visual Studio, we get lots of  `C4819` warnings from CUDA header files, so I added 
`<DisableSpecificWarnings>4819</DisableSpecificWarnings>` to `CommonSettings.props` but `extract_features.vcxproj` ignores it. `libcaffe.vcxproj` [does not ignore it.](https://github.com/BVLC/caffe/blob/5db30745fd2b47cd9762b9ef64cc33df781a2876/windows/libcaffe/libcaffe.vcxproj#L63)