### PR TITLE
Explicit std::string to bp::object conversion

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -371,7 +371,7 @@ bp::object NCCL_New_Uid() {
   return bp::object(bp::handle<>(py_uid));
 #else
   // automatic conversion is correct for python 2.
-  return uid;
+  return bp::object(uid);
 #endif
 }
 #endif


### PR DESCRIPTION
Follow up on #5527, some compilers will require explicit conversion since boost::python::object is marked as `explicit`. 