### PR TITLE
fix bug when adding the extra top blob in SoftmaxWithLoss

### DIFF
--- a/src/caffe/layers/softmax_loss_layer.cpp
+++ b/src/caffe/layers/softmax_loss_layer.cpp
@@ -13,6 +13,7 @@ void SoftmaxWithLossLayer<Dtype>::LayerSetUp(
   LossLayer<Dtype>::LayerSetUp(bottom, top);
   LayerParameter softmax_param(this->layer_param_);
   softmax_param.set_type("Softmax");
+  softmax_param.clear_loss_weight();
   softmax_layer_ = LayerRegistry<Dtype>::CreateLayer(softmax_param);
   softmax_bottom_vec_.clear();
   softmax_bottom_vec_.push_back(bottom[0]);


### PR DESCRIPTION
When adding extra top for computing softmax prob, it will throw the exceptions.

```
F0423 15:09:26.128675 31870 layer.hpp:392] Check failed: top.size() == num_loss_weights (1 vs. 2) loss_weight must be unspecified or specified once per top blob.
```

this PR solves this issue by removing the weight in the internal softmax layer.