### PR TITLE
Upgrading SoftmaxWithLoss layer to accept also spatially varying weights

### DIFF
--- a/include/caffe/layers/weighted_softmax_loss_layer.hpp
+++ b/include/caffe/layers/weighted_softmax_loss_layer.hpp
@@ -1,0 +1,153 @@
+#ifndef CAFFE_WEIGHTED_SOFTMAX_WITH_LOSS_LAYER_HPP_
+#define CAFFE_WEIGHTED_SOFTMAX_WITH_LOSS_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+#include "caffe/layers/loss_layer.hpp"
+#include "caffe/layers/softmax_layer.hpp"
+
+namespace caffe {
+
+/**
+ * @brief Computes the multinomial logistic loss for a one-of-many
+ *        classification task, passing real-valued predictions through a
+ *        softmax to get a probability distribution over classes.
+ *
+ * This layer should be preferred over separate
+ * SoftmaxLayer + MultinomialLogisticLossLayer
+ * as its gradient computation is more numerically stable.
+ * At test time, this layer can be replaced simply by a SoftmaxLayer.
+ *
+ * @param bottom input Blob vector (length 2)
+ *   -# @f$ (N \times C \times H \times W) @f$
+ *      the predictions @f$ x @f$, a Blob with values in
+ *      @f$ [-\infty, +\infty] @f$ indicating the predicted score for each of
+ *      the @f$ K = CHW @f$ classes. This layer maps these scores to a
+ *      probability distribution over classes using the softmax function
+ *      @f$ \hat{p}_{nk} = \exp(x_{nk}) /
+ *      \left[\sum_{k'} \exp(x_{nk'})\right] @f$ (see SoftmaxLayer).
+ *   -# @f$ (N \times 1 \times 1 \times 1) @f$
+ *      the labels @f$ l @f$, an integer-valued Blob with values
+ *      @f$ l_n \in [0, 1, 2, ..., K - 1] @f$
+ *      indicating the correct class label among the @f$ K @f$ classes
+ * @param top output Blob vector (length 1)
+ *   -# @f$ (1 \times 1 \times 1 \times 1) @f$
+ *      the computed cross-entropy classification loss: @f$ E =
+ *        \frac{-1}{N} \sum\limits_{n=1}^N \log(\hat{p}_{n,l_n})
+ *      @f$, for softmax output class probabilites @f$ \hat{p} @f$
+ */
+template <typename Dtype>
+class WeightedSoftmaxWithLossLayer : public LossLayer<Dtype> {
+ public:
+   /**
+    * @param param provides LossParameter loss_param, with options:
+    *  - ignore_label (optional)
+    *    Specify a label value that should be ignored when computing the loss.
+    *  - normalize (optional, default true)
+    *    If true, the loss is normalized by the number of (nonignored) labels
+    *    present; otherwise the loss is simply summed over spatial locations.
+    */
+  explicit WeightedSoftmaxWithLossLayer(const LayerParameter& param)
+      : LossLayer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "WeightedSoftmaxWithLoss"; }
+  virtual inline int ExactNumTopBlobs() const { return -1; }
+  virtual inline int MinTopBlobs() const { return 1; }
+  virtual inline int MaxTopBlobs() const { return 2; }
+
+  /**
+   * must have three inputs: (1) prediction, (2) GT labels, (3) weights
+   */
+  virtual inline int ExactNumBottomBlobs() const { return 3; }
+
+
+  /// prob stores the output probability predictions from the SoftmaxLayer.
+  Blob<Dtype> prob_;  // this is public beacuase of the test.
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  /**
+   * @brief Computes the softmax loss error gradient w.r.t. the predictions.
+   *        weight the loss according to provided weight blob
+   *
+   * Gradients cannot be computed with respect to the label inputs (bottom[1]),
+   * so this method ignores bottom[1] and requires !propagate_down[1], crashing
+   * if propagate_down[1] is set.
+   *
+   * Gradients cannot be computed with respect to pixel weights. crash if required.
+   *
+   * @param top output Blob vector (length 1), providing the error gradient with
+   *      respect to the outputs
+   *   -# @f$ (1 \times 1 \times 1 \times 1) @f$
+   *      This Blob's diff will simply contain the loss_weight* @f$ \lambda @f$,
+   *      as @f$ \lambda @f$ is the coefficient of this layer's output
+   *      @f$\ell_i@f$ in the overall Net loss
+   *      @f$ E = \lambda_i \ell_i + \mbox{other loss terms}@f$; hence
+   *      @f$ \frac{\partial E}{\partial \ell_i} = \lambda_i @f$.
+   *      (*Assuming that this top Blob is not used as a bottom (input) by any
+   *      other layer of the Net.)
+   * @param propagate_down see Layer::Backward.
+   *      propagate_down[1] must be false as we can't compute gradients with
+   *      respect to the labels.
+   * @param bottom input Blob vector (length 3)
+   *   -# @f$ (N \times C \times H \times W) @f$
+   *      the predictions @f$ x @f$; Backward computes diff
+   *      @f$ \frac{\partial E}{\partial x} @f$
+   *   -# @f$ (N \times 1 \times 1 \times 1) @f$
+   *      the labels -- ignored as we can't compute their error gradients
+   *   -# @f$ same shape as labels @f$
+   *      the weight per error per pixel location.
+   */
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  /// Read the normalization mode parameter and compute the normalizer based
+  /// on the blob size.  If normalization_mode is VALID, the count of valid
+  /// outputs will be read from valid_count, unless it is -1 in which case
+  /// all outputs are assumed to be valid.
+  virtual Dtype get_normalizer(
+      LossParameter_NormalizationMode normalization_mode, Dtype valid_count);
+
+  /// The internal SoftmaxLayer used to map predictions to a distribution.
+  shared_ptr<Layer<Dtype> > softmax_layer_;
+  /// bottom vector holder used in call to the underlying SoftmaxLayer::Forward
+  vector<Blob<Dtype>*> softmax_bottom_vec_;
+  /// top vector holder used in call to the underlying SoftmaxLayer::Forward
+  vector<Blob<Dtype>*> softmax_top_vec_;
+
+  /// for fast backward computation,
+  /// we tile the weight blob to the same shape as the prob
+  shared_ptr<Layer<Dtype> > tile_layer_;
+  /// store the tiled weights
+  Blob<Dtype> tweight_;
+  /// bottom vector holder used in call to the underlying TileLayer::Forward
+  vector<Blob<Dtype>*> tile_bottom_vec_;
+  /// top vector holder used in call to the underlying TileLayer::Forward
+  vector<Blob<Dtype>*> tile_top_vec_;
+
+  /// Whether to ignore instances with a certain label.
+  bool has_ignore_label_;
+  /// The label indicating that an instance should be ignored.
+  int ignore_label_;
+  /// How to normalize the output loss.
+  LossParameter_NormalizationMode normalization_;
+
+  int softmax_axis_, outer_num_, inner_num_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_WEIGHTED_SOFTMAX_WITH_LOSS_LAYER_HPP_

--- a/src/caffe/layers/weighted_softmax_loss_layer.cpp
+++ b/src/caffe/layers/weighted_softmax_loss_layer.cpp
@@ -1,0 +1,194 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/weighted_softmax_loss_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void WeightedSoftmaxWithLossLayer<Dtype>::LayerSetUp(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::LayerSetUp(bottom, top);
+  LayerParameter softmax_param(this->layer_param_);
+  softmax_param.set_type("Softmax");
+  softmax_layer_ = LayerRegistry<Dtype>::CreateLayer(softmax_param);
+  softmax_bottom_vec_.clear();
+  softmax_bottom_vec_.push_back(bottom[0]);
+  softmax_top_vec_.clear();
+  softmax_top_vec_.push_back(&prob_);
+  softmax_layer_->SetUp(softmax_bottom_vec_, softmax_top_vec_);
+
+  softmax_axis_ =
+      bottom[0]->CanonicalAxisIndex(this->layer_param_.softmax_param().axis());
+
+  // set up tile layer for fast backward computation
+  LayerParameter tile_param;
+  TileParameter* tile_layer_params = tile_param.mutable_tile_param();
+  tile_layer_params->set_axis(softmax_axis_);
+  tile_layer_params->set_tiles(bottom[0]->shape(softmax_axis_));
+  tile_param.set_type("Tile");
+  tile_layer_ = LayerRegistry<Dtype>::CreateLayer(tile_param);
+  tile_bottom_vec_.clear();
+  tile_bottom_vec_.push_back(bottom[2]);  // tile the weights
+  tile_top_vec_.clear();
+  tile_top_vec_.push_back(&tweight_);
+  tile_layer_->SetUp(tile_bottom_vec_, tile_top_vec_);
+
+  has_ignore_label_ =
+    this->layer_param_.loss_param().has_ignore_label();
+  if (has_ignore_label_) {
+    ignore_label_ = this->layer_param_.loss_param().ignore_label();
+  }
+  if (!this->layer_param_.loss_param().has_normalization() &&
+      this->layer_param_.loss_param().has_normalize()) {
+    normalization_ = this->layer_param_.loss_param().normalize() ?
+                     LossParameter_NormalizationMode_VALID :
+                     LossParameter_NormalizationMode_BATCH_SIZE;
+  } else {
+    normalization_ = this->layer_param_.loss_param().normalization();
+  }
+}
+
+template <typename Dtype>
+void WeightedSoftmaxWithLossLayer<Dtype>::Reshape(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::Reshape(bottom, top);
+  softmax_layer_->Reshape(softmax_bottom_vec_, softmax_top_vec_);
+  tile_layer_->Reshape(tile_bottom_vec_, tile_top_vec_);
+  softmax_axis_ =
+      bottom[0]->CanonicalAxisIndex(this->layer_param_.softmax_param().axis());
+  outer_num_ = bottom[0]->count(0, softmax_axis_);
+  inner_num_ = bottom[0]->count(softmax_axis_ + 1);
+  CHECK_EQ(outer_num_ * inner_num_, bottom[1]->count())
+      << "Number of labels must match number of predictions; "
+      << "e.g., if softmax axis == 1 and prediction shape is (N, C, H, W), "
+      << "label count (number of labels) must be N*H*W, "
+      << "with integer values in {0, 1, ..., C-1}.";
+  CHECK_EQ(bottom[1]->count(), bottom[2]->count())
+      << "Weights and labels must have the same shape";
+  if (top.size() >= 2) {
+    // softmax output
+    top[1]->ReshapeLike(*bottom[0]);
+  }
+}
+
+template <typename Dtype>
+Dtype WeightedSoftmaxWithLossLayer<Dtype>::get_normalizer(
+    LossParameter_NormalizationMode normalization_mode, Dtype valid_count) {
+  Dtype normalizer;
+  switch (normalization_mode) {
+    case LossParameter_NormalizationMode_FULL:
+      normalizer = Dtype(outer_num_ * inner_num_);
+      break;
+    case LossParameter_NormalizationMode_VALID:
+      if (valid_count == -1) {
+        normalizer = Dtype(outer_num_ * inner_num_);
+      } else {
+        normalizer = Dtype(valid_count);
+      }
+      break;
+    case LossParameter_NormalizationMode_BATCH_SIZE:
+      normalizer = Dtype(outer_num_);
+      break;
+    case LossParameter_NormalizationMode_NONE:
+      normalizer = Dtype(1);
+      break;
+    default:
+      LOG(FATAL) << "Unknown normalization mode: "
+          << LossParameter_NormalizationMode_Name(normalization_mode);
+  }
+  // Some users will have no labels for some examples in order to 'turn off' a
+  // particular loss in a multi-task setup. The max prevents NaNs in that case.
+  return std::max(Dtype(1.0), normalizer);
+}
+
+template <typename Dtype>
+void WeightedSoftmaxWithLossLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  // The forward pass computes the softmax prob values.
+  softmax_layer_->Forward(softmax_bottom_vec_, softmax_top_vec_);
+  const Dtype* prob_data = prob_.cpu_data();
+  const Dtype* label = bottom[1]->cpu_data();
+  const Dtype* weight = bottom[2]->cpu_data();
+  int dim = prob_.count() / outer_num_;
+  Dtype agg_weight = 0;
+  Dtype loss = 0;
+  for (int i = 0; i < outer_num_; ++i) {
+    for (int j = 0; j < inner_num_; j++) {
+      const int label_value = static_cast<int>(label[i * inner_num_ + j]);
+      const Dtype weight_value = weight[i * inner_num_ + j];
+      if (has_ignore_label_ && label_value == ignore_label_) {
+        continue;
+      }
+      DCHECK_GE(label_value, 0);
+      DCHECK_LT(label_value, prob_.shape(softmax_axis_));
+      DCHECK_GE(weight_value, 0);  // do not allow negative weights...
+      loss -= weight_value
+        * log(std::max(prob_data[i * dim + label_value * inner_num_ + j],
+                           Dtype(FLT_MIN)));
+      agg_weight += weight_value;
+    }
+  }
+  top[0]->mutable_cpu_data()[0] = loss
+    / get_normalizer(normalization_, agg_weight);
+  if (top.size() == 2) {
+    top[1]->ShareData(prob_);
+  }
+}
+
+template <typename Dtype>
+void WeightedSoftmaxWithLossLayer<Dtype>::Backward_cpu(
+    const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
+  if (propagate_down[1]) {
+    LOG(FATAL) << this->type()
+               << " Layer cannot backpropagate to label inputs.";
+  }
+  if (propagate_down[2]) {
+    LOG(FATAL) << this->type()
+               << " LAyer cannot backpropagate to weight inputs.";
+  }
+  if (propagate_down[0]) {
+    tile_layer_->Forward(tile_bottom_vec_, tile_top_vec_);
+    Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+    const Dtype* prob_data = prob_.cpu_data();
+    const Dtype* weight = bottom[2]->cpu_data();
+    // gradient of all entries (apart from g.t. label) is the probability
+    caffe_copy(prob_.count(), prob_data, bottom_diff);
+    const Dtype* tweight = tweight_.cpu_data();
+    // weighted probabilities as gradient baseline
+    caffe_mul(tweight_.count(), bottom_diff, tweight, bottom_diff);
+    const Dtype* label = bottom[1]->cpu_data();
+    int dim = prob_.count() / outer_num_;
+    Dtype agg_weight = 0;
+    for (int i = 0; i < outer_num_; ++i) {
+      for (int j = 0; j < inner_num_; ++j) {
+        const int label_value = static_cast<int>(label[i * inner_num_ + j]);
+        const Dtype weight_value = weight[i * inner_num_ + j];
+        if (has_ignore_label_ && label_value == ignore_label_) {
+          for (int c = 0; c < bottom[0]->shape(softmax_axis_); ++c) {
+            bottom_diff[i * dim + c * inner_num_ + j] = 0;
+          }
+        } else {
+          bottom_diff[i * dim + label_value * inner_num_ + j] -= weight_value;
+          agg_weight += weight_value;
+        }
+      }
+    }
+    // Scale gradient
+    Dtype loss_weight = top[0]->cpu_diff()[0] /
+                        get_normalizer(normalization_, agg_weight);
+    caffe_scal(prob_.count(), loss_weight, bottom_diff);
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(WeightedSoftmaxWithLossLayer);
+#endif
+
+INSTANTIATE_CLASS(WeightedSoftmaxWithLossLayer);
+REGISTER_LAYER_CLASS(WeightedSoftmaxWithLoss);
+
+}  // namespace caffe

--- a/src/caffe/layers/weighted_softmax_loss_layer.cu
+++ b/src/caffe/layers/weighted_softmax_loss_layer.cu
@@ -1,0 +1,142 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/weighted_softmax_loss_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void WeightedSoftmaxLossForwardGPU(const int nthreads,
+          const Dtype* prob_data, const Dtype* label, const Dtype* weight,
+          Dtype* loss, const int num, const int dim, const int spatial_dim,
+          const bool has_ignore_label_, const int ignore_label_,
+          Dtype* counts) {
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int n = index / spatial_dim;
+    const int s = index % spatial_dim;
+    const int label_value = static_cast<int>(label[n * spatial_dim + s]);
+    const Dtype weight_value = weight[n * spatial_dim + s];
+    if (has_ignore_label_ && label_value == ignore_label_) {
+      loss[index] = 0;
+      counts[index] = 0;
+    } else {
+      loss[index] = -weight_value
+        *log(max(prob_data[n * dim + label_value * spatial_dim + s],
+                      Dtype(FLT_MIN)));
+      counts[index] = weight_value;
+    }
+  }
+}
+
+template <typename Dtype>
+void WeightedSoftmaxWithLossLayer<Dtype>::Forward_gpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  softmax_layer_->Forward(softmax_bottom_vec_, softmax_top_vec_);
+  const Dtype* prob_data = prob_.gpu_data();
+  const Dtype* label = bottom[1]->gpu_data();
+  const Dtype* weight = bottom[2]->gpu_data();
+  const int dim = prob_.count() / outer_num_;
+  const int nthreads = outer_num_ * inner_num_;
+  // Since this memory is not used for anything until it is overwritten
+  // on the backward pass, we use it here to avoid having to allocate new GPU
+  // memory to accumulate intermediate results in the kernel.
+  Dtype* loss_data = bottom[0]->mutable_gpu_diff();
+  // Similarly, this memory is never used elsewhere, and thus we can use it
+  // to avoid having to allocate additional GPU memory.
+  Dtype* counts = prob_.mutable_gpu_diff();
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  WeightedSoftmaxLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
+      CAFFE_CUDA_NUM_THREADS>>>(nthreads, prob_data, label, weight, loss_data,
+      outer_num_, dim, inner_num_, has_ignore_label_, ignore_label_, counts);
+  Dtype loss;
+  caffe_gpu_asum(nthreads, loss_data, &loss);
+  Dtype valid_count = -1;
+  // Only launch another CUDA kernel if we actually need the count of valid
+  // outputs.
+  if (normalization_ == LossParameter_NormalizationMode_VALID &&
+      has_ignore_label_) {
+    caffe_gpu_asum(nthreads, counts, &valid_count);
+  }
+  top[0]->mutable_cpu_data()[0] = loss / get_normalizer(normalization_,
+                                                        valid_count);
+  if (top.size() == 2) {
+    top[1]->ShareData(prob_);
+  }
+}
+
+template <typename Dtype>
+__global__ void WeightedSoftmaxLossBackwardGPU(const int nthreads,
+          const Dtype* top, const Dtype* label, const Dtype* weight,
+          Dtype* bottom_diff, const int num, const int dim,
+          const int spatial_dim, const bool has_ignore_label_,
+          const int ignore_label_, Dtype* counts) {
+  const int channels = dim / spatial_dim;
+
+  CUDA_KERNEL_LOOP(index, nthreads) {
+    const int n = index / spatial_dim;
+    const int s = index % spatial_dim;
+    const int label_value = static_cast<int>(label[n * spatial_dim + s]);
+    const Dtype weight_value = weight[n * spatial_dim + s];
+    if (has_ignore_label_ && label_value == ignore_label_) {
+      for (int c = 0; c < channels; ++c) {
+        bottom_diff[n * dim + c * spatial_dim + s] = 0;
+      }
+      counts[index] = 0;
+    } else {
+      bottom_diff[n * dim + label_value * spatial_dim + s] -= weight_value;
+      counts[index] = weight_value;
+    }
+  }
+}
+
+template <typename Dtype>
+void WeightedSoftmaxWithLossLayer<Dtype>::Backward_gpu(
+    const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
+  if (propagate_down[1]) {
+    LOG(FATAL) << this->type()
+               << " Layer cannot backpropagate to label inputs.";
+  }
+  if (propagate_down[2]) {
+    LOG(FATAL) << this->type()
+               << " Layer cannot backpropagate to weight inputs.";
+  }
+  if (propagate_down[0]) {
+    tile_layer_->Forward(tile_bottom_vec_, tile_top_vec_);
+    Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
+    const Dtype* prob_data = prob_.gpu_data();
+    const Dtype* top_data = top[0]->gpu_data();
+    caffe_gpu_memcpy(prob_.count() * sizeof(Dtype), prob_data, bottom_diff);
+    const Dtype* tweight = tweight_.gpu_data();
+    caffe_gpu_mul(tweight_.count(), bottom_diff, tweight, bottom_diff);
+    const Dtype* label = bottom[1]->gpu_data();
+    const Dtype* weight = bottom[2]->gpu_data();
+    const int dim = prob_.count() / outer_num_;
+    const int nthreads = outer_num_ * inner_num_;
+    // Since this memory is never used for anything else,
+    // we use to to avoid allocating new GPU memory.
+    Dtype* counts = prob_.mutable_gpu_diff();
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    WeightedSoftmaxLossBackwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
+        CAFFE_CUDA_NUM_THREADS>>>(nthreads, top_data, label, weight,
+        bottom_diff, outer_num_, dim, inner_num_, has_ignore_label_,
+        ignore_label_, counts);
+
+    Dtype valid_count = -1;
+    // Only launch another CUDA kernel if we actually need the count of valid
+    // outputs.
+    if (normalization_ == LossParameter_NormalizationMode_VALID &&
+        has_ignore_label_) {
+      caffe_gpu_asum(nthreads, counts, &valid_count);
+    }
+    const Dtype loss_weight = top[0]->cpu_diff()[0] /
+                              get_normalizer(normalization_, valid_count);
+    caffe_gpu_scal(prob_.count(), loss_weight , bottom_diff);
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(WeightedSoftmaxWithLossLayer);
+
+}  // namespace caffe

--- a/src/caffe/test/test_weighted_softmax_with_loss_layer.cpp
+++ b/src/caffe/test/test_weighted_softmax_with_loss_layer.cpp
@@ -1,0 +1,188 @@
+#include <algorithm>
+#include <cfloat>
+#include <cmath>
+#include <vector>
+
+#include "boost/scoped_ptr.hpp"
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/weighted_softmax_loss_layer.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+using boost::scoped_ptr;
+
+namespace caffe {
+
+template <typename TypeParam>
+class WeightedSoftmaxWithLossLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  WeightedSoftmaxWithLossLayerTest()
+      : blob_bottom_data_(new Blob<Dtype>(10, 5, 2, 3)),
+        blob_bottom_label_(new Blob<Dtype>(10, 1, 2, 3)),
+        blob_bottom_weight_(new Blob<Dtype>(10, 1, 2, 3)),
+        blob_top_loss_(new Blob<Dtype>()) {
+    // fill the values
+    FillerParameter filler_param;
+    filler_param.set_std(10);
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_data_);
+    blob_bottom_vec_.push_back(blob_bottom_data_);
+    for (int i = 0; i < blob_bottom_label_->count(); ++i) {
+      blob_bottom_label_->mutable_cpu_data()[i] = caffe_rng_rand() % 5;
+    }
+    blob_bottom_vec_.push_back(blob_bottom_label_);
+    filler_param.set_min(0.1);
+    filler_param.set_max(1);
+    UniformFiller<Dtype> ufiller(filler_param);
+    ufiller.Fill(this->blob_bottom_weight_);
+    blob_bottom_vec_.push_back(blob_bottom_weight_);
+    blob_top_vec_.push_back(blob_top_loss_);
+  }
+  virtual ~WeightedSoftmaxWithLossLayerTest() {
+    delete blob_bottom_data_;
+    delete blob_bottom_label_;
+    delete blob_bottom_weight_;
+    delete blob_top_loss_;
+  }
+  Blob<Dtype>* const blob_bottom_data_;
+  Blob<Dtype>* const blob_bottom_label_;
+  Blob<Dtype>* const blob_bottom_weight_;
+  Blob<Dtype>* const blob_top_loss_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+TYPED_TEST_CASE(WeightedSoftmaxWithLossLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(WeightedSoftmaxWithLossLayerTest, TestGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  layer_param.add_loss_weight(3);
+  WeightedSoftmaxWithLossLayer<Dtype> layer(layer_param);
+  GradientChecker<Dtype> checker(1e-2, 1e-2, 1701);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 0);
+}
+
+TYPED_TEST(WeightedSoftmaxWithLossLayerTest, TestForward) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  // no normalization
+  layer_param.mutable_loss_param()->
+    set_normalization(LossParameter_NormalizationMode_NONE);
+  WeightedSoftmaxWithLossLayer<Dtype> layer(layer_param);
+
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  Dtype layer_loss = this->blob_top_loss_->cpu_data()[0];
+
+  Dtype mloss = 0;
+  Dtype agg_weight = 0;
+  vector<int> prob_ind(4, 0);
+  vector<int> label_ind(4, 0);
+  for ( prob_ind[0]=0; prob_ind[0] < layer.prob_.shape(0); prob_ind[0]++ ) {
+    for ( prob_ind[2]=0; prob_ind[2] < layer.prob_.shape(2); prob_ind[2]++ ) {
+      for ( prob_ind[3]=0; prob_ind[3] < layer.prob_.shape(3); prob_ind[3]++ ) {
+        label_ind = prob_ind;
+        label_ind[1] = 0;
+        const int label_value = static_cast<int>
+          (this->blob_bottom_label_->data_at(label_ind));
+        prob_ind[1] = label_value;
+        mloss -= this->blob_bottom_weight_->data_at(label_ind)
+         * log(std::max(layer.prob_.data_at(prob_ind), Dtype(FLT_MIN)));
+        agg_weight += this->blob_bottom_weight_->data_at(label_ind);
+      }
+    }
+  }
+  EXPECT_NEAR(layer_loss, mloss, 1e-4);
+}
+
+TYPED_TEST(WeightedSoftmaxWithLossLayerTest, TestForwardIgnoreLabelOnce) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  // VALID normalization
+  layer_param.mutable_loss_param()->
+    set_normalization(LossParameter_NormalizationMode_VALID);
+  const int ignore_label = 0;
+  layer_param.mutable_loss_param()->set_ignore_label(ignore_label);
+  WeightedSoftmaxWithLossLayer<Dtype> layer(layer_param);
+
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  Dtype layer_loss = this->blob_top_loss_->cpu_data()[0];
+
+  Dtype mloss = 0;
+  Dtype agg_weight = 0;
+  vector<int> prob_ind(4, 0);
+  vector<int> label_ind(4, 0);
+  for ( prob_ind[0]=0; prob_ind[0] < layer.prob_.shape(0); prob_ind[0]++ ) {
+    for ( prob_ind[2]=0; prob_ind[2] < layer.prob_.shape(2); prob_ind[2]++ ) {
+      for ( prob_ind[3]=0; prob_ind[3] < layer.prob_.shape(3); prob_ind[3]++ ) {
+        label_ind = prob_ind;
+        label_ind[1] = 0;
+        const int label_value = static_cast<int>
+          (this->blob_bottom_label_->data_at(label_ind));
+        if (label_value == ignore_label)
+          continue;
+        prob_ind[1] = label_value;
+        mloss -= this->blob_bottom_weight_->data_at(label_ind)
+         * log(std::max(layer.prob_.data_at(prob_ind), Dtype(FLT_MIN)));
+        agg_weight += this->blob_bottom_weight_->data_at(label_ind);
+      }
+    }
+  }
+  EXPECT_NEAR(layer_loss, mloss/std::max(Dtype(1.0), agg_weight), 1e-4);
+}
+
+TYPED_TEST(WeightedSoftmaxWithLossLayerTest, TestForwardIgnoreLabel) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  layer_param.mutable_loss_param()->set_normalize(false);
+  // First, compute the loss with all labels
+  scoped_ptr<WeightedSoftmaxWithLossLayer<Dtype> > layer(
+      new WeightedSoftmaxWithLossLayer<Dtype>(layer_param));
+  layer->SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  Dtype full_loss = this->blob_top_loss_->cpu_data()[0];
+  // Now, accumulate the loss, ignoring each label in {0, ..., 4} in turn.
+  Dtype accum_loss = 0;
+  for (int label = 0; label < 5; ++label) {
+    layer_param.mutable_loss_param()->set_ignore_label(label);
+    layer.reset(new WeightedSoftmaxWithLossLayer<Dtype>(layer_param));
+    layer->SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+    layer->Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+    accum_loss += this->blob_top_loss_->cpu_data()[0];
+  }
+  // Check that each label was included all but once.
+  EXPECT_NEAR(4 * full_loss, accum_loss, 1e-4);
+}
+
+TYPED_TEST(WeightedSoftmaxWithLossLayerTest, TestGradientIgnoreLabel) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  // labels are in {0, ..., 4}, so we'll ignore about a fifth of them
+  layer_param.mutable_loss_param()->set_ignore_label(0);
+  WeightedSoftmaxWithLossLayer<Dtype> layer(layer_param);
+  GradientChecker<Dtype> checker(1e-2, 1e-2, 1701);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 0);
+}
+
+TYPED_TEST(WeightedSoftmaxWithLossLayerTest, TestGradientUnnormalized) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  layer_param.mutable_loss_param()->set_normalize(false);
+  WeightedSoftmaxWithLossLayer<Dtype> layer(layer_param);
+  GradientChecker<Dtype> checker(1e-2, 1e-2, 1701);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_, 0);
+}
+
+}  // namespace caffe


### PR DESCRIPTION
adding "WeightedSoftmaxWithloss" layer. 
This new loss layer upgrades "SoftmaxWithLoss" layer to accept spatially varying non-negative weights for the loss.
Usage:

    layer {
      name: "weighted_loss"
      type: "WeightedSoftmaxWithLoss"
      bottom: "predictions"  # raw predictions, e.g., B-C-H-W
      bottom: "labels"  # per-pixel label, e.g., B-1-H-W
      bottom: "weights"  # per pixel loss weight, e.g., B-1-H-W
      top: "loss"
      softmax_param { axis: 1 }
      loss_param { ignore_label: -1 normalization: VALID } # normalize by the SUM of the valid weights
    }

This PR includes GPU implementation and tests. 

This PR is **SELF CONTAINED**: it has NO changes to other code in caffe (not even to caffe.proto!).