### PR TITLE
Update Classifier and Detector to avoid deprecation warning

### DIFF
--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -23,7 +23,7 @@ class Classifier(caffe.Net):
     def __init__(self, model_file, pretrained_file, image_dims=None,
                  mean=None, input_scale=None, raw_scale=None,
                  channel_swap=None):
-        caffe.Net.__init__(self, model_file, pretrained_file, caffe.TEST)
+        caffe.Net.__init__(self, model_file, caffe.TEST, weights=pretrained_file)
 
         # configure pre-processing
         in_ = self.inputs[0]

--- a/python/caffe/detector.py
+++ b/python/caffe/detector.py
@@ -35,7 +35,7 @@ class Detector(caffe.Net):
     def __init__(self, model_file, pretrained_file, mean=None,
                  input_scale=None, raw_scale=None, channel_swap=None,
                  context_pad=None):
-        caffe.Net.__init__(self, model_file, pretrained_file, caffe.TEST)
+        caffe.Net.__init__(self, model_file, caffe.TEST, weights=pretrained_file)
 
         # configure pre-processing
         in_ = self.inputs[0]


### PR DESCRIPTION
A system I'm working on uses `caffe.Classifier` and continually logs warnings like those below. This PR changes the underlying `Net` call to match the new signature.

```
W0202 20:51:24.142218     1 _caffe.cpp:135] DEPRECATION WARNING - deprecated use of Python interface
W0202 20:51:24.142246     1 _caffe.cpp:136] Use this instead (with the named "weights" parameter):
W0202 20:51:24.142249     1 _caffe.cpp:138] Net('/path/to/deploy.prototxt', 1, weights='/path/to/model_name.caffemodel')
```