### PR TITLE
Incorrect namespace for pycaffe submodule caffe_pb2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -641,7 +641,7 @@ $(PROTO_BUILD_DIR)/%.pb.cc $(PROTO_BUILD_DIR)/%.pb.h : \
 $(PY_PROTO_BUILD_DIR)/%_pb2.py : $(PROTO_SRC_DIR)/%.proto \
 		$(PY_PROTO_INIT) | $(PY_PROTO_BUILD_DIR)
 	@ echo PROTOC \(python\) $<
-	$(Q)protoc --proto_path=$(PROTO_SRC_DIR) --python_out=$(PY_PROTO_BUILD_DIR) $<
+	$(Q)protoc --proto_path=src --python_out=python $<
 
 $(PY_PROTO_INIT): | $(PY_PROTO_BUILD_DIR)
 	touch $(PY_PROTO_INIT)

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -78,7 +78,7 @@ function(caffe_protobuf_generate_cpp_py output_dir srcs_var hdrs_var python_var)
              "${output_dir}/${fil_we}_pb2.py"
       COMMAND ${CMAKE_COMMAND} -E make_directory "${output_dir}"
       COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --cpp_out    ${output_dir} ${_protoc_include} ${abs_fil}
-      COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --python_out ${output_dir} ${_protoc_include} ${abs_fil}
+      COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} --python_out ${PROJECT_BINARY_DIR}/include --proto_path ${PROJECT_SOURCE_DIR}/src ${_protoc_include} ${abs_fil}
       DEPENDS ${abs_fil}
       COMMENT "Running C++/Python protocol buffer compiler on ${fil}" VERBATIM )
   endforeach()


### PR DESCRIPTION
Protobuf compiler builds python caffe_pb2 submodule within wrong namespace ('caffe_pb2' instead of 'caffe.proto.caffe_pb2'). It causes error when pickling object.
```
>>> from caffe.proto import caffe_pb2
>>> net = caffe_pb2.NetParameter()
>>> print net.__module__
caffe_pb2
>>>import pickle
>>>pickle.dump(net, open('save.p','wb'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python2.7/pickle.py", line 1370, in dump
    Pickler(file, protocol).dump(obj)
  File "/usr/lib64/python2.7/pickle.py", line 224, in dump
    self.save(obj)
  File "/usr/lib64/python2.7/pickle.py", line 331, in save
    self.save_reduce(obj=obj, *rv)
  File "/usr/lib64/python2.7/pickle.py", line 400, in save_reduce
    save(func)
  File "/usr/lib64/python2.7/pickle.py", line 300, in save
    self.save_global(obj)
  File "/usr/lib64/python2.7/pickle.py", line 748, in save_global
    (obj, module, name))
pickle.PicklingError: Can't pickle <class 'caffe_pb2.NetParameter'>: it's not found as caffe_pb2.NetParameter
```
Some developers uses workaround by loading caffe_pb2 submodule as standalone module. It may causes collisions with the main package and errors that hard to locate.
```
>>> import sys
>>> import os
>>> import caffe
>>> sys.path.insert(0, os.path.join(os.path.dirname(caffe.__file__), 'proto'))
>>> import caffe_pb2
>>> net = caffe_pb2.NetParameter()
>>> import pickle
>>> pickle.dump(net, open('save.p','wb'))
>>> net = caffe.proto.caffe_pb2.NetParameter()
>>> pickle.dump(net, open('save.p','wb'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python2.7/pickle.py", line 1370, in dump
    Pickler(file, protocol).dump(obj)
  File "/usr/lib64/python2.7/pickle.py", line 224, in dump
    self.save(obj)
  File "/usr/lib64/python2.7/pickle.py", line 331, in save
    self.save_reduce(obj=obj, *rv)
  File "/usr/lib64/python2.7/pickle.py", line 400, in save_reduce
    save(func)
  File "/usr/lib64/python2.7/pickle.py", line 300, in save
    self.save_global(obj)
  File "/usr/lib64/python2.7/pickle.py", line 753, in save_global
    (obj, module, name))
pickle.PicklingError: Can't pickle <class 'caffe_pb2.NetParameter'>: it's not the same object as caffe_pb2.NetParameter
```
In my opinion if caffe_pb2 is the caffe package submodule, it should be imported as submodule and have namespace for submodule.