### PR TITLE
Eltwise layer shape mismatch => log dimensions

### DIFF
--- a/src/caffe/layers/eltwise_layer.cpp
+++ b/src/caffe/layers/eltwise_layer.cpp
@@ -31,7 +31,9 @@ template <typename Dtype>
 void EltwiseLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   for (int i = 1; i < bottom.size(); ++i) {
-    CHECK(bottom[i]->shape() == bottom[0]->shape());
+    CHECK(bottom[0]->shape() == bottom[i]->shape())
+        << "bottom[0]: " << bottom[0]->shape_string()
+        << ", bottom[" << i << "]: " << bottom[i]->shape_string();
   }
   top[0]->ReshapeLike(*bottom[0]);
   // If max operation, we will initialize the vector index part.


### PR DESCRIPTION
When layer shapes mismatch for the eltwise layer, caffe will fail a
check but doesn't give any information on how the shapes mismatch.
This logging information will make it easier to debug. Additionally
this reorders the variables to CHECK(expected == actual), matching
the JUnit convention.

```
BEFORE: Check failed: bottom[i]->shape() == bottom[0]->shape()
```
```
AFTER:  Check failed: bottom[0]->shape() == bottom[i]->shape()
        bottom[0]: 1 3 (3), bottom[1]: 1 5 (5)
```

NOTE: This removes use of CHECK_EQ in an earlier version of this PR,
which caused a build warning due to include of glog/stl_logging.h.