### PR TITLE
Improved matlab interfaces for robustness

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -170,6 +170,12 @@ class Caffe {
   inline static void set_multiprocess(bool val) { Get().multiprocess_ = val; }
   inline static bool root_solver() { return Get().solver_rank_ == 0; }
 
+#ifdef MATLAB_MEX_FILE
+  // Whether is called from matlab
+  inline static bool using_Matlab() { return Get().using_Matlab_; }
+  inline static void set_using_Matlab(bool val) { Get().using_Matlab_ = val; }
+#endif
+
  protected:
 #ifndef CPU_ONLY
   cublasHandle_t cublas_handle_;
@@ -183,6 +189,11 @@ class Caffe {
   int solver_count_;
   int solver_rank_;
   bool multiprocess_;
+
+#ifdef MATLAB_MEX_FILE
+  // Use matlab
+  bool using_Matlab_ = false;
+#endif
 
  private:
   // The private constructor to avoid duplicate instantiation.

--- a/matlab/+caffe/Net.m
+++ b/matlab/+caffe/Net.m
@@ -123,10 +123,14 @@ classdef Net < handle
     function copy_from(self, weights_file)
       CHECK(ischar(weights_file), 'weights_file must be a string');
       CHECK_FILE_EXIST(weights_file);
-      caffe_('net_copy_from', self.hNet_self, weights_file);
+      if caffe_('net_copy_from', self.hNet_self, weights_file) == -1
+         error('null returned in caffe.Net.copy_from(weights_file)');
+      end
     end
     function reshape(self)
-      caffe_('net_reshape', self.hNet_self);
+      if caffe_('net_reshape', self.hNet_self) == -1
+          error('null returned in caffe.Net.reshape');
+      end
     end
     function save(self, weights_file)
       CHECK(ischar(weights_file), 'weights_file must be a string');

--- a/matlab/+caffe/Solver.m
+++ b/matlab/+caffe/Solver.m
@@ -45,15 +45,21 @@ classdef Solver < handle
     function restore(self, snapshot_filename)
       CHECK(ischar(snapshot_filename), 'snapshot_filename must be a string');
       CHECK_FILE_EXIST(snapshot_filename);
-      caffe_('solver_restore', self.hSolver_self, snapshot_filename);
+      if caffe_('solver_restore', self.hSolver_self, snapshot_filename) == -1
+          error('null returned in caffe.Solver.restore(snapshot_filename)');
+      end
     end
     function solve(self)
-      caffe_('solver_solve', self.hSolver_self);
+      if caffe_('solver_solve', self.hSolver_self) == -1
+          error('null returned in caffe.Solver.solve()');
+      end
     end
     function step(self, iters)
       CHECK(isscalar(iters) && iters > 0, 'iters must be positive integer');
       iters = double(iters);
-      caffe_('solver_step', self.hSolver_self, iters);
+      if caffe_('solver_step', self.hSolver_self, iters) == -1
+          error('null returned in caffe.Solver.step()');
+      end
     end
   end
 end

--- a/matlab/+caffe/get_net.m
+++ b/matlab/+caffe/get_net.m
@@ -25,7 +25,11 @@ CHECK(strcmp(phase_name, 'train') || strcmp(phase_name, 'test'), ...
 
 % construct caffe net from model_file
 hNet = caffe_('get_net', model_file, phase_name);
-net = caffe.Net(hNet);
+if ~isstruct(hNet)
+    error('null returned in get_net');
+else
+    net = caffe.Net(hNet);
+end
 
 % load weights from weights_file
 if nargin == 3

--- a/matlab/+caffe/get_solver.m
+++ b/matlab/+caffe/get_solver.m
@@ -5,6 +5,10 @@ function solver = get_solver(solver_file)
 CHECK(ischar(solver_file), 'solver_file must be a string');
 CHECK_FILE_EXIST(solver_file);
 pSolver = caffe_('get_solver', solver_file);
-solver = caffe.Solver(pSolver);
+if ~isstruct(pSolver)   % pSolver should be a handle (struct)
+    error('null returned in get_solver');
+else
+    solver = caffe.Solver(pSolver);
+end
 
 end

--- a/windows/libcaffe/libcaffe.vcxproj
+++ b/windows/libcaffe/libcaffe.vcxproj
@@ -93,7 +93,6 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\caffe\blob.cpp" />
     <ClCompile Include="..\..\src\caffe\common.cpp" />
-    <ClCompile Include="..\..\src\caffe\data_reader.cpp" />
     <ClCompile Include="..\..\src\caffe\data_transformer.cpp" />
     <ClCompile Include="..\..\src\caffe\internal_thread.cpp" />
     <ClCompile Include="..\..\src\caffe\layer.cpp" />

--- a/windows/libcaffe/libcaffe.vcxproj.filters
+++ b/windows/libcaffe/libcaffe.vcxproj.filters
@@ -108,9 +108,6 @@
     <ClCompile Include="..\..\src\caffe\parallel.cpp">
       <Filter>src</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\caffe\data_reader.cpp">
-      <Filter>src</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\caffe\util\blocking_queue.cpp">
       <Filter>src\util</Filter>
     </ClCompile>


### PR DESCRIPTION
**Major improvements**
1. Prevent crushing by installing failure function and throw-catch exception
in caffe_.cpp
2. Add LogSink to log error and warning to matlab, in caffe_.cpp
3. Add check for the return value from mex-calls in matlab code, to handle some of the common exceptions

**Reasons for the previous crushing**
google::glog call abort() by default when a Fatal message occurs. When loaded as a mex function, this causes matlab to crush.

**Implementation notes**
1. add first-call flag in failurefunction and matlabsink, since the error message may be sent more than once before it got handled.
2. use mexWarnMsgTxt to print (error) messages in matlab, since
mexErrMsgTxt results in crushing
3. remove reference to data_reader.cpp from libcaffe project
