### PR TITLE
Clear Scratch Diffs to Prevent Contaminating Backward through Splits

### DIFF
--- a/src/caffe/layers/accuracy_layer.cu
+++ b/src/caffe/layers/accuracy_layer.cu
@@ -71,9 +71,8 @@ void AccuracyLayer<Dtype>::Forward_gpu(
   const int dim = bottom[0]->count() / outer_num_;
   const int num_labels = bottom[0]->shape(label_axis_);
   const int nthreads = outer_num_ * inner_num_;
-  // Since this memory is not used for anything,
-  // we use it here to avoid having to allocate new GPU
-  // memory to accumulate intermediate results in the kernel.
+  // Since this memory is not used for anything, we use it here to avoid having
+  // to allocate new GPU memory to accumulate intermediate results.
   Dtype* acc_data = bottom[0]->mutable_gpu_diff();
   if (top.size() == 1) {
     // simple case - report only global accuracy.
@@ -134,6 +133,7 @@ void AccuracyLayer<Dtype>::Forward_gpu(
       }
     }
   }
+  // Clear scratch memory to prevent interfering with backward (see #6202).
   caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
 }
 

--- a/src/caffe/layers/accuracy_layer.cu
+++ b/src/caffe/layers/accuracy_layer.cu
@@ -134,6 +134,7 @@ void AccuracyLayer<Dtype>::Forward_gpu(
       }
     }
   }
+  caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
 }
 
 

--- a/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cu
+++ b/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cu
@@ -48,9 +48,8 @@ void SigmoidCrossEntropyLossLayer<Dtype>::Forward_gpu(
   // Stable version of loss computation from input data
   const Dtype* input_data = bottom[0]->gpu_data();
   const Dtype* target = bottom[1]->gpu_data();
-  // Since this memory is not used for anything until it is overwritten
-  // on the backward pass, we use it here to avoid having to allocate new GPU
-  // memory to accumulate intermediate results in the kernel.
+  // Since this memory is not used for anything, we use it here to avoid having
+  // to allocate new GPU memory to accumulate intermediate results.
   Dtype* loss_data = bottom[0]->mutable_gpu_diff();
   Dtype* count_data = bottom[1]->mutable_gpu_diff();
   Dtype valid_count;
@@ -70,6 +69,7 @@ void SigmoidCrossEntropyLossLayer<Dtype>::Forward_gpu(
   normalizer_ = get_normalizer(normalization_, valid_count);
   top[0]->mutable_cpu_data()[0] = loss / normalizer_;
 
+  // Clear scratch memory to prevent interfering with backward (see #6202).
   caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
   caffe_gpu_set(bottom[1]->count(), Dtype(0), bottom[1]->mutable_gpu_diff());
 }

--- a/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cu
+++ b/src/caffe/layers/sigmoid_cross_entropy_loss_layer.cu
@@ -69,6 +69,9 @@ void SigmoidCrossEntropyLossLayer<Dtype>::Forward_gpu(
   caffe_gpu_asum(count, loss_data, &loss);
   normalizer_ = get_normalizer(normalization_, valid_count);
   top[0]->mutable_cpu_data()[0] = loss / normalizer_;
+
+  caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
+  caffe_gpu_set(bottom[1]->count(), Dtype(0), bottom[1]->mutable_gpu_diff());
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/softmax_loss_layer.cu
+++ b/src/caffe/layers/softmax_loss_layer.cu
@@ -36,9 +36,8 @@ void SoftmaxWithLossLayer<Dtype>::Forward_gpu(
   const Dtype* label = bottom[1]->gpu_data();
   const int dim = prob_.count() / outer_num_;
   const int nthreads = outer_num_ * inner_num_;
-  // Since this memory is not used for anything until it is overwritten
-  // on the backward pass, we use it here to avoid having to allocate new GPU
-  // memory to accumulate intermediate results in the kernel.
+  // Since this memory is not used for anything, we use it here to avoid having
+  // to allocate new GPU memory to accumulate intermediate results.
   Dtype* loss_data = bottom[0]->mutable_gpu_diff();
   // Similarly, this memory is never used elsewhere, and thus we can use it
   // to avoid having to allocate additional GPU memory.
@@ -62,6 +61,7 @@ void SoftmaxWithLossLayer<Dtype>::Forward_gpu(
     top[1]->ShareData(prob_);
   }
 
+  // Clear scratch memory to prevent interfering with backward (see #6202).
   caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
 }
 

--- a/src/caffe/layers/softmax_loss_layer.cu
+++ b/src/caffe/layers/softmax_loss_layer.cu
@@ -61,6 +61,8 @@ void SoftmaxWithLossLayer<Dtype>::Forward_gpu(
   if (top.size() == 2) {
     top[1]->ShareData(prob_);
   }
+
+  caffe_gpu_set(bottom[0]->count(), Dtype(0), bottom[0]->mutable_gpu_diff());
 }
 
 template <typename Dtype>


### PR DESCRIPTION
Certain layers (`SoftmaxWithLossLayer`, `SigmoidCrossEntropyLossLayer`, and `AccuracyLayer`) save memory during forward by making use of bottom diffs that are otherwise unused or overwritten during backward. The trouble is that these scratch diffs can be mistakenly propagated by backward through split layers. All of the top diffs of a split are accumulated even when backward is not called for the losses (when their loss weight is zero) or accuracy (which has no backward step). This was missed at first because it requires the interaction of split layers and the backward pruning that prevents computation of unnecessary gradients.

This fix zeros out the scratch diffs to prevent this kind of contamination. This requires a little computation but not much at all. This is preferable to requiring more memory for internal buffers because the further memory usage might cause an unexpected crash for a previously good configuration.

See https://github.com/BVLC/caffe/issues/2895#issuecomment-130984651 for the first explanation of this issue.

Related:
- fix #2895, fix #5981
- close #3868, close #5987, close #6141

Credits:
- Thanks @vlomonaco for reporting the `Accuracy` layer issue in #5981.
- Thanks @Noiredd for proposing an internal buffer fix in #5987 and @sonack for another version of the same in #6141
- Thanks @orzlibo for proposing the clearing fix for losses in #6186. Note the
cherry-pick of that fix in this PR.