### PR TITLE
Resolve build failure in libdnn_conv_spatial

### DIFF
--- a/src/caffe/greentea/libdnn_conv_spatial.cpp
+++ b/src/caffe/greentea/libdnn_conv_spatial.cpp
@@ -2755,25 +2755,6 @@ void LibDNNConvSpatial<Dtype>::SetUp(
   }
 }
 
-template void LibDNNConvSpatial<float>::SetUp(
-    const float *bottom, const float *top,
-    caffe::Backend backend);
-
-template void LibDNNConvSpatial<double>::SetUp(
-    const double *bottom, const double *top,
-    caffe::Backend backend);
-
-template void LibDNNConvSpatial<float>::swizzleWeights(
-    const float *bottom,
-    const float *top,
-    int_tp swizzle_factor,
-    bool interleave = false);
-template void LibDNNConvSpatial<double>::swizzleWeights(
-    const double *bottom,
-    const double *top,
-    int_tp swizzle_factor,
-    bool interleave = false);
-
 template<>
 void LibDNNConvSpatial<double>::create_convolution_kernel(
     const double *bottom, const double *top,


### PR DESCRIPTION
@naibaf7  By following caffe's coding convention, template instantiation occurred at 0b22688 have to use [INSTANTIATE_CLASS](https://github.com/BVLC/caffe/blob/opencl/src/caffe/greentea/libdnn_conv_spatial.cpp#L2865) instead of writing [separate instantiation](https://github.com/BVLC/caffe/blob/opencl/src/caffe/greentea/libdnn_conv_spatial.cpp#L2758-L2775), which results in build error as indicated in #5657.