### PR TITLE
Multi-GPU segfault fix

### DIFF
--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -171,7 +171,7 @@ void DevicePair::compute(const vector<int> devices, vector<DevicePair>* pairs) {
   // Group remaining
   remaining_depth = ceil(log2(remaining.size()));
   for (int d = 0; d < remaining_depth; ++d) {
-    for (int i = 0; i < remaining.size(); ++i) {
+    for (int i = 0; i < remaining.size()-1; ++i) {
       pairs->push_back(DevicePair(remaining[i], remaining[i + 1]));
       DLOG(INFO) << "Remaining pair: " << remaining[i] << ":"
                  << remaining[i + 1];


### PR DESCRIPTION
This PR fixes #4917, which is caused by indexing out of bounds on the list of remaining devices after having done card- and P2P-pairing.
Example:
Devices 0, 1, 2, 3
P2P paired: (1,2)
Remaining: 0,1,3
Current passing in one "depth" iteration (the root of the segfault): (0,1), (3,3)
Correct passing in two "depth" iterations: (0,1) + (0,3)