### PR TITLE
added CrossEntropy loss layer

### DIFF
--- a/include/caffe/layers/cross_entropy_loss.hpp
+++ b/include/caffe/layers/cross_entropy_loss.hpp
@@ -1,0 +1,44 @@
+#ifndef CAFFE_CROSS_ENTROPY_LAYER_HPP
+#define CAFFE_CROSS_ENTROPY_LAYER_HPP
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+  template <typename Dtype>
+  class CrossEntropyLossLayer : public Layer<Dtype> {
+  public:
+    explicit CrossEntropyLossLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+    virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+			 const vector<Blob<Dtype>*>& top);
+
+    virtual inline const char* type() const { return "CrossEntropyLoss"; }
+    virtual inline int ExactNumBottomBlobs() const { return 2; }
+    virtual inline int ExactNumTopBlobs() const { return 1; }
+
+  protected:
+    virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+			     const vector<Blob<Dtype>*>& top);
+    virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+			      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom)
+    {
+      NOT_IMPLEMENTED;
+    }
+    virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+			      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom)
+    {
+      NOT_IMPLEMENTED;
+    }
+
+    int outer_num_;
+    int inner_num_;
+  };
+  
+}
+
+#endif

--- a/src/caffe/layers/cross_entropy_loss.cpp
+++ b/src/caffe/layers/cross_entropy_loss.cpp
@@ -1,0 +1,33 @@
+#include "caffe/layers/cross_entropy_loss.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+  template <typename Dtype>
+  void CrossEntropyLossLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+					 const vector<Blob<Dtype>*>& top) {
+    top[0]->ReshapeLike(*bottom[0]);
+  }
+
+  template <typename Dtype>
+  void CrossEntropyLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+					     const vector<Blob<Dtype>*> &top) {
+    const int count = bottom[0]->count();
+    const int num = bottom[0]->num();
+    const Dtype* input_data = bottom[0]->cpu_data();
+    const Dtype* target = bottom[1]->cpu_data();
+    const int dim = count / num;
+    for (int i=0;i<num;i++) {
+      Dtype loss = 0;
+      for (int j=i*dim;j<(i+1)*dim;j++) {
+	loss -= target[j] * log(input_data[j] + (target[j] == Dtype(0))) +
+	  (1 - target[j]) * log(1 - input_data[j] + (target[j] == Dtype(1)));
+      }
+      top[0]->mutable_cpu_data()[i] = loss / num;
+    }
+  }
+
+INSTANTIATE_CLASS(CrossEntropyLossLayer);
+REGISTER_LAYER_CLASS(CrossEntropyLoss);
+  
+}

