### PR TITLE
Add "set -e" and $@ to example scripts

### DIFF
--- a/examples/cifar10/create_cifar10.sh
+++ b/examples/cifar10/create_cifar10.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 # This script converts the cifar data into leveldb format.
+set -e
 
 EXAMPLE=examples/cifar10
 DATA=data/cifar10

--- a/examples/cifar10/train_full.sh
+++ b/examples/cifar10/train_full.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env sh
+set -e
 
 TOOLS=./build/tools
 
 $TOOLS/caffe train \
-    --solver=examples/cifar10/cifar10_full_solver.prototxt
+    --solver=examples/cifar10/cifar10_full_solver.prototxt $@
 
 # reduce learning rate by factor of 10
 $TOOLS/caffe train \
     --solver=examples/cifar10/cifar10_full_solver_lr1.prototxt \
-    --snapshot=examples/cifar10/cifar10_full_iter_60000.solverstate.h5
+    --snapshot=examples/cifar10/cifar10_full_iter_60000.solverstate.h5 $@
 
 # reduce learning rate by factor of 10
 $TOOLS/caffe train \
     --solver=examples/cifar10/cifar10_full_solver_lr2.prototxt \
-    --snapshot=examples/cifar10/cifar10_full_iter_65000.solverstate.h5
+    --snapshot=examples/cifar10/cifar10_full_iter_65000.solverstate.h5 $@

--- a/examples/cifar10/train_full_sigmoid.sh
+++ b/examples/cifar10/train_full_sigmoid.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
+set -e
 
 TOOLS=./build/tools
 
 $TOOLS/caffe train \
-    --solver=examples/cifar10/cifar10_full_sigmoid_solver.prototxt
+    --solver=examples/cifar10/cifar10_full_sigmoid_solver.prototxt $@
 

--- a/examples/cifar10/train_full_sigmoid_bn.sh
+++ b/examples/cifar10/train_full_sigmoid_bn.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
+set -e
 
 TOOLS=./build/tools
 
 $TOOLS/caffe train \
-    --solver=examples/cifar10/cifar10_full_sigmoid_solver_bn.prototxt
+    --solver=examples/cifar10/cifar10_full_sigmoid_solver_bn.prototxt $@
 

--- a/examples/cifar10/train_quick.sh
+++ b/examples/cifar10/train_quick.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env sh
+set -e
 
 TOOLS=./build/tools
 
 $TOOLS/caffe train \
-  --solver=examples/cifar10/cifar10_quick_solver.prototxt
+  --solver=examples/cifar10/cifar10_quick_solver.prototxt $@
 
 # reduce learning rate by factor of 10 after 8 epochs
 $TOOLS/caffe train \
   --solver=examples/cifar10/cifar10_quick_solver_lr1.prototxt \
-  --snapshot=examples/cifar10/cifar10_quick_iter_4000.solverstate.h5
+  --snapshot=examples/cifar10/cifar10_quick_iter_4000.solverstate.h5 $@

--- a/examples/imagenet/create_imagenet.sh
+++ b/examples/imagenet/create_imagenet.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 # Create the imagenet lmdb inputs
 # N.B. set the path to the imagenet train + val data dirs
+set -e
 
 EXAMPLE=examples/imagenet
 DATA=data/ilsvrc12

--- a/examples/imagenet/resume_training.sh
+++ b/examples/imagenet/resume_training.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
+set -e
 
 ./build/tools/caffe train \
     --solver=models/bvlc_reference_caffenet/solver.prototxt \
-    --snapshot=models/bvlc_reference_caffenet/caffenet_train_10000.solverstate.h5
+    --snapshot=models/bvlc_reference_caffenet/caffenet_train_10000.solverstate.h5 \
+    $@

--- a/examples/imagenet/train_caffenet.sh
+++ b/examples/imagenet/train_caffenet.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 ./build/tools/caffe train \
-    --solver=models/bvlc_reference_caffenet/solver.prototxt
+    --solver=models/bvlc_reference_caffenet/solver.prototxt $@

--- a/examples/mnist/create_mnist.sh
+++ b/examples/mnist/create_mnist.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 # This script converts the mnist data into lmdb/leveldb format,
 # depending on the value assigned to $BACKEND.
+set -e
 
 EXAMPLE=examples/mnist
 DATA=data/mnist

--- a/examples/mnist/train_lenet.sh
+++ b/examples/mnist/train_lenet.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+set -e
 
-./build/tools/caffe train --solver=examples/mnist/lenet_solver.prototxt
+./build/tools/caffe train --solver=examples/mnist/lenet_solver.prototxt $@

