### PR TITLE
docs: update apt installation guide for Debian and Ubuntu

### DIFF
--- a/docs/install_apt.md
+++ b/docs/install_apt.md
@@ -4,6 +4,34 @@ title: "Installation: Ubuntu"
 
 # Ubuntu Installation
 
+### For Ubuntu (>= 17.04)
+
+**Installing pre-compiled Caffe**
+
+Everything including caffe itself is packaged in 17.04 and higher versions.
+To install pre-compiled Caffe package, just do it by
+
+    sudo apt install caffe-cpu
+
+for CPU-only version, or
+
+    sudo apt install caffe-cuda
+
+for CUDA version. Note, the cuda version may break if your NVIDIA driver
+and CUDA toolkit are not installed by APT.
+
+**Installing Caffe from source**
+
+We may install the dependencies by merely one line
+
+    sudo apt build-dep caffe-cpu        # dependencies for CPU-only version
+    sudo apt build-dep caffe-cuda       # dependencies for CUDA version
+
+It requires a `deb-src` line in your `sources.list`.
+Continue with [compilation](installation.html#compilation).
+
+### For Ubuntu (\< 17.04)
+
 **General dependencies**
 
     sudo apt-get install libprotobuf-dev libleveldb-dev libsnappy-dev libopencv-dev libhdf5-serial-dev protobuf-compiler

--- a/docs/install_apt.md
+++ b/docs/install_apt.md
@@ -20,6 +20,10 @@ for CPU-only version, or
 for CUDA version. Note, the cuda version may break if your NVIDIA driver
 and CUDA toolkit are not installed by APT.
 
+[Package status of CPU-only version](https://launchpad.net/ubuntu/+source/caffe)
+
+[Package status of CUDA version](https://launchpad.net/ubuntu/+source/caffe-contrib)
+
 **Installing Caffe from source**
 
 We may install the dependencies by merely one line

--- a/docs/install_apt_debian.md
+++ b/docs/install_apt_debian.md
@@ -8,24 +8,28 @@ Caffe packages are available for several Debian versions, as shown in the
 following chart:
 
 ```
-Your Distro     |  CPU_ONLY  |  CUDA  |     Alias
+Your Distro     |  CPU_ONLY  |  CUDA  | Codename
 ----------------+------------+--------+-------------------
-Debian/stable   |     ✘      |   ✘    | Debian Jessie
-Debian/testing  |     ✔      |   ✔    | Debian Stretch/Sid
-Debian/unstable |     ✔      |   ✔    | Debian Sid
+Debian/oldstable|     ✘      |   ✘    | Jessie (8.0)
+Debian/stable   |     ✔      |   ✔    | Stretch (9.0)
+Debian/testing  |     ✔      |   ✔    | Buster
+Debian/unstable |     ✔      |   ✔    | Buster
 ```
 
 * `✘ ` You should take a look at [Ubuntu installation instruction](install_apt.html).
 
 * `✔ ` You can install caffe with a single command line following this guide.
 
-Last update: 2017-02-01
+* [Package status of CPU-only version](https://tracker.debian.org/pkg/caffe)
+
+* [Package status of CUDA version](https://tracker.debian.org/pkg/caffe-contrib)
+
+Last update: 2017-07-08
 
 ## Binary installation with APT
 
-Apart from the installation methods based on source, Debian/unstable
-and Debian/testing users can install pre-compiled Caffe packages from
-the official archive.
+Apart from the installation methods based on source, Debian users can install
+pre-compiled Caffe packages from the official archive with APT.
 
 Make sure that your `/etc/apt/sources.list` contains `contrib` and `non-free`
 sections if you want to install the CUDA version, for instance:
@@ -44,7 +48,8 @@ $ caffe                                              # command line interface wo
 $ python3 -c 'import caffe; print(caffe.__path__)'   # python3 interface working
 ```
 
-These Caffe packages should work for you out of box.
+These Caffe packages should work for you out of box. However, the CUDA version
+may break if your NVIDIA driver and CUDA toolkit are not installed with APT.
 
 #### Customizing caffe packages
 
@@ -155,11 +160,4 @@ and hack the packaging scripts, then build your customized package.
 ```
 $ sudo apt install caffe-doc
 $ dpkg -L caffe-doc
-```
-
-* Where can I find the Debian package status?
-
-```
-https://tracker.debian.org/pkg/caffe          (for the CPU_ONLY version)
-https://tracker.debian.org/pkg/caffe-contrib  (for the CUDA version)
 ```


### PR DESCRIPTION
This PR changes not only the Debian guide but also the Ubuntu guide.