### PR TITLE
fix matchExt

### DIFF
--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -105,7 +105,7 @@ cv::Mat ReadImageToCVMat(const string& filename) {
 // Do the file extension and encoding match?
 static bool matchExt(const std::string & fn,
                      std::string en) {
-  size_t p = fn.rfind('.');
+  size_t p = fn.rfind('.') + 1;
   std::string ext = p != fn.npos ? fn.substr(p) : fn;
   std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
   std::transform(en.begin(), en.end(), en.begin(), ::tolower);


### PR DESCRIPTION
In implementation of ReadImageToDatum in io.cpp uses matchExt, however the ext postion is not correct.