### PR TITLE
[TravisCI] - build protobuf3 GA

### DIFF
--- a/scripts/travis/install-deps.sh
+++ b/scripts/travis/install-deps.sh
@@ -56,7 +56,7 @@ else
       dh-autoreconf \
       unzip
 
-    wget https://github.com/google/protobuf/archive/v3.0.0-beta-3.tar.gz -O protobuf3.tar.gz
+    wget https://github.com/google/protobuf/archive/3.0.0-GA.tar.gz -O protobuf3.tar.gz
     tar -xzf protobuf3.tar.gz -C $PROTOBUF3_DIR --strip 1
     rm protobuf3.tar.gz
     cd $PROTOBUF3_DIR


### PR DESCRIPTION
Cherry-pick of https://github.com/NVIDIA/caffe/pull/222

Clear the build cache and you'll start seeing failures like this in the BVLC fork:
```
[gtest-1.7.0.zip]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of gtest-1.7.0.zip or
        gtest-1.7.0.zip.zip, and cannot find gtest-1.7.0.zip.ZIP, period.
```
e.g.
https://travis-ci.org/BVLC/caffe/jobs/155609508 (that one failed because he based his PR off of an old commit without build caching)
https://travis-ci.org/NVIDIA/caffe/jobs/155406776