### PR TITLE
upgrading matlab interface by adding new methods to matlab class Net

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,12 +192,12 @@ ifeq ($(USE_LMDB), 1)
 	LIBRARIES += lmdb
 endif
 ifeq ($(USE_OPENCV), 1)
-	LIBRARIES += opencv_core opencv_highgui opencv_imgproc 
+	LIBRARIES += opencv_core opencv_highgui opencv_imgproc
 
 	ifeq ($(OPENCV_VERSION), 3)
 		LIBRARIES += opencv_imgcodecs
 	endif
-		
+
 endif
 PYTHON_LIBRARIES ?= boost_python python2.7
 WARNINGS := -Wall -Wno-sign-compare
@@ -385,7 +385,7 @@ else
 		XCODE_CLT_GEQ_7 := $(shell [ $(XCODE_CLT_VER) -gt 6 ] && echo 1)
 		XCODE_CLT_GEQ_6 := $(shell [ $(XCODE_CLT_VER) -gt 5 ] && echo 1)
 		ifeq ($(XCODE_CLT_GEQ_7), 1)
-			BLAS_INCLUDE ?= /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/Headers
+			BLAS_INCLUDE ?= /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/$(shell ls /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ | sort | tail -1)/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/Headers
 		else ifeq ($(XCODE_CLT_GEQ_6), 1)
 			BLAS_INCLUDE ?= /System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
 			LDFLAGS += -framework Accelerate

--- a/Makefile
+++ b/Makefile
@@ -409,6 +409,14 @@ CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
 NVCCFLAGS += -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS)
 # mex may invoke an older gcc that is too liberal with -Wuninitalized
 MATLAB_CXXFLAGS := $(CXXFLAGS) -Wno-uninitialized
+ifneq ($(CPU_ONLY), 1)
+	# required for compiling with support for mxGPUArray
+	MATLAB_INCLUDE := -I$(MATLAB_DIR)/toolbox/distcomp/gpu/extern/include
+	MATLAB_LIBS := -lmwgpu
+else
+	MATLAB_INCLUDE :=
+	MATLAB_LIBS :=
+endif
 LINKFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
 
 USE_PKG_CONFIG ?= 0
@@ -517,7 +525,9 @@ $(MAT$(PROJECT)_SO): $(MAT$(PROJECT)_SRC) $(STATIC_NAME)
 	$(Q)$(MATLAB_DIR)/bin/mex $(MAT$(PROJECT)_SRC) \
 			CXX="$(CXX)" \
 			CXXFLAGS="\$$CXXFLAGS $(MATLAB_CXXFLAGS)" \
