### PR TITLE
enhance matcaffe: allow update params manually

### DIFF
--- a/matlab/+caffe/Solver.m
+++ b/matlab/+caffe/Solver.m
@@ -36,6 +36,9 @@ classdef Solver < handle
         self.test_nets(n) = caffe.Net(self.attributes.hNet_test_nets(n));
       end
     end
+    function update(self)
+      caffe_('solver_update', self.hSolver_self);
+    end
     function iter = iter(self)
       iter = caffe_('solver_get_iter', self.hSolver_self);
     end
@@ -52,5 +55,6 @@ classdef Solver < handle
       iters = double(iters);
       caffe_('solver_step', self.hSolver_self, iters);
     end
+
   end
 end

--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -249,6 +249,14 @@ static void solver_step(MEX_ARGS) {
   solver->Step(iters);
 }
 
+// Usage: caffe_('solver_update', hSolver, iters)
+static void solver_update(MEX_ARGS) {
+  mxCHECK(nrhs == 1 && mxIsStruct(prhs[0]),
+      "Usage: caffe_('solver_update', hSolver, iters)");
+  Solver<float>* solver = handle_to_ptr<Solver<float> >(prhs[0]);
+  solver->ApplyUpdate();
+}
+
 // Usage: caffe_('get_net', model_file, phase_name)
 static void get_net(MEX_ARGS) {
   mxCHECK(nrhs == 2 && mxIsChar(prhs[0]) && mxIsChar(prhs[1]),
@@ -527,6 +535,7 @@ static handler_registry handlers[] = {
   { "solver_restore",     solver_restore  },
   { "solver_solve",       solver_solve    },
   { "solver_step",        solver_step     },
+  { "solver_update",      solver_update   },
   { "get_net",            get_net         },
   { "net_get_attr",       net_get_attr    },
   { "net_forward",        net_forward     },


### PR DESCRIPTION
At #4758 I mentioned explicitly update net parameters after a forward() and backward() pass.

This PR makes it possible.

I think this can be very usefull, feed data by Matlab and then get the output, do some tricks on the ouput, and then compute loss and gradient manually, then call backward() to back pass gradient, finally call update() to update the net parameters.

This will make things easier to embed some other model to the back of CNN, such as graphical models and so on.