### PR TITLE
Fix division operator for Compatibility of python 3 in classifier.py

### DIFF
--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -92,7 +92,7 @@ class Classifier(caffe.Net):
 
         # For oversampling, average predictions across crops.
         if oversample:
-            predictions = predictions.reshape((len(predictions) / 10, 10, -1))
+            predictions = predictions.reshape((len(predictions) // 10, 10, -1))
             predictions = predictions.mean(1)
 
         return predictions


### PR DESCRIPTION
On python 3, `Classifier`'s `predict ()` method is failed on image `reshape`, because using float division(/) on the reshape of the image at oversample.
On python 2, division operator `/` is integer division. But on python 3, `/` is float division and `//` is integer division(floored division).
And `//` division operator is compatible with python 2.

So, I replaced to integer division (//) which is compatible with both python 2/3.