### PR TITLE
Enable C++11 in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,12 @@ if(USE_libstdcpp)
   message("-- Warning: forcing libstdc++ (controlled by USE_libstdcpp option in cmake)")
 endif()
 
+if (CMAKE_VERSION VERSION_LESS "3.1")
+  set(CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
+else ()
+  set(CMAKE_CXX_STANDARD 11)
+endif ()
+
 # ---[ Warnings
 caffe_warnings_disable(CMAKE_CXX_FLAGS -Wno-sign-compare -Wno-uninitialized)
 

--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -231,7 +231,7 @@ endfunction()
 ###  Non macro section
 ################################################################################################
 
-find_package(CUDA 5.5 QUIET)
+find_package(CUDA 7.0 QUIET)
 find_cuda_helper_libs(curand)  # cmake 2.8.7 compartibility which doesn't search for curand
 
 if(NOT CUDA_FOUND)
@@ -258,6 +258,10 @@ endif()
 caffe_select_nvcc_arch_flags(NVCC_FLAGS_EXTRA)
 list(APPEND CUDA_NVCC_FLAGS ${NVCC_FLAGS_EXTRA})
 message(STATUS "Added CUDA NVCC flags for: ${NVCC_FLAGS_EXTRA_readable}")
+
+# add C++11 support
+list(APPEND CUDA_NVCC_FLAGS "-std=c++11")
+set(CUDA_PROPAGATE_HOST_FLAGS off)
 
 # Boost 1.55 workaround, see https://svn.boost.org/trac/boost/ticket/9392 or
 # https://github.com/ComputationalRadiationPhysics/picongpu/blob/master/src/picongpu/CMakeLists.txt


### PR DESCRIPTION
This PR enables C++11 for compilation of both C++ and CUDA code (see https://github.com/BVLC/caffe/issues/5262).

As C++11 has been supported by CUDA since 7.0, the minimally required version is bumped as well in the cmake file. In order to not raise warnings, host compiler flag propagation to nvcc is disabled (see https://cmake.org/Bug/view.php?id=15240).