### PR TITLE
Gaussian filler tests adjustments

### DIFF
--- a/src/caffe/test/test_filler.cpp
+++ b/src/caffe/test/test_filler.cpp
@@ -257,16 +257,16 @@ TYPED_TEST(GaussianFillerTest, TestFill) {
 }
 
 TYPED_TEST(GaussianFillerTest, TestFill1D) {
-  vector<int> blob_shape(1, 25);
-  const TypeParam tolerance = TypeParam(5);
+  vector<int> blob_shape(1, 125);
+  const TypeParam tolerance = TypeParam(3);
   this->test_params(blob_shape, tolerance);
 }
 
 TYPED_TEST(GaussianFillerTest, TestFill2D) {
   vector<int> blob_shape;
   blob_shape.push_back(8);
-  blob_shape.push_back(3);
-  const TypeParam tolerance = TypeParam(5);
+  blob_shape.push_back(15);
+  const TypeParam tolerance = TypeParam(3);
   this->test_params(blob_shape, tolerance);
 }
 


### PR DESCRIPTION
Gaussian filler tests occasionally fail due to variance being outside the required tolerance. Clearly a false failure, it is caused by some of the test blobs being very small, and resulting variance within them varying wildly between tests.  
This PR makes the blobs larger and tweaks tolerance slightly (actually tightening it, but due to the larger blobs the estimate will be more accurate anyway).