### PR TITLE
[BugFix for OpenCL branch] Init two Caffe class at the same time will cause segment fault crash

### DIFF
--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -96,7 +96,7 @@ std::vector< shared_ptr<device> > Caffe::devices_;
 
 Caffe& Caffe::Get() {
   instance_mutex_.lock();
-  if (NULL == global_instance_) {
+  if (global_instance_ == nullptr) {
     // The first call must be single threaded
     // and defines the global instance
     thread_instance_.reset(new Caffe());

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <ctime>
 #include <tuple>
+#include <unistd.h>
 #include <vector>
 
 #include "caffe/common.hpp"

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -104,6 +104,8 @@ Caffe& Caffe::Get() {
     // Every thread initially gets a copy of the global initialization.
     // Later, every thread can switch to a different default device
     // or change other aspects of the Caffe object
+    while(!global_instance_)
+      usleep(1000);
     thread_instance_.reset(new Caffe(*global_instance_));
   }
   return *(thread_instance_.get());

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -1,6 +1,9 @@
 #if defined(_MSC_VER)
 #include <process.h>
+#include <windows.h>
 #define getpid() _getpid()
+#else
+#include <unistd.h>
 #endif
 
 #include <boost/thread.hpp>
@@ -11,7 +14,6 @@
 #include <cstdio>
 #include <ctime>
 #include <tuple>
-#include <unistd.h>
 #include <vector>
 
 #include "caffe/common.hpp"
@@ -106,7 +108,11 @@ Caffe& Caffe::Get() {
     // Later, every thread can switch to a different default device
     // or change other aspects of the Caffe object
     while(!global_instance_)
+#if defined(_MSC_VER)
+      Sleep(1);
+#else
       usleep(1000);
+#endif
     thread_instance_.reset(new Caffe(*global_instance_));
   }
   return *(thread_instance_.get());


### PR DESCRIPTION
Suppose there are two threads init Caffe class at the same time, the first thread will init the global caffe instance, but if the second thread init Caffe before global caffe init finish, it will use a NULL global caffe instance to init itself and cause a segment fault crash.