### PR TITLE
add support CUDA on Jetson-TX1 sm_53, and Jetson-TX2 sm_62

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -39,9 +39,11 @@ CUDA_ARCH := -gencode arch=compute_20,code=sm_20 \
 		-gencode arch=compute_35,code=sm_35 \
 		-gencode arch=compute_50,code=sm_50 \
 		-gencode arch=compute_52,code=sm_52 \
+		-gencode arch=compute_53,code=sm_53 \
 		-gencode arch=compute_60,code=sm_60 \
 		-gencode arch=compute_61,code=sm_61 \
-		-gencode arch=compute_61,code=compute_61
+		-gencode arch=compute_62,code=sm_62 \
+		-gencode arch=compute_62,code=compute_62 
 
 # BLAS choice:
 # atlas for ATLAS (default)


### PR DESCRIPTION
due to mismatch  capacity, Caffe would fail with an error : " cuda api error - cudaLaunch returns 0x8"  on Jetson-TX1 and Jetson-TX2.