### PR TITLE
Feature/ignore euclideanloss

### DIFF
--- a/include/caffe/layers/euclidean_loss_layer.hpp
+++ b/include/caffe/layers/euclidean_loss_layer.hpp
@@ -99,6 +99,10 @@ class EuclideanLossLayer : public LossLayer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
+  /// Whether to ignore instances with a certain label.
+  bool has_ignore_label_;
+  /// The label indicating that an instance should be ignored.
+  int ignore_label_;
   Blob<Dtype> diff_;
 };
 

--- a/src/caffe/layers/euclidean_loss_layer.cpp
+++ b/src/caffe/layers/euclidean_loss_layer.cpp
@@ -33,8 +33,9 @@ void EuclideanLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     const Dtype* label_data = bottom[1]->cpu_data();
     Dtype* diff__data = diff_.mutable_cpu_data();
     for (int i = 0; i < count; ++i) {
-      const int label_value = static_cast<int>(label_data[i]);
-      if (label_value == ignore_label_) {
+      float ignore_label_low_range = ((float)this->layer_param_.loss_param().ignore_label()) - 0.0000001;
+      float ignore_label_high_range = ((float)this->layer_param_.loss_param().ignore_label()) + 0.0000001;
+      if (label_data[i] > ignore_label_low_range && label_data[i] < ignore_label_high_range) {
         diff__data[i] = 0;
       }
     }

--- a/src/caffe/layers/euclidean_loss_layer.cpp
+++ b/src/caffe/layers/euclidean_loss_layer.cpp
@@ -30,12 +30,19 @@ void EuclideanLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       bottom[1]->cpu_data(),
       diff_.mutable_cpu_data());
   if (has_ignore_label_) {
+    const float DELTA_RANGE = 0.000000000001;
     const Dtype* label_data = bottom[1]->cpu_data();
     Dtype* diff__data = diff_.mutable_cpu_data();
     for (int i = 0; i < count; ++i) {
-      float ignore_label_low_range = ((float)this->layer_param_.loss_param().ignore_label()) - 0.0000001;
-      float ignore_label_high_range = ((float)this->layer_param_.loss_param().ignore_label()) + 0.0000001;
-      if (label_data[i] > ignore_label_low_range && label_data[i] < ignore_label_high_range) {
+      float ignore_label_low_range =
+            static_cast<float>(this->layer_param_.loss_param().ignore_label())
+            - DELTA_RANGE;
+      float ignore_label_high_range =
+            static_cast<float>(this->layer_param_.loss_param().ignore_label())
+            + DELTA_RANGE;
+
+      if (label_data[i] > ignore_label_low_range &&
+          label_data[i] < ignore_label_high_range) {
         diff__data[i] = 0;
       }
     }

--- a/src/caffe/layers/euclidean_loss_layer.cu
+++ b/src/caffe/layers/euclidean_loss_layer.cu
@@ -10,10 +10,13 @@ __global__ void EuclideanLossForwardGPU(const int n,
           const Dtype* label_data_, Dtype* diff__data_,
           const int ignore_label_) {
   CUDA_KERNEL_LOOP(index, n) {
-    //const int label_value = static_cast<int>(label_data_[index]);
-    float ignore_label_low_range = ((float)ignore_label_) - 0.0000001;
-    float ignore_label_high_range = ((float)ignore_label_) + 0.0000001;
-    if (label_data_[index] > ignore_label_low_range && label_data_[index] < ignore_label_high_range) {
+    const float DELTA_RANGE = 0.000000000001;
+    float ignore_label_low_range =
+          static_cast<float>(ignore_label_) - DELTA_RANGE;
+    float ignore_label_high_range =
+          static_cast<float>(ignore_label_) + DELTA_RANGE;
+    if (label_data_[index] > ignore_label_low_range &&
+        label_data_[index] < ignore_label_high_range) {
       diff__data_[index] = 0;
     }
   }

--- a/src/caffe/layers/euclidean_loss_layer.cu
+++ b/src/caffe/layers/euclidean_loss_layer.cu
@@ -6,6 +6,18 @@
 namespace caffe {
 
 template <typename Dtype>
+__global__ void EuclideanLossForwardGPU(const int n,
+          const Dtype* label_data_, Dtype* diff__data_,
+          const int ignore_label_) {
+  CUDA_KERNEL_LOOP(index, n) {
+    const int label_value = static_cast<int>(label_data_[index]);
+    if (label_value == ignore_label_) {
+      diff__data_[index] = 0;
+    }
+  }
+}
+
+template <typename Dtype>
 void EuclideanLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   int count = bottom[0]->count();
@@ -14,6 +26,13 @@ void EuclideanLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       bottom[0]->gpu_data(),
       bottom[1]->gpu_data(),
       diff_.mutable_gpu_data());
+  if (has_ignore_label_) {
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    EuclideanLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(count),
+        CAFFE_CUDA_NUM_THREADS>>>(count, bottom[1]->gpu_data(),
+                                  diff_.mutable_gpu_data(),
+                                  ignore_label_);
+  }
   Dtype dot;
   caffe_gpu_dot(count, diff_.gpu_data(), diff_.gpu_data(), &dot);
   Dtype loss = dot / bottom[0]->num() / Dtype(2);

--- a/src/caffe/layers/euclidean_loss_layer.cu
+++ b/src/caffe/layers/euclidean_loss_layer.cu
@@ -10,8 +10,10 @@ __global__ void EuclideanLossForwardGPU(const int n,
           const Dtype* label_data_, Dtype* diff__data_,
           const int ignore_label_) {
   CUDA_KERNEL_LOOP(index, n) {
-    const int label_value = static_cast<int>(label_data_[index]);
-    if (label_value == ignore_label_) {
+    //const int label_value = static_cast<int>(label_data_[index]);
+    float ignore_label_low_range = ((float)ignore_label_) - 0.0000001;
+    float ignore_label_high_range = ((float)ignore_label_) + 0.0000001;
+    if (label_data_[index] > ignore_label_low_range && label_data_[index] < ignore_label_high_range) {
       diff__data_[index] = 0;
     }
   }

--- a/src/caffe/test/test_euclidean_loss_layer.cpp
+++ b/src/caffe/test/test_euclidean_loss_layer.cpp
@@ -86,4 +86,54 @@ TYPED_TEST(EuclideanLossLayerTest, TestGradient) {
       this->blob_top_vec_);
 }
 
+TYPED_TEST(EuclideanLossLayerTest, TestForwardIgnoreLabel) {
+  typedef typename TypeParam::Dtype Dtype;
+  // First, compute the loss with ignored labels
+  LayerParameter layer_param;
+  const Dtype kIgnoreLabelValue = -1;
+  layer_param.mutable_loss_param()->set_ignore_label(kIgnoreLabelValue);
+  this->blob_bottom_label_->mutable_cpu_data()[1] = kIgnoreLabelValue;
+  this->blob_bottom_label_->mutable_cpu_data()[5] = kIgnoreLabelValue;
+  this->blob_bottom_label_->mutable_cpu_data()[10] = kIgnoreLabelValue;
+  EuclideanLossLayer<Dtype> layer_ignore(layer_param);
+  layer_ignore.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  const Dtype loss_ignore =
+      layer_ignore.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  // Then, manually compute the loss for known ignored indices
+  int count = this->blob_bottom_label_->count();
+  Dtype loss_manual = 0;
+  for (int i = 0; i < count; ++i) {
+    if (i == 1 || i == 5 || i == 10) {
+      continue;
+    }
+    const Dtype label = this->blob_bottom_label_->cpu_data()[i];
+    // Some random labels might be typecast to ignored label
+    const int label_int = static_cast<int>(label);
+    if (label_int == static_cast<int>(kIgnoreLabelValue)) {
+      continue;
+    }
+    const Dtype data = this->blob_bottom_data_->cpu_data()[i];
+    loss_manual += (label-data)*(label-data);
+  }
+  loss_manual = loss_manual / this->blob_bottom_data_->num() / Dtype(2);
+  // Finally, compare the two losses
+  EXPECT_NEAR(loss_ignore, loss_manual, 1e-4);
+}
+
+TYPED_TEST(EuclideanLossLayerTest, TestGradientIgnoreLabel) {
+  typedef typename TypeParam::Dtype Dtype;
+  // First, set some labels to the ignored label
+  LayerParameter layer_param;
+  const Dtype kIgnoreLabelValue = -1;
+  this->blob_bottom_label_->mutable_cpu_data()[2] = kIgnoreLabelValue;
+  this->blob_bottom_label_->mutable_cpu_data()[6] = kIgnoreLabelValue;
+  this->blob_bottom_label_->mutable_cpu_data()[11] = kIgnoreLabelValue;
+  EuclideanLossLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  // Check gradients
+  GradientChecker<Dtype> checker(1e-2, 1e-2, 1701);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_);
+}
+
 }  // namespace caffe


### PR DESCRIPTION
This PR allows me to use an "ignore_label" value in the EuclideanLoss layer.  For example:

```
layer {
  name: "loss_match"
  type: "EuclideanLoss"
  bottom: "convb"
  bottom: "regression_label"
  top: "loss_match"
  loss_param {
    ignore_label: 0
  }
}
```

The issue I was having was that I am training against multiple loss functions with different data.  Part of my dataset is missing.  I still want to use the data when I have it, but I do not want to back-propagate when those values are missing.  Simply setting the values to zero causes the regression to lean towards the zero values, rather than learning to ignore them.

SoftmaxWithLoss already has this feature, this PR adds parity for the EuclideanLoss layer.

99% of this PR is pulled from this PR: https://github.com/BVLC/caffe/pull/3677

However, that PR was not ideal, since it simply casts the value to an int and ignores it if it matches.  My values are normalized between -1 and 1 so that wouldn't work.  Instead, I am simply checking that the float value is within a narrow range around the configured integer.  After making this change, my network's accuracy was much higher.