### PR TITLE
Solver: check and set type to reconcile class and proto type

### DIFF
--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -108,6 +108,8 @@ class Solver {
   virtual void RestoreSolverStateFromBinaryProto(const string& state_file) = 0;
   void DisplayOutputBlobs(const int net_id);
   void UpdateSmoothedLoss(Dtype loss, int start_iter, int average_loss);
+  /// Harmonize solver class type with configured proto type.
+  void CheckType(SolverParameter* param);
 
   SolverParameter param_;
   int iter_;

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -38,7 +38,19 @@ Solver<Dtype>::Solver(const string& param_file, const Solver* root_solver)
       requested_early_exit_(false) {
   SolverParameter param;
   ReadSolverParamsFromTextFileOrDie(param_file, &param);
+  CheckType(&param);
   Init(param);
+}
+
+template <typename Dtype>
+void Solver<Dtype>::CheckType(SolverParameter* param) {
+  // Harmonize solver class type with configured type to avoid confusion.
+  if (param->has_type()) {
+    CHECK_EQ(param->type(), this->type())
+        << "Solver type must agree with instantiated solver class.";
+  } else {
+    param->set_type(this->type());
+  }
 }
 
 template <typename Dtype>

--- a/src/caffe/test/test_gradient_based_solver.cpp
+++ b/src/caffe/test/test_gradient_based_solver.cpp
@@ -694,6 +694,11 @@ TYPED_TEST(SGDSolverTest, TestSnapshotShare) {
   }
 }
 
+TYPED_TEST(SGDSolverTest, TestSolverType) {
+  this->TestLeastSquaresUpdate();
+  EXPECT_NE(this->solver_->type(), string(""));
+  EXPECT_EQ(this->solver_->type(), this->solver_->param().type());
+}
 
 template <typename TypeParam>
 class AdaGradSolverTest : public GradientBasedSolverTest<TypeParam> {


### PR DESCRIPTION
The solver checks its proto type (SolverParameter.type) on instantiation:

- if the proto type is unspecified it's set according to the class type `Solver::type()` 
- if the proto type and class type conflict, the solver dies loudly

This helps avoid accidental instantiation of a different solver type than intended when the solver def and class differ. 
For instance if the solver def specifies `type: "Nesterov"` but one instantiates an `SGDSolver` with that def which type the solver is could be a surprise (it's an `SGDSolver`).

Guaranteed type information in the SolverParameter will simplify multi-solver coordination too; in particular it's needed for correctness of #4563. 

@cypof