### PR TITLE
add name scope and arg scope for netspec

### DIFF
--- a/python/caffe/__init__.py
+++ b/python/caffe/__init__.py
@@ -5,4 +5,4 @@ from .proto.caffe_pb2 import TRAIN, TEST
 from .classifier import Classifier
 from .detector import Detector
 from . import io
-from .net_spec import layers, params, NetSpec, to_proto
+from .net_spec import layers, params, NetSpec, to_proto, name_scope, arg_scope

--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -309,7 +309,7 @@ class arg_scope(object):
 
     def check_args(self, kwargs):
         for layer_type in self.layer_types:
-            for key, value in kwargs.iteritems():
+            for key, value in six.iteritems(kwargs):
                 if key in ('param', 'in_place'):
                     continue
                 getattr(getattr(caffe_pb2, layer_type + 'Parameter')(), key)
@@ -317,7 +317,7 @@ class arg_scope(object):
     def __enter__(self):
         global ARG_SCOPE_KEYS
         for layer_type in self.layer_types:
-            for key, value in self.args.iteritems():
+            for key, value in six.iteritems(self.args):
                 ARG_SCOPE_KEYS[layer_type][key] = value
 
     def __exit__(self, *args):

--- a/python/caffe/net_spec.py
+++ b/python/caffe/net_spec.py
@@ -20,10 +20,10 @@ are not guaranteed to be forward-compatible.
 
 from collections import OrderedDict, Counter, defaultdict
 
+from ._caffe import layer_type_list
 from .proto import caffe_pb2
 from google import protobuf
 import six
-import _caffe
 
 NAME_SCOPE_KEYS = list()
 ARG_SCOPE_KEYS = defaultdict(dict)
@@ -114,7 +114,7 @@ class Function(object):
                 raise TypeError('%s input %d is not a Top (type is %s)' %
                                 (type_name, index, type(input)))
 
-        self.scope_name = get_scope_name()
+        self.scope = get_scope_name()
         self.scope_arg = get_scope_arg(type_name)
 
         self.inputs = inputs
@@ -168,10 +168,12 @@ class Function(object):
             for top in self.tops:
                 layer.top.append(self._get_top_name(top, names, autonames))
 
-        layer.name = self.scope_name
+        layer.name = ''
+        if self.scope:
+            layer.name = self.scope.name
         if 'name' in self.params:
             if layer.name != '':
-                layer.name += '/'
+                layer.name += self.scope.sep
             layer.name += self.params['name']
         if layer.name == '':
             layer.name = self._get_name(names, autonames)
@@ -183,9 +185,9 @@ class Function(object):
                 self.params[k] = v
 
         for k, v in six.iteritems(self.params):
-            # special case to handle generic *params
             if k == 'name':
                 continue
+            # special case to handle generic *params
             if k.endswith('param'):
                 assign_proto(layer, k, v)
             else:
@@ -208,24 +210,23 @@ class NetSpec(object):
         super(NetSpec, self).__setattr__('tops', OrderedDict())
 
     def __setattr__(self, name, value):
-        scope_name = get_scope_name()
+        scope = get_scope_name()
         new_name = name
-        if scope_name != '':
-            new_name = scope_name + '/' + name
-        # if name is a dash, then we just replace the scope name
-        if name == '_':
-            new_name = scope_name
+        if scope:
+            new_name = scope.name + scope.sep + name
+        # if name is a dash, then we just replace with the scope name
+        if name == '_' and scope:
+            new_name = scope.name
         name = new_name
         self.tops[name] = value
 
     def __getattr__(self, name):
-        scope_name = get_scope_name()
+        scope = get_scope_name()
         new_name = name
-        if scope_name != '':
-            new_name = scope_name + '/' + name
-        if name == '_':
-            assert (scope_name != ''), 'a dash top name should be within in a name scope'
-            new_name = scope_name
+        if scope:
+            new_name = scope.name + scope.sep + name
+        if name == '_' and scope:
+            new_name = scope.name
         name = new_name
         return self.tops[name]
 
@@ -280,14 +281,15 @@ layers = Layers()
 params = Parameters()
 
 class name_scope(object):
-    def __init__(self, name):
+    def __init__(self, name, sep='/'):
         assert(name != '')
         self.name = name
+        self.sep = sep
     def __enter__(self):
         global NAME_SCOPE_KEYS
         if len(NAME_SCOPE_KEYS) > 0:
             p_scope = NAME_SCOPE_KEYS[-1]
-            self.name = p_scope.name + '/' + self.name
+            self.name = p_scope.name + p_scope.sep + self.name
         NAME_SCOPE_KEYS.append(self)
     def __exit__(self, *args):
         global NAME_SCOPE_KEYS
