### PR TITLE
Removing the duplicated Reshape in Layer->Forward()

### DIFF
--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -413,7 +413,7 @@ template <typename Dtype>
 inline Dtype Layer<Dtype>::Forward(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   Dtype loss = 0;
-  //Reshape(bottom, top);
+  // Reshape(bottom, top);
   switch (Caffe::mode()) {
   case Caffe::CPU:
     Forward_cpu(bottom, top);

--- a/include/caffe/layer.hpp
+++ b/include/caffe/layer.hpp
@@ -413,7 +413,7 @@ template <typename Dtype>
 inline Dtype Layer<Dtype>::Forward(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   Dtype loss = 0;
-  Reshape(bottom, top);
+  //Reshape(bottom, top);
   switch (Caffe::mode()) {
   case Caffe::CPU:
     Forward_cpu(bottom, top);

--- a/src/caffe/test/test_lstm_layer.cpp
+++ b/src/caffe/test/test_lstm_layer.cpp
@@ -149,6 +149,7 @@ TYPED_TEST(LSTMLayerTest, TestForward) {
       this->blob_bottom_cont_.mutable_cpu_data()[n] = t > 0;
     }
     LOG(INFO) << "Calling forward for LSTM timestep " << t;
+    layer->Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
     layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
     for (int i = 0; i < top_count; ++i) {
       ASSERT_LT(t * top_count + i, top_copy.count());
@@ -170,6 +171,7 @@ TYPED_TEST(LSTMLayerTest, TestForward) {
       this->blob_bottom_cont_.mutable_cpu_data()[n] = 0;
     }
     LOG(INFO) << "Calling forward for LSTM timestep " << t;
+    layer->Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
     layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
     for (int i = 0; i < top_count; ++i) {
       if (t == 0) {

--- a/src/caffe/test/test_net.cpp
+++ b/src/caffe/test/test_net.cpp
@@ -2397,6 +2397,7 @@ TYPED_TEST(NetTest, TestReshape) {
   input_blob->Reshape(blob1.num(), blob1.channels(), blob1.height(),
       blob1.width());
   caffe_copy(blob1.count(), blob1.cpu_data(), input_blob->mutable_cpu_data());
+  this->net_->Reshape();
   this->net_->Forward();
   // call backward just to make sure it runs
   this->net_->Backward();
@@ -2408,6 +2409,7 @@ TYPED_TEST(NetTest, TestReshape) {
   input_blob->Reshape(blob2.num(), blob2.channels(), blob2.height(),
       blob2.width());
   caffe_copy(blob2.count(), blob2.cpu_data(), input_blob->mutable_cpu_data());
+  this->net_->Reshape();
   this->net_->Forward();
   this->net_->Backward();
   Blob<Dtype> output2(output_blob->num(), output_blob->channels(),
@@ -2418,6 +2420,7 @@ TYPED_TEST(NetTest, TestReshape) {
   input_blob->Reshape(blob1.num(), blob1.channels(), blob1.height(),
       blob1.width());
   caffe_copy(blob1.count(), blob1.cpu_data(), input_blob->mutable_cpu_data());
+  this->net_->Reshape();
   this->net_->Forward();
   this->net_->Backward();
   for (int i = 0; i < output1.count(); ++i) {
@@ -2427,6 +2430,7 @@ TYPED_TEST(NetTest, TestReshape) {
   input_blob->Reshape(blob2.num(), blob2.channels(), blob2.height(),
       blob2.width());
   caffe_copy(blob2.count(), blob2.cpu_data(), input_blob->mutable_cpu_data());
+  this->net_->Reshape();
   this->net_->Forward();
   this->net_->Backward();
   for (int i = 0; i < output2.count(); ++i) {

--- a/src/caffe/test/test_rnn_layer.cpp
+++ b/src/caffe/test/test_rnn_layer.cpp
@@ -124,6 +124,7 @@ TYPED_TEST(RNNLayerTest, TestForward) {
       this->blob_bottom_cont_.mutable_cpu_data()[n] = t > 0;
     }
     LOG(INFO) << "Calling forward for RNN timestep " << t;
+    layer->Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
     layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
     for (int i = 0; i < top_count; ++i) {
       ASSERT_LT(t * top_count + i, top_copy.count());
@@ -145,6 +146,7 @@ TYPED_TEST(RNNLayerTest, TestForward) {
       this->blob_bottom_cont_.mutable_cpu_data()[n] = 0;
     }
     LOG(INFO) << "Calling forward for RNN timestep " << t;
+    layer->Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
     layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
     for (int i = 0; i < top_count; ++i) {
       if (t == 0) {

--- a/src/caffe/test/test_scale_layer.cpp
+++ b/src/caffe/test/test_scale_layer.cpp
@@ -139,6 +139,8 @@ TYPED_TEST(ScaleLayerTest, TestBackwardEltwiseInPlace) {
   // Rerun forward + backward with in-place computation;
   // check that resulting bottom diffs are the same.
   this->blob_top_vec_[0] = this->blob_bottom_;  // in-place computation
+
+  layer->Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
   layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
   caffe_copy(top_diff.count(), top_diff.cpu_data(),
              this->blob_bottom_->mutable_cpu_diff());
@@ -276,6 +278,7 @@ TYPED_TEST(ScaleLayerTest, TestBackwardBroadcastMiddleInPlace) {
   // Rerun forward + backward with in-place computation;
   // check that resulting bottom diffs are the same.
   this->blob_top_vec_[0] = this->blob_bottom_;  // in-place computation
+  layer->Reshape(this->blob_bottom_vec_, this->blob_top_vec_);
   layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
   caffe_copy(top_diff.count(), top_diff.cpu_data(),
              this->blob_bottom_->mutable_cpu_diff());


### PR DESCRIPTION
Reshape is called already in Layer->SetUp().
The other call in Layer->Forward() is not necessary and will result in Reshape be called twice, while this behavior is never documented.

