### PR TITLE
Remove legacy tools

### DIFF
--- a/tools/device_query.cpp
+++ b/tools/device_query.cpp
@@ -1,7 +1,0 @@
-#include "caffe/common.hpp"
-
-int main(int argc, char** argv) {
-  LOG(FATAL) << "Deprecated. Use caffe device_query "
-                "[--device_id=0] instead.";
-  return 0;
-}

--- a/tools/finetune_net.cpp
+++ b/tools/finetune_net.cpp
@@ -1,7 +1,0 @@
-#include "caffe/caffe.hpp"
-
-int main(int argc, char** argv) {
-  LOG(FATAL) << "Deprecated. Use caffe train --solver=... "
-                "[--weights=...] instead.";
-  return 0;
-}

--- a/tools/net_speed_benchmark.cpp
+++ b/tools/net_speed_benchmark.cpp
@@ -1,7 +1,0 @@
-#include "caffe/caffe.hpp"
-
-int main(int argc, char** argv) {
-  LOG(FATAL) << "Deprecated. Use caffe time --model=... "
-             "[--iterations=50] [--gpu] [--device_id=0]";
-  return 0;
-}

--- a/tools/test_net.cpp
+++ b/tools/test_net.cpp
@@ -1,7 +1,0 @@
-#include "caffe/caffe.hpp"
-
-int main(int argc, char** argv) {
-  LOG(FATAL) << "Deprecated. Use caffe test --model=... "
-      "--weights=... instead.";
-  return 0;
-}

--- a/tools/train_net.cpp
+++ b/tools/train_net.cpp
@@ -1,7 +1,0 @@
-#include "caffe/caffe.hpp"
-
-int main(int argc, char** argv) {
-  LOG(FATAL) << "Deprecated. Use caffe train --solver=... "
-                "[--snapshot=...] instead.";
-  return 0;
-}


### PR DESCRIPTION
It's been almost 4 years (since a916ef4), I think we can get rid of those?

Fixes #5543