### PR TITLE
Add doxygen comments for the batchnorm params.

### DIFF
--- a/include/caffe/layers/batch_norm_layer.hpp
+++ b/include/caffe/layers/batch_norm_layer.hpp
@@ -39,6 +39,27 @@ namespace caffe {
 template <typename Dtype>
 class BatchNormLayer : public Layer<Dtype> {
  public:
+  /**
+   * @param param provides BatchNormParameter batch_norm_param with 
+   *     BatchNormLayer options:
+   *  - use_global_stats (\b optional, default true if phase is "test" 
+   *    otherwise false).
+   *    If true, the stored mean and variance are used for the normalization.
+   *    Otherwise the mean and variance are calculated from the the current
+   *    batch. 
+   *  - moving_average_fraction parameter (\b optional, default 0.999).
+   *    Each iteration updates the moving average @f$S_{t-1}@f$ with the
+   *    current mean @f$ Y_t @f$ by
+   *    @f$ S_t = (1-\beta)Y_t + \beta \cdot S_{t-1} @f$, where @f$ \beta @f$
+   *    is the moving_average_fraction parameter.
+   *    Smaller values make the moving average decay faster, giving more
+   *    weight to the recent values. This value does not effect the output
+   *    of the layer when use_global_stats is false.
+   *  - eps (\b optional, default 1e-5).
+   *    Small value to add to the variance estimate so that we don't divide by 
+   *    zero.
+   *
+   */
   explicit BatchNormLayer(const LayerParameter& param)
       : Layer<Dtype>(param) {}
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,


### PR DESCRIPTION
I'm adding documentation for the BatchNormLayer parameters (use_global_stats, moving_average_fraction, eps).