### PR TITLE
Update caffe.cpp

### DIFF
--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -203,9 +203,9 @@ int train() {
           FLAGS_gpu = "" + boost::lexical_cast<string>(0);
       }
   }
-
   vector<int> gpus;
   get_gpus(&gpus);
+#ifndef CPU_ONLY
   if (gpus.size() == 0) {
     LOG(INFO) << "Use CPU.";
     Caffe::set_mode(Caffe::CPU);
@@ -215,19 +215,20 @@ int train() {
       s << (i ? ", " : "") << gpus[i];
     }
     LOG(INFO) << "Using GPUs " << s.str();
-#ifndef CPU_ONLY
     cudaDeviceProp device_prop;
     for (int i = 0; i < gpus.size(); ++i) {
       cudaGetDeviceProperties(&device_prop, gpus[i]);
       LOG(INFO) << "GPU " << gpus[i] << ": " << device_prop.name;
     }
-#endif
     solver_param.set_device_id(gpus[0]);
     Caffe::SetDevice(gpus[0]);
     Caffe::set_mode(Caffe::GPU);
     Caffe::set_solver_count(gpus.size());
   }
-
+#else
+    LOG(INFO) << "Use CPU.";
+    Caffe::set_mode(Caffe::CPU);
+#endif
   caffe::SignalHandler signal_handler(
         GetRequestedAction(FLAGS_sigint_effect),
         GetRequestedAction(FLAGS_sighup_effect));


### PR DESCRIPTION
 If there is a GPU in your computer and you enable the CPU_ONLY, you cannot train a net using the build/tools/caffe.bin command becuase the gpus.size() !=0 if you have a GPU and you will run the function Caffe::SetDevice(gpus[0]); then error is reported:
`F1004 13:59:57.352250 4383 common.cpp:66] Cannot use GPU in CPU-only Caffe: check mode.`