### PR TITLE
Support spaces in path when downloading ILSVRC12 and MNIST

### DIFF
--- a/data/ilsvrc12/get_ilsvrc_aux.sh
+++ b/data/ilsvrc12/get_ilsvrc_aux.sh
@@ -8,7 +8,7 @@
 # - the training splits with labels
 
 DIR="$( cd "$(dirname "$0")" ; pwd -P )"
-cd $DIR
+cd "$DIR"
 
 echo "Downloading..."
 

--- a/data/mnist/get_mnist.sh
+++ b/data/mnist/get_mnist.sh
@@ -2,7 +2,7 @@
 # This scripts downloads the mnist data and unzips it.
 
 DIR="$( cd "$(dirname "$0")" ; pwd -P )"
-cd $DIR
+cd "$DIR"
 
 echo "Downloading..."
 


### PR DESCRIPTION
Similar changes to support spaces in the path when downloading ILSVRC12 and MNIST as CIFAR10.
I probably should've checked these too when I did the other one :P