### PR TITLE
Fixed bilinear filler

### DIFF
--- a/include/caffe/filler.hpp
+++ b/include/caffe/filler.hpp
@@ -250,10 +250,10 @@ class BilinearFiller : public Filler<Dtype> {
     CHECK_EQ(blob->width(), blob->height()) << "Filter must be square";
     Dtype* data = blob->mutable_cpu_data();
     int f = ceil(blob->width() / 2.);
-    float c = (2 * f - 1 - f % 2) / (2. * f);
+    Dtype c = (blob->width() - 1) / (2. * f);
     for (int i = 0; i < blob->count(); ++i) {
-      float x = i % blob->width();
-      float y = (i / blob->width()) % blob->height();
+      Dtype x = i % blob->width();
+      Dtype y = (i / blob->width()) % blob->height();
       data[i] = (1 - fabs(x / f - c)) * (1 - fabs(y / f - c));
     }
     CHECK_EQ(this->filler_param_.sparse(), -1)


### PR DESCRIPTION
`BilinearFiller` seems broken for some small values of `kernel_size`, for example 3, 6, 7, ~8~ 10. For size 3 it generates this:
```
[ 0.0625  0.1875  0.1875]
[ 0.1875  0.5625  0.5625]
[ 0.1875  0.5625  0.5625]
```
instead of something more symmetric. ~I feel like it's an issue, since this is the exact size of filter needed for upsampling by factor of 2.~ (see below)
You can verify the problem exists, just run the following [code](https://gist.github.com/Noiredd/1e21baf8b4e4c1a3598d849142560e3d) on this [network](https://gist.github.com/Noiredd/bfdcc002a03a5746a726035a8deab270).

This PR corrects the crucial line in filler code.  
BTW, this was noticed earlier in #4677, but due to a typo it never passed the basic tests. Besides, I noticed that this filler is never tested - unlike all others. Let me know if this is worth pursuing and I'll write a test or two in my spare time.

~Additionally, the current implementation, quoting the [comment](https://github.com/BVLC/caffe/blob/4efdf7ee49cffefdd7ea099c00dc5ea327640f04/include/caffe/filler.hpp#L238) from current master, _is equivalent to the following call in Python with Scikit.Image_:
`out = skimage.transform.rescale(img, factor, mode='constant', cval=0)`  
Possibly I don't understand it, but it seems to me that it doesn't work like that. For example, with `factor=2` we would have to create a deconv layer of `stride: 2`, `kernel_size: 3` and `pad: 1` - per formulas in the section quoted above. And the output of rescaling some image via scikit should be the same as if we forwarded it through [this little net](https://gist.github.com/Noiredd/e03acca43251b3eba2ae42421fa856b1) - correct? I [tried to do that](https://gist.github.com/Noiredd/3aad529fc6e05f094b1a7e682ee94029) but the results differ - even the output shape is different for two methods: (3,7) for deconv, (4,8) for scikit. Contents are somewhat similar other than that. With my PR merged, they differ noticeably - possibly by fixing something I need, I'm breaking a functionality I don't understand?~
EDIT (regarding compatibility with scikit): Indeed it was my mistake - hastily calculated the filter size. So the issue I'm describing does not concern scikit compatibility, neither my PR disrupts it. The fault still exists though - _it just so happens_ that none of the broken filters are used for integer factor upsampling: factors 1-5 require kernels of sizes 4, 5, 8, 9 and 12 respectively, and all of those values work well with the current filler implementation. However, for kernels of size 3, 6, 7, 10 (or in general: any size that is not representable by `4*n-1` or `4n-2` where `n` is a natural number) generated filters are wrong.

Task list:
 - [x] fix bilinear filler
 - [x] sort out compatibility with scikit
 - [x] write unit tests