### PR TITLE
Minor fix on conv layer doc

### DIFF
--- a/include/caffe/layers/conv_layer.hpp
+++ b/include/caffe/layers/conv_layer.hpp
@@ -20,7 +20,7 @@ namespace caffe {
  *   the cost of memory for matrices. This makes use of efficiency in BLAS.
  *
  *   The input is "im2col" transformed to a channel K' x H x W data matrix
- *   for multiplication with the N x K' x H x W filter matrix to yield a
+ *   for multiplication with the N' x K' filter matrix to yield a
  *   N' x H x W output matrix that is then "col2im" restored. K' is the
  *   input channel * kernel height * kernel width dimension of the unrolled
  *   inputs so that the im2col matrix has a column for each input region to


### PR DESCRIPTION
The dimension of the filter should be N'(output channels) x K'(number of items in the kernels). The original doc says N x K' x H x W. 
Correct me if I was wrong.
Thanks.