### PR TITLE
Changed paths in example 00-classification.ipynb for portability/consistency

### DIFF
--- a/examples/00-classification.ipynb
+++ b/examples/00-classification.ipynb
@@ -89,11 +89,12 @@
    ],
    "source": [
     "import os\n",
-    "if os.path.isfile(caffe_root + 'models/bvlc_reference_caffenet/bvlc_reference_caffenet.caffemodel'):\n",
+    "os.chdir(caffe_root) # run scripts from caffe root\n",
+    "if os.path.isfile('models/bvlc_reference_caffenet/bvlc_reference_caffenet.caffemodel'):\n",
     "    print 'CaffeNet found.'\n",
     "else:\n",
     "    print 'Downloading pre-trained CaffeNet model...'\n",
-    "    !../scripts/download_model_binary.py ../models/bvlc_reference_caffenet"
+    "    !scripts/download_model_binary.py models/bvlc_reference_caffenet"
    ]
   },
   {
@@ -115,8 +116,8 @@
    "source": [
     "caffe.set_mode_cpu()\n",
     "\n",
-    "model_def = caffe_root + 'models/bvlc_reference_caffenet/deploy.prototxt'\n",
-    "model_weights = caffe_root + 'models/bvlc_reference_caffenet/bvlc_reference_caffenet.caffemodel'\n",
+    "model_def = 'models/bvlc_reference_caffenet/deploy.prototxt'\n",
+    "model_weights = 'models/bvlc_reference_caffenet/bvlc_reference_caffenet.caffemodel'\n",
     "\n",
     "net = caffe.Net(model_def,      # defines the structure of the model\n",
     "                model_weights,  # contains the trained weights\n",
@@ -151,7 +152,7 @@
    ],
    "source": [
     "# load the mean ImageNet image (as distributed with Caffe) for subtraction\n",
-    "mu = np.load(caffe_root + 'python/caffe/imagenet/ilsvrc_2012_mean.npy')\n",
+    "mu = np.load('python/caffe/imagenet/ilsvrc_2012_mean.npy')\n",
     "mu = mu.mean(1).mean(1)  # average over pixels to obtain the mean (BGR) pixel values\n",
     "print 'mean-subtracted values:', zip('BGR', mu)\n",
     "\n",
@@ -224,7 +225,7 @@
     }
    ],
    "source": [
-    "image = caffe.io.load_image(caffe_root + 'examples/images/cat.jpg')\n",
+    "image = caffe.io.load_image('examples/images/cat.jpg')\n",
     "transformed_image = transformer.preprocess('data', image)\n",
     "plt.imshow(image)"
    ]
@@ -287,9 +288,9 @@
    ],
    "source": [
     "# load ImageNet labels\n",
-    "labels_file = caffe_root + 'data/ilsvrc12/synset_words.txt'\n",
+    "labels_file = 'data/ilsvrc12/synset_words.txt'\n",
     "if not os.path.exists(labels_file):\n",
-    "    !../data/ilsvrc12/get_ilsvrc_aux.sh\n",
+    "    !data/ilsvrc12/get_ilsvrc_aux.sh\n",
     "    \n",
     "labels = np.loadtxt(labels_file, str, delimiter='\\t')\n",
     "\n",
@@ -730,10 +731,10 @@
     "my_image_url = \"...\"  # paste your URL here\n",
     "# for example:\n",
     "# my_image_url = \"https://upload.wikimedia.org/wikipedia/commons/b/be/Orang_Utan%2C_Semenggok_Forest_Reserve%2C_Sarawak%2C_Borneo%2C_Malaysia.JPG\"\n",
-    "!wget -O image.jpg $my_image_url\n",
+    "!wget -O examples/image.jpg $my_image_url\n",
     "\n",
     "# transform it and copy it into the net\n",
-    "image = caffe.io.load_image('image.jpg')\n",
+    "image = caffe.io.load_image('examples/image.jpg')\n",
     "net.blobs['data'].data[...] = transformer.preprocess('data', image)\n",
     "\n",
     "# perform classification\n",


### PR DESCRIPTION
Changed working directory to caffe_root with `os.chdir(caffe_root)` and changed other paths accordingly. 

Example now has no more "hard" paths (`../`) and is more consistent with examples [01](https://github.com/BVLC/caffe/blob/master/examples/01-learning-lenet.ipynb) and [02](https://github.com/BVLC/caffe/blob/master/examples/02-fine-tuning.ipynb)