### PR TITLE
Added count==0 safeguard to CPU accuracy calculation

### DIFF
--- a/src/caffe/layers/accuracy_layer.cpp
+++ b/src/caffe/layers/accuracy_layer.cpp
@@ -86,7 +86,7 @@ void AccuracyLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   }
 
   // LOG(INFO) << "Accuracy: " << accuracy;
-  top[0]->mutable_cpu_data()[0] = accuracy / count;
+  top[0]->mutable_cpu_data()[0] = (count == 0) ? 0 : (accuracy / count);
   if (top.size() > 1) {
     for (int i = 0; i < top[1]->count(); ++i) {
       top[1]->mutable_cpu_data()[i] =


### PR DESCRIPTION
Fixes #5949.

Behavior is now consistent across CPU/GPU implementations - in case all labels are equal to `ignore_label_` and thus `count` is never incremented beyond zero, the output will be 0 (instead of dividing by 0).