### PR TITLE
Update net.cpp

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -705,7 +705,7 @@ void Net<Dtype>::ShareTrainedLayersWith(const Net* other) {
           << source_layer_name << "'; shape mismatch.  Source param shape is "
           << source_blob->shape_string() << "; target param shape is "
           << target_blobs[j]->shape_string();
-      target_blobs[j]->ShareData(*source_blob);
+      target_blobs[j]->CopyFrom(*source_blob, false, false);
     }
   }
 }


### PR DESCRIPTION
If I design a net like
layer{
name: conv11
type: conv
....
param{name: conv11_w}
param{name: conv11_b}
}
layer{
name: conv11_p
type: conv
...
param{name: conv11_w}
param{name: conv11_p}
phase{ TEST }
}

There are 1 branch in training phase and 2 branches in testing phase which shares paramter with training phase net.

In caffe code, it is implemented by the function

template 
void Net::ShareTrainedLayersWith(const Net* other) {
int num_source_layers = other->layers().size();
for (int i = 0; i < num_source_layers; ++i) {
Layer* source_layer = other->layers()[i].get();
const string& source_layer_name = other->layer_names()[i];
int target_layer_id = 0;
while (target_layer_id != layer_names_.size() &&
layer_names_[target_layer_id] != source_layer_name) {
++target_layer_id;
}
if (target_layer_id == layer_names_.size()) {
LOG(INFO) << "Ignoring source layer " << source_layer_name;
continue;
}
DLOG(INFO) << "Copying source layer " << source_layer_name;
vector > >& target_blobs =
layers_[target_layer_id]->blobs();
CHECK_EQ(target_blobs.size(), source_layer->blobs().size())
<< "Incompatible number of blobs for layer " << source_layer_name;
for (int j = 0; j < target_blobs.size(); ++j) {
Blob* source_blob = source_layer->blobs()[j].get();
CHECK(target_blobs[j]->shape() == source_blob->shape())
<< "Cannot share param " << j << " weights from layer '"
<< source_layer_name << "'; shape mismatch. Source param shape is "
<< source_blob->shape_string() << "; target param shape is "
<< target_blobs[j]->shape_string();
target_blobs[j]->CopyFrom(source_blob, false, false); 
//target_blobs[j]->ShareData(source_blob);
}
}
}

Note that in caffe's code structure, firstly it initial the net with sharing weights by sharedptr.
Then in testing phase, it run the code upon to share blobs with training net which just based on the layer name. So it break the sharing relation which written in the function Net::Init().

After I modified it with CopyFrom function, it worked well.
I think in the future, author could add a more flex structure to support weight-sharing for saving memory. Now shared-ptr dosen't support back object linking.