### PR TITLE
Obsolete reference to `bool solver` in caffe.proto

### DIFF
--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -128,8 +128,7 @@ message SolverParameter {
   // The states for the train/test nets. Must be unspecified or
   // specified once per net.
   //
-  // By default, all states will have solver = true;
-  // train_state will have phase = TRAIN,
+  // By default, train_state will have phase = TRAIN,
   // and all test_state's will have phase = TEST.
   // Other defaults are set according to the NetState defaults.
   optional NetState train_state = 26;


### PR DESCRIPTION
`NetState` field `bool solver` was introduced in https://github.com/BVLC/caffe/pull/734, but it has never made it to the master, @jeffdonahue decided against it (https://github.com/BVLC/caffe/pull/734#issuecomment-49568384).