### PR TITLE
Fixing relative import for caffe module

### DIFF
--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -5,10 +5,9 @@ Classifier is an image classifier specialization of Net.
 
 import numpy as np
 
-import caffe
+from . import Net, io, TEST
 
-
-class Classifier(caffe.Net):
+class Classifier(Net):
     """
     Classifier extends Net for image class prediction
     by scaling, center cropping, or oversampling.
@@ -23,7 +22,7 @@ class Classifier(caffe.Net):
     def __init__(self, model_file, pretrained_file, image_dims=None,
                  mean=None, input_scale=None, raw_scale=None,
                  channel_swap=None):
-        caffe.Net.__init__(self, model_file, pretrained_file, caffe.TEST)
+        Net.__init__(self, model_file, pretrained_file, TEST)
 
         # configure pre-processing
         in_ = self.inputs[0]
@@ -67,11 +66,11 @@ class Classifier(caffe.Net):
                            inputs[0].shape[2]),
                           dtype=np.float32)
         for ix, in_ in enumerate(inputs):
-            input_[ix] = caffe.io.resize_image(in_, self.image_dims)
+            input_[ix] = io.resize_image(in_, self.image_dims)
 
         if oversample:
             # Generate center, corner, and mirrored crops.
-            input_ = caffe.io.oversample(input_, self.crop_dims)
+            input_ = io.oversample(input_, self.crop_dims)
         else:
             # Take center crop.
             center = np.array(self.image_dims) / 2.0

--- a/python/caffe/detector.py
+++ b/python/caffe/detector.py
@@ -16,10 +16,9 @@ proposal mode is available at
 import numpy as np
 import os
 
-import caffe
+from . import Net, TEST, io
 
-
-class Detector(caffe.Net):
+class Detector(Net):
     """
     Detector extends Net for windowed detection by a list of crops or
     selective search proposals.
@@ -35,11 +34,11 @@ class Detector(caffe.Net):
     def __init__(self, model_file, pretrained_file, mean=None,
                  input_scale=None, raw_scale=None, channel_swap=None,
                  context_pad=None):
-        caffe.Net.__init__(self, model_file, pretrained_file, caffe.TEST)
+        Net.__init__(self, model_file, pretrained_file, TEST)
 
         # configure pre-processing
         in_ = self.inputs[0]
-        self.transformer = caffe.io.Transformer(
+        self.transformer = io.Transformer(
             {in_: self.blobs[in_].data.shape})
         self.transformer.set_transpose(in_, (2, 0, 1))
         if mean is not None:
@@ -71,7 +70,7 @@ class Detector(caffe.Net):
         # Extract windows.
         window_inputs = []
         for image_fname, windows in images_windows:
-            image = caffe.io.load_image(image_fname).astype(np.float32)
+            image = io.load_image(image_fname).astype(np.float32)
             for window in windows:
                 window_inputs.append(self.crop(image, window))
 
@@ -172,7 +171,7 @@ class Detector(caffe.Net):
             # collect with context padding and place in input
             # with mean padding
             context_crop = im[box[0]:box[2], box[1]:box[3]]
-            context_crop = caffe.io.resize_image(context_crop, (crop_h, crop_w))
+            context_crop = io.resize_image(context_crop, (crop_h, crop_w))
             crop = np.ones(self.crop_dims, dtype=np.float32) * self.crop_mean
             crop[pad_y:(pad_y + crop_h), pad_x:(pad_x + crop_w)] = context_crop
 

--- a/python/caffe/draw.py
+++ b/python/caffe/draw.py
@@ -9,7 +9,7 @@ Caffe network visualization: draw the NetParameter protobuffer.
     Caffe.
 """
 
-from caffe.proto import caffe_pb2
+from .proto import caffe_pb2
 
 """
 pydot is not supported under python 3 and pydot2 doesn't work properly.

--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -2,17 +2,7 @@ import numpy as np
 import skimage.io
 from scipy.ndimage import zoom
 from skimage.transform import resize
-
-try:
-    # Python3 will most likely not be able to load protobuf
-    from caffe.proto import caffe_pb2
-except:
-    import sys
-    if sys.version_info >= (3, 0):
-        print("Failed to include caffe_pb2, things might go wrong!")
-    else:
-        raise
-
+from .proto import caffe_pb2
 
 ## proto / datum / ndarray conversion
 def blobproto_to_array(blob, return_diff=False):

--- a/python/caffe/pycaffe.py
+++ b/python/caffe/pycaffe.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ._caffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, \
         RMSPropSolver, AdaDeltaSolver, AdamSolver
-import caffe.io
+from . import io
 
 import six
 


### PR DESCRIPTION
Currently caffe can only be imported in python if there is a top level caffe directory, but not if caffe resides in a subdirectory. The reason for this is that several files in `python/caffe/` reference the caffe module (that only exists if caffe is a top level directory).
This PR fixes this and makes all import inside the `python/caffe/` directory relative.

I also removed the proto import warning in io.py as proto is imported in other places without warning.
