### PR TITLE
Standardization in data transformer

### DIFF
--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -147,6 +147,7 @@ class DataTransformer {
   Phase phase_;
   Blob<Dtype> data_mean_;
   vector<Dtype> mean_values_;
+  Blob<Dtype> data_sd_;
 };
 
 }  // namespace caffe

--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -148,6 +148,7 @@ class DataTransformer {
   Blob<Dtype> data_mean_;
   vector<Dtype> mean_values_;
   Blob<Dtype> data_sd_;
+  vector<Dtype> sd_values_;
 };
 
 }  // namespace caffe

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -131,21 +131,21 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
           datum_element = datum.float_data(data_index);
         }
         if (has_mean_file) {
-          datum_element =
-            (datum_element - mean[data_index]) * scale;
+          if (has_sd_file) {
+            transformed_data[top_index] =
+              (datum_element - mean[data_index]) / sd[data_index] * scale;
+          } else {
+            transformed_data[top_index] =
+              (datum_element - mean[data_index]) * scale;
+          }
         } else {
           if (has_mean_values) {
-            datum_element =
+            transformed_data[top_index] =
               (datum_element - mean_values_[c]) * scale;
           } else {
-            datum_element = datum_element * scale;
+            transformed_data[top_index] = datum_element * scale;
           }
         }
-		if (has_sd_file) {
-	      transformed_data[top_index] = datum_element / sd[data_index];
-		} else {
-		  transformed_data[top_index] = datum_element;
-		}
       }
     }
   }
@@ -342,20 +342,21 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
         Dtype pixel = static_cast<Dtype>(ptr[img_index++]);
         if (has_mean_file) {
           int mean_index = (c * img_height + h_off + h) * img_width + w_off + w;
-          pixel = (pixel - mean[mean_index]) * scale;
+          if (has_sd_file) {
+            transformed_data[top_index] =
+              (pixel - mean[mean_index]) / sd[sd_index] * scale;
+          } else {
+            transformed_data[top_index] =
+              (pixel - mean[mean_index]) * scale;
+          }
         } else {
           if (has_mean_values) {
-            pixel = (pixel - mean_values_[c]) * scale;
+            transformed_data[top_index] =
+              (pixel - mean_values_[c]) * scale;
           } else {
-            pixel = pixel * scale;
+            transformed_data[top_index] = pixel * scale;
           }
         }
