### PR TITLE
Matlab: CMakeLists.txt: install all Matlab files

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -67,6 +67,6 @@ elseif(build_using MATCHES "Octave")
 endif()
 
 # ---[ Install
-file(GLOB mfiles caffe/*.m)
-install(FILES ${mfiles} ${Matlab_caffe_mex} DESTINATION matlab)
+install(FILES ${Matlab_caffe_mex} DESTINATION matlab/+caffe/private)
 
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ DESTINATION matlab/ FILES_MATCHING PATTERN "*.m")


### PR DESCRIPTION
The current install rules appear to be a left-over of the old Matlab
bindings; consequently, they install the .mex file in incorrect
location, and fail to install any .m file at all.