### PR TITLE
OpenCL: fix one incorrect constant value type.

### DIFF
--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -138,7 +138,7 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "counts[i] = 0.0;",    // NOLINT
 "} else {",    // NOLINT
 "loss[i] = input_data[i] * (target[i] - (input_data[i] >= 0.0)) -",    // NOLINT
-"log(1.0 + exp(input_data[i] - 2.0 * input_data[i] *",    // NOLINT
+"log((Dtype)1.0 + exp(input_data[i] - (Dtype)2.0 * input_data[i] *",    // NOLINT
 "(input_data[i] >= 0.0)));",    // NOLINT
 "counts[i] = 1.0;",    // NOLINT
 "}",    // NOLINT

--- a/src/caffe/greentea/cl_kernels/activation.cl
+++ b/src/caffe/greentea/cl_kernels/activation.cl
@@ -121,7 +121,7 @@ __kernel void TEMPLATE(sce_loss_forward,Dtype)(const int_tp nthreads,
       counts[i] = 0.0;
     } else {
       loss[i] = input_data[i] * (target[i] - (input_data[i] >= 0.0)) -
-          log(1.0 + exp(input_data[i] - 2.0 * input_data[i] *
+          log((Dtype)1.0 + exp(input_data[i] - (Dtype)2.0 * input_data[i] *
           (input_data[i] >= 0.0)));
       counts[i] = 1.0;
     }


### PR DESCRIPTION
We should always use Dtype constant value by default. Otherwise
it may cause compilation error for the platform doesn't support
double type. And even if the platform does support double, when
we build float type kernel, it will promote some of the routines
to double type which is not efficient.

Signed-off-by: Zhigang Gong <zhigang.gong@intel.com>