### PR TITLE
Suppress skimage warning "The default mode, 'constant', will be changed to 'reflect'"

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -323,7 +323,8 @@ def resize_image(im, new_dims, interp_order=1):
             # skimage is fast but only understands {1,3} channel images
             # in [0, 1].
             im_std = (im - im_min) / (im_max - im_min)
-            resized_std = resize(im_std, new_dims, order=interp_order)
+            resized_std = resize(im_std, new_dims, mode='constant',
+                                 order=interp_order)
             resized_im = resized_std * (im_max - im_min) + im_min
         else:
             # the image is a constant -- avoid divide by 0


### PR DESCRIPTION
A warning has been introduced in `skimage.transform.resize` due to a change in the default value for the padding mode parameter.
This change suppresses the warning by setting the old default value explicitly.