### PR TITLE
Fix MultiGPU hangs when interrupting training

### DIFF
--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -354,11 +354,12 @@ void NCCL<Dtype>::Run(const vector<int>& gpus, const char* restore) {
   // Run first solver on current thread
   Broadcast();
   solver_->Solve();
-  barrier.wait();  // Hangs without it when running tests
   // Wait for shutdown
   for (int i = 1; i < gpus.size(); ++i) {
     workers[i]->StopInternalThread();
   }
+  // Hangs without it when running tests or multi-gpu training.
+  barrier.wait();
 }
 
 INSTANTIATE_CLASS(Params);


### PR DESCRIPTION
I met the same problem as mentioned in #5615 for months. Inspired by @bfdream's comment and after some digging, I think it could solve the hanging issue after canceling the job during MultiGPU training.