### PR TITLE
Improve performance by creating in_place versions of key vector functions

### DIFF
--- a/include/caffe/util/math_functions.hpp
+++ b/include/caffe/util/math_functions.hpp
@@ -56,13 +56,22 @@ template <typename Dtype>
 void caffe_add(const int N, const Dtype* a, const Dtype* b, Dtype* y);
 
 template <typename Dtype>
+void caffe_add_in_place(const int N, Dtype* a, const Dtype* b);
+
+template <typename Dtype>
 void caffe_sub(const int N, const Dtype* a, const Dtype* b, Dtype* y);
 
 template <typename Dtype>
 void caffe_mul(const int N, const Dtype* a, const Dtype* b, Dtype* y);
 
 template <typename Dtype>
+void caffe_mul_in_place(const int N, Dtype* a, const Dtype* b);
+
+template <typename Dtype>
 void caffe_div(const int N, const Dtype* a, const Dtype* b, Dtype* y);
+
+template <typename Dtype>
+void caffe_div_in_place(const int N, Dtype* a, const Dtype* b);
 
 template <typename Dtype>
 void caffe_powx(const int n, const Dtype* a, const Dtype b, Dtype* y);

--- a/include/caffe/util/mkl_alternate.hpp
+++ b/include/caffe/util/mkl_alternate.hpp
@@ -77,6 +77,28 @@ DEFINE_VSL_BINARY_FUNC(Sub, y[i] = a[i] - b[i]);
 DEFINE_VSL_BINARY_FUNC(Mul, y[i] = a[i] * b[i]);
 DEFINE_VSL_BINARY_FUNC(Div, y[i] = a[i] / b[i]);
 
+
+// A simple way to define the vsl binary functions. The operation should
+// be in the form e.g. a[i] = a[i] + b[i]
+#define DEFINE_VSL_BINARY_TO_FUNC(name, operation) \
+  template<typename Dtype> \
+  void v##name(const int n, Dtype* a, const Dtype* b) { \
+    CHECK_GT(n, 0); CHECK(a); CHECK(b); \
+    for (int i = 0; i < n; ++i) { operation; } \
+  } \
+  inline void vs##name( \
+    const int n, float* a, const float* b) { \
+    v##name<float>(n, a, b); \
+  } \
+  inline void vd##name( \
+      const int n, double* a, const double* b) { \
+    v##name<double>(n, a, b); \
+  }
+
+DEFINE_VSL_BINARY_TO_FUNC(Add_in_place, a[i] = a[i] + b[i]);
+DEFINE_VSL_BINARY_TO_FUNC(Mul_in_place, a[i] = a[i] * b[i]);
+DEFINE_VSL_BINARY_TO_FUNC(Div_in_place, a[i] = a[i] / b[i]);
+
 // In addition, MKL comes with an additional function axpby that is not present
 // in standard blas. We will simply use a two-step (inefficient, of course) way
 // to mimic that.

--- a/src/caffe/layers/absval_layer.cpp
+++ b/src/caffe/layers/absval_layer.cpp
@@ -30,7 +30,7 @@ void AbsValLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     const Dtype* bottom_data = bottom[0]->cpu_data();
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
     caffe_cpu_sign(count, bottom_data, bottom_diff);
-    caffe_mul(count, bottom_diff, top_diff, bottom_diff);
+    caffe_mul_in_place(count, bottom_diff, top_diff);
   }
 }
 

--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -146,7 +146,7 @@ void BatchNormLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, channels_ * num,
       spatial_dim, 1, 1., num_by_chans_.cpu_data(),
       spatial_sum_multiplier_.cpu_data(), 0., temp_.mutable_cpu_data());
-  caffe_div(temp_.count(), top_data, temp_.cpu_data(), top_data);
+  caffe_div_in_place(temp_.count(), top_data, temp_.cpu_data());
   // TODO(cdoersch): The caching is only needed because later in-place layers
   //                 might clobber the data.  Can we skip this if they won't?
   caffe_copy(x_norm_.count(), top_data,
@@ -202,7 +202,7 @@ void BatchNormLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       spatial_sum_multiplier_.cpu_data(), 0., bottom_diff);
 
   // sum(dE/dY \cdot Y) \cdot Y
-  caffe_mul(temp_.count(), top_data, bottom_diff, bottom_diff);
+  caffe_mul_in_place(temp_.count(), bottom_diff, top_data);
 
   // sum(dE/dY)-sum(dE/dY \cdot Y) \cdot Y
   caffe_cpu_gemv<Dtype>(CblasNoTrans, channels_ * num, spatial_dim, 1.,
@@ -226,7 +226,7 @@ void BatchNormLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
 
   // note: temp_ still contains sqrt(var(X)+eps), computed during the forward
   // pass.
-  caffe_div(temp_.count(), bottom_diff, temp_.cpu_data(), bottom_diff);
+  caffe_div_in_place(temp_.count(), bottom_diff, temp_.cpu_data());
 }
 
 

