### PR TITLE
Modification to Solver to get Stages in Testing

### DIFF
--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -45,7 +45,7 @@ class Solver {
   explicit Solver(const string& param_file);
   void Init(const SolverParameter& param);
   void InitTrainNet();
-  void InitTestNets();
+  void InitTestNets(const std::vector<std::string>* stages = NULL);
 
   // Client of the Solver optionally may call this in order to set the function
   // that the solver uses to see what action it should take (e.g. snapshot or


### PR DESCRIPTION
As mentioned in #5369, when specifying stages to the caffe executable, the created test nets in the solver do not include the stages.

The simplest way I found to deal with this was to extract the stages from the train_state. While I don't think this is the most ideal solution, the alternative as best as I could see (modifying one of the constructors to take the stages) would involve a much larger change to the code base.

I specified the parameter to InitTestNets to be a pointer with a default NULL in order to not break any existing code that may rely on InitTestNets without any arguments. I do note that the only place in the code-base that calls InitTestNets is in the Init method; however, as it's a public method, I decided it best to try and not break the interface.

