### PR TITLE
fix typo when including cmake files of opencv

### DIFF
--- a/cmake/Templates/CaffeConfig.cmake.in
+++ b/cmake/Templates/CaffeConfig.cmake.in
@@ -30,7 +30,7 @@ if(@USE_OPENCV@)
         if(MSVC)
           # The path to OpenCVModules.cmake is mangled according to 
 	  # compiler and arch on Windows
-          include(${Caffe_OpenCV_CONFIG_PATH}/OpenConfig.cmake)
+          include(${Caffe_OpenCV_CONFIG_PATH}/OpenCVConfig.cmake)
         else()
           include(${Caffe_OpenCV_CONFIG_PATH}/OpenCVModules.cmake)
         endif()


### PR DESCRIPTION
fix typo which may cause build failures