### PR TITLE
Support Ctrl-C interruption for Matlab training

### DIFF
--- a/windows/CommonSettings.props.example
+++ b/windows/CommonSettings.props.example
@@ -6,19 +6,19 @@
         <!--NOTE: CpuOnlyBuild and UseCuDNN flags can't be set at the same time.-->
         <CpuOnlyBuild>false</CpuOnlyBuild>
         <UseCuDNN>true</UseCuDNN>
-        <CudaVersion>7.5</CudaVersion>
+        <CudaVersion>8.0</CudaVersion>
         <!-- NOTE: If Python support is enabled, PythonDir (below) needs to be
          set to the root of your Python installation. If your Python installation
          does not contain debug libraries, debug build will not work. -->
-        <PythonSupport>false</PythonSupport>
+        <PythonSupport>true</PythonSupport>
         <!-- NOTE: If Matlab support is enabled, MatlabDir (below) needs to be
          set to the root of your Matlab installation. -->
-        <MatlabSupport>false</MatlabSupport>
+        <MatlabSupport>true</MatlabSupport>
         <CudaDependencies></CudaDependencies>
 
         <!-- Set CUDA architecture suitable for your GPU.
          Setting proper architecture is important to mimize your run and compile time. -->
-        <CudaArchitecture>compute_35,sm_35;compute_52,sm_52</CudaArchitecture>
+        <CudaArchitecture>compute_61,sm_61</CudaArchitecture>
 
         <!-- CuDNN 3 and 4 are supported -->
         <CuDnnPath></CuDnnPath>
@@ -45,12 +45,12 @@
         <IncludePath>$(SolutionDir)..\include;$(SolutionDir)..\include\caffe\proto;$(CUDA_PATH)\include;$(IncludePath)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(PythonSupport)'=='true'">
-        <PythonDir>C:\Miniconda2\</PythonDir>
+        <PythonDir>C:\Program Files\Anaconda2\</PythonDir>
         <LibraryPath>$(PythonDir)\libs;$(LibraryPath)</LibraryPath>
         <IncludePath>$(PythonDir)\include;$(IncludePath)</IncludePath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(MatlabSupport)'=='true'">
-        <MatlabDir>C:\Program Files\MATLAB\R2014b</MatlabDir>
+        <MatlabDir>C:\Program Files\MATLAB\R2016a</MatlabDir>
         <LibraryPath>$(MatlabDir)\extern\lib\win64\microsoft;$(LibraryPath)</LibraryPath>
         <IncludePath>$(MatlabDir)\extern\include;$(IncludePath)</IncludePath>
     </PropertyGroup>
@@ -76,6 +76,11 @@
         <ClCompile>
             <PreprocessorDefinitions>MATLAB_MEX_FILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
         </ClCompile>
+      <Link>
+        <AdditionalDependencies>
+          $(MatlabDir)\extern\lib\win64\microsoft\libut.lib; libmx.lib;libmex.lib;%(AdditionalDependencies)
+        </AdditionalDependencies>
+      </Link>
     </ItemDefinitionGroup>
     <ItemDefinitionGroup>
         <ClCompile>


### PR DESCRIPTION
**Major changes**
1. Change step() function in Solver.cpp to check interruption signal from matlab, using a undocumented mex interface `utIsInterruptPending`, as instructed [here](http://www.caam.rice.edu/~wy1/links/mex_ctrl_c_trick/).
2. Update CommonSettings.props.example for AdditionalDependencies.