### PR TITLE
COMP: Fix using find_package(Caffe) missed build tree include path

### DIFF
--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(caffe ${Caffe_LINKER_LIBS})
 target_include_directories(caffe ${Caffe_INCLUDE_DIRS}
                                  PUBLIC
                                  $<BUILD_INTERFACE:${Caffe_INCLUDE_DIR}>
+                                 $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include> #Needed for finding caffe.pb.h
                                  $<INSTALL_INTERFACE:include>)
 target_compile_definitions(caffe ${Caffe_DEFINITIONS})
 if(Caffe_COMPILE_OPTIONS)


### PR DESCRIPTION
When building caffe outside of the source tree with cmake
(i.e. mkdir caffe-bld; cd caffe-bld; cmake ../caffe ) the
resulting IMPORTED target was missing the include path
caffe-bld/include/caffe/proto/caffe.pb.h

which prevented '#include "caffe/proto/caffe.pb.h"'
from being found when building tools that depend on caffe.