### PR TITLE
Bilinear filler value corrected when matrix size is odd.

### DIFF
--- a/include/caffe/filler.hpp
+++ b/include/caffe/filler.hpp
@@ -250,7 +250,7 @@ class BilinearFiller : public Filler<Dtype> {
     CHECK_EQ(blob->width(), blob->height()) << "Filter must be square";
     Dtype* data = blob->mutable_cpu_data();
     int f = ceil(blob->width() / 2.);
-    float c = (2 * f - 1 - f % 2) / (2. * f);
+    float c = (2 * f - 1 - blod->width() % 2) / (2. * f);
     for (int i = 0; i < blob->count(); ++i) {
       float x = i % blob->width();
       float y = (i / blob->width()) % blob->height();


### PR DESCRIPTION
I believe there was an typo in BilinearFiller. 
E.g. if you set the kernel size to be 3. the filler produces the following result:

```
0.062500 0.187500 0.187500 
0.187500 0.562500 0.562500 
0.187500 0.562500 0.562500
```

Where it should have been

```
0.250000 0.500000 0.250000 
0.500000 1.000000 0.500000 
0.250000 0.500000 0.250000 
```

Looking at the code and this is because the matrix size condition (f%2) should have used the actual matrix size. 

Let me know what you think.
