### PR TITLE
Only delete Caffe Solver object if reference is defined

### DIFF
--- a/matlab/+caffe/Solver.m
+++ b/matlab/+caffe/Solver.m
@@ -37,7 +37,9 @@ classdef Solver < handle
       end
     end
     function delete (self)
-      caffe_('delete_solver', self.hSolver_self);
+      if ~isempty(self.hSolver_self)
+        caffe_('delete_solver', self.hSolver_self);
+      end
     end
     function iter = iter(self)
       iter = caffe_('solver_get_iter', self.hSolver_self);


### PR DESCRIPTION
Similar fix as #5588 but for Solver objects.