### PR TITLE
Expose GPU pointers to Python

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -464,6 +464,14 @@ BOOST_PYTHON_MODULE(_caffe) {
     .add_property("count",    static_cast<int (Blob<Dtype>::*)() const>(
         &Blob<Dtype>::count))
     .def("reshape",           bp::raw_function(&Blob_Reshape))
+#ifndef CPU_ONLY
+    .add_property("_gpu_data_ptr",
+        reinterpret_cast<uintptr_t (Blob<Dtype>::*)()>(
+          &Blob<Dtype>::mutable_gpu_data))
+    .add_property("_gpu_diff_ptr",
+        reinterpret_cast<uintptr_t (Blob<Dtype>::*)()>(
+          &Blob<Dtype>::mutable_gpu_diff))
+#endif
     .add_property("data",     bp::make_function(&Blob<Dtype>::mutable_cpu_data,
           NdarrayCallPolicies()))
     .add_property("diff",     bp::make_function(&Blob<Dtype>::mutable_cpu_diff,


### PR DESCRIPTION
This is a rebased and cleaned-up version of a commit from @tnarihi, https://github.com/BVLC/caffe/pull/2102/commits/7b99436379141de709666d3910357cfd23988979.

The purpose of this is to expose the GPU blob pointers, permitting use of libraries like PyCUDA without needless and expensive blob roundtripping.

This commit has been modified from the original in the following ways:
* Wrapper functions are removed; instead the accessors are cast directly. This reduces the amount of code and also makes the low-level nature of the call a bit more evident at the place where such things are normally specified.
* `reinterpret_cast` is used instead of C-style casting.
* `uintptr_t` is used instead of `size_t`.
* An underscore is prepended to the property names, emphasizing that these are low-level, at-your-own-risk properties. Since these are raw pointers, it's up to the user to decide when they remain valid.

I am making this PR now to have minimal mergeable access to blob GPU memory. On the Python side, it's easy to write code to convert `Blob`s to (e.g.) `GPUArray`s. Such code could also be brought in as desired (see @tnarihi's PRs).