### PR TITLE
reinit global_instance_ when it has been deleted

### DIFF
--- a/python/caffe/draw.py
+++ b/python/caffe/draw.py
@@ -244,7 +244,7 @@ def get_pydot_graph(caffe_net, rankdir, margin, page, pagesize, size, label_edge
     return pydot_graph
 
 
-def draw_net(caffe_net, rankdir, margin, page, pagesize, size, ext='png', phase=None):
+def draw_net(caffe_net, rankdir, margin='', page='', pagesize='', size='', ext='png', phase=None):
     """Draws a caffe net and returns the image string encoded using the given
     extension.
 

--- a/python/caffe/net_gen.py
+++ b/python/caffe/net_gen.py
@@ -501,8 +501,8 @@ def fix_input_dims(net, source_layers, max_shapes=[], min_shapes=[], shape_coupl
 
                 # Test the shape
                 if (verbose or not error):
-                    print test_current_shapes
-                    print "Valid shape: " + str(not error)
+                    print(test_current_shapes)
+                    print("Valid shape: " + str(not error))
                 
                 if (error and ((len(test_current_shapes[curr_src_idx]) - 2 <= dim_idx) or (test_current_shapes[curr_src_idx][2 + dim_idx] == test_min_shapes[curr_src_idx][2 + dim_idx]))):
                     # Reached minimum shape, reset source and go to previous source

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -254,6 +254,10 @@ void Caffe::set_random_seed(const size_t seed, device* device_context) {
   Get().random_generator_.reset(new RNG(seed));
 }
 
+void Caffe::SetDevices(std::vector<int> device_ids) {
+  NO_GPU;
+}
+
 void Caffe::SetDevice(const int device_id) {
   NO_GPU;
 }

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -324,6 +324,7 @@ Caffe::~Caffe() {
   // Make sure all device contexts and
   // dependent memory blocks are freed properly
   if (this == global_instance_) {
+      first.store(true);
       devices_.clear();
   }
 #ifdef USE_CUDA


### PR DESCRIPTION
when global_instance_ has been deleted, we have to set 'first' to true to trigger Caffe::Get() to create a new global_instance_, otherwise we will use deleted global_instance_ to initialize other Caffe object and this will cause segment fault.