--- a/examples/mnist/train_lenet_adam.sh
+++ b/examples/mnist/train_lenet_adam.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+set -e
 
-./build/tools/caffe train --solver=examples/mnist/lenet_solver_adam.prototxt
+./build/tools/caffe train --solver=examples/mnist/lenet_solver_adam.prototxt $@

--- a/examples/mnist/train_lenet_consolidated.sh
+++ b/examples/mnist/train_lenet_consolidated.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 ./build/tools/caffe train \
-  --solver=examples/mnist/lenet_consolidated_solver.prototxt
+  --solver=examples/mnist/lenet_consolidated_solver.prototxt $@

--- a/examples/mnist/train_lenet_rmsprop.sh
+++ b/examples/mnist/train_lenet_rmsprop.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
-./build/tools/caffe train --solver=examples/mnist/lenet_solver_rmsprop.prototxt
+./build/tools/caffe train \
+    --solver=examples/mnist/lenet_solver_rmsprop.prototxt $@

--- a/examples/mnist/train_mnist_autoencoder.sh
+++ b/examples/mnist/train_mnist_autoencoder.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 ./build/tools/caffe train \
-  --solver=examples/mnist/mnist_autoencoder_solver.prototxt
+  --solver=examples/mnist/mnist_autoencoder_solver.prototxt $@

--- a/examples/mnist/train_mnist_autoencoder_adadelta.sh
+++ b/examples/mnist/train_mnist_autoencoder_adadelta.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 ./build/tools/caffe train \
-  --solver=examples/mnist/mnist_autoencoder_solver_adadelta.prototxt
+  --solver=examples/mnist/mnist_autoencoder_solver_adadelta.prototxt $@

--- a/examples/mnist/train_mnist_autoencoder_adagrad.sh
+++ b/examples/mnist/train_mnist_autoencoder_adagrad.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 ./build/tools/caffe train \
-  --solver=examples/mnist/mnist_autoencoder_solver_adagrad.prototxt
+  --solver=examples/mnist/mnist_autoencoder_solver_adagrad.prototxt $@

--- a/examples/mnist/train_mnist_autoencoder_nesterov.sh
+++ b/examples/mnist/train_mnist_autoencoder_nesterov.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 ./build/tools/caffe train \
-  --solver=examples/mnist/mnist_autoencoder_solver_nesterov.prototxt
+  --solver=examples/mnist/mnist_autoencoder_solver_nesterov.prototxt $@

--- a/examples/siamese/create_mnist_siamese.sh
+++ b/examples/siamese/create_mnist_siamese.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 # This script converts the mnist data into leveldb format.
+set -e
 
 EXAMPLES=./build/examples/siamese
 DATA=./data/mnist

--- a/examples/siamese/train_mnist_siamese.sh
+++ b/examples/siamese/train_mnist_siamese.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
+set -e
 
 TOOLS=./build/tools
 
-$TOOLS/caffe train --solver=examples/siamese/mnist_siamese_solver.prototxt
+$TOOLS/caffe train --solver=examples/siamese/mnist_siamese_solver.prototxt $@


### PR DESCRIPTION
I haven't tested all the scripts because some of them take quite a while, but I tested these at least:
```
./examples/mnist/create_mnist.sh
./examples/siamese/create_mnist_siamese.sh
./examples/cifar10/create_cifar10.sh
./examples/mnist/train_lenet.sh
./examples/cifar10/train_quick.sh
```

##### `set -e`
Mostly useful for the multi-command scripts, so you don't try and fail 3 successive `caffe train` commands, for example. This is usually preferred for shell scripts in general.
```sh
# bad
$ ./examples/cifar10/train_full.sh 
./examples/cifar10/train_full.sh: 5: ./examples/cifar10/train_full.sh: ./build/tools/caffe: not found
./examples/cifar10/train_full.sh: 9: ./examples/cifar10/train_full.sh: ./build/tools/caffe: not found
./examples/cifar10/train_full.sh: 14: ./examples/cifar10/train_full.sh: ./build/tools/caffe: not found

# good
$ ./examples/cifar10/train_full.sh 
./examples/cifar10/train_full.sh: 6: ./examples/cifar10/train_full.sh: ./build/tools/caffe: not found
```

##### `$@`
Useful for quickly setting the GPU[s] for training
```sh
# multi-gpu lenet training
$ ./examples/mnist/train_lenet.sh -gpu 0,1
I0713 16:06:10.111279 21251 caffe.cpp:217] Using GPUs 0, 1
I0713 16:06:10.130893 21251 caffe.cpp:222] GPU 0: GeForce GTX TITAN X
I0713 16:06:10.131564 21251 caffe.cpp:222] GPU 1: GeForce GTX TITAN X
...
```