### PR TITLE
Stop setting cache timeout in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
     - BUILD_NAME="cudnn-cmake" WITH_CMAKE=true WITH_CUDA=true WITH_CUDNN=true
 
 cache:
-  timeout: 604800  # 1 week
   apt: true
   directories:
     - ~/protobuf3


### PR DESCRIPTION
It refers to the caching command timeout, not how long before the caches expire as I had thought.

> The caches expire when they are 45 days old, and this value is not configurable.
 https://github.com/travis-ci/travis-ci/issues/6317#issuecomment-233065994

So this line is at best useless, and at worst will cause the build to hang for a week!?