### PR TITLE
Meixiaofeng net object validcheck

### DIFF
--- a/matlab/+caffe/Net.m
+++ b/matlab/+caffe/Net.m
@@ -69,9 +69,7 @@ classdef Net < handle
       self.blob_names = self.attributes.blob_names;
     end
     function delete (self)
-      if ~isempty(self.hNet_self)
-        caffe_('delete_net', self.hNet_self);
-      end
+      caffe_('delete_net', self.hNet_self);
     end
     function layer = layers(self, layer_name)
       CHECK(ischar(layer_name), 'layer_name must be a string');

--- a/matlab/+caffe/Net.m
+++ b/matlab/+caffe/Net.m
@@ -69,7 +69,9 @@ classdef Net < handle
       self.blob_names = self.attributes.blob_names;
     end
     function delete (self)
-      caffe_('delete_net', self.hNet_self);
+        if self.isvalid
+          caffe_('delete_net', self.hNet_self);
+        end
     end
     function layer = layers(self, layer_name)
       CHECK(ischar(layer_name), 'layer_name must be a string');


### PR DESCRIPTION
I run the matlab classification_demo on windows, and I get the following error:

Warning: The following error was caught while executing 'caffe.Net' class destructor:
Error using caffe_
Could not convert handle to pointer due to invalid init_key. The object might have been cleared.

Error in caffe.Net/delete (line 72)
          caffe_('delete_net', self.hNet_self);

Just like @ShaggO put it," When constructing a network, the internal object initialization of Matlab actually creates a new network and replaces the already instantiated object, causing an empty network to be deleted" [PR #5588 ](https://github.com/BVLC/caffe/pull/5588) .But the method and code commited in  [PR #5588 ](https://github.com/BVLC/caffe/pull/5588) does not work for me.Since the Net object may have already been deleted but we still reference it like this, 'self.hNet_self '. We must check if the Net object is still valid before deleting it.