--- a/src/caffe/test/test_cross_entropy_loss.cpp
+++ b/src/caffe/test/test_cross_entropy_loss.cpp
@@ -1,0 +1,127 @@
+#include <cmath>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/cross_entropy_loss.hpp"
+#include "caffe/layers/sigmoid_layer.hpp"
+
+#ifdef USE_CUDNN
+#include "caffe/layers/cudnn_sigmoid_layer.hpp"
+#endif
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+namespace caffe {
+
+template <typename TypeParam>
+class CrossEntropyLossLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  CrossEntropyLossLayerTest()
+      : blob_bottom_data_(new Blob<Dtype>(10, 5, 1, 1)),
+        blob_bottom_targets_(new Blob<Dtype>(10, 5, 1, 1)),
+	blob_top_sig_(new Blob<Dtype>()),
+        blob_top_loss_(new Blob<Dtype>()) {
+    // Fill the data vector
+    FillerParameter data_filler_param;
+    data_filler_param.set_std(1);
+    GaussianFiller<Dtype> data_filler(data_filler_param);
+    data_filler.Fill(blob_bottom_data_);
+    blob_bottom_vec_.push_back(blob_bottom_data_);
+    // Set bottom sig vector
+    blob_top_vec_sig_.push_back(blob_top_sig_);
+    blob_tmp_vec_.push_back(blob_top_sig_);
+    
+    // Fill the targets vector
+    FillerParameter targets_filler_param;
+    targets_filler_param.set_min(0);
+    targets_filler_param.set_max(1);
+    UniformFiller<Dtype> targets_filler(targets_filler_param);
+    targets_filler.Fill(blob_bottom_targets_);
+    blob_tmp_vec_.push_back(blob_bottom_targets_);
+    blob_top_vec_.push_back(blob_top_loss_);
+  }
+  virtual ~CrossEntropyLossLayerTest() {
+    delete blob_bottom_data_;
+    delete blob_bottom_targets_;
+    delete blob_top_sig_;
+    delete blob_top_loss_;
+  }
+
+  Dtype CrossEntropyReference(const int count, const int num,
+				  const Dtype* input,
+				  const Dtype* target) {
+    Dtype loss = 0;
+    for (int i = 0; i < count; ++i) {
+      const Dtype prediction = 1 / (1 + exp(-input[i]));
+      EXPECT_LE(prediction, 1);
+      EXPECT_GE(prediction, 0);
+      EXPECT_LE(target[i], 1);
+      EXPECT_GE(target[i], 0);
+      loss -= target[i] * log(prediction + (target[i] == Dtype(0)));
+      loss -= (1 - target[i]) * log(1 - prediction + (target[i] == Dtype(1)));
+    }
+    return loss / num;
+  }
+
+  void TestForward() {
+    LayerParameter layer_param_sigmoid;
+    LayerParameter layer_param;
+    const Dtype kLossWeight = 3.7;
+    layer_param.add_loss_weight(kLossWeight);
+    FillerParameter data_filler_param;
+    data_filler_param.set_std(1);
+    GaussianFiller<Dtype> data_filler(data_filler_param);
+    FillerParameter targets_filler_param;
+    targets_filler_param.set_min(0.0);
+    targets_filler_param.set_max(1.0);
+    UniformFiller<Dtype> targets_filler(targets_filler_param);
+    Dtype eps = 2e-2;
+    for (int i = 0; i < 100; ++i) {
+      // Fill the data vector
+      data_filler.Fill(this->blob_bottom_data_);
+      // Fill the targets vector
+      targets_filler.Fill(this->blob_bottom_targets_);
+
+      // sigmoid layer
+      SigmoidLayer<Dtype> siglayer(layer_param_sigmoid);
+      siglayer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_sig_);
+      siglayer.Forward(this->blob_bottom_vec_, this->blob_top_vec_sig_);
+      
+      // cross entropy layer
+      CrossEntropyLossLayer<Dtype> layer(layer_param);
+      layer.SetUp(this->blob_tmp_vec_, this->blob_top_vec_);
+      Dtype layer_loss =
+          layer.Forward(this->blob_tmp_vec_, this->blob_top_vec_);
+      const int count = this->blob_bottom_data_->count();
+      const int num = this->blob_bottom_data_->num();
+      const Dtype* blob_bottom_data = this->blob_bottom_data_->cpu_data();
+      const Dtype* blob_bottom_targets =
+          this->blob_bottom_targets_->cpu_data();
+      Dtype reference_loss = kLossWeight * CrossEntropyReference(
+          count, num, blob_bottom_data, blob_bottom_targets);
+      EXPECT_NEAR(reference_loss, layer_loss, eps) << "debug: trial #" << i;
+    }
+  }
+
+  Blob<Dtype>* const blob_bottom_data_;
+  Blob<Dtype>* const blob_bottom_targets_;
+  Blob<Dtype>* const blob_top_sig_;
+  Blob<Dtype>* const blob_top_loss_;
+  vector<Blob<Dtype>*> blob_bottom_vec_, blob_tmp_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_,blob_top_vec_sig_;
+};
+
+TYPED_TEST_CASE(CrossEntropyLossLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(CrossEntropyLossLayerTest, TestCrossEntropy) {
+  this->TestForward();
+}
+
+}  // namespace caffe


### PR DESCRIPTION
When using an autoencoder, one of the losses of choice is `SigmoidCrossEntropyLoss`. However, at runtime, since the `Sigmoid` and the loss are merged in together, it is not possible to recover the decoded output easily, right after the `Sigmoid`.

Admittedly, this is a niche use case where we might want to look the decoded output up for debug or other assessment purposes (e.g. denoising, etc...).

This PR adds a `CrossEntropyLoss` layer to Caffe that can be used along a `Sigmoid` layer in `deploy.prototxt` so that at prediction time the output of the autoencoder can be easily retrieved. There's no implementation of `backward_cpu/_gpu()` since for training purposes the `SigmoidCrossEntropyLoss` should be preferred.

Of course Caffe already allows to do this by defining a `deploy.prototxt` with and without the `SigmoidCrossEntropyLoss` layer, so this PR really only allows to have only a single deploy file.

In summary, a niche PR just in case it proves useful to others one of these days.
