### PR TITLE
Fix a bug in host memory free for OpenCL backend

### DIFF
--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -63,6 +63,9 @@ void CaffeFreeHost(void* ptr, device* dev) {
       cudaFreeHost(ptr);
       return;
 #endif  // USE_CUDA
+    } else {
+      free(ptr);
+      return;
     }
   }
 #endif


### PR DESCRIPTION
We need to use normal free to deallocate memory for OpenCL backend.
If MKL is enabled, current code will use mkl_free to deallocate a
memory allocated by normal posix_memalign/malloc() and will cause
segfault.

Signed-off-by: Zhigang Gong <zhigang.gong@intel.com>