### PR TITLE
slightly relax batch norm check

### DIFF
--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -36,11 +36,15 @@ void BatchNormLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   }
   // Mask statistics from optimization by setting local learning rates
   // for mean, variance, and the bias correction to zero.
-  CHECK_EQ(this->layer_param_.param_size(), 0)
-      << "Cannot configure batch normalization statistics as layer parameters.";
   for (int i = 0; i < this->blobs_.size(); ++i) {
-    ParamSpec* fixed_param_spec = this->layer_param_.add_param();
-    fixed_param_spec->set_lr_mult(0.);
+    if (this->layer_param_.param_size() == i) {
+      ParamSpec* fixed_param_spec = this->layer_param_.add_param();
+      fixed_param_spec->set_lr_mult(0.f);
+    } else {
+      CHECK_EQ(this->layer_param_.param(i).lr_mult(), 0.f)
+          << "Cannot configure batch normalization statistics as layer "
+          << "parameters.";
+    }
   }
 }
 


### PR DESCRIPTION
As already raised in #4704, the current LayerSetup method of the BatchNormLayer expects to have **no** LayerParamter configured at all, but also adds 3 LayerParameter itself (cf. [batch_norm_layer.cpp](https://github.com/BVLC/caffe/blob/master/src/caffe/layers/batch_norm_layer.cpp#L39-L44)).
This all is done to avoid any unintenional backward modification of the global stats in the BatchNormLayer and therefore forcing `lr_mult = 0.f`.

As a consequence, a valid (upgraded) net, which was passed once into `Net<Dtype>(net_param)` and read back via `ToProto(...)` cannot be passed a second time into `Net` without being upgraded again.

This PR slightly relaxes the checks in LayerSetUp, to just ensure `lr_mult == 0.f` or adding it, if the LayerParameter is missing (as it was introduced in #4704).