### PR TITLE
use cv2 to load_image, resize_image

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -295,7 +295,7 @@ def load_image(filename, color=True):
         of size (H x W x 1) in grayscale.
     """
     # img = skimage.img_as_float(skimage.io.imread(filename, as_grey=not color)).astype(np.float32)
-    img = cv2.imread(filename).astype(np.float32) / 255.0
+    img = cv2.imread(filename)[:, :, (2, 1, 0)].astype(np.float32) / 255.0
     if img.ndim == 2:
         img = img[:, :, np.newaxis]
         if color:

--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -2,6 +2,7 @@ import numpy as np
 import skimage.io
 from scipy.ndimage import zoom
 from skimage.transform import resize
+import cv2
 
 try:
     # Python3 will most likely not be able to load protobuf
@@ -293,7 +294,8 @@ def load_image(filename, color=True):
         of size (H x W x 3) in RGB or
         of size (H x W x 1) in grayscale.
     """
-    img = skimage.img_as_float(skimage.io.imread(filename, as_grey=not color)).astype(np.float32)
+    # img = skimage.img_as_float(skimage.io.imread(filename, as_grey=not color)).astype(np.float32)
+    img = cv2.imread(filename).astype(np.float32) / 255.0
     if img.ndim == 2:
         img = img[:, :, np.newaxis]
         if color:
@@ -323,7 +325,8 @@ def resize_image(im, new_dims, interp_order=1):
             # skimage is fast but only understands {1,3} channel images
             # in [0, 1].
             im_std = (im - im_min) / (im_max - im_min)
-            resized_std = resize(im_std, new_dims, order=interp_order)
+            # resized_std = resize(im_std, new_dims, order=interp_order)
+            resized_std = cv2.resize(im, new_dims)
             resized_im = resized_std * (im_max - im_min) + im_min
         else:
             # the image is a constant -- avoid divide by 0


### PR DESCRIPTION
scikit-image is too slow, so I use cv2 to load/resize image

I made a test with an image (image_size = (3120,4160)), 
run 100 times
| load image function | load image time(s) | resize image function | resize image(s) | 
|---|---|---|---|
| cv2.imread | 14.90 | cv2.resize | 0.087 |
| skimage.io.imread | 18.18 | skimage.transform.resize | 29.609 |
| caffe.io.load_image | 38.01 | caffe.io.resize | 26.35 |
| caffe.io.load_image(cv2) | 22.01 | caffe.io.resize(cv2) | 7.085 |