--- a/src/caffe/layers/eltwise_layer.cpp
+++ b/src/caffe/layers/eltwise_layer.cpp
@@ -53,7 +53,7 @@ void EltwiseLayer<Dtype>::Forward_cpu(
   case EltwiseParameter_EltwiseOp_PROD:
     caffe_mul(count, bottom[0]->cpu_data(), bottom[1]->cpu_data(), top_data);
     for (int i = 2; i < bottom.size(); ++i) {
-      caffe_mul(count, top_data, bottom[i]->cpu_data(), top_data);
+      caffe_mul_in_place(count, top_data, bottom[i]->cpu_data());
     }
     break;
   case EltwiseParameter_EltwiseOp_SUM:
@@ -117,14 +117,13 @@ void EltwiseLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
               caffe_copy(count, bottom[j]->cpu_data(), bottom_diff);
               initialized = true;
             } else {
-              caffe_mul(count, bottom[j]->cpu_data(), bottom_diff,
-                        bottom_diff);
+              caffe_mul_in_place(count, bottom_diff, bottom[j]->cpu_data());
             }
           }
         } else {
           caffe_div(count, top_data, bottom_data, bottom_diff);
         }
-        caffe_mul(count, bottom_diff, top_diff, bottom_diff);
+        caffe_mul_in_place(count, bottom_diff, top_diff);
         break;
       case EltwiseParameter_EltwiseOp_SUM:
         if (coeffs_[i] == Dtype(1)) {

--- a/src/caffe/layers/log_layer.cpp
+++ b/src/caffe/layers/log_layer.cpp
@@ -72,7 +72,7 @@ void LogLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
   if (backward_num_scale_ != Dtype(1)) {
     caffe_scal(count, backward_num_scale_, bottom_diff);
   }
-  caffe_mul(count, top_diff, bottom_diff, bottom_diff);
+  caffe_mul_in_place(count, bottom_diff, top_diff);
 }
 
 #ifdef CPU_ONLY

--- a/src/caffe/layers/lrn_layer.cpp
+++ b/src/caffe/layers/lrn_layer.cpp
@@ -148,7 +148,7 @@ void LRNLayer<Dtype>::CrossChannelForward_cpu(
 
   // In the end, compute output
   caffe_powx<Dtype>(scale_.count(), scale_data, -beta_, top_data);
-  caffe_mul<Dtype>(scale_.count(), top_data, bottom_data, top_data);
+  caffe_mul_in_place<Dtype>(scale_.count(), top_data, bottom_data);
 }
 
 template <typename Dtype>
@@ -195,7 +195,7 @@ void LRNLayer<Dtype>::CrossChannelBackward_cpu(
   Dtype cache_ratio_value = 2. * alpha_ * beta_ / size_;
 
   caffe_powx<Dtype>(scale_.count(), scale_data, -beta_, bottom_diff);
-  caffe_mul<Dtype>(scale_.count(), top_diff, bottom_diff, bottom_diff);
+  caffe_mul_in_place<Dtype>(scale_.count(), bottom_diff, top_diff);
 
   // go through individual data
   int inverse_pre_pad = size_ - (size_ + 1) / 2;

--- a/src/caffe/layers/mvn_layer.cpp
+++ b/src/caffe/layers/mvn_layer.cpp
@@ -66,7 +66,7 @@ void MVNLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
           variance_.cpu_data(), sum_multiplier_.cpu_data(), 0.,
           temp_.mutable_cpu_data());
 
-    caffe_div(temp_.count(), top_data, temp_.cpu_data(), top_data);
+    caffe_div_in_place(temp_.count(), top_data, temp_.cpu_data());
   }
 }
 
@@ -94,7 +94,7 @@ void MVNLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, num, dim, 1, 1.,
           mean_.cpu_data(), sum_multiplier_.cpu_data(), 0.,
           bottom_diff);
-    caffe_mul(temp_.count(), top_data, bottom_diff, bottom_diff);
+    caffe_mul_in_place(temp_.count(), bottom_diff, top_data);
 
     caffe_cpu_gemv<Dtype>(CblasNoTrans, num, dim, 1., top_diff,
             sum_multiplier_.cpu_data(), 0., mean_.mutable_cpu_data());
@@ -112,7 +112,7 @@ void MVNLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
         variance_.cpu_data(), sum_multiplier_.cpu_data(), 0.,
         temp_.mutable_cpu_data());
 
