### PR TITLE
Fix link issue when using Homebrew OpenCV on OS X.

### DIFF
--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -9,6 +9,7 @@
 
 # uncomment to disable IO dependencies and corresponding data layers
 # USE_OPENCV := 0
+OPENCV_VERSION := 3
 # USE_LEVELDB := 0
 # USE_LMDB := 0
 


### PR DESCRIPTION
I'm suggesting this change to the config example because it resolves the problem reported in this thread (and also experienced by myself on OS X): https://github.com/BVLC/caffe/issues/2307#issuecomment-357552138

Let me know if I should raise a specific issue in addition to this PR.