### PR TITLE
Fix int_tp not defined in extract_seconds.py

### DIFF
--- a/tools/extra/extract_seconds.py
+++ b/tools/extra/extract_seconds.py
@@ -6,15 +6,15 @@ import sys
 def extract_datetime_from_line(line, year):
     # Expected format: I0210 13:39:22.381027 25210 solver.cpp:204] Iteration 100, lr = 0.00992565
     line = line.strip().split()
-    month = int_tp(line[0][1:3])
-    day = int_tp(line[0][3:])
+    month = int(line[0][1:3])
+    day = int(line[0][3:])
     timestamp = line[1]
     pos = timestamp.rfind('.')
-    ts = [int_tp(x) for x in timestamp[:pos].split(':')]
+    ts = [int(x) for x in timestamp[:pos].split(':')]
     hour = ts[0]
     minute = ts[1]
     second = ts[2]
-    microsecond = int_tp(timestamp[pos + 1:])
+    microsecond = int(timestamp[pos + 1:])
     dt = datetime.datetime(year, month, day, hour, minute, second, microsecond)
     return dt
 


### PR DESCRIPTION
fixes "NameError: name 'int_tp' is not defined" when running plot_training_log.py