### PR TITLE
Find veclib on MacOS automatically.

### DIFF
--- a/cmake/Modules/FindvecLib.cmake
+++ b/cmake/Modules/FindvecLib.cmake
@@ -10,13 +10,18 @@ if(NOT APPLE)
   return()
 endif()
 
+if(APPLE)
+  EXEC_PROGRAM(sw_vers ARGS -productVersion OUTPUT_VARIABLE DARWIN_VERSION)
+  STRING(REGEX MATCH "10\\.([0-9]*)" DARWIN_VERSION ${DARWIN_VERSION})
+endif()
+
 set(__veclib_include_suffix "Frameworks/vecLib.framework/Versions/Current/Headers")
 
 find_path(vecLib_INCLUDE_DIR vecLib.h
           DOC "vecLib include directory"
           PATHS /System/Library/Frameworks/Accelerate.framework/Versions/Current/${__veclib_include_suffix}
                 /System/Library/${__veclib_include_suffix}
-                /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
+                /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${DARWIN_VERSION}.sdk/System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Headers/
           NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Fix https://github.com/BVLC/caffe/issues/4637.