### PR TITLE
Hotfix for accuracy interfering with training

### DIFF
--- a/include/caffe/layers/accuracy_layer.hpp
+++ b/include/caffe/layers/accuracy_layer.hpp
@@ -92,6 +92,8 @@ class AccuracyLayer : public Layer<Dtype> {
   int ignore_label_;
   /// Keeps counts of the number of samples per class.
   Blob<Dtype> nums_buffer_;
+  /// Intermediate results for the GPU implementation
+  Blob<Dtype> gpu_buffer_;
 };
 
 }  // namespace caffe

--- a/src/caffe/layers/accuracy_layer.cpp
+++ b/src/caffe/layers/accuracy_layer.cpp
@@ -34,6 +34,7 @@ void AccuracyLayer<Dtype>::Reshape(
       << "label count (number of labels) must be N*H*W, "
       << "with integer values in {0, 1, ..., C-1}.";
   vector<int> top_shape(0);  // Accuracy is a scalar; 0 axes.
+  gpu_buffer_.ReshapeLike(*bottom[0]);
   top[0]->Reshape(top_shape);
   if (top.size() > 1) {
     // Per-class accuracy is a vector; 1 axes.


### PR DESCRIPTION
Instead of reusing "unused" memory of the bottom blob (`diff`), it's safer to allocate some internal blob (`gpu_buffer_`) to make sure the layer does not interact with external memory that might be potentially used elsewhere (as was demonstrated in #5981). Bug was initially introduced in 62e0c85.

In the long run, we might want to optimize this to eg. only allocate GPU memory (instead of an entire blob), or even take a closer look at what is exactly going on in that buffer (i.e. how much memory do we actually need). On the other hand, using Accuracy layer during training is not very common usage - so we might leave this PR pending for now (for the affected users to pull) and only accept after said optimizations.