### PR TITLE
Adjustable clipping

### DIFF
--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -98,7 +98,7 @@ message NetParameter {
 // NOTE
 // Update the next available ID when you add a new SolverParameter field.
 //
-// SolverParameter next available ID: 42 (last added: layer_wise_reduce)
+// SolverParameter next available ID: 43 (last added: adjustable_clipping)
 message SolverParameter {
   //////////////////////////////////////////////////////////////////////////////
   // Specifying the train and test networks
@@ -185,6 +185,13 @@ message SolverParameter {
   // Set clip_gradients to >= 0 to clip parameter gradients to that L2 norm,
   // whenever their actual L2 norm is larger.
   optional float clip_gradients = 35 [default = -1];
+  // Set adjustable_clipping to true to enable adjustable gradient clipping.
+  //  (adjust clipping threshold based on current learning rate
+  //   threshold = clip_gradients / current_lr )
+  // For more information, refer to the following paper :
+  //    Accurate Image Super-Resolution Using Very Deep Convolutional Networks
+  //    Jiwon Kim et al.
+  optional bool adjustable_clipping = 42 [default = false];
 
   optional int32 snapshot = 14 [default = 0]; // The snapshot interval
   optional string snapshot_prefix = 15; // The prefix for the snapshot.

--- a/src/caffe/solvers/sgd_solver.cpp
+++ b/src/caffe/solvers/sgd_solver.cpp
@@ -87,8 +87,10 @@ void SGDSolver<Dtype>::ClipGradients() {
     sumsq_diff += net_params[i]->sumsq_diff();
   }
   const Dtype l2norm_diff = std::sqrt(sumsq_diff);
-  if (l2norm_diff > clip_gradients) {
-    Dtype scale_factor = clip_gradients / l2norm_diff;
+  // If adjustable_clipping is true, divide threshold by current_lr
+  const Dtype lr_rate = this->param_.adjustable_clipping() ? GetLearningRate() : 1.0;
+  if (l2norm_diff > clip_gradients / lr_rate) {
+    Dtype scale_factor = (clip_gradients / lr_rate) / l2norm_diff;
     LOG(INFO) << "Gradient clipping: scaling down gradients (L2 norm "
         << l2norm_diff << " > " << clip_gradients << ") "
         << "by scale factor " << scale_factor;

--- a/src/caffe/solvers/sgd_solver.cpp
+++ b/src/caffe/solvers/sgd_solver.cpp
@@ -91,9 +91,12 @@ void SGDSolver<Dtype>::ClipGradients() {
   const Dtype lr_rate = this->param_.adjustable_clipping() ? GetLearningRate() : 1.0;
   if (l2norm_diff > clip_gradients / lr_rate) {
     Dtype scale_factor = (clip_gradients / lr_rate) / l2norm_diff;
-    LOG(INFO) << "Gradient clipping: scaling down gradients (L2 norm "
-        << l2norm_diff << " > " << clip_gradients << ") "
-        << "by scale factor " << scale_factor;
+    if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
+      LOG_IF(INFO, Caffe::root_solver())
+          << "Gradient clipping: scaling down gradients (L2 norm "
+          << l2norm_diff << " > " << clip_gradients << ") "
+          << "by scale factor " << scale_factor;
+    }
     for (int i = 0; i < net_params.size(); ++i) {
       net_params[i]->scale_diff(scale_factor);
     }


### PR DESCRIPTION
I added adjustable gradient clipping(AGC) to sgd_solver.
AGC is needed to shorten learning time during training deep CNN for super-resolution.
I've tested this code, and it worked well for my super-resolution task.

In short description, it adjusts clipping threshold based on current learning rate :
    threshold = clip_gradients / current_lr 

For more information, refer to the following paper :
   Accurate Image Super-Resolution Using Very Deep Convolutional Networks
  ( Jiwon Kim et al. )
