### PR TITLE
Installation: include pointer to AWS AMI

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,7 @@ The official Makefile and `Makefile.config` build are complemented by a [communi
 - [RHEL / CentOS / Fedora installation](install_yum.html)
 - [Windows](https://github.com/BVLC/caffe/tree/windows) *see the Windows branch led by Guillaume Dumont*
 - [OpenCL](https://github.com/BVLC/caffe/tree/opencl) *see the OpenCL branch led by Fabian Tschopp*
+- [AWS AMI](https://github.com/bitfusionio/amis/tree/master/awsmrkt-bfboost-ubuntu14-cuda75-caffe) *pre-configured for AWS*
 
 **Overview**:
 


### PR DESCRIPTION
bitfusion has a [pre-configured instance definition](https://github.com/bitfusionio/amis/tree/master/awsmrkt-bfboost-ubuntu14-cuda75-caffe) for running Caffe on ec2/AWS.