### PR TITLE
Fixing broken links to installation

### DIFF
--- a/docs/install_apt.md
+++ b/docs/install_apt.md
@@ -32,7 +32,7 @@ We may install the dependencies by merely one line
     sudo apt build-dep caffe-cuda       # dependencies for CUDA version
 
 It requires a `deb-src` line in your `sources.list`.
-Continue with [compilation](installation.html#compilation).
+Continue with [compilation](installation.md#compilation).
 
 ### For Ubuntu (\< 17.04)
 
@@ -84,4 +84,4 @@ These dependencies need manual installation in 12.04.
 
 Note that glog does not compile with the most recent gflags version (2.1), so before that is resolved you will need to build with glog first.
 
-Continue with [compilation](installation.html#compilation).
+Continue with [compilation](installation.md#compilation).


### PR DESCRIPTION
It seems like installation.html was renamed to installation.md. This update fixes the two links in the page to compilation that were broken.