### PR TITLE
sane h5df file type check for weights

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -769,8 +769,7 @@ void Net<Dtype>::CopyTrainedLayersFrom(const NetParameter& param) {
 
 template <typename Dtype>
 void Net<Dtype>::CopyTrainedLayersFrom(const string trained_filename) {
-  if (trained_filename.size() >= 3 &&
-      trained_filename.compare(trained_filename.size() - 3, 3, ".h5") == 0) {
+  if (H5Fis_hdf5(trained_filename.c_str())) {
     CopyTrainedLayersFromHDF5(trained_filename);
   } else {
     CopyTrainedLayersFromBinaryProto(trained_filename);


### PR DESCRIPTION
If we save a model using hdf5 and load it using caffe.Net it produces the wrong results silently
I would prefer to have caffe.Net check if the filetype is a hdf5 or a protobuff file to avoid confusion.

```
import caffe
from caffe import layers as L

def conv(bottom, ks_h, ks_w, nout, stride, pad_h, pad_w,
         param_name=''):
  return L.Convolution(bottom, kernel_h=ks_h, kernel_w=ks_w,
                      stride=stride, num_output=nout,
                      pad_h=pad_h, pad_w=pad_w)

def DQN_net():
  n = caffe.NetSpec()
  n.data = L.Input(shape=[dict(dim=[1, 4, 84, 84])])
  n.conv1 = conv(n.data, 8, 8, 16, 4, 0, 0, 'conv1')
  return n.to_proto()

if __name__ == "__main__":
    caffe.set_mode_cpu()
    net_str = DQN_net()
    fn = "savetest.proto"
    weights = "savetest.caffemodel"
    with open(fn,"w") as fo:
        fo.write(str(net_str))
    net = caffe.Net(fn, caffe.TEST)
    net.params["conv1"][0].data[...] = 1
    net.save_hdf5(weights)
    net2 = caffe.Net(fn, weights, caffe.TEST)
    print(net.params["conv1"][0].data.sum())
    print(net2.params["conv1"][0].data.sum())
```
