### PR TITLE
Update `include/caffe/blob.hpp` to remove `-Wsign-compare` warning

### DIFF
--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -53,7 +53,7 @@ class Blob {
   void ReshapeLike(const Blob& other);
   inline string shape_string() const {
     ostringstream stream;
-    for (auto i = 0u; i < shape_.size(); ++i) {
+    for (unsigned int i = 0u; i < shape_.size(); ++i) {
       stream << shape_[i] << " ";
     }
     stream << "(" << count_ << ")";

--- a/include/caffe/blob.hpp
+++ b/include/caffe/blob.hpp
@@ -53,7 +53,7 @@ class Blob {
   void ReshapeLike(const Blob& other);
   inline string shape_string() const {
     ostringstream stream;
-    for (int i = 0; i < shape_.size(); ++i) {
+    for (auto i = 0u; i < shape_.size(); ++i) {
       stream << shape_[i] << " ";
     }
     stream << "(" << count_ << ")";


### PR DESCRIPTION
I've just reformulated `include/caffe/blob.hpp` to remove a `-Wsign-compare` warning. No other difference.

I know Caffe does uses `-W-nosign-compare` in their Makefile to remove these kind of warnings, but I must use Caffe with that warning, so adding this change the warning disappears.

EDITED: 2nd commit to change `auto` keyword by `unsigned int` so that non-C++11 compilers can also compile it.

Highly tested and it's being currently used in [OpenPose](https://github.com/CMU-Perceptual-Computing-Lab/openpose)