### PR TITLE
Make caffe compile with CUDA 9.1

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -109,6 +109,12 @@ function(caffe_select_nvcc_arch_flags out_variable)
   set(__nvcc_flags "")
   set(__nvcc_archs_readable "")
 
+  string(COMPARE GREATER_EQUAL "${CUDA_VERSION}" "9.1" iscudanewerthan91)
+  if(iscudanewerthan91)
+    string(REPLACE "21(20)" "" __cuda_arch_bin "${__cuda_arch_bin}")
+    string(REPLACE "20" "" __cuda_arch_bin "${__cuda_arch_bin}")
+  endif()
+
   # Tell NVCC to add binaries for the specified GPUs
   foreach(__arch ${__cuda_arch_bin})
     if(__arch MATCHES "([0-9]+)\\(([0-9]+)\\)")


### PR DESCRIPTION
CUDA 9.1 doesn't support sm_20 and sm_21 anymore. This PR allows caffe to compile with CUDA 9.1 successfully. 