### PR TITLE
Installation: switch pointer to official AWS AMI

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,7 +17,7 @@ The official Makefile and `Makefile.config` build are complemented by a [communi
 - [RHEL / CentOS / Fedora installation](install_yum.html)
 - [Windows](https://github.com/BVLC/caffe/tree/windows) *see the Windows branch led by Guillaume Dumont*
 - [OpenCL](https://github.com/BVLC/caffe/tree/opencl) *see the OpenCL branch led by Fabian Tschopp*
-- [AWS AMI](https://github.com/bitfusionio/amis/tree/master/awsmrkt-bfboost-ubuntu14-cuda75-caffe) *pre-configured for AWS*
+- [AWS AMI](https://aws.amazon.com/marketplace/pp/B01M0AXXQB) *official deep learning amazon machine image from AWS*
 
 **Overview**:
 


### PR DESCRIPTION
AWS has their own deep learning AMI with Caffe 1.0 and other frameworks. Since it is the official image it is taking priority.