### PR TITLE
Fix compatibility with CUDA 2.1

### DIFF
--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -86,7 +86,13 @@ const int CAFFE_CUDA_NUM_THREADS = 512;
 
 // CUDA: number of blocks for threads.
 inline int CAFFE_GET_BLOCKS(const int N) {
-  return (N + CAFFE_CUDA_NUM_THREADS - 1) / CAFFE_CUDA_NUM_THREADS;
+  cudaDeviceProp prop;
+  int device;
+  cudaGetDevice(&device);
+  CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
+  int num_blocks = (N + CAFFE_CUDA_NUM_THREADS - 1) / CAFFE_CUDA_NUM_THREADS;
+  int max_blocks = prop.maxGridSize[0];
+  return num_blocks < max_blocks ? num_blocks : max_blocks;
 }
 
 }  // namespace caffe

--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -87,12 +87,16 @@ const int CAFFE_CUDA_NUM_THREADS = 512;
 
 // CUDA: number of blocks for threads.
 inline int CAFFE_GET_BLOCKS(const int N) {
-  cudaDeviceProp prop;
-  int device;
-  cudaGetDevice(&device);
-  CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
+  static cudaDeviceProp *prop = NULL;
+  if (!prop) {
+    int device;
+    cudaGetDevice(&device);
+    prop = new cudaDeviceProp;
+    CUDA_CHECK(cudaGetDeviceProperties(prop, device));
+  }
+
   int num_blocks = (N + CAFFE_CUDA_NUM_THREADS - 1) / CAFFE_CUDA_NUM_THREADS;
-  int max_blocks = prop.maxGridSize[0];
+  int max_blocks = prop->maxGridSize[0];
   return std::min<int>(num_blocks, max_blocks);
 }
 

--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -92,7 +92,7 @@ inline int CAFFE_GET_BLOCKS(const int N) {
   CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
   int num_blocks = (N + CAFFE_CUDA_NUM_THREADS - 1) / CAFFE_CUDA_NUM_THREADS;
   int max_blocks = prop.maxGridSize[0];
-  return num_blocks < max_blocks ? num_blocks : max_blocks;
+  return std::min<int>(num_blocks, max_blocks);
 }
 
 }  // namespace caffe

--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -4,6 +4,7 @@
 #ifdef CPU_ONLY  // CPU-only Caffe.
 
 #include <vector>
+#include <algorithm>
 
 // Stub out GPU calls as unavailable.
 

--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -3,8 +3,8 @@
 
 #ifdef CPU_ONLY  // CPU-only Caffe.
 
-#include <vector>
 #include <algorithm>
+#include <vector>
 
 // Stub out GPU calls as unavailable.
 


### PR DESCRIPTION
Limit CAFFE_GET_BLOCKS to return not more than max device supported blocks number

See [this](https://groups.google.com/forum/#!topic/caffe-users/8mRYC_uXVzM) and [this](https://groups.google.com/forum/#!topic/caffe-users/DWsH35-6HWA) issues and #707.

The problem is that `CAFFE_GET_BLOCKS` returns more blocks than devices with < 3.0 support can handle. On this [wiki page](https://en.wikipedia.org/wiki/CUDA#Version_features_and_specifications) in the table with row "Maximum x-dimension of a grid of thread blocks" you can see that the maximum dimension for CUDA < 3.0 is 65535.

I'm getting this error with GTX 580 when trying to train images with resolution > 198x198, independently of `batch_size`.