### PR TITLE
Handling destruction of empty Net objects

### DIFF
--- a/matlab/+caffe/Net.m
+++ b/matlab/+caffe/Net.m
@@ -69,7 +69,9 @@ classdef Net < handle
       self.blob_names = self.attributes.blob_names;
     end
     function delete (self)
-      caffe_('delete_net', self.hNet_self);
+      if ~isempty(self.hNet_self)
+        caffe_('delete_net', self.hNet_self);
+      end
     end
     function layer = layers(self, layer_name)
       CHECK(ischar(layer_name), 'layer_name must be a string');


### PR DESCRIPTION
When constructing a network, the internal object initialization of Matlab actually creates a new network and replaces the already instantiated object, causing an empty network to be deleted. This PR checks if the caffe net pointer is defined before calling the net-deletion-function in caffe_.cpp.
Fixes #5346 