### PR TITLE
Add Visual Studio Code files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@
 # PyCharm files
 .idea
 
+# Visual Studio Code files
+.vscode
+
 # OSX dir files
 .DS_Store
 


### PR DESCRIPTION
Using Visual Studio Code to organize the code, I find it creating a directory named ".vscode" containing files such as ".browse.VC.db", which should be ignored by Git.