-			CXXLIBS="\$$CXXLIBS $(STATIC_LINK_COMMAND) $(LDFLAGS)" -output $@
+			INCLUDE="\$$INCLUDE $(MATLAB_INCLUDE)" \
+			CXXLIBS="\$$CXXLIBS $(STATIC_LINK_COMMAND) $(LDFLAGS) $(MATLAB_LIBS)" \
+			-output $@
 	@ if [ -f "$(PROJECT)_.d" ]; then \
 		mv -f $(PROJECT)_.d $(BUILD_DIR)/${MAT$(PROJECT)_SO:.$(MAT_SO_EXT)=.d}; \
 	fi

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -320,7 +320,7 @@ class Layer {
    * @brief set phase
    *		   enable train and test with one network, for saving memory
    */
-  virtual inline void set_phase(Phase phase){
+  virtual inline void set_phase(Phase phase) {
     phase_ = phase;
   }
 

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -316,6 +316,13 @@ class Layer {
     param_propagate_down_[param_id] = value;
   }
 
+  /**
+   * @brief set phase
+   *		   enable train and test with one network, for saving memory
+   */
+  virtual inline void set_phase(Phase phase){
+    phase_ = phase;
+  }
 
  protected:
   /** The protobuf that stores the layer parameters */

--- a/include/caffe/layers/sigmoid_cross_entropy_loss_layer.hpp
+++ b/include/caffe/layers/sigmoid_cross_entropy_loss_layer.hpp
@@ -97,6 +97,13 @@ class SigmoidCrossEntropyLossLayer : public LossLayer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
+  /// Read the normalization mode parameter and compute the normalizer based
+  /// on the blob size.  If normalization_mode is VALID, the count of valid
+  /// outputs will be read from valid_count, unless it is -1 in which case
+  /// all outputs are assumed to be valid.
+  virtual Dtype get_normalizer(
+      LossParameter_NormalizationMode normalization_mode, int valid_count);
+
   /// The internal SigmoidLayer used to map predictions to probabilities.
   shared_ptr<SigmoidLayer<Dtype> > sigmoid_layer_;
   /// sigmoid_output stores the output of the SigmoidLayer.
@@ -105,6 +112,15 @@ class SigmoidCrossEntropyLossLayer : public LossLayer<Dtype> {
   vector<Blob<Dtype>*> sigmoid_bottom_vec_;
   /// top vector holder to call the underlying SigmoidLayer::Forward
   vector<Blob<Dtype>*> sigmoid_top_vec_;
+
+  /// Whether to ignore instances with a certain label.
+  bool has_ignore_label_;
+  /// The label indicating that an instance should be ignored.
+  int ignore_label_;
+  /// How to normalize the loss.
+  LossParameter_NormalizationMode normalization_;
+  Dtype normalizer_;
+  int outer_num_, inner_num_;
 };
 
 }  // namespace caffe

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -32,6 +32,10 @@ class Net {
   /// @brief Initialize a network with a NetParameter.
   void Init(const NetParameter& param);
 
+  /// @brief set phase
+  ///        enable train and test with one network, for saving memory
+  void SetPhase(Phase phase);
+  
   /**
    * @brief Run Forward and return the result.
    *
@@ -150,6 +154,14 @@ class Net {
   inline const vector<vector<Blob<Dtype>*> >& top_vecs() const {
     return top_vecs_;
   }
+  /// @brief returns the bottom vecs ids for each layer
+  inline const vector<vector<int> >& bottom_id_vecs() const {
+     return bottom_id_vecs_;
+  }
+  /// @brief returns the top vecs ids for each layer
+  inline const vector<vector<int> >& top_id_vecs() const {
+    return top_id_vecs_;
+  }  
   /// @brief returns the ids of the top blobs of layer i
   inline const vector<int> & top_ids(int i) const {
     CHECK_GE(i, 0) << "Invalid layer id";

--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -35,7 +35,7 @@ class Net {
   /// @brief set phase
   ///        enable train and test with one network, for saving memory
   void SetPhase(Phase phase);
-  
+
   /**
    * @brief Run Forward and return the result.
    *
@@ -161,7 +161,7 @@ class Net {
   /// @brief returns the top vecs ids for each layer
   inline const vector<vector<int> >& top_id_vecs() const {
     return top_id_vecs_;
-  }  
+  }
   /// @brief returns the ids of the top blobs of layer i
   inline const vector<int> & top_ids(int i) const {
     CHECK_GE(i, 0) << "Invalid layer id";

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -108,6 +108,8 @@ class Solver {
   virtual void RestoreSolverStateFromBinaryProto(const string& state_file) = 0;
   void DisplayOutputBlobs(const int net_id);
   void UpdateSmoothedLoss(Dtype loss, int start_iter, int average_loss);
+  /// Harmonize solver class type with configured proto type.
+  void CheckType(SolverParameter* param);
 
   SolverParameter param_;
   int iter_;

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -73,7 +73,8 @@ class Solver {
     return test_nets_;
   }
   int iter() { return iter_; }
-
+  int max_iter() const { return param_.max_iter(); }
+  
   // Invoked at specific points during an iteration
   class Callback {
    protected:

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -74,7 +74,6 @@ class Solver {
   }
   int iter() { return iter_; }
   int max_iter() const { return param_.max_iter(); }
-  
   // Invoked at specific points during an iteration
   class Callback {
    protected:

--- a/matlab/+caffe/Layer.m
+++ b/matlab/+caffe/Layer.m
@@ -25,6 +25,9 @@ classdef Layer < handle
         self.params(n) = caffe.Blob(self.attributes.hBlob_blobs(n));
       end
     end
+    function set_params_data(self, blob_index, params)
+        caffe.Blob(self.attributes.hBlob_blobs(blob_index)).set_data(params);
+    end
     function layer_type = type(self)
       layer_type = caffe_('layer_get_type', self.hLayer_self);
     end

--- a/matlab/+caffe/Net.m
+++ b/matlab/+caffe/Net.m
@@ -21,6 +21,8 @@ classdef Net < handle
     name2blob_index
     layer_names
     blob_names
+    bottom_id_vecs
+    top_id_vecs
   end
   
   methods
@@ -67,6 +69,23 @@ classdef Net < handle
       % expose layer_names and blob_names for public read access
       self.layer_names = self.attributes.layer_names;
       self.blob_names = self.attributes.blob_names;
+      
+      % expose bottom_id_vecs and top_id_vecs for public read access
+      self.attributes.bottom_id_vecs = cellfun(@(x) x+1, self.attributes.bottom_id_vecs, 'UniformOutput', false);
+      self.bottom_id_vecs = self.attributes.bottom_id_vecs;
+      self.attributes.top_id_vecs = cellfun(@(x) x+1, self.attributes.top_id_vecs, 'UniformOutput', false);
+      self.top_id_vecs = self.attributes.top_id_vecs;
+    end
+    function set_phase(self, phase_name)
+      CHECK(ischar(phase_name), 'phase_name must be a string');
+      CHECK(strcmp(phase_name, 'train') || strcmp(phase_name, 'test'), ...
+            sprintf('phase_name can only be %strain%s or %stest%s', ...
+            char(39), char(39), char(39), char(39)));
+      caffe_('net_set_phase', self.hNet_self, phase_name);
+    end
+    function share_weights_with(self, net)
+      CHECK(is_valid_handle(net.hNet_net), 'invalid Net handle');
+      caffe_('net_share_trained_layers_with', self.hNet_net, net.hNet_net);
     end
     function layer = layers(self, layer_name)
       CHECK(ischar(layer_name), 'layer_name must be a string');
@@ -81,11 +100,33 @@ classdef Net < handle
       CHECK(isscalar(blob_index), 'blob_index must be a scalar');
       blob = self.layer_vec(self.name2layer_index(layer_name)).params(blob_index);
     end
+    function set_params_data(self, layer_name, blob_index, data)
+      CHECK(ischar(layer_name), 'layer_name must be a string');
+      CHECK(isscalar(blob_index), 'blob_index must be a scalar');
+      self.layer_vec(self.name2layer_index(layer_name)).set_params_data(blob_index, data);
+    end
     function forward_prefilled(self)
       caffe_('net_forward', self.hNet_self);
     end
     function backward_prefilled(self)
       caffe_('net_backward', self.hNet_self);
+    end
+    function set_input_data(self, input_data)
+      CHECK(iscell(input_data), 'input_data must be a cell array');
+      CHECK(length(input_data) == length(self.inputs), ...
+        'input data cell length must match input blob number');
+      % copy data to input blobs
+      for n = 1:length(self.inputs)
+        self.blobs(self.inputs{n}).set_data(input_data{n});
+      end
+    end
+    function res = get_output(self)
+      % get onput blobs
+      res = struct('blob_name', '', 'data', []);
+      for n = 1:length(self.outputs)
+        res(n).blob_name = self.outputs{n};
+        res(n).data = self.blobs(self.outputs{n}).get_data();
+      end
     end
     function res = forward(self, input_data)
       CHECK(iscell(input_data), 'input_data must be a cell array');
@@ -93,6 +134,9 @@ classdef Net < handle
         'input data cell length must match input blob number');
       % copy data to input blobs
       for n = 1:length(self.inputs)
+        if isempty(input_data{n})
+            continue;
+        end
         self.blobs(self.inputs{n}).set_data(input_data{n});
       end
       self.forward_prefilled();
@@ -122,8 +166,24 @@ classdef Net < handle
       CHECK_FILE_EXIST(weights_file);
       caffe_('net_copy_from', self.hNet_self, weights_file);
     end
+
     function reshape(self)
       caffe_('net_reshape', self.hNet_self);
+    end
+    function reshape_as_input(self, input_data)
+      CHECK(iscell(input_data), 'input_data must be a cell array');
+      CHECK(length(input_data) == length(self.inputs), ...
+        'input data cell length must match input blob number');
+      % reshape input blobs
+      for n = 1:length(self.inputs)
+        if isempty(input_data{n})
+            continue;
+        end
+        input_data_size = size(input_data{n});
+        input_data_size_extended = [input_data_size, ones(1, 4 - length(input_data_size))];
+        self.blobs(self.inputs{n}).reshape(input_data_size_extended);
+      end
+      self.reshape();
     end
     function save(self, weights_file)
       CHECK(ischar(weights_file), 'weights_file must be a string');

--- a/matlab/+caffe/Solver.m
+++ b/matlab/+caffe/Solver.m
@@ -39,6 +39,9 @@ classdef Solver < handle
     function iter = iter(self)
       iter = caffe_('solver_get_iter', self.hSolver_self);
     end
+    function max_iter = max_iter(self)
+      max_iter = caffe_('solver_get_max_iter', self.hSolver_self);
+    end
     function restore(self, snapshot_filename)
       CHECK(ischar(snapshot_filename), 'snapshot_filename must be a string');
       CHECK_FILE_EXIST(snapshot_filename);

--- a/matlab/+caffe/init_log.m
+++ b/matlab/+caffe/init_log.m
@@ -1,0 +1,15 @@
+function init_log(log_base_filename)
+% init_log(log_base_filename)
+%   init Caffe's log
+
+CHECK(ischar(log_base_filename) && ~isempty(log_base_filename), ...
+  'log_base_filename must be string');
+
+[log_base_dir] = fileparts(log_base_filename);
+if ~exist(log_base_dir, 'dir')
+    mkdir(log_base_dir);
+end
+
+caffe_('init_log', log_base_filename);
+
+end

--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -13,8 +13,8 @@
 #include <string>
 #include <vector>
 
-#include "mex.h"
 #include "gpu/mxGPUArray.h"
+#include "mex.h"
 
 #include "caffe/caffe.hpp"
 
@@ -60,17 +60,17 @@ static void mx_mat_to_blob(const mxArray* mx_mat, Blob<float>* blob,
 
   const float* mat_mem_ptr = NULL;
   mxGPUArray const *mx_mat_gpu;
-  if (mxIsGPUArray(mx_mat)){
-	  mxInitGPU();
-	  mx_mat_gpu = mxGPUCreateFromMxArray(mx_mat);
-	  mat_mem_ptr = reinterpret_cast<const float*>(mxGPUGetDataReadOnly(mx_mat_gpu));
-	  mxCHECK(blob->count() == mxGPUGetNumberOfElements(mx_mat_gpu),
-		  "number of elements in target blob doesn't match that in input mxArray");
-  }
-  else{
-	  mxCHECK(blob->count() == mxGetNumberOfElements(mx_mat),
-		  "number of elements in target blob doesn't match that in input mxArray");
-	  mat_mem_ptr = reinterpret_cast<const float*>(mxGetData(mx_mat));
+  if (mxIsGPUArray(mx_mat)) {
+    mxInitGPU();
+    mx_mat_gpu = mxGPUCreateFromMxArray(mx_mat);
+    mat_mem_ptr = reinterpret_cast<const float*>(
+      mxGPUGetDataReadOnly(mx_mat_gpu));
+    mxCHECK(blob->count() == mxGPUGetNumberOfElements(mx_mat_gpu),
+      "number of elements in target blob doesn't match that in input mxArray");
+  } else {
+    mxCHECK(blob->count() == mxGetNumberOfElements(mx_mat),
+      "number of elements in target blob doesn't match that in input mxArray");
+    mat_mem_ptr = reinterpret_cast<const float*>(mxGetData(mx_mat));
   }
   float* blob_mem_ptr = NULL;
   switch (Caffe::mode()) {
@@ -87,8 +87,8 @@ static void mx_mat_to_blob(const mxArray* mx_mat, Blob<float>* blob,
   }
   caffe_copy(blob->count(), mat_mem_ptr, blob_mem_ptr);
 
-  if (mxIsGPUArray(mx_mat)){
-	  mxGPUDestroyGPUArray(mx_mat_gpu);
+  if (mxIsGPUArray(mx_mat)) {
+    mxGPUDestroyGPUArray(mx_mat_gpu);
   }
 }
 
@@ -135,12 +135,13 @@ static mxArray* int_vec_to_mx_vec(const vector<int>& int_vec) {
 
 
 // Convert vector<vector<int> > to matlab cell of (row vector)s
-static mxArray* int_vec_vec_to_mx_cell_vec(const vector<vector<int> >& int_vec_vec) {
-	mxArray* mx_cell_vec = mxCreateCellMatrix(int_vec_vec.size(), 1);
-	for (int i = 0; i < int_vec_vec.size(); i++){
-		mxSetCell(mx_cell_vec, i, int_vec_to_mx_vec(int_vec_vec[i]));
-	}
-	return mx_cell_vec;
+static mxArray* int_vec_vec_to_mx_cell_vec(
+  const vector<vector<int> >& int_vec_vec) {
+  mxArray* mx_cell_vec = mxCreateCellMatrix(int_vec_vec.size(), 1);
+  for (int i = 0; i < int_vec_vec.size(); i++) {
+    mxSetCell(mx_cell_vec, i, int_vec_to_mx_vec(int_vec_vec[i]));
+  }
+  return mx_cell_vec;
 }
 
 // Convert vector<string> to matlab cell vector of strings
@@ -250,10 +251,10 @@ static void solver_get_iter(MEX_ARGS) {
 
 // Usage: caffe_('solver_get_max_iter', hSolver)
 static void solver_get_max_iter(MEX_ARGS) {
-	mxCHECK(nrhs == 1 && mxIsStruct(prhs[0]),
-		"Usage: caffe_('solver_get_max_iter', hSolver)");
-	Solver<float>* solver = handle_to_ptr<Solver<float> >(prhs[0]);
-	plhs[0] = mxCreateDoubleScalar(solver->max_iter());
+  mxCHECK(nrhs == 1 && mxIsStruct(prhs[0]),
+    "Usage: caffe_('solver_get_max_iter', hSolver)");
+  Solver<float>* solver = handle_to_ptr<Solver<float> >(prhs[0]);
+  plhs[0] = mxCreateDoubleScalar(solver->max_iter());
 }
 
 // Usage: caffe_('solver_restore', hSolver, snapshot_file)
@@ -308,22 +309,20 @@ static void get_net(MEX_ARGS) {
 
 // Usage: caffe_('net_set_phase', hNet, phase_name)
 static void net_set_phase(MEX_ARGS) {
-	mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsChar(prhs[1]),
-		"Usage: caffe_('net_set_phase', hNet, phase_name)");
-	Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
-	char* phase_name = mxArrayToString(prhs[1]);
-	Phase phase;
-	if (strcmp(phase_name, "train") == 0) {
-		phase = TRAIN;
-	}
-	else if (strcmp(phase_name, "test") == 0) {
-		phase = TEST;
-	}
-	else {
-		mxERROR("Unknown phase");
-	}
-	net->SetPhase(phase);
-	mxFree(phase_name);
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsChar(prhs[1]),
+    "Usage: caffe_('net_set_phase', hNet, phase_name)");
+  Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
+  char* phase_name = mxArrayToString(prhs[1]);
+  Phase phase;
+  if (strcmp(phase_name, "train") == 0) {
+    phase = TRAIN;
+  } else if (strcmp(phase_name, "test") == 0) {
+    phase = TEST;
+  } else {
+    mxERROR("Unknown phase");
+  }
+  net->SetPhase(phase);
+  mxFree(phase_name);
 }
 
 // Usage: caffe_('net_get_attr', hNet)
@@ -333,7 +332,8 @@ static void net_get_attr(MEX_ARGS) {
   Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
   const int net_attr_num = 8;
   const char* net_attrs[net_attr_num] = { "hLayer_layers", "hBlob_blobs",
-	  "input_blob_indices", "output_blob_indices", "layer_names", "blob_names", "bottom_id_vecs", "top_id_vecs" };
+    "input_blob_indices", "output_blob_indices",
+    "layer_names", "blob_names", "bottom_id_vecs", "top_id_vecs" };
   mxArray* mx_net_attr = mxCreateStructMatrix(1, 1, net_attr_num,
       net_attrs);
   mxSetField(mx_net_attr, 0, "hLayer_layers",
@@ -349,9 +349,9 @@ static void net_get_attr(MEX_ARGS) {
   mxSetField(mx_net_attr, 0, "blob_names",
       str_vec_to_mx_strcell(net->blob_names()));
   mxSetField(mx_net_attr, 0, "bottom_id_vecs",
-	  int_vec_vec_to_mx_cell_vec(net->bottom_id_vecs()));
+    int_vec_vec_to_mx_cell_vec(net->bottom_id_vecs()));
   mxSetField(mx_net_attr, 0, "top_id_vecs",
-	  int_vec_vec_to_mx_cell_vec(net->top_id_vecs()));
+    int_vec_vec_to_mx_cell_vec(net->top_id_vecs()));
   plhs[0] = mx_net_attr;
 }
 
@@ -384,11 +384,11 @@ static void net_copy_from(MEX_ARGS) {
 
 // Usage: caffe_('net_shared_with', hNet, hNet_trained)
 static void net_share_trained_layers_with(MEX_ARGS) {
-	mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsStruct(prhs[1]),
-		"Usage: caffe_('net_shared_with', hNet, hNet_trained)");
-	Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
-	Net<float>* net_trained = handle_to_ptr<Net<float> >(prhs[1]);
-	net->ShareTrainedLayersWith(net_trained);
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsStruct(prhs[1]),
+    "Usage: caffe_('net_shared_with', hNet, hNet_trained)");
+  Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
+  Net<float>* net_trained = handle_to_ptr<Net<float> >(prhs[1]);
+  net->ShareTrainedLayersWith(net_trained);
 }
 
 // Usage: caffe_('net_reshape', hNet)
@@ -474,22 +474,23 @@ static void blob_get_data(MEX_ARGS) {
 
 // Usage: caffe_('blob_set_data', hBlob, new_data)
 static void blob_set_data(MEX_ARGS) {
-  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && (mxIsSingle(prhs[1]) || mxIsGPUArray(prhs[1])),
-      "Usage: caffe_('blob_set_data', hBlob, new_data)");
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) &&
+    (mxIsSingle(prhs[1]) || mxIsGPUArray(prhs[1])),
+    "Usage: caffe_('blob_set_data', hBlob, new_data)");
   Blob<float>* blob = handle_to_ptr<Blob<float> >(prhs[0]);
   mx_mat_to_blob(prhs[1], blob, DATA);
 }
 
 // Usage: caffe_('blob_copy_data', hBlob_to, hBlob_from)
 static void blob_copy_data(MEX_ARGS) {
-	mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsStruct(prhs[1]),
-		"Usage: caffe_('blob_copy_data', hBlob_to, hBlob_from)");
-	Blob<float>* blob_to = handle_to_ptr<Blob<float> >(prhs[0]);
-	Blob<float>* blob_from = handle_to_ptr<Blob<float> >(prhs[1]);
-	//mxCHECK(blob_from->count() == blob_to->count(),
-	//	"number of elements in target blob doesn't match that in source blob");
-	
-	blob_to->CopyFrom(*blob_from, false, true); 
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsStruct(prhs[1]),
+    "Usage: caffe_('blob_copy_data', hBlob_to, hBlob_from)");
+  Blob<float>* blob_to = handle_to_ptr<Blob<float> >(prhs[0]);
+  Blob<float>* blob_from = handle_to_ptr<Blob<float> >(prhs[1]);
+  // mxCHECK(blob_from->count() == blob_to->count(),
+  //  "number of elements in target blob doesn't match that in source blob");
+
+  blob_to->CopyFrom(*blob_from, false, true);
 }
 
 // Usage: caffe_('blob_get_diff', hBlob)
@@ -548,50 +549,49 @@ static void reset(MEX_ARGS) {
 
 // Usage: caffe_('set_random_seed', random_seed)
 static void set_random_seed(MEX_ARGS) {
-	mxCHECK(nrhs == 1 && mxIsDouble(prhs[0]),
-		"Usage: caffe_('set_random_seed', random_seed)");
-	int random_seed = static_cast<unsigned int>(mxGetScalar(prhs[0]));
-	Caffe::set_random_seed(random_seed);
+  mxCHECK(nrhs == 1 && mxIsDouble(prhs[0]),
+    "Usage: caffe_('set_random_seed', random_seed)");
+  int random_seed = static_cast<unsigned int>(mxGetScalar(prhs[0]));
+  Caffe::set_random_seed(random_seed);
 }
 
-static void glog_failure_handler(){
-	static bool is_glog_failure = false;
-	if (!is_glog_failure)
-	{
-		is_glog_failure = true;
-		::google::FlushLogFiles(0);
-		mexErrMsgTxt("glog check error, please check log and clear mex");
-	}
+static void glog_failure_handler() {
+  static bool is_glog_failure = false;
+  if (!is_glog_failure) {
+    is_glog_failure = true;
+    ::google::FlushLogFiles(0);
+    mexErrMsgTxt("glog check error, please check log and clear mex");
+  }
 }
 
-static void protobuf_log_handler(::google::protobuf::LogLevel level, const char* filename, int line,
-	const std::string& message)
-{
-	const int max_err_length = 512;
-	char err_message[max_err_length];
-	snprintf(err_message, max_err_length, "Protobuf : %s . at %s Line %d",
+static void protobuf_log_handler(::google::protobuf::LogLevel level,
+  const char* filename, int line, const std::string& message) {
+  // const int max_err_length = 512;
+  #define kMaxErrLength 512
+  char err_message[kMaxErrLength];
+  snprintf(err_message, kMaxErrLength, "Protobuf : %s . at %s Line %d",
            message.c_str(), filename, line);
-	LOG(INFO) << err_message;
-	::google::FlushLogFiles(0);
-	mexErrMsgTxt(err_message);
+  LOG(INFO) << err_message;
+  ::google::FlushLogFiles(0);
+  mexErrMsgTxt(err_message);
 }
 
 // Usage: caffe_('init_log', log_base_filename)
 static void init_log(MEX_ARGS) {
-	static bool is_log_inited = false;
+  static bool is_log_inited = false;
 
-	mxCHECK(nrhs == 1 && mxIsChar(prhs[0]),
-		"Usage: caffe_('init_log', log_dir)");
-	if (is_log_inited)
-		::google::ShutdownGoogleLogging();
-	char* log_base_filename = mxArrayToString(prhs[0]);
-	::google::SetLogDestination(0, log_base_filename);
-	mxFree(log_base_filename);
-	::google::protobuf::SetLogHandler(&protobuf_log_handler);
-	::google::InitGoogleLogging("caffe_mex");
-	::google::InstallFailureFunction(&glog_failure_handler);
+  mxCHECK(nrhs == 1 && mxIsChar(prhs[0]),
+    "Usage: caffe_('init_log', log_dir)");
+  if (is_log_inited)
+    ::google::ShutdownGoogleLogging();
+  char* log_base_filename = mxArrayToString(prhs[0]);
+  ::google::SetLogDestination(0, log_base_filename);
+  mxFree(log_base_filename);
+  ::google::protobuf::SetLogHandler(&protobuf_log_handler);
+  ::google::InitGoogleLogging("caffe_mex");
+  ::google::InstallFailureFunction(&glog_failure_handler);
 
-	is_log_inited = true;
+  is_log_inited = true;
 }
 
 // Usage: caffe_('read_mean', mean_proto_file)
@@ -671,7 +671,7 @@ static handler_registry handlers[] = {
   { "blob_reshape",                  blob_reshape                   },
   { "blob_get_data",                 blob_get_data                  },
   { "blob_set_data",                 blob_set_data                  },
-  { "blob_copy_data",				 blob_copy_data					},
+  { "blob_copy_data",         blob_copy_data          },
   { "blob_get_diff",                 blob_get_diff                  },
   { "blob_set_diff",                 blob_set_diff                  },
   { "set_mode_cpu",                  set_mode_cpu                   },
@@ -693,7 +693,7 @@ static handler_registry handlers[] = {
  **/
 // Usage: caffe_(api_command, arg1, arg2, ...)
 void mexFunction(MEX_ARGS) {
-  //mexLock();  // Avoid clearing the mex file.
+  // mexLock();  // Avoid clearing the mex file.
   mxCHECK(nrhs > 0, "Usage: caffe_(api_command, arg1, arg2, ...)");
   // Handle input command
   char* cmd = mxArrayToString(prhs[0]);

--- a/matlab/+caffe/private/caffe_.cpp
+++ b/matlab/+caffe/private/caffe_.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "mex.h"
+#include "gpu/mxGPUArray.h"
 
 #include "caffe/caffe.hpp"
 
@@ -56,9 +57,21 @@ enum WhichMemory { DATA, DIFF };
 // Copy matlab array to Blob data or diff
 static void mx_mat_to_blob(const mxArray* mx_mat, Blob<float>* blob,
     WhichMemory data_or_diff) {
-  mxCHECK(blob->count() == mxGetNumberOfElements(mx_mat),
-      "number of elements in target blob doesn't match that in input mxArray");
-  const float* mat_mem_ptr = reinterpret_cast<const float*>(mxGetData(mx_mat));
+
+  const float* mat_mem_ptr = NULL;
+  mxGPUArray const *mx_mat_gpu;
+  if (mxIsGPUArray(mx_mat)){
+	  mxInitGPU();
+	  mx_mat_gpu = mxGPUCreateFromMxArray(mx_mat);
+	  mat_mem_ptr = reinterpret_cast<const float*>(mxGPUGetDataReadOnly(mx_mat_gpu));
+	  mxCHECK(blob->count() == mxGPUGetNumberOfElements(mx_mat_gpu),
+		  "number of elements in target blob doesn't match that in input mxArray");
+  }
+  else{
+	  mxCHECK(blob->count() == mxGetNumberOfElements(mx_mat),
+		  "number of elements in target blob doesn't match that in input mxArray");
+	  mat_mem_ptr = reinterpret_cast<const float*>(mxGetData(mx_mat));
+  }
   float* blob_mem_ptr = NULL;
   switch (Caffe::mode()) {
   case Caffe::CPU:
@@ -73,6 +86,10 @@ static void mx_mat_to_blob(const mxArray* mx_mat, Blob<float>* blob,
     mxERROR("Unknown Caffe mode");
   }
   caffe_copy(blob->count(), mat_mem_ptr, blob_mem_ptr);
+
+  if (mxIsGPUArray(mx_mat)){
+	  mxGPUDestroyGPUArray(mx_mat_gpu);
+  }
 }
 
 // Copy Blob data or diff to matlab array
@@ -114,6 +131,16 @@ static mxArray* int_vec_to_mx_vec(const vector<int>& int_vec) {
     vec_mem_ptr[i] = static_cast<double>(int_vec[i]);
   }
   return mx_vec;
+}
+
+
+// Convert vector<vector<int> > to matlab cell of (row vector)s
+static mxArray* int_vec_vec_to_mx_cell_vec(const vector<vector<int> >& int_vec_vec) {
+	mxArray* mx_cell_vec = mxCreateCellMatrix(int_vec_vec.size(), 1);
+	for (int i = 0; i < int_vec_vec.size(); i++){
+		mxSetCell(mx_cell_vec, i, int_vec_to_mx_vec(int_vec_vec[i]));
+	}
+	return mx_cell_vec;
 }
 
 // Convert vector<string> to matlab cell vector of strings
@@ -221,6 +248,14 @@ static void solver_get_iter(MEX_ARGS) {
   plhs[0] = mxCreateDoubleScalar(solver->iter());
 }
 
+// Usage: caffe_('solver_get_max_iter', hSolver)
+static void solver_get_max_iter(MEX_ARGS) {
+	mxCHECK(nrhs == 1 && mxIsStruct(prhs[0]),
+		"Usage: caffe_('solver_get_max_iter', hSolver)");
+	Solver<float>* solver = handle_to_ptr<Solver<float> >(prhs[0]);
+	plhs[0] = mxCreateDoubleScalar(solver->max_iter());
+}
+
 // Usage: caffe_('solver_restore', hSolver, snapshot_file)
 static void solver_restore(MEX_ARGS) {
   mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsChar(prhs[1]),
@@ -271,14 +306,34 @@ static void get_net(MEX_ARGS) {
   mxFree(phase_name);
 }
 
+// Usage: caffe_('net_set_phase', hNet, phase_name)
+static void net_set_phase(MEX_ARGS) {
+	mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsChar(prhs[1]),
+		"Usage: caffe_('net_set_phase', hNet, phase_name)");
+	Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
+	char* phase_name = mxArrayToString(prhs[1]);
+	Phase phase;
+	if (strcmp(phase_name, "train") == 0) {
+		phase = TRAIN;
+	}
+	else if (strcmp(phase_name, "test") == 0) {
+		phase = TEST;
+	}
+	else {
+		mxERROR("Unknown phase");
+	}
+	net->SetPhase(phase);
+	mxFree(phase_name);
+}
+
 // Usage: caffe_('net_get_attr', hNet)
 static void net_get_attr(MEX_ARGS) {
   mxCHECK(nrhs == 1 && mxIsStruct(prhs[0]),
       "Usage: caffe_('net_get_attr', hNet)");
   Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
-  const int net_attr_num = 6;
+  const int net_attr_num = 8;
   const char* net_attrs[net_attr_num] = { "hLayer_layers", "hBlob_blobs",
-      "input_blob_indices", "output_blob_indices", "layer_names", "blob_names"};
+	  "input_blob_indices", "output_blob_indices", "layer_names", "blob_names", "bottom_id_vecs", "top_id_vecs" };
   mxArray* mx_net_attr = mxCreateStructMatrix(1, 1, net_attr_num,
       net_attrs);
   mxSetField(mx_net_attr, 0, "hLayer_layers",
@@ -293,6 +348,10 @@ static void net_get_attr(MEX_ARGS) {
       str_vec_to_mx_strcell(net->layer_names()));
   mxSetField(mx_net_attr, 0, "blob_names",
       str_vec_to_mx_strcell(net->blob_names()));
+  mxSetField(mx_net_attr, 0, "bottom_id_vecs",
+	  int_vec_vec_to_mx_cell_vec(net->bottom_id_vecs()));
+  mxSetField(mx_net_attr, 0, "top_id_vecs",
+	  int_vec_vec_to_mx_cell_vec(net->top_id_vecs()));
   plhs[0] = mx_net_attr;
 }
 
@@ -321,6 +380,15 @@ static void net_copy_from(MEX_ARGS) {
   mxCHECK_FILE_EXIST(weights_file);
   net->CopyTrainedLayersFrom(weights_file);
   mxFree(weights_file);
+}
+
+// Usage: caffe_('net_shared_with', hNet, hNet_trained)
+static void net_share_trained_layers_with(MEX_ARGS) {
+	mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsStruct(prhs[1]),
+		"Usage: caffe_('net_shared_with', hNet, hNet_trained)");
+	Net<float>* net = handle_to_ptr<Net<float> >(prhs[0]);
+	Net<float>* net_trained = handle_to_ptr<Net<float> >(prhs[1]);
+	net->ShareTrainedLayersWith(net_trained);
 }
 
 // Usage: caffe_('net_reshape', hNet)
@@ -406,10 +474,22 @@ static void blob_get_data(MEX_ARGS) {
 
 // Usage: caffe_('blob_set_data', hBlob, new_data)
 static void blob_set_data(MEX_ARGS) {
-  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsSingle(prhs[1]),
+  mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && (mxIsSingle(prhs[1]) || mxIsGPUArray(prhs[1])),
       "Usage: caffe_('blob_set_data', hBlob, new_data)");
   Blob<float>* blob = handle_to_ptr<Blob<float> >(prhs[0]);
   mx_mat_to_blob(prhs[1], blob, DATA);
+}
+
+// Usage: caffe_('blob_copy_data', hBlob_to, hBlob_from)
+static void blob_copy_data(MEX_ARGS) {
+	mxCHECK(nrhs == 2 && mxIsStruct(prhs[0]) && mxIsStruct(prhs[1]),
+		"Usage: caffe_('blob_copy_data', hBlob_to, hBlob_from)");
+	Blob<float>* blob_to = handle_to_ptr<Blob<float> >(prhs[0]);
+	Blob<float>* blob_from = handle_to_ptr<Blob<float> >(prhs[1]);
+	//mxCHECK(blob_from->count() == blob_to->count(),
+	//	"number of elements in target blob doesn't match that in source blob");
+	
+	blob_to->CopyFrom(*blob_from, false, true); 
 }
 
 // Usage: caffe_('blob_get_diff', hBlob)
@@ -464,6 +544,54 @@ static void reset(MEX_ARGS) {
   nets_.clear();
   // Generate new init_key, so that handles created before becomes invalid
   init_key = static_cast<double>(caffe_rng_rand());
+}
+
+// Usage: caffe_('set_random_seed', random_seed)
+static void set_random_seed(MEX_ARGS) {
+	mxCHECK(nrhs == 1 && mxIsDouble(prhs[0]),
+		"Usage: caffe_('set_random_seed', random_seed)");
+	int random_seed = static_cast<unsigned int>(mxGetScalar(prhs[0]));
+	Caffe::set_random_seed(random_seed);
+}
+
+static void glog_failure_handler(){
+	static bool is_glog_failure = false;
+	if (!is_glog_failure)
+	{
+		is_glog_failure = true;
+		::google::FlushLogFiles(0);
+		mexErrMsgTxt("glog check error, please check log and clear mex");
+	}
+}
+
+static void protobuf_log_handler(::google::protobuf::LogLevel level, const char* filename, int line,
+	const std::string& message)
+{
+	const int max_err_length = 512;
+	char err_message[max_err_length];
+	snprintf(err_message, max_err_length, "Protobuf : %s . at %s Line %d",
+           message.c_str(), filename, line);
+	LOG(INFO) << err_message;
+	::google::FlushLogFiles(0);
+	mexErrMsgTxt(err_message);
+}
+
+// Usage: caffe_('init_log', log_base_filename)
+static void init_log(MEX_ARGS) {
+	static bool is_log_inited = false;
+
+	mxCHECK(nrhs == 1 && mxIsChar(prhs[0]),
+		"Usage: caffe_('init_log', log_dir)");
+	if (is_log_inited)
+		::google::ShutdownGoogleLogging();
+	char* log_base_filename = mxArrayToString(prhs[0]);
+	::google::SetLogDestination(0, log_base_filename);
+	mxFree(log_base_filename);
+	::google::protobuf::SetLogHandler(&protobuf_log_handler);
+	::google::InitGoogleLogging("caffe_mex");
+	::google::InstallFailureFunction(&glog_failure_handler);
+
+	is_log_inited = true;
 }
 
 // Usage: caffe_('read_mean', mean_proto_file)
@@ -521,37 +649,43 @@ struct handler_registry {
 
 static handler_registry handlers[] = {
   // Public API functions
-  { "get_solver",         get_solver      },
-  { "solver_get_attr",    solver_get_attr },
-  { "solver_get_iter",    solver_get_iter },
-  { "solver_restore",     solver_restore  },
-  { "solver_solve",       solver_solve    },
-  { "solver_step",        solver_step     },
-  { "get_net",            get_net         },
-  { "net_get_attr",       net_get_attr    },
-  { "net_forward",        net_forward     },
-  { "net_backward",       net_backward    },
-  { "net_copy_from",      net_copy_from   },
-  { "net_reshape",        net_reshape     },
-  { "net_save",           net_save        },
-  { "layer_get_attr",     layer_get_attr  },
-  { "layer_get_type",     layer_get_type  },
-  { "blob_get_shape",     blob_get_shape  },
-  { "blob_reshape",       blob_reshape    },
-  { "blob_get_data",      blob_get_data   },
-  { "blob_set_data",      blob_set_data   },
-  { "blob_get_diff",      blob_get_diff   },
-  { "blob_set_diff",      blob_set_diff   },
-  { "set_mode_cpu",       set_mode_cpu    },
-  { "set_mode_gpu",       set_mode_gpu    },
-  { "set_device",         set_device      },
-  { "get_init_key",       get_init_key    },
-  { "reset",              reset           },
-  { "read_mean",          read_mean       },
-  { "write_mean",         write_mean      },
-  { "version",            version         },
+  { "get_solver",                    get_solver                     },
+  { "solver_get_attr",               solver_get_attr                },
+  { "solver_get_iter",               solver_get_iter                },
+  { "solver_get_max_iter",           solver_get_max_iter            },
+  { "solver_restore",                solver_restore                 },
+  { "solver_solve",                  solver_solve                   },
+  { "solver_step",                   solver_step                    },
+  { "get_net",                       get_net                        },
+  { "net_get_attr",                  net_get_attr                   },
+  { "net_set_phase",                 net_set_phase                  },
+  { "net_forward",                   net_forward                    },
+  { "net_backward",                  net_backward                   },
+  { "net_copy_from",                 net_copy_from                  },
+  { "net_share_trained_layers_with", net_share_trained_layers_with  },
+  { "net_reshape",                   net_reshape                    },
+  { "net_save",                      net_save                       },
+  { "layer_get_attr",                layer_get_attr                 },
+  { "layer_get_type",                layer_get_type                 },
+  { "blob_get_shape",                blob_get_shape                 },
+  { "blob_reshape",                  blob_reshape                   },
+  { "blob_get_data",                 blob_get_data                  },
+  { "blob_set_data",                 blob_set_data                  },
+  { "blob_copy_data",				 blob_copy_data					},
+  { "blob_get_diff",                 blob_get_diff                  },
+  { "blob_set_diff",                 blob_set_diff                  },
+  { "set_mode_cpu",                  set_mode_cpu                   },
+  { "set_mode_gpu",                  set_mode_gpu                   },
+  { "set_device",                    set_device                     },
+  { "set_random_seed",               set_random_seed                },
+  { "get_init_key",                  get_init_key                   },
+  { "init_log",                      init_log                       },
+  { "reset",                         reset                          },
+  { "read_mean",                     read_mean                      },
+  { "write_mean",                    write_mean                     },
+  { "version",                       version                        },
   // The end.
-  { "END",                NULL            },
+  { "END",                           NULL                           },
 };
 
 /** -----------------------------------------------------------------
@@ -559,7 +693,7 @@ static handler_registry handlers[] = {
  **/
 // Usage: caffe_(api_command, arg1, arg2, ...)
 void mexFunction(MEX_ARGS) {
-  mexLock();  // Avoid clearing the mex file.
+  //mexLock();  // Avoid clearing the mex file.
   mxCHECK(nrhs > 0, "Usage: caffe_(api_command, arg1, arg2, ...)");
   // Handle input command
   char* cmd = mxArrayToString(prhs[0]);

--- a/matlab/+caffe/set_random_seed.m
+++ b/matlab/+caffe/set_random_seed.m
@@ -1,0 +1,11 @@
+function set_random_seed(random_seed)
+% set_random_seed(random_seed)
+%   set Caffe's random_seed
+
+CHECK(isscalar(random_seed) && random_seed >= 0, ...
+  'random_seed must be non-negative integer');
+random_seed = double(random_seed);
+
+caffe_('set_random_seed', random_seed);
+
+end

--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -67,6 +67,7 @@ shared_ptr<Layer<Dtype> > GetConvolutionLayer(
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+    throw;  // Avoids missing return warning
   }
 }
 
@@ -104,6 +105,7 @@ shared_ptr<Layer<Dtype> > GetPoolingLayer(const LayerParameter& param) {
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+    throw;  // Avoids missing return warning
   }
 }
 
@@ -141,6 +143,7 @@ shared_ptr<Layer<Dtype> > GetLRNLayer(const LayerParameter& param) {
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+    throw;  // Avoids missing return warning
   }
 }
 
@@ -164,6 +167,7 @@ shared_ptr<Layer<Dtype> > GetReLULayer(const LayerParameter& param) {
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+    throw;  // Avoids missing return warning
   }
 }
 