-		if (has_sd_file) {
-			int sd_index = (c * img_height + h_off + h) * img_width + w_off + w;
-			transformed_data[top_index] = pixel / sd[sd_index];
-		} else {
-			transformed_data[top_index] = pixel;
-		}
       }
     }
   }

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -344,7 +344,7 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
           int mean_index = (c * img_height + h_off + h) * img_width + w_off + w;
           if (has_sd_file) {
             transformed_data[top_index] =
-              (pixel - mean[mean_index]) / sd[sd_index] * scale;
+              (pixel - mean[mean_index]) / sd[mean_index] * scale;
           } else {
             transformed_data[top_index] =
               (pixel - mean[mean_index]) * scale;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -418,7 +418,7 @@ message TransformationParameter {
   optional uint32 crop_size = 3 [default = 0];
   // mean_file and mean_value cannot be specified at the same time
   optional string mean_file = 4;
-  // if specified can be repeated once (would subtract it from all the channels)
+  // if specified can be repeated once (would substract it from all the channels)
   // or can be repeated the same number of times as channels
   // (would subtract them from the corresponding channel)
   repeated float mean_value = 5;
@@ -426,9 +426,14 @@ message TransformationParameter {
   optional bool force_color = 6 [default = false];
   // Force the decoded image to have 1 color channels.
   optional bool force_gray = 7 [default = false];
-  // sd_file is used to standardize the data using per element standard deviation 
-  // (mean_file is required, since per element mean substraction is required)
+  // sd_file is used to normalize the image by per pixel standard deviation after 
+  // subtraction of the mean_image
   optional string sd_file = 8;
+  // if specified can be repeated once (would standardize all channels using 
+  // one standard deviation for all channels) or can be repeated the same 
+  // number of times as channels (each sd_value would be used to standardize
+  // the corresponding channel)
+  repeated float sd_value = 9;
 }
 
 // Message that stores parameters shared by loss layers
@@ -437,7 +442,7 @@ message LossParameter {
   optional int32 ignore_label = 1;
   // How to normalize the loss for loss layers that aggregate across batches,
   // spatial dimensions, or other dimensions.  Currently only implemented in
-  // SoftmaxWithLoss and SigmoidCrossEntropyLoss layers.
+  // SoftmaxWithLoss layer.
   enum NormalizationMode {
     // Divide by the number of examples in the batch times spatial dimensions.
     // Outputs that receive the ignore label will NOT be ignored in computing
@@ -451,8 +456,6 @@ message LossParameter {
     // Do not normalize the loss.
     NONE = 3;
   }
-  // For historical reasons, the default normalization for
-  // SigmoidCrossEntropyLoss is BATCH_SIZE and *not* VALID.
   optional NormalizationMode normalization = 3 [default = VALID];
   // Deprecated.  Ignored if normalization is specified.  If normalization
   // is not specified, then setting this to false will be equivalent to
@@ -1399,6 +1402,6 @@ message PReLUParameter {
 
   // Initial value of a_i. Default is a_i=0.25 for all i.
   optional FillerParameter filler = 1;
-  // Whether or not slope parameters are shared across channels.
+  // Whether or not slope paramters are shared across channels.
   optional bool channel_shared = 2 [default = false];
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -426,6 +426,9 @@ message TransformationParameter {
   optional bool force_color = 6 [default = false];
   // Force the decoded image to have 1 color channels.
   optional bool force_gray = 7 [default = false];
+  // sd_file is used to standardize the data using per element standard deviation 
+  // (mean_file is required, since per element mean substraction is required)
+  optional string sd_file = 8;
 }
 
 // Message that stores parameters shared by loss layers

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -418,7 +418,7 @@ message TransformationParameter {
   optional uint32 crop_size = 3 [default = 0];
   // mean_file and mean_value cannot be specified at the same time
   optional string mean_file = 4;
-  // if specified can be repeated once (would substract it from all the channels)
+  // if specified can be repeated once (would subtract it from all the channels)
   // or can be repeated the same number of times as channels
   // (would subtract them from the corresponding channel)
   repeated float mean_value = 5;
@@ -442,7 +442,7 @@ message LossParameter {
   optional int32 ignore_label = 1;
   // How to normalize the loss for loss layers that aggregate across batches,
   // spatial dimensions, or other dimensions.  Currently only implemented in
-  // SoftmaxWithLoss layer.
+  // SoftmaxWithLoss and SigmoidCrossEntropyLoss layers.
   enum NormalizationMode {
     // Divide by the number of examples in the batch times spatial dimensions.
     // Outputs that receive the ignore label will NOT be ignored in computing
@@ -456,6 +456,8 @@ message LossParameter {
     // Do not normalize the loss.
     NONE = 3;
   }
+  // For historical reasons, the default normalization for
+  // SigmoidCrossEntropyLoss is BATCH_SIZE and *not* VALID.
   optional NormalizationMode normalization = 3 [default = VALID];
   // Deprecated.  Ignored if normalization is specified.  If normalization
   // is not specified, then setting this to false will be equivalent to
@@ -1402,6 +1404,6 @@ message PReLUParameter {
 
   // Initial value of a_i. Default is a_i=0.25 for all i.
   optional FillerParameter filler = 1;
-  // Whether or not slope paramters are shared across channels.
+  // Whether or not slope parameters are shared across channels.
   optional bool channel_shared = 2 [default = false];
 }

--- a/tools/compute_image_sd.cpp
+++ b/tools/compute_image_sd.cpp
@@ -115,7 +115,8 @@ int main(int argc, char** argv) {
     for (int i = 0; i < dim; ++i) {
       sd_values[c] += sum_blob.data(dim * c + i);
     }
-	sd_values[c] = static_cast<float>((double)sd_values[c] / (double)count * (double)dim);
+    sd_values[c] = static_cast<float>((double)sd_values[c] / ((double)count * 
+                                                              (double)dim));
     LOG(INFO) << "sd_value channel [" << c << "]:" << std::sqrt(sd_values[c]);
   }
 

--- a/tools/compute_image_sd.cpp
+++ b/tools/compute_image_sd.cpp
@@ -49,7 +49,6 @@ int main(int argc, char** argv) {
   BlobProto mean_blob;
   ReadProtoFromBinaryFileOrDie(argv[2], &mean_blob);
 
-
   BlobProto sum_blob;
   int count = 0;
   // load first datum
@@ -85,14 +84,14 @@ int main(int argc, char** argv) {
       CHECK_EQ(data.size(), size_in_datum);
       for (int i = 0; i < size_in_datum; ++i) {
         float val = (uint8_t)data[i];
-		val -= mean_blob.data(i);
+        val -= mean_blob.data(i);
         sum_blob.set_data(i, sum_blob.data(i) + val*val);
       }
     } else {
       CHECK_EQ(datum.float_data_size(), size_in_datum);
       for (int i = 0; i < size_in_datum; ++i) {
         float val = static_cast<float>(datum.float_data(i));
-		val -= mean_blob.data(i);
+        val -= mean_blob.data(i);
         sum_blob.set_data(i, sum_blob.data(i) + val*val);
       }
     }

--- a/tools/compute_image_sd.cpp
+++ b/tools/compute_image_sd.cpp
@@ -1,0 +1,121 @@
+#include <stdint.h>
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/scoped_ptr.hpp"
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/db.hpp"
+#include "caffe/util/io.hpp"
+
+using namespace caffe;  // NOLINT(build/namespaces)
+
+using std::max;
+using std::pair;
+using boost::scoped_ptr;
+
+DEFINE_string(backend, "lmdb",
+        "The backend {leveldb, lmdb} containing the images");
+
+int main(int argc, char** argv) {
+  ::google::InitGoogleLogging(argv[0]);
+
+#ifdef USE_OPENCV
+#ifndef GFLAGS_GFLAGS_H_
+  namespace gflags = google;
+#endif
+
+  gflags::SetUsageMessage("Compute the sd_image of a set of images given by"
+        " a leveldb/lmdb\n"
+        "Usage:\n"
+        "    compute_image_sd [FLAGS] INPUT_DB MEAN_FILE [OUTPUT_FILE]\n");
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (argc != 4) {
+    gflags::ShowUsageWithFlagsRestrict(argv[0], "tools/compute_image_sd");
+    return 1;
+  }
+
+  scoped_ptr<db::DB> db(db::GetDB(FLAGS_backend));
+  db->Open(argv[1], db::READ);
+  scoped_ptr<db::Cursor> cursor(db->NewCursor());
+
+  // Load mean file
+  BlobProto mean_blob;
+  ReadProtoFromBinaryFileOrDie(argv[2], &mean_blob);
+
+
+  BlobProto sum_blob;
+  int count = 0;
+  // load first datum
+  Datum datum;
+  datum.ParseFromString(cursor->value());
+
+  if (DecodeDatumNative(&datum)) {
+    LOG(INFO) << "Decoding Datum";
+  }
+
+  sum_blob.set_num(1);
+  sum_blob.set_channels(datum.channels());
+  sum_blob.set_height(datum.height());
+  sum_blob.set_width(datum.width());
+  const int data_size = datum.channels() * datum.height() * datum.width();
+  int size_in_datum = std::max<int>(datum.data().size(),
+                                    datum.float_data_size());
+  for (int i = 0; i < size_in_datum; ++i) {
+    sum_blob.add_data(0.);
+  }
+  LOG(INFO) << "Starting Iteration";
+  while (cursor->valid()) {
+    Datum datum;
+    datum.ParseFromString(cursor->value());
+    DecodeDatumNative(&datum);
+
+    const std::string& data = datum.data();
+    size_in_datum = std::max<int>(datum.data().size(),
+        datum.float_data_size());
+    CHECK_EQ(size_in_datum, data_size) << "Incorrect data field size " <<
+        size_in_datum;
+    if (data.size() != 0) {
+      CHECK_EQ(data.size(), size_in_datum);
+      for (int i = 0; i < size_in_datum; ++i) {
+        float val = (uint8_t)data[i];
+		val -= mean_blob.data(i);
+        sum_blob.set_data(i, sum_blob.data(i) + val*val);
+      }
+    } else {
+      CHECK_EQ(datum.float_data_size(), size_in_datum);
+      for (int i = 0; i < size_in_datum; ++i) {
+        float val = static_cast<float>(datum.float_data(i));
+		val -= mean_blob.data(i);
+        sum_blob.set_data(i, sum_blob.data(i) + val*val);
+      }
+    }
+    ++count;
+    if (count % 10000 == 0) {
+      LOG(INFO) << "Processed " << count << " files.";
+    }
+    cursor->Next();
+  }
+
+  if (count % 10000 != 0) {
+    LOG(INFO) << "Processed " << count << " files.";
+  }
+  for (int i = 0; i < sum_blob.data_size(); ++i) {
+    float sd = sum_blob.data(i) / count;
+    sd = std::sqrt(sd);
+    sum_blob.set_data(i, sd);
+  }
+  // Write to disk
+  LOG(INFO) << "Write to " << argv[3];
+  WriteProtoToBinaryFile(sum_blob, argv[3]);
+#else
+  LOG(FATAL) << "This tool requires OpenCV; compile with USE_OPENCV.";
+#endif  // USE_OPENCV
+  return 0;
+}

--- a/tools/compute_image_sd.cpp
+++ b/tools/compute_image_sd.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
   gflags::SetUsageMessage("Compute the sd_image of a set of images given by"
         " a leveldb/lmdb\n"
         "Usage:\n"
-        "    compute_image_sd [FLAGS] INPUT_DB MEAN_FILE [OUTPUT_FILE]\n");
+        "    compute_image_sd [FLAGS] INPUT_DB MEAN_FILE OUTPUT_FILE\n");
 
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 


### PR DESCRIPTION
This pull request adds standardization of data layers using per channel sd_value or a binaryproto as sd_file. Since caffe supports the substraction of mean values and therefore the centering of data, it would be reasonable to add standardization support to the master branch. The data transformer was extended to allow standardization if either mean_value or mean_file is specified. 

In addition a new tool called *compute_image_sd* is added (derived from the source code of compute_image_mean.cpp), which can compute a binaryproto file holding an array with standard deviations for each attribute/pixel. Since the computation of standard deviation requires the mean of the attributes, the commandline interface expects the binaryproto file produced from *compute_image_mean*.

Open point: Since we are dealing with large datasets, it could be better to compute the standard deviations with double precision (summing up squared distances). 