### PR TITLE
Fix parse_log tool for negative time duration if datetime across year boundary

### DIFF
--- a/tools/extra/extract_seconds.py
+++ b/tools/extra/extract_seconds.py
@@ -48,11 +48,19 @@ def extract_seconds(input_file, output_file):
     start_datetime = get_start_time(lines, log_created_year)
     assert start_datetime, 'Start time not found'
 
+    last_dt = start_datetime
     out = open(output_file, 'w')
     for line in lines:
         line = line.strip()
         if line.find('Iteration') != -1:
             dt = extract_datetime_from_line(line, log_created_year)
+
+            # if it's another year
+            if dt.month < last_dt.month:
+                log_created_year += 1
+                dt = extract_datetime_from_line(line, log_created_year)
+            last_dt = dt
+
             elapsed_seconds = (dt - start_datetime).total_seconds()
             out.write('%f\n' % elapsed_seconds)
     out.close()

--- a/tools/extra/parse_log.py
+++ b/tools/extra/parse_log.py
@@ -38,6 +38,7 @@ def parse_log(path_to_log):
     logfile_year = extract_seconds.get_log_created_year(path_to_log)
     with open(path_to_log) as f:
         start_time = extract_seconds.get_start_time(f, logfile_year)
+        last_time = start_time
 
         for line in f:
             iteration_match = regex_iteration.search(line)
@@ -54,6 +55,12 @@ def parse_log(path_to_log):
             except ValueError:
                 # Skip lines with bad formatting, for example when resuming solver
                 continue
+
+            # if it's another year
+            if time.month < last_time.month:
+                logfile_year += 1
+                time = extract_seconds.extract_datetime_from_line(line, logfile_year)
+            last_time = time
 
             seconds = (time - start_time).total_seconds()
 


### PR DESCRIPTION
Fix parse_log.py and parse_log.sh for negative time duration if datetime in log across year boundary.

===log===
I1231 23:57:26.978343  6523 sgd_solver.cpp:106] Iteration 2700, lr = 0.01
I0101 00:00:12.166026  6523 sgd_solver.cpp:106] Iteration 2720, lr = 0.01

===parse_log===
NumIters,Seconds,LearningRate,loss
2700.0,24590.183021,0.01,6.90322
2720.0,-31511244.629296,0.01,6.86348