@@ -187,6 +191,7 @@ shared_ptr<Layer<Dtype> > GetSigmoidLayer(const LayerParameter& param) {
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+    throw;  // Avoids missing return warning
   }
 }
 
@@ -210,6 +215,7 @@ shared_ptr<Layer<Dtype> > GetSoftmaxLayer(const LayerParameter& param) {
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+    throw;  // Avoids missing return warning
   }
 }
 
@@ -233,6 +239,7 @@ shared_ptr<Layer<Dtype> > GetTanHLayer(const LayerParameter& param) {
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";
+    throw;  // Avoids missing return warning
   }
 }
 

--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -27,7 +27,7 @@ void BatchNormLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     sz.push_back(channels_);
     this->blobs_[0].reset(new Blob<Dtype>(sz));
     this->blobs_[1].reset(new Blob<Dtype>(sz));
-    sz[0]=1;
+    sz[0] = 1;
     this->blobs_[2].reset(new Blob<Dtype>(sz));
     for (int i = 0; i < 3; ++i) {
       caffe_set(this->blobs_[i]->count(), Dtype(0),
@@ -61,7 +61,7 @@ void BatchNormLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   variance_.Reshape(sz);
   temp_.ReshapeLike(*bottom[0]);
   x_norm_.ReshapeLike(*bottom[0]);
-  sz[0]=bottom[0]->shape(0);
+  sz[0] = bottom[0]->shape(0);
   batch_sum_multiplier_.Reshape(sz);
 
   int spatial_dim = bottom[0]->count()/(channels_*bottom[0]->shape(0));

--- a/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cpp
+++ b/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <vector>
 
 #include "caffe/layers/sigmoid_cross_entropy_loss_layer.hpp"
@@ -14,15 +15,64 @@ void SigmoidCrossEntropyLossLayer<Dtype>::LayerSetUp(
   sigmoid_top_vec_.clear();
   sigmoid_top_vec_.push_back(sigmoid_output_.get());
   sigmoid_layer_->SetUp(sigmoid_bottom_vec_, sigmoid_top_vec_);
+
+  has_ignore_label_ =
+    this->layer_param_.loss_param().has_ignore_label();
+  if (has_ignore_label_) {
+    ignore_label_ = this->layer_param_.loss_param().ignore_label();
+  }
+  if (this->layer_param_.loss_param().has_normalization()) {
+    normalization_ = this->layer_param_.loss_param().normalization();
+  } else if (this->layer_param_.loss_param().has_normalize()) {
+    normalization_ = this->layer_param_.loss_param().normalize() ?
+                     LossParameter_NormalizationMode_VALID :
+                     LossParameter_NormalizationMode_BATCH_SIZE;
+  } else {
+    normalization_ = LossParameter_NormalizationMode_BATCH_SIZE;
+  }
 }
 
 template <typename Dtype>
 void SigmoidCrossEntropyLossLayer<Dtype>::Reshape(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   LossLayer<Dtype>::Reshape(bottom, top);
+  outer_num_ = bottom[0]->shape(0);  // batch size
+  inner_num_ = bottom[0]->count(1);  // instance size: |output| == |target|
   CHECK_EQ(bottom[0]->count(), bottom[1]->count()) <<
       "SIGMOID_CROSS_ENTROPY_LOSS layer inputs must have the same count.";
   sigmoid_layer_->Reshape(sigmoid_bottom_vec_, sigmoid_top_vec_);
+}
+
+// TODO(shelhamer) loss normalization should be pulled up into LossLayer,
+// instead of duplicated here and in SoftMaxWithLossLayer
+template <typename Dtype>
+Dtype SigmoidCrossEntropyLossLayer<Dtype>::get_normalizer(
+    LossParameter_NormalizationMode normalization_mode, int valid_count) {
+  Dtype normalizer;
+  switch (normalization_mode) {
+    case LossParameter_NormalizationMode_FULL:
+      normalizer = Dtype(outer_num_ * inner_num_);
+      break;
+    case LossParameter_NormalizationMode_VALID:
+      if (valid_count == -1) {
+        normalizer = Dtype(outer_num_ * inner_num_);
+      } else {
+        normalizer = Dtype(valid_count);
+      }
+      break;
+    case LossParameter_NormalizationMode_BATCH_SIZE:
+      normalizer = Dtype(outer_num_);
+      break;
+    case LossParameter_NormalizationMode_NONE:
+      normalizer = Dtype(1);
+      break;
+    default:
+      LOG(FATAL) << "Unknown normalization mode: "
+          << LossParameter_NormalizationMode_Name(normalization_mode);
+  }
+  // Some users will have no labels for some examples in order to 'turn off' a
+  // particular loss in a multi-task setup. The max prevents NaNs in that case.
+  return std::max(Dtype(1.0), normalizer);
 }
 
 template <typename Dtype>
@@ -32,17 +82,22 @@ void SigmoidCrossEntropyLossLayer<Dtype>::Forward_cpu(
   sigmoid_bottom_vec_[0] = bottom[0];
   sigmoid_layer_->Forward(sigmoid_bottom_vec_, sigmoid_top_vec_);
   // Compute the loss (negative log likelihood)
-  const int count = bottom[0]->count();
-  const int num = bottom[0]->num();
   // Stable version of loss computation from input data
   const Dtype* input_data = bottom[0]->cpu_data();
   const Dtype* target = bottom[1]->cpu_data();
+  int valid_count = 0;
   Dtype loss = 0;
-  for (int i = 0; i < count; ++i) {
+  for (int i = 0; i < bottom[0]->count(); ++i) {
+    const int target_value = static_cast<int>(target[i]);
+    if (has_ignore_label_ && target_value == ignore_label_) {
+      continue;
+    }
     loss -= input_data[i] * (target[i] - (input_data[i] >= 0)) -
         log(1 + exp(input_data[i] - 2 * input_data[i] * (input_data[i] >= 0)));
+    ++valid_count;
   }
-  top[0]->mutable_cpu_data()[0] = loss / num;
+  normalizer_ = get_normalizer(normalization_, valid_count);
+  top[0]->mutable_cpu_data()[0] = loss / normalizer_;
 }
 
 template <typename Dtype>
@@ -56,14 +111,22 @@ void SigmoidCrossEntropyLossLayer<Dtype>::Backward_cpu(
   if (propagate_down[0]) {
     // First, compute the diff
     const int count = bottom[0]->count();
-    const int num = bottom[0]->num();
     const Dtype* sigmoid_output_data = sigmoid_output_->cpu_data();
     const Dtype* target = bottom[1]->cpu_data();
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
     caffe_sub(count, sigmoid_output_data, target, bottom_diff);
+    // Zero out gradient of ignored targets.
+    if (has_ignore_label_) {
+      for (int i = 0; i < count; ++i) {
+        const int target_value = static_cast<int>(target[i]);
+        if (target_value == ignore_label_) {
+          bottom_diff[i] = 0;
+        }
+      }
+    }
     // Scale down gradient
-    const Dtype loss_weight = top[0]->cpu_diff()[0];
-    caffe_scal(count, loss_weight / num, bottom_diff);
+    Dtype loss_weight = top[0]->cpu_diff()[0] / normalizer_;
+    caffe_scal(count, loss_weight, bottom_diff);
   }
 }
 

--- a/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cu
+++ b/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cu
@@ -5,14 +5,37 @@
 
 namespace caffe {
 
+
 template <typename Dtype>
 __global__ void SigmoidCrossEntropyLossForwardGPU(const int nthreads,
-          const Dtype* input_data, const Dtype* target, Dtype* loss) {
+          const Dtype* input_data, const Dtype* target, Dtype* loss,
+          const bool has_ignore_label_, const int ignore_label_,
+          Dtype* counts) {
   CUDA_KERNEL_LOOP(i, nthreads) {
-    loss[i] = input_data[i] * (target[i] - (input_data[i] >= 0)) -
-        log(1 + exp(input_data[i] - 2 * input_data[i] * (input_data[i] >= 0)));
+    const int target_value = static_cast<int>(target[i]);
+    if (has_ignore_label_ && target_value == ignore_label_) {
+      loss[i] = 0;
+      counts[i] = 0;
+    } else {
+      loss[i] = input_data[i] * (target[i] - (input_data[i] >= 0)) -
+          log(1 + exp(input_data[i] - 2 * input_data[i] *
+          (input_data[i] >= 0)));
+      counts[i] = 1;
+    }
   }
 }
+
+template <typename Dtype>
+__global__ void SigmoidCrossEntropyLossIgnoreDiffGPU(const int count,
+    const int ignore_label, const Dtype* target, Dtype* diff) {
+  CUDA_KERNEL_LOOP(i, count) {
+    const int target_value = static_cast<int>(target[i]);
+    if (target_value == ignore_label) {
+      diff[i] = 0;
+    }
+  }
+}
+
 
 template <typename Dtype>
 void SigmoidCrossEntropyLossLayer<Dtype>::Forward_gpu(
@@ -22,7 +45,6 @@ void SigmoidCrossEntropyLossLayer<Dtype>::Forward_gpu(
   sigmoid_layer_->Forward(sigmoid_bottom_vec_, sigmoid_top_vec_);
   // Compute the loss (negative log likelihood)
   const int count = bottom[0]->count();
-  const int num = bottom[0]->num();
   // Stable version of loss computation from input data
   const Dtype* input_data = bottom[0]->gpu_data();
   const Dtype* target = bottom[1]->gpu_data();
@@ -30,12 +52,23 @@ void SigmoidCrossEntropyLossLayer<Dtype>::Forward_gpu(
   // on the backward pass, we use it here to avoid having to allocate new GPU
   // memory to accumulate intermediate results in the kernel.
   Dtype* loss_data = bottom[0]->mutable_gpu_diff();
+  Dtype* count_data = bottom[1]->mutable_gpu_diff();
+  Dtype valid_count;
   // NOLINT_NEXT_LINE(whitespace/operators)
   SigmoidCrossEntropyLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(count),
-      CAFFE_CUDA_NUM_THREADS>>>(count, input_data, target, loss_data);
+      CAFFE_CUDA_NUM_THREADS>>>(count, input_data, target, loss_data,
+      has_ignore_label_, ignore_label_, count_data);
+  // Only launch another CUDA kernel if we actually need the valid count.
+  if (normalization_ == LossParameter_NormalizationMode_VALID &&
+      has_ignore_label_) {
+    caffe_gpu_asum(count, count_data, &valid_count);
+  } else {
+    valid_count = count;
+  }
   Dtype loss;
   caffe_gpu_asum(count, loss_data, &loss);
-  top[0]->mutable_cpu_data()[0] = loss / num;
+  normalizer_ = get_normalizer(normalization_, valid_count);
+  top[0]->mutable_cpu_data()[0] = loss / normalizer_;
 }
 
 template <typename Dtype>
@@ -49,15 +82,20 @@ void SigmoidCrossEntropyLossLayer<Dtype>::Backward_gpu(
   if (propagate_down[0]) {
     // First, compute the diff
     const int count = bottom[0]->count();
-    const int num = bottom[0]->num();
     const Dtype* sigmoid_output_data = sigmoid_output_->gpu_data();
     const Dtype* target = bottom[1]->gpu_data();
     Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
     caffe_copy(count, sigmoid_output_data, bottom_diff);
     caffe_gpu_axpy(count, Dtype(-1), target, bottom_diff);
+    // Zero out gradient of ignored targets.
+    if (has_ignore_label_) {
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      SigmoidCrossEntropyLossIgnoreDiffGPU<Dtype><<<CAFFE_GET_BLOCKS(count),
+        CAFFE_CUDA_NUM_THREADS>>>(count, ignore_label_, target, bottom_diff);
+    }
     // Scale down gradient
-    const Dtype loss_weight = top[0]->cpu_diff()[0];
-    caffe_gpu_scal(count, loss_weight / num, bottom_diff);
+    Dtype loss_weight = top[0]->cpu_diff()[0] / normalizer_;
+    caffe_gpu_scal(count, loss_weight, bottom_diff);
   }
 }
 

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -284,13 +284,13 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
 }
 
 template <typename Dtype>
-void Net<Dtype>::SetPhase(Phase phase){
-	// set all layers 
-	for (int i = 0; i < layers_.size(); ++i){
-		layers_[i]->set_phase(phase);
-	}
-	// set net phase
-	phase_ = phase;
+void Net<Dtype>::SetPhase(Phase phase) {
+  // set all layers
+  for (int i = 0; i < layers_.size(); ++i) {
+    layers_[i]->set_phase(phase);
+  }
+  // set net phase
+  phase_ = phase;
 }
 
 template <typename Dtype>

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -284,6 +284,16 @@ void Net<Dtype>::Init(const NetParameter& in_param) {
 }
 
 template <typename Dtype>
+void Net<Dtype>::SetPhase(Phase phase){
+	// set all layers 
+	for (int i = 0; i < layers_.size(); ++i){
+		layers_[i]->set_phase(phase);
+	}
+	// set net phase
+	phase_ = phase;
+}
+
+template <typename Dtype>
 void Net<Dtype>::FilterNet(const NetParameter& param,
     NetParameter* param_filtered) {
   NetState net_state(param.state());

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -434,7 +434,7 @@ message LossParameter {
   optional int32 ignore_label = 1;
   // How to normalize the loss for loss layers that aggregate across batches,
   // spatial dimensions, or other dimensions.  Currently only implemented in
-  // SoftmaxWithLoss layer.
+  // SoftmaxWithLoss and SigmoidCrossEntropyLoss layers.
   enum NormalizationMode {
     // Divide by the number of examples in the batch times spatial dimensions.
     // Outputs that receive the ignore label will NOT be ignored in computing
@@ -448,6 +448,8 @@ message LossParameter {
     // Do not normalize the loss.
     NONE = 3;
   }
+  // For historical reasons, the default normalization for
+  // SigmoidCrossEntropyLoss is BATCH_SIZE and *not* VALID.
   optional NormalizationMode normalization = 3 [default = VALID];
   // Deprecated.  Ignored if normalization is specified.  If normalization
   // is not specified, then setting this to false will be equivalent to

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -38,7 +38,19 @@ Solver<Dtype>::Solver(const string& param_file, const Solver* root_solver)
       requested_early_exit_(false) {
   SolverParameter param;
   ReadSolverParamsFromTextFileOrDie(param_file, &param);
+  CheckType(&param);
   Init(param);
+}
+
+template <typename Dtype>
+void Solver<Dtype>::CheckType(SolverParameter* param) {
+  // Harmonize solver class type with configured type to avoid confusion.
+  if (param->has_type()) {
+    CHECK_EQ(param->type(), this->type())
+        << "Solver type must agree with instantiated solver class.";
+  } else {
+    param->set_type(this->type());
+  }
 }
 
 template <typename Dtype>

--- a/src/caffe/test/test_gradient_based_solver.cpp
+++ b/src/caffe/test/test_gradient_based_solver.cpp
@@ -694,6 +694,11 @@ TYPED_TEST(SGDSolverTest, TestSnapshotShare) {
   }
 }
 
+TYPED_TEST(SGDSolverTest, TestSolverType) {
+  this->TestLeastSquaresUpdate();
+  EXPECT_NE(this->solver_->type(), string(""));
+  EXPECT_EQ(this->solver_->type(), this->solver_->param().type());
+}
 
 template <typename TypeParam>
 class AdaGradSolverTest : public GradientBasedSolverTest<TypeParam> {

--- a/src/caffe/test/test_sigmoid_cross_entropy_loss_layer.cpp
+++ b/src/caffe/test/test_sigmoid_cross_entropy_loss_layer.cpp
@@ -116,5 +116,33 @@ TYPED_TEST(SigmoidCrossEntropyLossLayerTest, TestGradient) {
       this->blob_top_vec_, 0);
 }
 
+TYPED_TEST(SigmoidCrossEntropyLossLayerTest, TestIgnoreGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  FillerParameter data_filler_param;
+  data_filler_param.set_std(1);
+  GaussianFiller<Dtype> data_filler(data_filler_param);
+  data_filler.Fill(this->blob_bottom_data_);
+  LayerParameter layer_param;
+  LossParameter* loss_param = layer_param.mutable_loss_param();
+  loss_param->set_ignore_label(-1);
+  Dtype* target = this->blob_bottom_targets_->mutable_cpu_data();
+  const int count = this->blob_bottom_targets_->count();
+  // Ignore half of targets, then check that diff of this half is zero,
+  // while the other half is nonzero.
+  caffe_set(count / 2, Dtype(-1), target);
+  SigmoidCrossEntropyLossLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  vector<bool> propagate_down(2);
+  propagate_down[0] = true;
+  propagate_down[1] = false;
+  layer.Backward(this->blob_top_vec_, propagate_down, this->blob_bottom_vec_);
+  const Dtype* diff = this->blob_bottom_data_->cpu_diff();
+  for (int i = 0; i < count / 2; ++i) {
+    EXPECT_FLOAT_EQ(diff[i], 0.);
+    EXPECT_NE(diff[i + count / 2], 0.);
+  }
+}
+
 
 }  // namespace caffe

--- a/tools/extra/parse_log.py
+++ b/tools/extra/parse_log.py
@@ -48,8 +48,13 @@ def parse_log(path_to_log):
                 # iteration
                 continue
 
-            time = extract_seconds.extract_datetime_from_line(line,
-                                                              logfile_year)
+            try:
+                time = extract_seconds.extract_datetime_from_line(line,
+                                                                  logfile_year)
+            except ValueError:
+                # Skip lines with bad formatting, for example when resuming solver
+                continue
+
             seconds = (time - start_time).total_seconds()
 
             learning_rate_match = regex_learning_rate.search(line)


### PR DESCRIPTION
I took the updated matlab interface from [ShaoqingRen/caffe](https://github.com/ShaoqingRen/caffe), which adds many new methods compared to the current interface master branch.
These changes were originally done to support [faster_rcnn](https://github.com/ShaoqingRen/faster_rcnn) project but can be added to caffe master branch as independent update.

After accepting this PR, and merging #4163 , the projects [faster_rcnn](https://github.com/ShaoqingRen/faster_rcnn) and [py-faster-rcnn](https://github.com/rbgirshick/py-faster-rcnn) can be used alongside caffe master branch without having to use different caffe versions.