### PR TITLE
Downgrade boost requirement from 1.55 to 1.54

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -5,7 +5,7 @@ set(Caffe_DEFINITIONS "")
 set(Caffe_COMPILE_OPTIONS "")
 
 # ---[ Boost
-find_package(Boost 1.55 REQUIRED COMPONENTS system thread filesystem)
+find_package(Boost 1.54 REQUIRED COMPONENTS system thread filesystem)
 list(APPEND Caffe_INCLUDE_DIRS PUBLIC ${Boost_INCLUDE_DIRS})
 list(APPEND Caffe_LINKER_LIBS PUBLIC ${Boost_LIBRARIES})
 

--- a/scripts/travis/install-deps.sh
+++ b/scripts/travis/install-deps.sh
@@ -9,10 +9,10 @@ apt-get -y update
 apt-get install -y --no-install-recommends \
   build-essential \
   graphviz \
-  libboost-filesystem1.55-dev \
-  libboost-python1.55-dev \
-  libboost-system1.55-dev \
-  libboost-thread1.55-dev \
+  libboost-filesystem-dev \
+  libboost-python-dev \
+  libboost-system-dev \
+  libboost-thread-dev \
   libgflags-dev \
   libgoogle-glog-dev \
   libhdf5-serial-dev \


### PR DESCRIPTION
Address concern mentioned at https://github.com/BVLC/caffe/pull/5526#issuecomment-300934771.