### PR TITLE
Fix a bug when using hdf5_output_layer 

### DIFF
--- a/src/caffe/layers/hdf5_output_layer.cpp
+++ b/src/caffe/layers/hdf5_output_layer.cpp
@@ -1,5 +1,8 @@
-#include <vector>
 
+
+#include <vector>
+#include <string>
+#include <sstream>  
 #include "hdf5.h"
 #include "hdf5_hl.h"
 
@@ -11,30 +14,39 @@ namespace caffe {
 template <typename Dtype>
 void HDF5OutputLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
-  file_name_ = this->layer_param_.hdf5_output_param().file_name();
-  file_id_ = H5Fcreate(file_name_.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT,
-                       H5P_DEFAULT);
-  CHECK_GE(file_id_, 0) << "Failed to open HDF5 file" << file_name_;
-  file_opened_ = true;
 }
 
 template <typename Dtype>
 HDF5OutputLayer<Dtype>::~HDF5OutputLayer<Dtype>() {
-  if (file_opened_) {
-    herr_t status = H5Fclose(file_id_);
-    CHECK_GE(status, 0) << "Failed to close HDF5 file " << file_name_;
-  }
+//  if (file_opened_) {
+//   herr_t status = H5Fclose(file_id_);
+//    CHECK_GE(status, 0) << "Failed to close HDF5 file " << file_name_;
+//  }
 }
 
 template <typename Dtype>
 void HDF5OutputLayer<Dtype>::SaveBlobs() {
   // TODO: no limit on the number of blobs
+  static int cnt_file=0;
+  ostringstream oss;
+  oss.clear();
+  oss<<cnt_file++;
+  file_name_ = this->layer_param_.hdf5_output_param().file_name()+"_"+oss.str();
+  file_id_ = H5Fcreate(file_name_.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT,
+                       H5P_DEFAULT);
+  CHECK_GE(file_id_, 0) << "Failed to open HDF5 file" << file_name_;
+  file_opened_ = true;
+
   LOG(INFO) << "Saving HDF5 file " << file_name_;
   CHECK_EQ(data_blob_.num(), label_blob_.num()) <<
       "data blob and label blob must have the same batch size";
   hdf5_save_nd_dataset(file_id_, HDF5_DATA_DATASET_NAME, data_blob_);
   hdf5_save_nd_dataset(file_id_, HDF5_DATA_LABEL_NAME, label_blob_);
   LOG(INFO) << "Successfully saved " << data_blob_.num() << " rows";
+  if (file_opened_) {
+    herr_t status = H5Fclose(file_id_);
+    CHECK_GE(status, 0) << "Failed to close HDF5 file " << file_name_;
+  }
 }
 
 template <typename Dtype>
@@ -72,3 +84,5 @@ INSTANTIATE_CLASS(HDF5OutputLayer);
 REGISTER_LAYER_CLASS(HDF5Output);
 
 }  // namespace caffe
+
+


### PR DESCRIPTION
The PR is mainly for bug fixing when using hdf5_output_layer saving data of the bottom layer. In the latest hdf5_outout_laye, all data is saved in the same file when iteration. This will cause hdf5 crashed(https://github.com/BVLC/caffe/issues/1726). In this code, index of the iteration is added in the output filename. 
e.g.
layer {
  name: "pool5_out"
  type: "HDF5Output"
  bottom: "pool5"
  bottom: "label"
  hdf5_output_param {
    file_name: "abc"
  }
}
output of HDF5Output layer is "abc_0", "abc_1", ...
Then there will be no error.