@@ -329,9 +331,9 @@ class arg_scope(object):
 def get_scope_name():
     global NAME_SCOPE_KEYS
     if len(NAME_SCOPE_KEYS) > 0:
-        return NAME_SCOPE_KEYS[-1].name
+        return NAME_SCOPE_KEYS[-1]
     else:
-        return ''
+        return None
 
 def get_scope_arg(layer_type):
     global ARG_SCOPE_KEYS
@@ -347,4 +349,4 @@ def get_value_from_arg_scope(layey_type, key):
 
 
 _param_names = param_name_dict()
-layer_type_list = list(_caffe.layer_type_list())
+layer_type_list = list(layer_type_list())

--- a/python/caffe/test/test_net_spec.py
+++ b/python/caffe/test/test_net_spec.py
@@ -49,7 +49,9 @@ def scope_lenet(batch_size):
                         # this can be done by assigning the top name to a dash
                         block2 = n._ = L.Pooling(n.conv, name='pool', pool=P.Pooling.AVE)
 
-            n.ip1 = L.InnerProduct(block2, num_output=500)
+            # nested arg scope
+            with arg_scope(['InnerProduct'], weight_filler=dict(type='msra')):
+                n.ip1 = L.InnerProduct(block2, num_output=500)
             with arg_scope(['ReLU'], in_place=True):
                 n.relu = L.ReLU(n.ip1)
             n.ip2 = L.InnerProduct(n.relu, num_output=10)
@@ -116,7 +118,9 @@ class TestNetSpec(unittest.TestCase):
         self.assertEqual(net.layer[4].pooling_param.kernel_size, 2)
         self.assertEqual(net.layer[4].pooling_param.stride, 2)
         self.assertEqual(net.layer[4].pooling_param.pool, P.Pooling.AVE)
+        self.assertEqual(net.layer[5].inner_product_param.weight_filler.type, 'msra')
         self.assertEqual(net.layer[6].bottom, net.layer[6].top)
+        self.assertEqual(net.layer[7].inner_product_param.weight_filler.type, 'xavier')
 
 
     def test_lenet(self):

--- a/python/caffe/test/test_net_spec.py
+++ b/python/caffe/test/test_net_spec.py
@@ -3,6 +3,7 @@ import tempfile
 import caffe
 from caffe import layers as L
 from caffe import params as P
+from caffe import name_scope, arg_scope
 
 def lenet(batch_size):
     n = caffe.NetSpec()
@@ -21,6 +22,38 @@ def lenet(batch_size):
     n.ip2 = L.InnerProduct(n.relu1, num_output=10,
         weight_filler=dict(type='xavier'))
     n.loss = L.SoftmaxWithLoss(n.ip2, n.label)
+    return n.to_proto()
+
+def scope_lenet(batch_size):
+    n = caffe.NetSpec()
+    n.data, n.label = L.DummyData(shape=[dict(dim=[batch_size, 1, 28, 28]),
+                                         dict(dim=[batch_size, 1, 1, 1])],
+                                  transform_param=dict(scale=1./255), ntop=2)
+    input_data = n.data
+    # a bit more complicated for testing purpose
+    with arg_scope(['Pooling'], kernel_size=2, stride=2, pool=P.Pooling.MAX):
+        # both InnerProduct and Convolution have identical weight_filler
+        with arg_scope(['InnerProduct', 'Convolution'], weight_filler=dict(type='xavier')):
+            # add additional config for Convolution
+            with arg_scope(['Convolution'], param=[dict(lr_mult=0.1, decay_mult=0.1)]):
+                with name_scope('block1'):
+                    n.conv = L.Convolution(input_data, kernel_size=5, num_output=20, name='conv')
+                    block1 = n.pool = L.Pooling(n.conv, name='pool')
+                # nested scope with different seperator
+                with name_scope('parent', sep='_'):
+                    with name_scope('block2'):
+                        # override the learning rate
+                        n.conv = L.Convolution(block1, kernel_size=5, num_output=50, name='conv', param=[dict(lr_mult=1, decay_mult=2)])
+                        # override the pooling method
+                        # sometimes we may want to let the top name equal to the scope name
+                        # this can be done by assigning the top name to a dash
+                        block2 = n._ = L.Pooling(n.conv, name='pool', pool=P.Pooling.AVE)
+
+            n.ip1 = L.InnerProduct(block2, num_output=500)
+            with arg_scope(['ReLU'], in_place=True):
+                n.relu = L.ReLU(n.ip1)
+            n.ip2 = L.InnerProduct(n.relu, num_output=10)
+            n.loss = L.SoftmaxWithLoss(n.ip2, n.label)
     return n.to_proto()
 
 def anon_lenet(batch_size):
