### PR TITLE
check leveldb iterator status for snappy format.

### DIFF
--- a/include/caffe/util/db_leveldb.hpp
+++ b/include/caffe/util/db_leveldb.hpp
@@ -14,7 +14,10 @@ namespace caffe { namespace db {
 class LevelDBCursor : public Cursor {
  public:
   explicit LevelDBCursor(leveldb::Iterator* iter)
-    : iter_(iter) { SeekToFirst(); }
+    : iter_(iter) {
+    SeekToFirst();
+    CHECK(iter_->status().ok()) << iter_->status().ToString();
+  }
   ~LevelDBCursor() { delete iter_; }
   virtual void SeekToFirst() { iter_->SeekToFirst(); }
   virtual void Next() { iter_->Next(); }


### PR DESCRIPTION
When caffe process leveldb data  which do not use snappy compression,  but caffe is compiled with levevldb + snappy, caffe would be crashed (coredump).  And the coredump is always confused, like as: 

> 
> I1216 11:47:56.239313 18122 db_leveldb.cpp:18] Opened leveldb leveldb_0819/
> *** Aborted at 1481888876 (unix time) try "date -d @1481888876" if you are using GNU date ***
> PC: @           0xa5da88 leveldb::(anonymous namespace)::MergingIterator::value()
> *** SIGSEGV (@0x0) received by PID 18108 (TID 0x7f8c6da4b700) from PID 0; stack trace: ***
>     @       0x318b20f500 (unknown)
>     @           0xa5da88 leveldb::(anonymous namespace)::MergingIterator::value()
>     @           0xa4f3be leveldb::(anonymous namespace)::DBIter::value()
>     @           0x5a3962 caffe::db::LevelDBCursor::value()
>     @           0x57b88b caffe::DataReader::Body::read_one()
>     @           0x57badc caffe::DataReader::Body::InternalThreadEntry()
>     @           0x58aa3f caffe::InternalThread::entry()
>     @           0x78f639 thread_proxy
>     @       0x318b207851 (unknown)
>     @     0x7f8c7aa48fbd clone
> 
> 

so  i add check levedb status when SeekToFirst, and give readable error msg, like as:

> F1216 11:40:40.420825 28786 db_leveldb.hpp:19] Check failed: iter_->status().ok() Corruption: corrupted compressed block contents

Using this error msg, i can find the problem quickly.
