### PR TITLE
Multi GPU training from Python can use any solver

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -288,7 +288,7 @@ void Solver_add_callback(Solver<Dtype> * solver, bp::object on_start,
 }
 
 // Seems boost cannot call the base method directly
-void Solver_add_nccl(SGDSolver<Dtype>* solver
+void Solver_add_nccl(Solver<Dtype>* solver
 #ifdef USE_NCCL
   , NCCL<Dtype>* nccl
 #endif


### PR DESCRIPTION
During multi GPU training from Python, using anything other than SGDSolver results in a crash because of method signature mismatch. Modifying the signature of Solver_add_nccl fixes this and networks learn as expected with other solvers in my tests