### PR TITLE
Enhance SoftmaxWithLoss by adding select_label.

### DIFF
--- a/examples/mnist/lenet_train_test.prototxt
+++ b/examples/mnist/lenet_train_test.prototxt
@@ -166,3 +166,28 @@ layer {
   bottom: "label"
   top: "loss"
 }
+# Test code for select_label
+#layer {
+#  name: "loss1"
+#  type: "SoftmaxWithLoss"
+#  bottom: "ip2"
+#  bottom: "label"
+#  top: "loss1"
+#  loss_param {
+#      ignore_label: 1
+#      #select_label: 1
+#  }
+#  loss_weight: 1
+#}
+#
+#layer {
+#  name: "loss2"
+#  type: "SoftmaxWithLoss"
+#  bottom: "ip2"
+#  bottom: "label"
+#  top: "loss2"
+#  loss_param {
+#      select_label: 0
+#  }
+#  loss_weight: 2
+#}

--- a/include/caffe/layers/softmax_loss_layer.hpp
+++ b/include/caffe/layers/softmax_loss_layer.hpp
@@ -119,6 +119,10 @@ class SoftmaxWithLossLayer : public LossLayer<Dtype> {
   bool has_ignore_label_;
   /// The label indicating that an instance should be ignored.
   int ignore_label_;
+  /// Whether to select instances with a certain label.
+  bool has_select_label_;
+  /// Select just these instances for the loss calculation.
+  int select_label_;
   /// How to normalize the output loss.
   LossParameter_NormalizationMode normalization_;
 

--- a/src/caffe/layers/softmax_loss_layer.cu
+++ b/src/caffe/layers/softmax_loss_layer.cu
@@ -12,12 +12,14 @@ __global__ void SoftmaxLossForwardGPU(const int nthreads,
           const Dtype* prob_data, const Dtype* label, Dtype* loss,
           const int num, const int dim, const int spatial_dim,
           const bool has_ignore_label_, const int ignore_label_,
+          const bool has_select_label_, const int select_label_,
           Dtype* counts) {
   CUDA_KERNEL_LOOP(index, nthreads) {
     const int n = index / spatial_dim;
     const int s = index % spatial_dim;
     const int label_value = static_cast<int>(label[n * spatial_dim + s]);
-    if (has_ignore_label_ && label_value == ignore_label_) {
+    if ((has_ignore_label_ && label_value == ignore_label_) ||
+        (has_select_label_ && label_value != select_label_)) {
       loss[index] = 0;
       counts[index] = 0;
     } else {
@@ -45,14 +47,15 @@ void SoftmaxWithLossLayer<Dtype>::Forward_gpu(
   // NOLINT_NEXT_LINE(whitespace/operators)
   SoftmaxLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
       CAFFE_CUDA_NUM_THREADS>>>(nthreads, prob_data, label, loss_data,
-      outer_num_, dim, inner_num_, has_ignore_label_, ignore_label_, counts);
+      outer_num_, dim, inner_num_, has_ignore_label_, ignore_label_,
+      has_select_label_, select_label_, counts);
   Dtype loss;
   caffe_gpu_asum(nthreads, loss_data, &loss);
   Dtype valid_count = -1;
   // Only launch another CUDA kernel if we actually need the count of valid
   // outputs.
   if (normalization_ == LossParameter_NormalizationMode_VALID &&
-      has_ignore_label_) {
+      (has_ignore_label_ || has_select_label_)) {
     caffe_gpu_asum(nthreads, counts, &valid_count);
   }
   top[0]->mutable_cpu_data()[0] = loss / get_normalizer(normalization_,
@@ -69,7 +72,8 @@ template <typename Dtype>
 __global__ void SoftmaxLossBackwardGPU(const int nthreads, const Dtype* top,
           const Dtype* label, Dtype* bottom_diff, const int num, const int dim,
           const int spatial_dim, const bool has_ignore_label_,
-          const int ignore_label_, Dtype* counts) {
+          const int ignore_label_, const bool has_select_label_,
+          const int select_label_, Dtype* counts) {
   const int channels = dim / spatial_dim;
 
   CUDA_KERNEL_LOOP(index, nthreads) {
@@ -77,7 +81,8 @@ __global__ void SoftmaxLossBackwardGPU(const int nthreads, const Dtype* top,
     const int s = index % spatial_dim;
     const int label_value = static_cast<int>(label[n * spatial_dim + s]);
 
-    if (has_ignore_label_ && label_value == ignore_label_) {
+    if ((has_ignore_label_ && label_value == ignore_label_) ||
+        (has_select_label_ && label_value != select_label_)) {
       for (int c = 0; c < channels; ++c) {
         bottom_diff[n * dim + c * spatial_dim + s] = 0;
       }
@@ -110,13 +115,14 @@ void SoftmaxWithLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     // NOLINT_NEXT_LINE(whitespace/operators)
     SoftmaxLossBackwardGPU<Dtype><<<CAFFE_GET_BLOCKS(nthreads),
         CAFFE_CUDA_NUM_THREADS>>>(nthreads, top_data, label, bottom_diff,
-        outer_num_, dim, inner_num_, has_ignore_label_, ignore_label_, counts);
+        outer_num_, dim, inner_num_, has_ignore_label_, ignore_label_,
+        has_select_label_, select_label_, counts);
 
     Dtype valid_count = -1;
     // Only launch another CUDA kernel if we actually need the count of valid
     // outputs.
     if (normalization_ == LossParameter_NormalizationMode_VALID &&
-        has_ignore_label_) {
+        (has_ignore_label_ || has_select_label_)) {
       caffe_gpu_asum(nthreads, counts, &valid_count);
     }
     const Dtype loss_weight = top[0]->cpu_diff()[0] /

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -449,6 +449,7 @@ message TransformationParameter {
 message LossParameter {
   // If specified, ignore instances with the given label.
   optional int32 ignore_label = 1;
+  optional int32 select_label = 4;
   // How to normalize the loss for loss layers that aggregate across batches,
   // spatial dimensions, or other dimensions.  Currently only implemented in
   // SoftmaxWithLoss and SigmoidCrossEntropyLoss layers.


### PR DESCRIPTION
Selecting only a specified class for backprop using SoftmaxWithLoss.

1. Add an new variable for softmax_loss_layer to allow the user to give
different weight to different class ( or label).
   use select_label like:
   loss_param {
     select_label: 0
     }
2. Tested with examples/mnist/train_lenet.sh for both GPU mode and CPU
   mode.
3. Use examples/mnist/lenet_train_test.prototxt as an example for
   select_label (has been commented out).
4. Note: ignore_label gets the priority if select_label and ignore_label
   were in conflict.