### PR TITLE
Fix missing proto header path in CMake

### DIFF
--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(caffe ${Caffe_LINKER_LIBS})
 target_include_directories(caffe ${Caffe_INCLUDE_DIRS}
                                  PUBLIC
                                  $<BUILD_INTERFACE:${Caffe_INCLUDE_DIR}>
+                                 $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
                                  $<INSTALL_INTERFACE:include>)
 target_compile_definitions(caffe ${Caffe_DEFINITIONS})
 if(Caffe_COMPILE_OPTIONS)


### PR DESCRIPTION
The generated protobuf header path is not included in Caffe target,
a consumer links to Caffe will not find the protobuf header.

The generated header is at CMake build directory but only source include direcotry is added in CMake target Caffe.

For example a minimal CMake project:
```
find_package(Caffe REQUIRED)
add_executable(mytest main.cpp)
target_link_libraries(mytest ${Caffe_LIBRARIES})
```

Compile error:
> In file included from /home/xzhang84/projects/caffe/include/caffe/caffe.hpp:7:0,
>                  from /home/xzhang84/projects/test/main.cpp:2:
> /home/xzhang84/projects/caffe/include/caffe/blob.hpp:10:34: fatal error: caffe/proto/caffe.pb.h: No such file or directory