-    caffe_div(temp_.count(), bottom_diff, temp_.cpu_data(), bottom_diff);
+    caffe_div_in_place(temp_.count(), bottom_diff, temp_.cpu_data());
   } else {
     caffe_cpu_gemv<Dtype>(CblasNoTrans, num, dim, 1. / dim, top_diff,
       sum_multiplier_.cpu_data(), 0., mean_.mutable_cpu_data());

--- a/src/caffe/layers/power_layer.cpp
+++ b/src/caffe/layers/power_layer.cpp
@@ -87,7 +87,7 @@ void PowerLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       }
     }
     if (diff_scale_ != Dtype(0)) {
-      caffe_mul(count, top_diff, bottom_diff, bottom_diff);
+      caffe_mul_in_place(count, bottom_diff, top_diff);
     }
   }
 }

--- a/src/caffe/layers/softmax_layer.cpp
+++ b/src/caffe/layers/softmax_layer.cpp
@@ -53,7 +53,7 @@ void SoftmaxLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
         top_data, sum_multiplier_.cpu_data(), 0., scale_data);
     // division
     for (int j = 0; j < channels; j++) {
-      caffe_div(inner_num_, top_data, scale_data, top_data);
+      caffe_div_in_place(inner_num_, top_data, scale_data);
       top_data += inner_num_;
     }
   }
@@ -82,7 +82,7 @@ void SoftmaxLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
         -1., sum_multiplier_.cpu_data(), scale_data, 1., bottom_diff + i * dim);
   }
   // elementwise multiplication
-  caffe_mul(top[0]->count(), bottom_diff, top_data, bottom_diff);
+  caffe_mul_in_place(top[0]->count(), bottom_diff, top_data);
 }
 
 

--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -138,6 +138,17 @@ void caffe_add<double>(const int n, const double* a, const double* b,
   vdAdd(n, a, b, y);
 }
 
+
+template <>
+void caffe_add_in_place<float>(const int n, float* a, const float* b) {
+  vsAdd_in_place(n, a, b);
+}
+
+template <>
+void caffe_add_in_place<double>(const int n, double* a, const double* b) {
+  vdAdd_in_place(n, a, b);
+}
+
 template <>
 void caffe_sub<float>(const int n, const float* a, const float* b,
     float* y) {
@@ -162,6 +173,17 @@ void caffe_mul<double>(const int n, const double* a, const double* b,
   vdMul(n, a, b, y);
 }
 
+
+template <>
+void caffe_mul_in_place<float>(const int n, float* a, const float* b) {
+  vsMul_in_place(n, a, b);
+}
+
+template <>
+void caffe_mul_in_place<double>(const int n, double* a, const double* b) {
+  vdMul_in_place(n, a, b);
+}
+
 template <>
 void caffe_div<float>(const int n, const float* a, const float* b,
     float* y) {
@@ -172,6 +194,16 @@ template <>
 void caffe_div<double>(const int n, const double* a, const double* b,
     double* y) {
   vdDiv(n, a, b, y);
+}
+
+template <>
+void caffe_div_in_place<float>(const int n, float* a, const float* b) {
+  vsDiv_in_place(n, a, b);
+}
+
+template <>
+void caffe_div_in_place<double>(const int n, double* a, const double* b) {
+  vdDiv_in_place(n, a, b);
 }
 
 template <>


### PR DESCRIPTION
Caffe implements a series of functions that operate on vectors, including
caffe_add, caffe_mul and caffe_div (there are more, but these are the
ones that seem to be used the most based on profiling).

These functions implement a vector  y = a op b  operation.

Now there is a slight inefficiency with this;
the compiler will nicely auto-vectorize these functions for the general
case, but because it can't prove that a, b and y are not overlapping aliases of eachother,
so it will also generate a non-SIMD version to fall back to.
(with aliases, the autovectorization in compilers, especially gcc, breaks
down so they fall back to the slow path).

this is all great, but there is a common pattern in the caffe code
that really wants to do

a = a op b

or in other words, an in-place add / mul / div.

This common pattern will ensure that "y" and "a" will alias, and this
then ends up executing the fallback, non-vectorized code, which is 4x or 8x
slower than the vectorized version.

This patch provides a solution to this problem by introducing "in_place" versions
of these 3 common operations; the next patch will introduce the users of these
new functions.

In the CPU profiles, the caffe_add/mul/div end up consuming several percent
CPU time (cpu-only configuration) and with this patch, that reduces drastically
giving a few percent (2 to 3% depending on hardware) performance improvement on
the alexnet benchmark.
