### PR TITLE
Fix: docs/yum_install.md glog broken link

### DIFF
--- a/docs/install_yum.md
+++ b/docs/install_yum.md
@@ -15,7 +15,7 @@ title: Installation: RHEL / Fedora / CentOS
 **Remaining dependencies, if not found**
 
     # glog
-    wget https://google-glog.googlecode.com/files/glog-0.3.3.tar.gz
+    wget https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/google-glog/glog-0.3.3.tar.gz
     tar zxvf glog-0.3.3.tar.gz
     cd glog-0.3.3
     ./configure


### PR DESCRIPTION
fixes the broken glog link in yum_install.md which is currently returning a 404.