### PR TITLE
[AVE POOL ISSUE] New thread of #6296, Add an optional switch to support dynamic pool_size in AVE pooling

### DIFF
--- a/src/caffe/layers/pooling_layer.cpp
+++ b/src/caffe/layers/pooling_layer.cpp
@@ -127,6 +127,7 @@ void PoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void PoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
+  PoolingParameter pool_param = this->layer_param_.pooling_param();
   const Dtype* bottom_data = bottom[0]->cpu_data();
   Dtype* top_data = top[0]->mutable_cpu_data();
   const int top_count = top[0]->count();
@@ -203,6 +204,9 @@ void PoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
             wstart = max(wstart, 0);
             hend = min(hend, height_);
             wend = min(wend, width_);
+	    if(pool_param.dynamic_ave_pool_size()==true) {
+	      pool_size = (hend - hstart) * (wend - wstart);
+	    }
             for (int h = hstart; h < hend; ++h) {
               for (int w = wstart; w < wend; ++w) {
                 top_data[ph * pooled_width_ + pw] +=
@@ -229,6 +233,7 @@ void PoolingLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void PoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  PoolingParameter pool_param = this->layer_param_.pooling_param();
   if (!propagate_down[0]) {
     return;
   }
@@ -284,6 +289,9 @@ void PoolingLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
             wstart = max(wstart, 0);
             hend = min(hend, height_);
             wend = min(wend, width_);
+	    if(pool_param.dynamic_ave_pool_size()==true) {
+	      pool_size = (hend - hstart) * (wend - wstart);
+	    }
             for (int h = hstart; h < hend; ++h) {
               for (int w = wstart; w < wend; ++w) {
                 bottom_diff[h * width_ + w] +=

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -935,6 +935,7 @@ message PoolingParameter {
   // If global_pooling then it will pool over the size of the bottom by doing
   // kernel_h = bottom->height and kernel_w = bottom->width
   optional bool global_pooling = 12 [default = false];
+  optional bool dynamic_ave_pool_size = 13 [default=false];
 }
 
 message PowerParameter {


### PR DESCRIPTION
Because the commits on old thread #6296 got messed up, I try to create this new thread based on a clean branch. If @Noiredd could help close that thread, it will be very helpful.

1) In this fix, I add an optional boolean switch named "dynamic_ave_pool_size" in the caffe.proto, and default=false. 
2) Then pass the handle of layer_param_.pooling_param() into Forward_cpu() and Backward_cpu() functions in pooling_layer.cpp, and the AvePoolForward() function in pooling_layer.cu (The AvePoolBackward() seems correct already).
3) If the dynamic_ave_pool_size==true, the variable "pool_size" would be updated immediately after the 4 coordinates been updated. 

I just tested the Forward_cpu() version, it seems good. I will test the GPU forward version later on, but need some help on the Backward_cpu().

I'm not quite familiar with travis, I will try to learn the scripts of travis under the repo and try to use it on my own travis account later.

Thanks,
Xiaolun Cao