### PR TITLE
Added pydot as a requirement

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -15,3 +15,4 @@ python-gflags>=2.0
 pyyaml>=3.10
 Pillow>=2.3.0
 six>=1.1.0
+pydot>=1.0.2


### PR DESCRIPTION
I get an `ImportError: No module named pydot` error when running `./python/draw_net.py`.