### PR TITLE
Move root_net_ check in net constructor

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -47,8 +47,6 @@ Net<Dtype>::Net(const string& param_file, Phase phase,
 
 template <typename Dtype>
 void Net<Dtype>::Init(const NetParameter& in_param) {
-  CHECK(Caffe::root_solver() || root_net_)
-      << "root_net_ needs to be set for all non-root solvers";
   // Set phase from the state.
   phase_ = in_param.state().phase();
   // Filter layers based on their include/exclude rules and
@@ -76,6 +74,7 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
   for (int layer_id = 0; layer_id < param.layer_size(); ++layer_id) {
     // For non-root solvers, whether this layer is shared from root_net_.
     bool share_from_root = !Caffe::root_solver()
+        && root_net_ != NULL
         && root_net_->layers_[layer_id]->ShareInParallel();
     // Inherit phase from net if unset.
     if (!param.layer(layer_id).has_phase()) {


### PR DESCRIPTION
This PR extends recurrent_layer to the multi-gpu settings.

Currently, the recurrent_layer constructs a net internally (the unrolled net), https://github.com/BVLC/caffe/blob/master/src/caffe/layers/recurrent_layer.cpp#L108.
No root_net_ is set in that constructor.   In a multi-gpu setting, worker solver will create an unrolled net too, however it will fail at the line below, https://github.com/BVLC/caffe/blob/master/src/caffe/net.cpp#L50-L51, because the worker solver is not a root solver and the net does not have a root_net.

Since root_net is only used in share_from_root, this PR moves the check to where share_from_root is defined.
