### PR TITLE
Simple fix to avoid unnecessary download

### DIFF
--- a/data/ilsvrc12/get_ilsvrc_aux.sh
+++ b/data/ilsvrc12/get_ilsvrc_aux.sh
@@ -10,12 +10,13 @@
 DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 cd "$DIR"
 
-echo "Downloading..."
-
-wget -c http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz
-
-echo "Unzipping..."
-
-tar -xf caffe_ilsvrc12.tar.gz && rm -f caffe_ilsvrc12.tar.gz
-
-echo "Done."
+if ! [ -f ./det_synset_words.txt -a -f ./imagenet_mean.binaryproto -a -f ./synsets.txt \
+        -a -f ./train.txt -a -f ./imagenet.bet.pickle -a -f ./synset_words.txt -a -f ./test.txt -a -f ./val.txt ]; then
+        echo "Downloading..."
+        wget -c http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz
+        echo "Unzipping..."
+        tar -xf caffe_ilsvrc12.tar.gz && rm -f caffe_ilsvrc12.tar.gz
+        echo "Done."
+else
+        echo "ImageNet example aux files already exist."
+fi


### PR DESCRIPTION
Every time we call get_ilsvrc_aux.sh, it downloads the auxiliary files and extracts them–even if they already exist. It could be annoying so fixing it. This isn't the best way however it serves the purpose.