### PR TITLE
AdaMax solver

### DIFF
--- a/include/caffe/sgd_solvers.hpp
+++ b/include/caffe/sgd_solvers.hpp
@@ -143,6 +143,26 @@ class AdamSolver : public SGDSolver<Dtype> {
   DISABLE_COPY_AND_ASSIGN(AdamSolver);
 };
 
+/**
+ * @brief AdaMaxSolver, extension of Adam based on infinity norm.
+*/
+
+template <typename Dtype>
+class AdaMaxSolver : public SGDSolver <Dtype> {
+ public:
+  explicit AdaMaxSolver(const SolverParameter& param)
+      : SGDSolver<Dtype>(param) { AdaMaxPreSolve(); }
+  explicit AdaMaxSolver(const string& param_file)
+      : SGDSolver<Dtype>(param_file) { AdaMaxPreSolve(); }
+  virtual inline const char* type() const { return "AdaMax"; }
+
+ protected:
+  void AdaMaxPreSolve();
+  virtual void ComputeUpdateValue(int param_id, Dtype rate);
+
+  DISABLE_COPY_AND_ASSIGN(AdaMaxSolver);
+};
+
 }  // namespace caffe
 
 #endif  // CAFFE_SGD_SOLVERS_HPP_

--- a/src/caffe/solvers/adamax_solver.cpp
+++ b/src/caffe/solvers/adamax_solver.cpp
@@ -1,0 +1,87 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/sgd_solvers.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void AdaMaxSolver<Dtype>::AdaMaxPreSolve() {
+  // Essentially the same as with Adam
+  const vector<Blob<Dtype>*>& net_params = this->net_->learnable_params();
+  for (int i = 0; i < net_params.size(); ++i) {
+    const vector<int>& shape = net_params[i]->shape();
+    this->history_.push_back(
+            shared_ptr<Blob<Dtype> >(new Blob<Dtype>(shape)));
+  }
+}
+
+#ifndef CPU_ONLY
+template <typename Dtype>
+void adamax_update_gpu(int N, Dtype* g, Dtype* m, Dtype* v, Dtype beta1,
+    Dtype beta2, Dtype corrected_local_rate);
+#endif
+
+template <typename Dtype>
+void AdaMaxSolver<Dtype>::ComputeUpdateValue(int param_id, Dtype rate) {
+  const vector<Blob<Dtype>*>& net_params = this->net_->learnable_params();
+  const vector<float>& net_params_lr = this->net_->params_lr();
+  Dtype local_rate = rate * net_params_lr[param_id];
+  const Dtype beta1 = this->param_.momentum();
+  const Dtype beta2 = this->param_.momentum2();
+
+  // we create aliases for convenience
+  size_t update_history_offset = net_params.size();
+  Blob<Dtype>* val_m = this->history_[param_id].get();
+  Blob<Dtype>* val_v = this->history_[param_id + update_history_offset].get();
+  Blob<Dtype>* val_t = this->temp_[param_id].get();
+
+  const int t = this->iter_ + 1;
+  const Dtype correction = Dtype(1) / (Dtype(1) - pow(beta1, t));
+  const int N = net_params[param_id]->count();
+
+  switch (Caffe::mode()) {
+    case Caffe::CPU: {
+    // update m <- \beta_1 m_{t-1} + (1-\beta_1)g_t
+    caffe_cpu_axpby(N, Dtype(1)-beta1,
+        net_params[param_id]->cpu_diff(), beta1,
+        val_m->mutable_cpu_data());
+
+    // update v <- max(\beta_2 v_{t-1}, |g_t|)
+    // for stability, add a small epsilon to \beta_2 v_{t-1}
+    caffe_abs(N, net_params[param_id]->cpu_diff(), val_t->mutable_cpu_data());
+    for (int i = 0; i < N; ++i) {
+      val_v->mutable_cpu_data()[i] = std::max(
+          val_v->cpu_data()[i] * beta2 + Dtype(1e-7),
+          val_t->cpu_data()[i]);
+    }
+
+    // set update
+    caffe_div(N,
+        val_m->cpu_data(),
+        val_v->cpu_data(),
+        val_t->mutable_cpu_data());
+    caffe_cpu_scale(N, local_rate*correction, val_t->cpu_data(),
+        net_params[param_id]->mutable_cpu_diff());
+
+    break;
+  }
+  case Caffe::GPU: {
+#ifndef CPU_ONLY
+    adamax_update_gpu(N, net_params[param_id]->mutable_gpu_diff(),
+        val_m->mutable_gpu_data(), val_v->mutable_gpu_data(), beta1, beta2,
+        local_rate*correction);
+#else
+    NO_GPU;
+#endif
+    break;
+  }
+  default:
+    LOG(FATAL) << "Unknown caffe mode: " << Caffe::mode();
+  }
+}
+
+INSTANTIATE_CLASS(AdaMaxSolver);
+REGISTER_SOLVER_CLASS(AdaMax);
+
+}  // namespace caffe

--- a/src/caffe/solvers/adamax_solver.cu
+++ b/src/caffe/solvers/adamax_solver.cu
@@ -1,0 +1,31 @@
+#include <algorithm>
+
+#include "caffe/util/math_functions.hpp"
+
+
+namespace caffe {
+
+template <typename Dtype>
+__global__ void AdaMaxUpdate(int N, Dtype* g, Dtype* m, Dtype* v,
+    Dtype beta1, Dtype beta2, Dtype corrected_local_rate) {
+  CUDA_KERNEL_LOOP(i, N) {
+    float gi = g[i];
+    float mi = m[i] = m[i]*beta1 + gi*(1-beta1);
+    float vi = v[i] = max(v[i]*beta2 + Dtype(1e-7), abs(gi));
+    g[i] = corrected_local_rate * mi / vi;
+  }
+}
+template <typename Dtype>
+void adamax_update_gpu(int N, Dtype* g, Dtype* m, Dtype* v, Dtype beta1,
+    Dtype beta2, Dtype corrected_local_rate) {
+  AdaMaxUpdate<Dtype>  // NOLINT_NEXT_LINE(whitespace/operators)
+      <<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(
+      N, g, m, v, beta1, beta2, corrected_local_rate);
+  CUDA_POST_KERNEL_CHECK;
+}
+template void adamax_update_gpu<float>(int, float*, float*, float*,
+    float, float, float);
+template void adamax_update_gpu<double>(int, double*, double*, double*,
+    double, double, double);
+
+}  // namespace caffe


### PR DESCRIPTION
An implementation of a variant of Adam with the L2 norm replaced with infinite norm (see section 7.1 of [Kingma & Lei Ba, 2014](https://arxiv.org/abs/1412.6980)).  
The code is in large part taken from the Adam solver so there's a lot of duplication - if that is an issue, there's another way of implementing this. `AdamSolver` could have a protected method `GradientNorm` which would be called by `ComputeUpdateValue`, then the `AdaMaxSolver` would derive from it and override this method. For GPU version, the whole `adam_update_gpu()` would become a virtual method of the class, overridden in `AdaMaxSolver`.

I considered having both variants in one class (and then just `switch` between them at runtime), but this raises issues with instantiating the solver (due to how `SolverFactory` works).

Thoughts?