### PR TITLE
expose phase in pycaffe

### DIFF
--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -315,7 +315,10 @@ class Layer {
     }
     param_propagate_down_[param_id] = value;
   }
-
+  /**
+   * @brief Return the phase
+   */
+  inline Phase phase() { return phase_; }
 
  protected:
   /** The protobuf that stores the layer parameters */

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -290,6 +290,11 @@ BOOST_PYTHON_MODULE(_caffe) {
 
   bp::def("layer_type_list", &LayerRegistry<Dtype>::LayerTypeList);
 
+  bp::enum_<Phase>("Phase")
+    .value("TRAIN", caffe::TRAIN)
+    .value("TEST", caffe::TEST)
+    .export_values();
+
   bp::class_<Net<Dtype>, shared_ptr<Net<Dtype> >, boost::noncopyable >("Net",
     bp::no_init)
     // Constructor
@@ -359,6 +364,7 @@ BOOST_PYTHON_MODULE(_caffe) {
           bp::return_internal_reference<>()))
     .def("setup", &Layer<Dtype>::LayerSetUp)
     .def("reshape", &Layer<Dtype>::Reshape)
+    .add_property("phase", bp::make_function(&Layer<Dtype>::phase))
     .add_property("type", bp::make_function(&Layer<Dtype>::type));
   BP_REGISTER_SHARED_PTR_TO_PYTHON(Layer<Dtype>);
 


### PR DESCRIPTION
Inspired by https://github.com/rbgirshick/caffe-fast-rcnn/commit/0dcd397b29507b8314e252e850518c5695efbb83, exposing phase in pycaffe for different configuration is useful.