### PR TITLE
add double-margin contrastive loss layer

### DIFF
--- a/include/caffe/layers/double_margin_contrastive_loss_layer.hpp
+++ b/include/caffe/layers/double_margin_contrastive_loss_layer.hpp
@@ -1,0 +1,105 @@
+#ifndef CAFFE_DOUBLE_MARGIN_CONTRASTIVE_LOSS_LAYER_HPP_
+#define CAFFE_DOUBLE_MARGIN_CONTRASTIVE_LOSS_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/loss_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Computes the double margin contrastive loss @f$
+ *          E = \frac{1}{2N} \sum\limits_{n=1}^N 
+ *              \left(y\right) \max \left(d-margin_1, 0\right)^2 +
+ *              \left(1-y\right) \max \left(margin_2-d, 0\right)^2
+ *          @f$ where @f$
+ *          d = \left| \left| a_n - b_n \right| \right|_2 @f$. This can be
+ *          used to train siamese networks.
+ *
+ * @param bottom input Blob vector (length 3)
+ *   -# @f$ (N \times C \times 1 \times 1) @f$
+ *      the features @f$ a \in [-\infty, +\infty]@f$
+ *   -# @f$ (N \times C \times 1 \times 1) @f$
+ *      the features @f$ b \in [-\infty, +\infty]@f$
+ *   -# @f$ (N \times 1 \times 1 \times 1) @f$
+ *      the binary similarity @f$ s \in [0, 1]@f$
+ * @param top output Blob vector (length 1)
+ *   -# @f$ (1 \times 1 \times 1 \times 1) @f$
+ *      the computed double margin contrastive loss: @f$ E =
+ *          \frac{1}{2N} \sum\limits_{n=1}^N 
+ *          \left(y\right) \max \left(d-margin_1, 0\right)^2 +
+ *          \left(1-y\right) \max \left(margin_2-d, 0\right)^2
+ *          @f$ where @f$
+ *          d = \left| \left| a_n - b_n \right| \right|_2 @f$.
+ * This can be used to train siamese networks.
+ */
+template <typename Dtype>
+class DoubleMarginContrastiveLossLayer : public LossLayer<Dtype> {
+ public:
+  explicit DoubleMarginContrastiveLossLayer(const LayerParameter& param)
+      : LossLayer<Dtype>(param), diff_() {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline int ExactNumBottomBlobs() const { return 3; }
+  virtual inline const char* type() const {
+    return "DoubleMarginContrastiveLoss";
+  }
+  /**
+   * Unlike most loss layers, in the DoubleMarginContrastiveLossLayer
+   * we can backpropagate to the first two inputs.
+   */
+  virtual inline bool AllowForceBackward(const int bottom_index) const {
+    return bottom_index != 2;
+  }
+
+ protected:
+  /// @copydoc DoubleMarginContrastiveLossLayer
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  /**
+   * @brief Computes the Contrastive error gradient w.r.t. the inputs.
+   *
+   * Computes the gradients with respect to the two input vectors (bottom[0] and
+   * bottom[1]), but not the similarity label (bottom[2]).
+   *
+   * @param top output Blob vector (length 1), providing the error gradient with
+   *      respect to the outputs
+   *   -# @f$ (1 \times 1 \times 1 \times 1) @f$
+   *      This Blob's diff will simply contain the loss_weight* @f$ \lambda @f$,
+   *      as @f$ \lambda @f$ is the coefficient of this layer's output
+   *      @f$\ell_i@f$ in the overall Net loss
+   *      @f$ E = \lambda_i \ell_i + \mbox{other loss terms}@f$; hence
+   *      @f$ \frac{\partial E}{\partial \ell_i} = \lambda_i @f$.
+   *      (*Assuming that this top Blob is not used as a bottom (input) by any
+   *      other layer of the Net.)
+   * @param propagate_down see Layer::Backward.
+   * @param bottom input Blob vector (length 2)
+   *   -# @f$ (N \times C \times 1 \times 1) @f$
+   *      the features @f$a@f$; Backward fills their diff with
+   *      gradients if propagate_down[0]
+   *   -# @f$ (N \times C \times 1 \times 1) @f$
+   *      the features @f$b@f$; Backward fills their diff with gradients if
+   *      propagate_down[1]
+   */
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  Blob<Dtype> diff_;  // cached for backward pass
+  Blob<Dtype> dist_sq_;  // cached for backward pass
+  Blob<Dtype> diff_sq_;  // tmp storage for gpu forward pass
+  Blob<Dtype> summer_vec_;  // tmp storage for gpu forward pass
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_DOUBLE_MARGIN_CONTRASTIVE_LOSS_LAYER_HPP_

--- a/src/caffe/layers/double_margin_contrastive_loss_layer.cpp
+++ b/src/caffe/layers/double_margin_contrastive_loss_layer.cpp
@@ -1,0 +1,123 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/layers/double_margin_contrastive_loss_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void DoubleMarginContrastiveLossLayer<Dtype>::LayerSetUp(
+  const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::LayerSetUp(bottom, top);
+  CHECK_EQ(bottom[0]->channels(), bottom[1]->channels());
+  CHECK_EQ(bottom[0]->height(), 1);
+  CHECK_EQ(bottom[0]->width(), 1);
+  CHECK_EQ(bottom[1]->height(), 1);
+  CHECK_EQ(bottom[1]->width(), 1);
+  CHECK_EQ(bottom[2]->channels(), 1);
+  CHECK_EQ(bottom[2]->height(), 1);
+  CHECK_EQ(bottom[2]->width(), 1);
+  diff_.Reshape(bottom[0]->num(), bottom[0]->channels(), 1, 1);
+  diff_sq_.Reshape(bottom[0]->num(), bottom[0]->channels(), 1, 1);
+  dist_sq_.Reshape(bottom[0]->num(), 1, 1, 1);
+  // vector of ones used to sum along channels
+  summer_vec_.Reshape(bottom[0]->channels(), 1, 1, 1);
+  for (int i = 0; i < bottom[0]->channels(); ++i)
+    summer_vec_.mutable_cpu_data()[i] = Dtype(1);
+}
+
+template <typename Dtype>
+void DoubleMarginContrastiveLossLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  int count = bottom[0]->count();
+  caffe_sub(
+      count,
+      bottom[0]->cpu_data(),  // a
+      bottom[1]->cpu_data(),  // b
+      diff_.mutable_cpu_data());  // a_i-b_i
+  const int channels = bottom[0]->channels();
+  Dtype margin_gen =
+    this->layer_param_.double_margin_contrastive_loss_param().margin_gen();
+  Dtype margin_imp =
+    this->layer_param_.double_margin_contrastive_loss_param().margin_imp();
+  Dtype loss(0.0);
+  for (int i = 0; i < bottom[0]->num(); ++i) {
+    dist_sq_.mutable_cpu_data()[i] = caffe_cpu_dot(channels,
+        diff_.cpu_data() + (i*channels), diff_.cpu_data() + (i*channels));
+    if (static_cast<int>(bottom[2]->cpu_data()[i])) {  // similar pairs
+      Dtype dist = std::max<Dtype>(sqrt(dist_sq_.cpu_data()[i]) - margin_gen,
+        Dtype(0.0));
+      loss += dist*dist;
+    } else {  // dissimilar pairs
+      Dtype dist = std::max<Dtype>(margin_imp - sqrt(dist_sq_.cpu_data()[i]),
+        Dtype(0.0));
+      loss += dist*dist;
+    }
+  }
+  loss = loss / static_cast<Dtype>(bottom[0]->num()) / Dtype(2);
+  top[0]->mutable_cpu_data()[0] = loss;
+}
+
+template <typename Dtype>
+void DoubleMarginContrastiveLossLayer<Dtype>::Backward_cpu(
+    const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
+  Dtype margin_gen =
+    this->layer_param_.double_margin_contrastive_loss_param().margin_gen();
+  Dtype margin_imp =
+    this->layer_param_.double_margin_contrastive_loss_param().margin_imp();
+  for (int i = 0; i < 2; ++i) {
+    if (propagate_down[i]) {
+      const Dtype sign = (i == 0) ? 1 : -1;
+      const Dtype alpha = sign * top[0]->cpu_diff()[0] /
+          static_cast<Dtype>(bottom[i]->num());
+      int num = bottom[i]->num();
+      int channels = bottom[i]->channels();
+      for (int j = 0; j < num; ++j) {
+        Dtype* bout = bottom[i]->mutable_cpu_diff();
+        Dtype dist = sqrt(dist_sq_.cpu_data()[j]);
+        Dtype mdist(0.0);
+        Dtype beta(0.0);
+        if (static_cast<int>(bottom[2]->cpu_data()[j])) {  // similar pairs
+          mdist = dist - margin_gen;
+          beta = alpha * mdist / (dist + Dtype(1e-4));
+          if (mdist > Dtype(0.0)) {
+            caffe_cpu_axpby(
+                channels,
+                beta,
+                diff_.cpu_data() + (j*channels),
+                Dtype(0.0),
+                bout + (j*channels));
+          } else {
+            caffe_set(channels, Dtype(0), bout + (j*channels));
+          }
+        } else {  // dissimilar pairs
+          mdist = margin_imp - dist;
+          beta = -alpha * mdist / (dist + Dtype(1e-4));
+          if (mdist > Dtype(0.0)) {
+            caffe_cpu_axpby(
+                channels,
+                beta,
+                diff_.cpu_data() + (j*channels),
+                Dtype(0.0),
+                bout + (j*channels));
+          } else {
+            caffe_set(channels, Dtype(0), bout + (j*channels));
+          }
+        }
+      }
+    }
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(DoubleMarginContrastiveLossLayer);
+#endif
+
+INSTANTIATE_CLASS(DoubleMarginContrastiveLossLayer);
+REGISTER_LAYER_CLASS(DoubleMarginContrastiveLoss);
+
+}  // namespace caffe

--- a/src/caffe/layers/double_margin_contrastive_loss_layer.cu
+++ b/src/caffe/layers/double_margin_contrastive_loss_layer.cu
@@ -1,0 +1,111 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/layers/double_margin_contrastive_loss_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void DoubleMarginContrastiveLossLayer<Dtype>::Forward_gpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  const int count = bottom[0]->count();
+  caffe_gpu_sub(
+      count,
+      bottom[0]->gpu_data(),  // a
+      bottom[1]->gpu_data(),  // b
+      diff_.mutable_gpu_data());  // a_i-b_i
+  caffe_gpu_powx(
+      count,
+      diff_.mutable_gpu_data(),  // a_i-b_i
+      Dtype(2),
+      diff_sq_.mutable_gpu_data());  // (a_i-b_i)^2
+  caffe_gpu_gemv(
+      CblasNoTrans,
+      bottom[0]->num(),
+      bottom[0]->channels(),
+      Dtype(1.0),
+      diff_sq_.gpu_data(),  // (a_i-b_i)^2
+      summer_vec_.gpu_data(),
+      Dtype(0.0),
+      dist_sq_.mutable_gpu_data());  // \Sum (a_i-b_i)^2
+  Dtype margin_gen =
+      this->layer_param_.double_margin_contrastive_loss_param().margin_gen();
+  Dtype margin_imp =
+      this->layer_param_.double_margin_contrastive_loss_param().margin_imp();
+  Dtype loss(0.0);
+  for (int i = 0; i < bottom[0]->num(); ++i) {
+    if (static_cast<int>(bottom[2]->cpu_data()[i])) {  // similar pairs
+      Dtype dist = std::max(sqrt(dist_sq_.cpu_data()[i]) - margin_gen,
+                            Dtype(0.0));
+      loss += dist*dist;
+    } else {  // dissimilar pairs
+      Dtype dist = std::max(margin_imp - sqrt(dist_sq_.cpu_data()[i]),
+                            Dtype(0.0));
+      loss += dist*dist;
+    }
+  }
+  loss = loss / static_cast<Dtype>(bottom[0]->num()) / Dtype(2);
+  top[0]->mutable_cpu_data()[0] = loss;
+}
+
+template <typename Dtype>
+__global__ void CLLBackward(const int count, const int channels,
+    const Dtype margin_gen, const Dtype margin_imp, const Dtype alpha,
+    const Dtype* y, const Dtype* diff, const Dtype* dist_sq,
+    Dtype *bottom_diff) {
+  CUDA_KERNEL_LOOP(i, count) {
+    int n = i / channels;  // the num index, to access y and dist_sq
+    Dtype dist = sqrt(dist_sq[n]);
+    Dtype mdist(0.0);
+    Dtype beta(0.0);
+    if (static_cast<int>(y[n])) {  // similar pairs
+      mdist = (dist - margin_gen);
+      beta = alpha * mdist / (dist + Dtype(1e-4)) * diff[i];
+      if (mdist > 0.0) {
+        bottom_diff[i] = beta;
+      } else {
+        bottom_diff[i] = 0;
+      }
+    } else {  // dissimilar pairs
+      mdist = (margin_imp - dist);
+      beta = -alpha * mdist / (dist + Dtype(1e-4)) * diff[i];
+      if (mdist > 0.0) {
+        bottom_diff[i] = beta;
+      } else {
+        bottom_diff[i] = 0;
+      }
+    }
+  }
+}
+
+template <typename Dtype>
+void DoubleMarginContrastiveLossLayer<Dtype>::Backward_gpu(
+    const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
+  for (int i = 0; i < 2; ++i) {
+    if (propagate_down[i]) {
+      const int count = bottom[0]->count();
+      const int channels = bottom[0]->channels();
+      Dtype margin_gen =
+        this->layer_param_.double_margin_contrastive_loss_param().margin_gen();
+      Dtype margin_imp =
+        this->layer_param_.double_margin_contrastive_loss_param().margin_imp();
+      const Dtype sign = (i == 0) ? 1 : -1;
+      const Dtype alpha = sign * top[0]->cpu_diff()[0] /
+          static_cast<Dtype>(bottom[0]->num());
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      CLLBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+          count, channels, margin_gen, margin_imp, alpha,
+          bottom[2]->gpu_data(),  // pair similarity 0 or 1
+          diff_.gpu_data(),  // the cached eltwise difference between a and b
+          dist_sq_.gpu_data(),  // the cached square distance between a and b
+          bottom[i]->mutable_gpu_diff());
+      CUDA_POST_KERNEL_CHECK;
+    }
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(DoubleMarginContrastiveLossLayer);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -306,7 +306,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 147 (last added: recurrent_param)
+// LayerParameter next available layer-specific ID: 148 (last added: double_margin_contrastive_loss_param)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -367,6 +367,7 @@ message LayerParameter {
   optional ConvolutionParameter convolution_param = 106;
   optional CropParameter crop_param = 144;
   optional DataParameter data_param = 107;
+  optional DoubleMarginContrastiveLossParameter double_margin_contrastive_loss_param = 147;
   optional DropoutParameter dropout_param = 108;
   optional DummyDataParameter dummy_data_param = 109;
   optional EltwiseParameter eltwise_param = 110;
@@ -656,6 +657,14 @@ message DataParameter {
   // Prefetch queue (Number of batches to prefetch to host memory, increase if
   // data access bandwidth varies).
   optional uint32 prefetch = 10 [default = 4];
+}
+
+// Message that stores parameters used by DoubleMarginContrastiveLossLayer
+message DoubleMarginContrastiveLossParameter {
+  // margin for genuine pairs
+  optional float margin_gen = 1 [default = 1.0];
+  // margin for impostor pairs
+  optional float margin_imp = 2 [default = 1.0];
 }
 
 message DropoutParameter {

--- a/src/caffe/test/test_double_margin_contrastive_loss_layer.cpp
+++ b/src/caffe/test/test_double_margin_contrastive_loss_layer.cpp
@@ -1,0 +1,105 @@
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/double_margin_contrastive_loss_layer.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+namespace caffe {
+
+template <typename TypeParam>
+class DoubleMarginContrastiveLossLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  DoubleMarginContrastiveLossLayerTest()
+      : blob_bottom_data_i_(new Blob<Dtype>(512, 2, 1, 1)),
+        blob_bottom_data_j_(new Blob<Dtype>(512, 2, 1, 1)),
+        blob_bottom_y_(new Blob<Dtype>(512, 1, 1, 1)),
+        blob_top_loss_(new Blob<Dtype>()) {
+    // fill the values
+    FillerParameter filler_param;
+    filler_param.set_min(-1.0);
+    filler_param.set_max(1.0);  // distances~=1.0 to test both sides of margin
+    UniformFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_data_i_);
+    blob_bottom_vec_.push_back(blob_bottom_data_i_);
+    filler.Fill(this->blob_bottom_data_j_);
+    blob_bottom_vec_.push_back(blob_bottom_data_j_);
+    for (int i = 0; i < blob_bottom_y_->count(); ++i) {
+      blob_bottom_y_->mutable_cpu_data()[i] = caffe_rng_rand() % 2;  // 0 or 1
+    }
+    blob_bottom_vec_.push_back(blob_bottom_y_);
+    blob_top_vec_.push_back(blob_top_loss_);
+  }
+  virtual ~DoubleMarginContrastiveLossLayerTest() {
+    delete blob_bottom_data_i_;
+    delete blob_bottom_data_j_;
+    delete blob_bottom_y_;
+    delete blob_top_loss_;
+  }
+
+  Blob<Dtype>* const blob_bottom_data_i_;
+  Blob<Dtype>* const blob_bottom_data_j_;
+  Blob<Dtype>* const blob_bottom_y_;
+  Blob<Dtype>* const blob_top_loss_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(DoubleMarginContrastiveLossLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(DoubleMarginContrastiveLossLayerTest, TestForward) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  DoubleMarginContrastiveLossLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // manually compute to compare
+  const Dtype margin_gen =
+      layer_param.double_margin_contrastive_loss_param().margin_gen();
+  const Dtype margin_imp =
+      layer_param.double_margin_contrastive_loss_param().margin_imp();
+  const int num = this->blob_bottom_data_i_->num();
+  const int channels = this->blob_bottom_data_i_->channels();
+  Dtype loss(0);
+  for (int i = 0; i < num; ++i) {
+    Dtype dist_sq(0);
+    for (int j = 0; j < channels; ++j) {
+      Dtype diff = this->blob_bottom_data_i_->cpu_data()[i*channels+j] -
+          this->blob_bottom_data_j_->cpu_data()[i*channels+j];
+      dist_sq += diff*diff;
+    }
+    if (this->blob_bottom_y_->cpu_data()[i]) {  // similar pairs
+      Dtype dist = std::max<Dtype>(sqrt(dist_sq) - margin_gen, 0.0);
+      loss += dist*dist;
+    } else {
+      Dtype dist = std::max<Dtype>(margin_imp - sqrt(dist_sq), 0.0);
+      loss += dist*dist;
+    }
+  }
+  loss /= static_cast<Dtype>(num) * Dtype(2);
+  EXPECT_NEAR(this->blob_top_loss_->cpu_data()[0], loss, 1e-6);
+}
+
+TYPED_TEST(DoubleMarginContrastiveLossLayerTest, TestGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  DoubleMarginContrastiveLossLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  GradientChecker<Dtype> checker(1e-2, 1e-2, 1701);
+  // check the gradient for the first two bottom layers
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 0);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 1);
+}
+
+}  // namespace caffe


### PR DESCRIPTION
Migrate and reimplement the `double-margin contrastive loss` from [https://bitbucket.org/jonbakerfish/caffe](https://bitbucket.org/jonbakerfish/caffe). For consistency (see [#2308](https://github.com/BVLC/caffe/issues/2308)), this implementation is slightly different from the above repo.
The bitbucket one implements the loss in the following form:
      L = y * max(d^2 - margin1, 0)     + (1-y) * max(margin2 - d^2, 0)
whereas this PR implements:
      L = y * max(d     - margin1, 0)^2 + (1-y) * max(margin2 - d, 0)^2

This loss has been used in the following works:
[1] Lin et al. [DeepHash: Getting Regularization, Depth and Fine-Tuning Right](https://arxiv.org/abs/1501.04711). CoRR, 2015
[2] Sadeghi et al. [VISALOGY: Answering Visual Analogy Questions](https://arxiv.org/abs/1510.08973). In NIPS, 2015.
[3] Cao et al. [Quartet-net Learning for Visual Instance Retrieval](https://sites.google.com/site/quartetnetlearning/). In MM, 2016.