### PR TITLE
May be a bug in net.cpp?

### DIFF
--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -413,6 +413,7 @@ int Net<Dtype>::AppendBottom(const NetParameter& param, const int layer_id,
   if (layer_param.propagate_down_size() > 0) {
     need_backward = layer_param.propagate_down(bottom_id);
   }
+  blob_need_backward_[blob_id] = need_backward;
   bottom_need_backward_[layer_id].push_back(need_backward);
   return blob_id;
 }


### PR DESCRIPTION
line 94 may be a bug, blob_need_backward_[blob_id] is always false because line 386.  And from line 411 to 416 shows that need_backward equals layer_param.propagate_down(bottom_id), so I think it needs `blob_need_backward_[blob_id] = need_backward;`.