### PR TITLE
Added const getters and fixed constness of existing getters for vario…

### DIFF
--- a/include/caffe/common.hpp
+++ b/include/caffe/common.hpp
@@ -19,7 +19,9 @@
 #include "caffe/util/device_alternate.hpp"
 
 // Convert macro to string
+#undef STRINGIFY
 #define STRINGIFY(m) #m
+#undef AS_STRING
 #define AS_STRING(m) STRINGIFY(m)
 
 // gflags 2.1 issue: namespace google was changed to gflags without warning.

--- a/include/caffe/sgd_solvers.hpp
+++ b/include/caffe/sgd_solvers.hpp
@@ -21,7 +21,8 @@ class SGDSolver : public Solver<Dtype> {
       : Solver<Dtype>(param_file) { PreSolve(); }
   virtual inline const char* type() const { return "SGD"; }
 
-  const vector<shared_ptr<Blob<Dtype> > >& history() { return history_; }
+  const vector<shared_ptr<Blob<Dtype> > >& history() const { return history_; }
+  Dtype learning_rate() const { return learning_rate_; }
 
  protected:
   void PreSolve();
@@ -41,6 +42,7 @@ class SGDSolver : public Solver<Dtype> {
   // temp maintains other information that might be needed in computation
   //   of gradients/updates and is not needed in snapshots
   vector<shared_ptr<Blob<Dtype> > > history_, update_, temp_;
+  Dtype learning_rate_;
 
   DISABLE_COPY_AND_ASSIGN(SGDSolver);
 };

--- a/include/caffe/solver.hpp
+++ b/include/caffe/solver.hpp
@@ -68,11 +68,13 @@ class Solver {
   void Snapshot();
   virtual ~Solver() {}
   inline const SolverParameter& param() const { return param_; }
-  inline shared_ptr<Net<Dtype> > net() { return net_; }
-  inline const vector<shared_ptr<Net<Dtype> > >& test_nets() {
+  inline shared_ptr<Net<Dtype> > net() const { return net_; }
+  inline const vector<shared_ptr<Net<Dtype> > >& test_nets() const {
     return test_nets_;
   }
   int iter() const { return iter_; }
+  const vector<Dtype>& mean_scores() const { return mean_scores_; }
+  Dtype smoothed_loss() const { return smoothed_loss_; }
 
   // Invoked at specific points during an iteration
   class Callback {
@@ -115,6 +117,7 @@ class Solver {
   shared_ptr<Net<Dtype> > net_;
   vector<shared_ptr<Net<Dtype> > > test_nets_;
   vector<Callback*> callbacks_;
+  vector<Dtype> mean_scores_;
   vector<Dtype> losses_;
   Dtype smoothed_loss_;
 

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -174,6 +174,7 @@ void Solver<Dtype>::InitTestNets() {
     test_nets_[i].reset(new Net<Dtype>(net_params[i]));
     test_nets_[i]->set_debug_info(param_.debug_info());
   }
+  mean_scores_.resize(num_test_net_instances);
 }
 
 template <typename Dtype>
@@ -182,6 +183,7 @@ void Solver<Dtype>::Step(int iters) {
   const int stop_iter = iter_ + iters;
   int average_loss = this->param_.average_loss();
   losses_.clear();
+  mean_scores_.assign(mean_scores_.size(), 0);
   smoothed_loss_ = 0;
   iteration_timer_.Start();
 
@@ -390,6 +392,7 @@ void Solver<Dtype>::Test(const int test_net_id) {
     const Dtype loss_weight = test_net->blob_loss_weights()[output_blob_index];
     ostringstream loss_msg_stream;
     const Dtype mean_score = test_score[i] / param_.test_iter(test_net_id);
+    mean_scores_[i] = mean_score;
     if (loss_weight) {
       loss_msg_stream << " (* " << loss_weight
                       << " = " << loss_weight * mean_score << " loss)";

--- a/src/caffe/solvers/sgd_solver.cpp
+++ b/src/caffe/solvers/sgd_solver.cpp
@@ -64,6 +64,7 @@ Dtype SGDSolver<Dtype>::GetLearningRate() {
 
 template <typename Dtype>
 void SGDSolver<Dtype>::PreSolve() {
+  learning_rate_ = 0;
   // Initialize the history
   const vector<Blob<Dtype>*>& net_params = this->net_->learnable_params();
   history_.clear();
@@ -101,6 +102,7 @@ void SGDSolver<Dtype>::ClipGradients() {
 template <typename Dtype>
 void SGDSolver<Dtype>::ApplyUpdate() {
   Dtype rate = GetLearningRate();
+  learning_rate_ = rate;
   if (this->param_.display() && this->iter_ % this->param_.display() == 0) {
     LOG_IF(INFO, Caffe::root_solver()) << "Iteration " << this->iter_
         << ", lr = " << rate;


### PR DESCRIPTION
Added const getters and fixed constness of existing getters for various parameters that applications may wish to track via the C++ API during training.  Added member variables to make temporary variables persistent and accessible via getters, including learning rate and mean scores (accuracy).

Also, undefined preprocessor macros that get redefined and sometimes cause conflicts.  Perhaps CAFFE_STRINGIFY and CAFFE_AS_STRING are better choices?  