### PR TITLE
Fix comment error in parse_log.py

### DIFF
--- a/tools/extra/parse_log.py
+++ b/tools/extra/parse_log.py
@@ -16,13 +16,10 @@ from collections import OrderedDict
 
 def parse_log(path_to_log):
     """Parse log file
-    Returns (train_dict_list, train_dict_names, test_dict_list, test_dict_names)
+    Returns (train_dict_list, test_dict_list)
 
     train_dict_list and test_dict_list are lists of dicts that define the table
     rows
-
-    train_dict_names and test_dict_names are ordered tuples of the column names
-    for the two dict_lists
     """
 
     regex_iteration = re.compile('Iteration (\d+)')


### PR DESCRIPTION
Aligned output description in docstring with actual output returned by parse_log function