### PR TITLE
Fixing Typo In Sigmoid CIFAR-10 Examples

### DIFF
--- a/examples/cifar10/cifar10_full_sigmoid_solver.prototxt
+++ b/examples/cifar10/cifar10_full_sigmoid_solver.prototxt
@@ -17,7 +17,7 @@ momentum: 0.9
 lr_policy: "step"
 gamma: 1
 stepsize: 5000
-# Display every 200 iterations
+# Display every 100 iterations
 display: 100
 # The maximum number of iterations
 max_iter: 60000

--- a/examples/cifar10/cifar10_full_sigmoid_solver_bn.prototxt
+++ b/examples/cifar10/cifar10_full_sigmoid_solver_bn.prototxt
@@ -17,7 +17,7 @@ momentum: 0.9
 lr_policy: "step"
 gamma: 1
 stepsize: 5000
-# Display every 200 iterations
+# Display every 100 iterations
 display: 100
 # The maximum number of iterations
 max_iter: 60000


### PR DESCRIPTION
There was a mismatch between the iterations interval in the comment and the actual code. I know the typo is quite minor and maybe obvious to most people but is potentially confusing to new-comers. 