### PR TITLE
Remove duplicated template instantiation to resolve build failure

### DIFF
--- a/src/caffe/greentea/libdnn_conv_spatial.cpp
+++ b/src/caffe/greentea/libdnn_conv_spatial.cpp
@@ -2862,8 +2862,6 @@ void LibDNNConvSpatial<double>::calculate_global_size(
   NOT_IMPLEMENTED;
 }
 
-INSTANTIATE_CLASS(LibDNNConvSpatial);
-
 }  // namespace caffe
 #endif  // USE_GREENTEA
 #endif  // USE_LIBDNN


### PR DESCRIPTION
Resolve the following build failure
src/caffe/greentea/libdnn_conv_spatial.cpp:2865:19: error: duplicate explicit instantiation of 'swizzleWeights'
INSTANTIATE_CLASS(LibDNNConvSpatial);