### PR TITLE
Save many datasets in the same hdf5 file

### DIFF
--- a/include/caffe/layers/hdf5_output_layer.hpp
+++ b/include/caffe/layers/hdf5_output_layer.hpp
@@ -54,6 +54,7 @@ class HDF5OutputLayer : public Layer<Dtype> {
 
   bool file_opened_;
   std::string file_name_;
+  int ds_iter_;
   hid_t file_id_;
   Blob<Dtype> data_blob_;
   Blob<Dtype> label_blob_;

--- a/src/caffe/layers/hdf5_output_layer.cpp
+++ b/src/caffe/layers/hdf5_output_layer.cpp
@@ -14,6 +14,7 @@ void HDF5OutputLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   file_name_ = this->layer_param_.hdf5_output_param().file_name();
   file_id_ = H5Fcreate(file_name_.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT,
                        H5P_DEFAULT);
+  ds_iter_ = 0;
   CHECK_GE(file_id_, 0) << "Failed to open HDF5 file" << file_name_;
   file_opened_ = true;
 }
@@ -29,12 +30,27 @@ HDF5OutputLayer<Dtype>::~HDF5OutputLayer<Dtype>() {
 template <typename Dtype>
 void HDF5OutputLayer<Dtype>::SaveBlobs() {
   // TODO: no limit on the number of blobs
-  LOG(INFO) << "Saving HDF5 file " << file_name_;
+  LOG(INFO) << "Saving HDF5 file " << file_name_ << "ds: " << ds_iter_;
   CHECK_EQ(data_blob_.num(), label_blob_.num()) <<
       "data blob and label blob must have the same batch size";
-  hdf5_save_nd_dataset(file_id_, HDF5_DATA_DATASET_NAME, data_blob_);
-  hdf5_save_nd_dataset(file_id_, HDF5_DATA_LABEL_NAME, label_blob_);
+  ostringstream dataset_name;
+  dataset_name << HDF5_DATA_DATASET_NAME;
+
+  if (ds_iter_ != 0) {
+    dataset_name << ds_iter_;
+  }
+
+  hdf5_save_nd_dataset(file_id_, dataset_name.str(), data_blob_);
+  dataset_name.str("");
+  dataset_name << HDF5_DATA_LABEL_NAME;
+
+  if (ds_iter_ != 0) {
+    dataset_name << ds_iter_;
+  }
+
+  hdf5_save_nd_dataset(file_id_, dataset_name.str(), label_blob_);
   LOG(INFO) << "Successfully saved " << data_blob_.num() << " rows";
+  ds_iter_++;
 }
 
 template <typename Dtype>


### PR DESCRIPTION
This fixes an issue where you cannot save use the HDF5 output layer when running multiple iterations. This adapted from the original version by @escorciav (mentioned https://groups.google.com/forum/#!topic/caffe-users/zkGKk5UbInI) but updated to the latest verison of caffe and amended to fix the unit tests. 

This has come up in questions on stackoverflow previously (e.g. http://stackoverflow.com/questions/38753530/caffe-hdf5-output-layer-error-looking-for-working-example)