### PR TITLE
Opencl - replace deprecated method call in prelu layer backwards_gpu()

### DIFF
--- a/src/caffe/layers/prelu_layer.cu
+++ b/src/caffe/layers/prelu_layer.cu
@@ -175,35 +175,32 @@ void PReLULayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
       vector<int> offset_vector(bottom[0]->num_axes(),0);
       for (int n = 0; n < bottom[0]->shape(0); ++n) {
         offset_vector[0] = n;
+        // compute element-wise diff
+        viennacl::ocl::kernel &oclk_prelu = program.get_kernel(CL_KERNEL_SELECT("prelu_param_backward"));
+          viennacl::ocl::enqueue(
+              oclk_prelu(cdim, bottom[0]->shape(0), top[0]->offset(offset_vector),
+                  WrapHandle((cl_mem)top_diff, &ctx),
+                  WrapHandle((cl_mem) bottom_data, &ctx),
+                  WrapHandle((cl_mem) (backward_buff_.mutable_gpu_diff()), &ctx)),
+                  ctx.get_queue());
 
-		  // compute element-wise diff
-
-		  viennacl::ocl::kernel &oclk_prelu = program.get_kernel(
-			  CL_KERNEL_SELECT("prelu_param_backward"));
-		  viennacl::ocl::enqueue(
-			  oclk_prelu(cdim, bottom[0]->shape(0), top[0]->offset(offset_vector),
-						 WrapHandle((cl_mem)top_diff, &ctx),
-				  WrapHandle((cl_mem) bottom_data, &ctx),
-				  WrapHandle((cl_mem) (backward_buff_.mutable_gpu_diff()), &ctx)),
-			  ctx.get_queue());
-
-		  if (channel_shared_) {
-			Dtype d ;
-			greentea_gpu_dot<Dtype>(this->device_->id(), channels * dim,
-									(cl_mem) (backward_buff_.gpu_diff()), 0,
-									(cl_mem) (multiplier_.gpu_data()), 0, &d);
-			dsum += d;
-		  } else {
-			greentea_gpu_gemv<Dtype>(this->device_->id(), CblasNoTrans, channels,
-									 dim, 1., (cl_mem) (backward_buff_.gpu_diff()),
-									 0, (cl_mem) (multiplier_.gpu_data()), 0, 1.,
-									 (cl_mem) slope_diff, 0);
-		  }
-	   }
-	   if (channel_shared_) {
-			greentea_gpu_add_scalar(this->device_->id(),
-			                this->blobs_[0]->count(), Dtype(dsum), (cl_mem) slope_diff, 0);
-		}
+          if (channel_shared_) {
+            Dtype d;
+            greentea_gpu_dot<Dtype>(this->device_->id(), channels * dim,
+                                    (cl_mem) (backward_buff_.gpu_diff()), 0,
+                                    (cl_mem) (multiplier_.gpu_data()), 0, &d);
+            dsum += d;
+          } else {
+            greentea_gpu_gemv<Dtype>(this->device_->id(), CblasNoTrans, channels,
+                                     dim, 1., (cl_mem) (backward_buff_.gpu_diff()),
+                                     0, (cl_mem) (multiplier_.gpu_data()), 0, 1.,
+                                     (cl_mem) slope_diff, 0);
+          }
+       }
+       if (channel_shared_) {
+            greentea_gpu_add_scalar(this->device_->id(),
+                            this->blobs_[0]->count(), Dtype(dsum), (cl_mem) slope_diff, 0);
+        }
     }
     // Propagate to bottom
     if (propagate_down[0]) {


### PR DESCRIPTION
While developing a 3d convnet I've noticed that prelu layer implementation uses a deprecated offset() method. Replaced it with a "modern" vector-based one. 