### PR TITLE
Use the __restrict__ keyword for the low level vector functions

### DIFF
--- a/include/caffe/util/mkl_alternate.hpp
+++ b/include/caffe/util/mkl_alternate.hpp
@@ -23,7 +23,7 @@ extern "C" {
 // be in the form e.g. y[i] = sqrt(a[i])
 #define DEFINE_VSL_UNARY_FUNC(name, operation) \
   template<typename Dtype> \
-  void v##name(const int n, const Dtype* a, Dtype* y) { \
+  void v##name(const int n, const Dtype* __restrict__ a, Dtype* __restrict__ y) { \
     CHECK_GT(n, 0); CHECK(a); CHECK(y); \
     for (int i = 0; i < n; ++i) { operation; } \
   } \
@@ -45,7 +45,7 @@ DEFINE_VSL_UNARY_FUNC(Abs, y[i] = fabs(a[i]));
 // The operation should be in the form e.g. y[i] = pow(a[i], b)
 #define DEFINE_VSL_UNARY_FUNC_WITH_PARAM(name, operation) \
   template<typename Dtype> \
-  void v##name(const int n, const Dtype* a, const Dtype b, Dtype* y) { \
+  void v##name(const int n, const Dtype* __restrict__ a, const Dtype b, Dtype* __restrict__ y) { \
     CHECK_GT(n, 0); CHECK(a); CHECK(y); \
     for (int i = 0; i < n; ++i) { operation; } \
   } \
@@ -64,7 +64,7 @@ DEFINE_VSL_UNARY_FUNC_WITH_PARAM(Powx, y[i] = pow(a[i], b));
 // be in the form e.g. y[i] = a[i] + b[i]
 #define DEFINE_VSL_BINARY_FUNC(name, operation) \
   template<typename Dtype> \
-  void v##name(const int n, const Dtype* a, const Dtype* b, Dtype* y) { \
+  void v##name(const int n, const Dtype* __restrict__ a, const Dtype* __restrict__ b, Dtype* __restrict__ y) { \
     CHECK_GT(n, 0); CHECK(a); CHECK(b); CHECK(y); \
     for (int i = 0; i < n; ++i) { operation; } \
   } \


### PR DESCRIPTION
The C++ restrict keyword gives the hint to the compiler that pointers
don't do partial overlaps, which in turn allows the compiler to apply
a set of optimizations that it otherwise would struggle with.

Specifically, for the vector functions, this results in SIMD getting
used for all the vector add/sub/div/sqrt operations, giving a huge
speedup on a micro-scale (4x to 8x) while giving a 5%+ speedup
on a full Alexnet