### PR TITLE
Add Github issue template to curb misuse.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+Please use the [caffe-users list](https://groups.google.com/forum/#!forum/caffe-users) for usage, installation, or modeling questions, or other requests for help.
+_Do not post such requests to Issues._ Doing so interferes with the development of Caffe.
+
+Please read the [guidelines for contributing](https://github.com/BVLC/caffe/blob/master/CONTRIBUTING.md) before submitting this issue.
+
+### Issue summary
+
+
+### Steps to reproduce
+
+If you are having difficulty building Caffe or training a model, please ask the caffe-users mailing list. If you are reporting a build error that seems to be due to a bug in Caffe, please attach your build configuration (either Makefile.config or CMakeCache.txt) and the output of the make (or cmake) command.
+
+### Your system configuration
+Operating system:
+Compiler:
+CUDA version (if applicable):
+CUDNN version (if applicable):
+BLAS:
+Python or MATLAB version (for pycaffe and matcaffe respectively):


### PR DESCRIPTION
This merge adds a file ".github/ISSUE_TEMPLATE.md" which will appear in the text box when someone starts to create an issue. This is an effort to reduce the issues that do not follow the guidelines for contributing. You can see what this looks like by going to:
https://github.com/williford/segmentation-caffe/issues/new

Unfortunately, Github doesn't allow us to change the message "Please review the guidelines for contributing to this repository" in order to make the guidelines more apparent (ideally, I think this should show the guidelines).

The file could also be placed in the root directory, but then clutters that directory. I'm happy to modify the message as desired.

For information on Github issue templates, see:
https://github.com/blog/2111-issue-and-pull-request-templates
