### PR TITLE
Fix plot_training_log.py.example

### DIFF
--- a/tools/extra/plot_training_log.py.example
+++ b/tools/extra/plot_training_log.py.example
@@ -82,8 +82,12 @@ def load_data(data_file, field_idx0, field_idx1):
     with open(data_file, 'r') as f:
         for line in f:
             line = line.strip()
-            if line[0] != '#':
+            if line[0] == '#':
+		num_fields = len(line.split())
+            else:
                 fields = line.split()
+                if len(fields) != num_fields:
+		    continue
                 data[0].append(float(fields[field_idx0].strip()))
                 data[1].append(float(fields[field_idx1].strip()))
     return data


### PR DESCRIPTION
When all of the fields (e.g. Iters, Seconds, TestAccuracy, TestLoss) of the log file are not completely filled in during the testing, this script is not working. The error is as follows:

> Traceback (most recent call last):
>   File "../../tools/extra/plot_training_log.py.example", line 191, in <module>
>     plot_chart(chart_type, path_to_png, path_to_logs)
>   File "../../tools/extra/plot_training_log.py.example", line 117, in plot_chart
>     data = load_data(data_file, x, y)
>   File "../../tools/extra/plot_training_log.py.example", line 88, in load_data
>     data[1].append(float(fields[field_idx1].strip()))
> IndexError: list index out of range

This pull request contains a minor change to allow the script to skip the incomplete row.