### PR TITLE
update the module of the scikit-learn (in example/brewing-logreg)

### DIFF
--- a/examples/brewing-logreg.ipynb
+++ b/examples/brewing-logreg.ipynb
@@ -73,7 +73,7 @@
     ")\n",
     "\n",
     "# Split into train and test\n",
-    "X, Xt, y, yt = sklearn.cross_validation.train_test_split(X, y)\n",
+    "X, Xt, y, yt = sklearn.model_selection.train_test_split(X, y)\n",
     "\n",
     "# Visualize sample of the data\n",
     "ind = np.random.permutation(X.shape[0])[:1000]\n",


### PR DESCRIPTION
Newer version of scikit-learn doesn't have sklearn.cross_validation.train_test_split anymore, they use sklearn.model_selection.train_test_split instread.
