### PR TITLE
Fixing harsh upgrade_proto for `"BatchNorm"` layer

### DIFF
--- a/src/caffe/util/upgrade_proto.cpp
+++ b/src/caffe/util/upgrade_proto.cpp
@@ -1018,7 +1018,13 @@ void UpgradeNetBatchNorm(NetParameter* net_param) {
     // the previous BatchNorm layer definition.
     if (net_param->layer(i).type() == "BatchNorm"
         && net_param->layer(i).param_size() == 3) {
-      net_param->mutable_layer(i)->clear_param();
+      // set lr_mult and decay_mult to zero. leave all other param intact.
+      for (int ip = 0; ip < net_param->layer(i).param_size(); ip++) {
+        ParamSpec* fixed_param_spec =
+          net_param->mutable_layer(i)->mutable_param(ip);
+        fixed_param_spec->set_lr_mult(0.f);
+        fixed_param_spec->set_decay_mult(0.f);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR attempts to fix issues #5171 and #5120 cuased by PR #4704:
PR#4704 **removes completely** all `param` arguments of `"BatchNorm"` layers, and resetting them to `param {lr_mult: 0}`. This "upgrade" is too harsh and it discards `"name"` argument that might be set by user.

This PR fixes `upgrade_proto.cpp` for `"BatchNorm"` layer to be more conservative, leave `"name"` in param, and only set `lr_mult` and `decay_mult` to zero.

Example of such upgrade:  
**Input prototxt**  
```
layer {
  type: "BatchNorm"
  name: "bn0"
  bottom: "data"
  top: "bn0"
  # old style params
  param: { lr_mult: 0 }
  param: { lr_mult: 0 }
  param: { lr_mult: 0 }
}
layer {
  type: "BatchNorm"
  name: "bn1"
  bottom: "bn0"
  top: "bn1"
  # wrong params
  param: { lr_mult: 1 decay_mult: 1}
  param: { lr_mult: 1 decay_mult: 0}
  param: { lr_mult: 1 decay_mult: 1}
}
layer {
  type: "BatchNorm"
  name: "bn2"
  bottom: "bn1"
  top: "bn2"
  # no params at all
}
layer {
  type: "BatchNorm"
  name: "bn3"
  bottom: "bn2"
  top: "bn3"
  # wrong with "name"
  param: { lr_mult: 1 decay_mult: 1 name: "bn_m"}
  param: { lr_mult: 1 decay_mult: 1 name: "bn_s"}
  param: { lr_mult: 1 decay_mult: 1 name: "bn_b"}
}
layer {
  type: "BatchNorm"
  name: "bn4"
  bottom: "bn3"
  top: "bn4"
  # only "name"
  param: { name: "bn_m"}
  param: { name: "bn_s"}
  param: { name: "bn_b"}
}
```
**"Upgraded" prorotxt:**
```
layer {
  name: "bn0"
  type: "BatchNorm"
  bottom: "data"
  top: "bn0"
  param {
    lr_mult: 0
    decay_mult: 0
  }
  param {
    lr_mult: 0
    decay_mult: 0
  }
  param {
    lr_mult: 0
    decay_mult: 0
  }
}
layer {
  name: "bn1"
  type: "BatchNorm"
  bottom: "bn0"
  top: "bn1"
  param {
    lr_mult: 0
    decay_mult: 0
  }
  param {
    lr_mult: 0
    decay_mult: 0
  }
  param {
    lr_mult: 0
    decay_mult: 0
  }
}
layer {
  name: "bn2"
  type: "BatchNorm"
  bottom: "bn1"
  top: "bn2"
}
layer {
  name: "bn3"
  type: "BatchNorm"
  bottom: "bn2"
  top: "bn3"
  param {
    name: "bn_m"
    lr_mult: 0
    decay_mult: 0
  }
  param {
    name: "bn_s"
    lr_mult: 0
    decay_mult: 0
  }
  param {
    name: "bn_b"
    lr_mult: 0
    decay_mult: 0
  }
}
layer {
  name: "bn4"
  type: "BatchNorm"
  bottom: "bn3"
  top: "bn4"
  param {
    name: "bn_m"
    lr_mult: 0
    decay_mult: 0
  }
  param {
    name: "bn_s"
    lr_mult: 0
    decay_mult: 0
  }
  param {
    name: "bn_b"
    lr_mult: 0
    decay_mult: 0
  }
}
```
As you can see `lr_mult` and `decay_mult` are set to zero leaving `name` intact when explicitly set by user.
