### PR TITLE
Fix default mode warning in io.resize_image

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -323,7 +323,7 @@ def resize_image(im, new_dims, interp_order=1):
             # skimage is fast but only understands {1,3} channel images
             # in [0, 1].
             im_std = (im - im_min) / (im_max - im_min)
-            resized_std = resize(im_std, new_dims, order=interp_order)
+            resized_std = resize(im_std, new_dims, order=interp_order, mode='constant')
             resized_im = resized_std * (im_max - im_min) + im_min
         else:
             # the image is a constant -- avoid divide by 0


### PR DESCRIPTION
Signed-off-by: Finnian Anderson <get@finnian.io>

This fixes a warning in `io.resize_image` which originates in `skimage.transform.resize`.
The default mode for `resize` will change from `constant` to `reflect`, so this commit changes the call to `resize` so that it passes `mode` manually.
Warning:
```
.../python2.7/site-packages/skimage/transform/_warps.py:84: UserWarning: The default mode, 'constant', will be changed to 'reflect' in skimage 0.15.
```

Fixes #5602 