@@ -54,6 +87,37 @@ class TestNetSpec(unittest.TestCase):
         f.write(str(net_proto))
         f.close()
         return caffe.Net(f.name, caffe.TEST)
+
+    def test_scope(self):
+        net = scope_lenet(50)
+        self.assertEqual(len(net.layer), 9)
+        # check name scope
+        # check layer name
+        self.assertEqual(net.layer[1].name, 'block1/conv')
+        self.assertEqual(net.layer[2].name, 'block1/pool')
+        self.assertEqual(net.layer[3].name, 'parent_block2/conv')
+        self.assertEqual(net.layer[4].name, 'parent_block2/pool')
+        # check top name
+        self.assertEqual(net.layer[1].top[0], 'block1/conv')
+        self.assertEqual(net.layer[2].top[0], 'block1/pool')
+        self.assertEqual(net.layer[3].top[0], 'parent_block2/conv')
+        # this should be eqaul to scope name
+        self.assertEqual(net.layer[4].top[0], 'parent_block2')
+        # check arg scope
+        self.assertEqual(net.layer[1].convolution_param.weight_filler.type, 'xavier')
+        self.assertEqual(round(net.layer[1].param[0].lr_mult, 2), 0.1)
+        self.assertEqual(round(net.layer[1].param[0].decay_mult, 2), 0.1)
+        self.assertEqual(net.layer[2].pooling_param.kernel_size, 2)
+        self.assertEqual(net.layer[2].pooling_param.stride, 2)
+        self.assertEqual(net.layer[2].pooling_param.pool, P.Pooling.MAX)
+        self.assertEqual(net.layer[3].convolution_param.weight_filler.type, 'xavier')
+        self.assertEqual(net.layer[3].param[0].lr_mult, 1)
+        self.assertEqual(net.layer[3].param[0].decay_mult, 2)
+        self.assertEqual(net.layer[4].pooling_param.kernel_size, 2)
+        self.assertEqual(net.layer[4].pooling_param.stride, 2)
+        self.assertEqual(net.layer[4].pooling_param.pool, P.Pooling.AVE)
+        self.assertEqual(net.layer[6].bottom, net.layer[6].top)
+
 
     def test_lenet(self):
         """Construct and build the Caffe version of LeNet."""


### PR DESCRIPTION
add name scope and arg scope like tensorflow slim (https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/slim).

tensorflow slim has defined `name_scope` and `arg_scope`, this can be done with a similar way in caffe.

and both `name_scope` and `arg_scope`  help organize the network when using netspec.

with `name_scope`, every layer name is renamed to `scope_name / layer_name`, you can have identical layer's names but with different scope names. you can also define the separator you want, for example,  [resent](https://github.com/KaimingHe/deep-residual-networks/blob/master/prototxt/ResNet-50-deploy.prototxt#L179) uses `_` as the separator. 

```python
with name_scope('conv3_1'):
# this layer name would be conv3_1/conv
    L.Convolution(bottom, name='conv', pad_h=3, pad_w=3, kernel_h=7, kernel_w=7, stride_h=2, stride_w=2, num_output=16, bias_term=False)

with name_scope('conv4_1'):
# this layer name would be conv4_1/conv
    L.Convolution(bottom, name='conv', pad_h=3, pad_w=3, kernel_h=7, kernel_w=7, stride_h=2, stride_w=2, num_output=16, bias_term=False)

with name_scope('conv5', sep='_'):
# this layer name would be conv5_conv
    L.Convolution(bottom, name='conv', pad_h=3, pad_w=3, kernel_h=7, kernel_w=7, stride_h=2, stride_w=2, num_output=16, bias_term=False)
```

with `arg_scope`, it helps a lot to define common configs for each layer within a scope.

for example, in batch normalization, we always need to define the learning rate for each parameter to zero.

```python
L.BatchNorm(bottom, param=[dict(lr_mult=0),dict(lr_mult=0),dict(lr_mult=0)], in_place=True)
```

it's annoying if you have to define many of these.

Instead, with the help from `arg_scope`, you have less code to define the layers.

```python
with arg_scope(['BatchNorm'], param=[dict(lr_mult=0),dict(lr_mult=0),dict(lr_mult=0)], in_place=True):
    with arg_scope(['Scale'], param=[dict(lr_mult=0.1, decay_mult=0), dict(lr_mult=0.1, decay_mult=0)], bias_term=True, in_place=True):
        with arg_scope(['Convolution'], param=[dict(lr_mult=0.1, decay_mult=0.1)]):
# arg_scope works like defalut configs
# you can override default configs if you want
    L.BatchNorm(bottom, name="bn", in_place=False)
```