### PR TITLE
Put quotes around titles in YAML front matter.

### DIFF
--- a/docs/install_apt.md
+++ b/docs/install_apt.md
@@ -1,5 +1,5 @@
 ---
-title: Installation: Ubuntu
+title: "Installation: Ubuntu"
 ---
 
 # Ubuntu Installation

--- a/docs/install_osx.md
+++ b/docs/install_osx.md
@@ -1,5 +1,5 @@
 ---
-title: Installation: OS X
+title: "Installation: OS X"
 ---
 
 # OS X Installation

--- a/docs/install_yum.md
+++ b/docs/install_yum.md
@@ -1,5 +1,5 @@
 ---
-title: Installation: RHEL / Fedora / CentOS
+title: "Installation: RHEL / Fedora / CentOS"
 ---
 
 # RHEL / Fedora / CentOS Installation


### PR DESCRIPTION
When generating the documents, the colon produces errors unless the title is in quotes. This commit just puts the titles of the installation pages in quotes.

This commit makes the HTML title appear for the corresponding 3 pages. You can see that it is currently missing:
http://caffe.berkeleyvision.org/install_apt.html

See https://github.com/jekyll/jekyll/issues/549