### PR TITLE
Update rms_decay in caffe.proto to match docs

### DIFF
--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -219,7 +219,7 @@ message SolverParameter {
 
   // RMSProp decay value
   // MeanSquare(t) = rms_decay*MeanSquare(t-1) + (1-rms_decay)*SquareGradient(t)
-  optional float rms_decay = 38;
+  optional float rms_decay = 38 [default = 0.02];
 
   // If true, print information about the state of the net that may help with
   // debugging learning problems.


### PR DESCRIPTION
@smichalowski pointed out in https://github.com/NVIDIA/DIGITS/pull/956 that the docs say the default value for `rms_decay` is 0.02:

> The default value of $$\delta$$ (rms_decay) is set to $$\delta = 0.02$$.
https://github.com/BVLC/caffe/blob/rc3/docs/tutorial/solver.md#rmsprop

But it looks like the default is actually 0. Am I missing something?