### PR TITLE
Put the acc_data in a new syncedmemory block

### DIFF
--- a/src/caffe/layers/accuracy_layer.cu
+++ b/src/caffe/layers/accuracy_layer.cu
@@ -71,10 +71,8 @@ void AccuracyLayer<Dtype>::Forward_gpu(
   const int dim = bottom[0]->count() / outer_num_;
   const int num_labels = bottom[0]->shape(label_axis_);
   const int nthreads = outer_num_ * inner_num_;
-  // Since this memory is not used for anything,
-  // we use it here to avoid having to allocate new GPU
-  // memory to accumulate intermediate results in the kernel.
-  Dtype* acc_data = bottom[0]->mutable_gpu_diff();
+
+  Dtype* acc_data = static_cast<Dtype*>((new SyncedMemory(bottom[0]->count() * sizeof(Dtype)))->mutable_gpu_data());
   if (top.size() == 1) {
     // simple case - report only global accuracy.
 

--- a/src/caffe/layers/accuracy_layer.cu
+++ b/src/caffe/layers/accuracy_layer.cu
@@ -72,7 +72,9 @@ void AccuracyLayer<Dtype>::Forward_gpu(
   const int num_labels = bottom[0]->shape(label_axis_);
   const int nthreads = outer_num_ * inner_num_;
 
-  Dtype* acc_data = static_cast<Dtype*>((new SyncedMemory(bottom[0]->count() * sizeof(Dtype)))->mutable_gpu_data());
+  Dtype* acc_data = static_cast<Dtype*> \
+            ((new SyncedMemory(bottom[0]->count() * sizeof(Dtype)))   \
+             ->mutable_gpu_data());
   if (top.size() == 1) {
     // simple case - report only global accuracy.
 


### PR DESCRIPTION
When I was using Accuracy Layer in Training Phase, I found something weird, the loss was increasing and the gradient was much larger than normal. 
A easy reproduction example is to uncomment the `include_phase` of accuracy layer in `caffe/examples/cifar10/cifar10_quick_train_test.prototxt`  and use `train_quick.sh` to train it.
After strugglely reviewing the source code, I found this line in `accuracy_layer.cu` is the cause for it, it was saying `Since this memory is not used for anything,we use it here to avoid having to allocate new GPU memory to accumulate intermediate results in the kernel.` 
But it is wrong, because when I use some blob in both loss layer and accuracy layer, caffe would insert split layer to duplicate this blob, and during the backward pass, the splited blob for accuracy layer 's diff would not be updated(covered) and should always be zero. However,  here changed its value to the accuracy, which made the gradient after split layer is much larger.

I modified this line to allocate a new syncedmem object to store the acc_data, which made it independent with the bottom[0]'s diff field and solved above issue.
