### PR TITLE
Fix broken build on windows when not defining WITH_CUDA

### DIFF
--- a/scripts/build_win.cmd
+++ b/scripts/build_win.cmd
@@ -44,7 +44,7 @@ if DEFINED APPVEYOR (
     )
 
     :: Install cuda and disable tests if needed
-    if %WITH_CUDA% == 1 (
+    if !WITH_CUDA! == 1 (
         call %~dp0\appveyor\appveyor_install_cuda.cmd
         set CPU_ONLY=0
         set RUN_TESTS=0


### PR DESCRIPTION
Fix the following error when running the script without first defining "WITH_CUDA": `( was unexpected at this time.`

The problem was introduced by 372e920eb5c0ccdf70a7caaa344847d1485919c6 (part of https://github.com/BVLC/caffe/pull/4895)