### PR TITLE
enhance matcaffe: allow explicitly update parameters

### DIFF
--- a/include/caffe/sgd_solvers.hpp
+++ b/include/caffe/sgd_solvers.hpp
@@ -22,6 +22,7 @@ class SGDSolver : public Solver<Dtype> {
   virtual inline const char* type() const { return "SGD"; }
 
   const vector<shared_ptr<Blob<Dtype> > >& history() { return history_; }
+  void UpdateClearDiff();
 
  protected:
   void PreSolve();

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -94,6 +94,7 @@ class Solver {
    */
   virtual inline const char* type() const { return ""; }
   virtual void ApplyUpdate() = 0;
+  virtual void UpdateClearDiff(){};
 
  protected:
   // Make and apply the update value for the current iteration.

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -93,10 +93,10 @@ class Solver {
    * @brief Returns the solver type.
    */
   virtual inline const char* type() const { return ""; }
+  virtual void ApplyUpdate() = 0;
 
  protected:
   // Make and apply the update value for the current iteration.
-  virtual void ApplyUpdate() = 0;
   string SnapshotFilename(const string extension);
   string SnapshotToBinaryProto();
   string SnapshotToHDF5();
@@ -142,9 +142,8 @@ class WorkerSolver : public Solver<Dtype> {
   explicit WorkerSolver(const SolverParameter& param,
       const Solver<Dtype>* root_solver = NULL)
       : Solver<Dtype>(param, root_solver) {}
-
- protected:
   void ApplyUpdate() {}
+ protected:
   void SnapshotSolverState(const string& model_filename) {
     LOG(FATAL) << "Should not be called on worker solver.";
   }

--- a/matlab/+caffe/Solver.m
+++ b/matlab/+caffe/Solver.m
@@ -36,6 +36,9 @@ classdef Solver < handle
         self.test_nets(n) = caffe.Net(self.attributes.hNet_test_nets(n));
       end
     end
+    function update(self)
+      caffe_('solver_update', self.hSolver_self);
+    end
     function iter = iter(self)
       iter = caffe_('solver_get_iter', self.hSolver_self);
     end
@@ -52,5 +55,6 @@ classdef Solver < handle
       iters = double(iters);
       caffe_('solver_step', self.hSolver_self, iters);
     end
+
   end
 end

--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -249,6 +249,14 @@ static void solver_step(MEX_ARGS) {
   solver->Step(iters);
 }
 
+// Usage: caffe_('solver_update', hSolver, iters)
+static void solver_update(MEX_ARGS) {
+  mxCHECK(nrhs == 1 && mxIsStruct(prhs[0]),
+      "Usage: caffe_('solver_update', hSolver, iters)");
+  Solver<float>* solver = handle_to_ptr<Solver<float> >(prhs[0]);
+  solver->ApplyUpdate();
+}
+
 // Usage: caffe_('get_net', model_file, phase_name)
 static void get_net(MEX_ARGS) {
   mxCHECK(nrhs == 2 && mxIsChar(prhs[0]) && mxIsChar(prhs[1]),
@@ -527,6 +535,7 @@ static handler_registry handlers[] = {
   { "solver_restore",     solver_restore  },
   { "solver_solve",       solver_solve    },
   { "solver_step",        solver_step     },
+  { "solver_update",      solver_update   },
   { "get_net",            get_net         },
   { "net_get_attr",       net_get_attr    },
   { "net_forward",        net_forward     },

--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -254,7 +254,7 @@ static void solver_update(MEX_ARGS) {
   mxCHECK(nrhs == 1 && mxIsStruct(prhs[0]),
       "Usage: caffe_('solver_update', hSolver, iters)");
   Solver<float>* solver = handle_to_ptr<Solver<float> >(prhs[0]);
-  solver->ApplyUpdate();
+  solver->UpdateClearDiff();
 }
 
 // Usage: caffe_('get_net', model_file, phase_name)

--- a/src/caffe/solvers/sgd_solver.cpp
+++ b/src/caffe/solvers/sgd_solver.cpp
@@ -116,6 +116,14 @@ void SGDSolver<Dtype>::ApplyUpdate() {
 }
 
 template <typename Dtype>
+void SGDSolver<Dtype>::UpdateClearDiff() {
+  ApplyUpdate();
+  this->net_->ClearParamDiffs();
+  this->iter_++;
+  GetLearningRate();
+}
+
+template <typename Dtype>
 void SGDSolver<Dtype>::Normalize(int param_id) {
   if (this->param_.iter_size() == 1) { return; }
   // Scale gradient to counterbalance accumulation.


### PR DESCRIPTION
At  #4758  I mentioned explicitly update net parameters after a forward() and backward() pass.

This PR makes it possible.

I think this can be very usefull:

feed data by Matlab and then get the output, do some tricks on the ouput, and then compute loss and gradient manually, then call backward() to back pass gradient, finally call update() to update the net parameters.

This will make things easier to embed some other model to the back of CNN, such as graphical models and so on.