### PR TITLE
* Fix hard-coded osx system path with a CMake variable CMAKE_OSX_SYSROOT

### DIFF
--- a/cmake/Modules/FindvecLib.cmake
+++ b/cmake/Modules/FindvecLib.cmake
@@ -16,7 +16,7 @@ find_path(vecLib_INCLUDE_DIR vecLibTypes.h
           DOC "vecLib include directory"
           PATHS /System/Library/${__veclib_include_suffix}
                 /System/Library/Frameworks/Accelerate.framework/Versions/Current/${__veclib_include_suffix}
-                /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/)
+                ${CMAKE_OSX_SYSROOT}/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(vecLib DEFAULT_MSG vecLib_INCLUDE_DIR)


### PR DESCRIPTION
Caffe 'opencl' branch project cmake configuration/generation fails on Mac OSX 10.11 with 
messages : 
```
CMake Error at /usr/local/Cellar/cmake/3.6.0/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:148 (message):
  Could NOT find vecLib (missing: vecLib_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.6.0/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:388 (_FPHSA_FAILURE_MESSAGE)
  cmake/Modules/FindvecLib.cmake:26 (find_package_handle_standard_args)
  cmake/Dependencies.cmake:176 (find_package)
  CMakeLists.txt:62 (include)
```
This is due to the hard-coded osx system sdk path : 
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/
``` 
We can replace this by CMAKE_OSX_SYSROOT and it works with recent CMake versions. This variable is introduced in **CMake 3.02** (probably) does not exist in 2.8.7 (minimal version)
