### PR TITLE
Support for spaces in directories when downloading cifar10

### DIFF
--- a/data/cifar10/get_cifar10.sh
+++ b/data/cifar10/get_cifar10.sh
@@ -2,7 +2,7 @@
 # This scripts downloads the CIFAR10 (binary version) data and unzips it.
 
 DIR="$( cd "$(dirname "$0")" ; pwd -P )"
-cd $DIR
+cd "$DIR"
 
 echo "Downloading..."
 


### PR DESCRIPTION
The get_cifar10.sh script has been slightly modified to support caffe root directories with spaces.