### PR TITLE
Support solver resumes in parse_log.py

### DIFF
--- a/tools/extra/parse_log.py
+++ b/tools/extra/parse_log.py
@@ -48,8 +48,13 @@ def parse_log(path_to_log):
                 # iteration
                 continue
 
-            time = extract_seconds.extract_datetime_from_line(line,
-                                                              logfile_year)
+            try:
+                time = extract_seconds.extract_datetime_from_line(line,
+                                                                  logfile_year)
+            except ValueError:
+                # Skip lines with bad formatting, for example when resuming solver
+                continue
+
             seconds = (time - start_time).total_seconds()
 
             learning_rate_match = regex_learning_rate.search(line)


### PR DESCRIPTION
Currently parse_log.py skips all non timestamped lines
only once. When resuming a solver and appending to the
same log file, it creates more non timestamped log lines.
This change allows the script to silently skip those lines.