### PR TITLE
Extra interfaces to use caffe operator from mxnet

### DIFF
--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -218,6 +218,9 @@ class Blob {
 
   const Dtype* cpu_data() const;
   void set_cpu_data(Dtype* data);
+  void set_cpu_diff(Dtype* data);
+  void set_gpu_data(Dtype* data);
+  void set_gpu_diff(Dtype* data);
   const int* gpu_shape() const;
   const Dtype* gpu_data() const;
   const Dtype* cpu_diff() const;

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -177,6 +177,13 @@ class Layer {
       const vector<Blob<Dtype>*>& bottom);
 
   /**
+   * @brief Set phase: TRAIN or TEST
+   */
+  inline void SetPhase(Phase p) {
+    phase_ = p;
+  }
+
+  /**
    * @brief Returns the vector of learnable parameter blobs.
    */
   vector<shared_ptr<Blob<Dtype> > >& blobs() {

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -184,25 +184,6 @@ class Layer {
   }
 
   /**
-   * @brief Sets blobs
-   */
-  void SetBlobs(const vector<Blob<Dtype>*>& weights) {
-    CHECK_EQ(blobs_.size(), weights.size());
-    for (int i = 0; i < weights.size(); ++i)
-      blobs_[i].reset(weights[i]);
-  }
-
-  /**
-   * @brief Gets blobs with normal pointer
-   */
-  vector<Blob<Dtype>*> GetBlobs() {
-    vector<Blob<Dtype>*> ans;
-    for (int i = 0; i < blobs_.size(); ++i)
-      ans.push_back(blobs_[i].get());
-    return ans;
-  }
-
-  /**
    * @brief Returns the layer parameter.
    */
   const LayerParameter& layer_param() const { return layer_param_; }

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -184,6 +184,25 @@ class Layer {
   }
 
   /**
+   * @brief Sets blobs
+   */
+  void SetBlobs(const vector<Blob<Dtype>*>& weights) {
+    CHECK_EQ(blobs_.size(), weights.size());
+    for (int i = 0; i < weights.size(); ++i)
+      blobs_[i].reset(weights[i]);
+  }
+
+  /**
+   * @brief Gets blobs with normal pointer
+   */
+  vector<Blob<Dtype>*> GetBlobs() {
+    vector<Blob<Dtype>*> ans;
+    for (int i = 0; i < blobs_.size(); ++i)
+      ans.push_back(blobs_[i].get());
+    return ans;
+  }
+
+  /**
    * @brief Returns the layer parameter.
    */
   const LayerParameter& layer_param() const { return layer_param_; }

--- a/src/caffe/blob.cpp
+++ b/src/caffe/blob.cpp
@@ -93,6 +93,24 @@ void Blob<Dtype>::set_cpu_data(Dtype* data) {
 }
 
 template <typename Dtype>
+void Blob<Dtype>::set_gpu_data(Dtype* data) {
+  CHECK(data);
+  data_->set_gpu_data(data);
+}
+
+template <typename Dtype>
+void Blob<Dtype>::set_cpu_diff(Dtype* diff) {
+  CHECK(diff);
+  diff_->set_cpu_data(diff);
+}
+
+template <typename Dtype>
+void Blob<Dtype>::set_gpu_diff(Dtype* diff) {
+  CHECK(diff);
+  diff_->set_gpu_data(diff);
+}
+
+template <typename Dtype>
 const Dtype* Blob<Dtype>::gpu_data() const {
   CHECK(data_);
   return (const Dtype*)data_->gpu_data();


### PR DESCRIPTION
Hi,

I've added several interfaces in Blob & Layer to support caffe plugin in mxnet. Two prime purposes for those interfaces are:
- to set gpu_data/diff & cpu_diff in caffe::blob, currently it only supports cpu_data(). With those methods, mxnet could build a caffe::blob with its own data.
- to provide access to blobs_ in caffe::layer. In this way, mxnet could set its own weights into caffe layer.

With these interfaces, mxnet could call caffe op in its symbolic interface without doing memory copy.  

If you're interested in how caffe op is wrapped in mxnet, please check the https://github.com/dmlc/mxnet/pull/2746. The caffe-plugin feature would be merged to mxnet master in 1 or 2 days.

We deeply believe this plugin is beneficial to both caffe & mxnet communities, also for convenience of both side users.

Thank you, Haoran
