### PR TITLE
Fixed a bug in AccuracyLayer.

### DIFF
--- a/src/caffe/layers/accuracy_layer.cu
+++ b/src/caffe/layers/accuracy_layer.cu
@@ -134,6 +134,9 @@ void AccuracyLayer<Dtype>::Forward_gpu(
       }
     }
   }
+  // Set gpu_diff of bottom[0] back to zeros to avoid propagating down any
+  // gradient from the accuracy layer during training.
+  caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
 }
 
 


### PR DESCRIPTION
gpu_diff of bottom[0] used as temporary buffer needs to be set back to
zeros. Otherwise the AccurarcyLayer may propagate back wrong gradient
values in training.