### PR TITLE
concat empty blob

### DIFF
--- a/include/caffe/test/test_gradient_check_util.hpp
+++ b/include/caffe/test/test_gradient_check_util.hpp
@@ -116,9 +116,13 @@ void GradientChecker<Dtype>::CheckGradientSingle(Layer<Dtype>* layer,
       computed_gradient_blobs(blobs_to_check.size());
   for (int blob_id = 0; blob_id < blobs_to_check.size(); ++blob_id) {
     Blob<Dtype>* current_blob = blobs_to_check[blob_id];
+    // some blob may be zero size, like the bottom of concat layer
+    const int count = blobs_to_check[blob_id]->count();
+    if (count == 0) {
+      continue;
+    }
     computed_gradient_blobs[blob_id].reset(new Blob<Dtype>());
     computed_gradient_blobs[blob_id]->ReshapeLike(*current_blob);
-    const int count = blobs_to_check[blob_id]->count();
     const Dtype* diff = blobs_to_check[blob_id]->cpu_diff();
     Dtype* computed_gradients =
         computed_gradient_blobs[blob_id]->mutable_cpu_data();
@@ -129,6 +133,9 @@ void GradientChecker<Dtype>::CheckGradientSingle(Layer<Dtype>* layer,
   // LOG(ERROR) << "Checking " << blobs_to_check.size() << " blobs.";
   for (int blob_id = 0; blob_id < blobs_to_check.size(); ++blob_id) {
     Blob<Dtype>* current_blob = blobs_to_check[blob_id];
+    if (current_blob->count() == 0) {
+      continue;
+    }
     const Dtype* computed_gradients =
         computed_gradient_blobs[blob_id]->cpu_data();
     // LOG(ERROR) << "Blob " << blob_id << ": checking "

--- a/src/caffe/layers/concat_layer.cpp
+++ b/src/caffe/layers/concat_layer.cpp
@@ -61,6 +61,9 @@ void ConcatLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   int offset_concat_axis = 0;
   const int top_concat_axis = top[0]->shape(concat_axis_);
   for (int i = 0; i < bottom.size(); ++i) {
+    if (bottom[i]->count() == 0) {
+      continue;
+    }
     const Dtype* bottom_data = bottom[i]->cpu_data();
     const int bottom_concat_axis = bottom[i]->shape(concat_axis_);
     for (int n = 0; n < num_concats_; ++n) {
@@ -83,6 +86,9 @@ void ConcatLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
   for (int i = 0; i < bottom.size(); ++i) {
     const int bottom_concat_axis = bottom[i]->shape(concat_axis_);
     if (propagate_down[i]) {
+      if (bottom_concat_axis == 0) {
+        continue;
+      }
       Dtype* bottom_diff = bottom[i]->mutable_cpu_diff();
       for (int n = 0; n < num_concats_; ++n) {
         caffe_copy(bottom_concat_axis * concat_input_size_, top_diff +

--- a/src/caffe/layers/concat_layer.cu
+++ b/src/caffe/layers/concat_layer.cu
@@ -33,8 +33,11 @@ void ConcatLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   const int top_concat_axis = top[0]->shape(concat_axis_);
   const bool kForward = true;
   for (int i = 0; i < bottom.size(); ++i) {
-    const Dtype* bottom_data = bottom[i]->gpu_data();
     const int bottom_concat_axis = bottom[i]->shape(concat_axis_);
+    if (bottom_concat_axis == 0) {
+        continue;
+    }
+    const Dtype* bottom_data = bottom[i]->gpu_data();
     const int bottom_concat_size = bottom_concat_axis * concat_input_size_;
     const int nthreads = bottom_concat_size * num_concats_;
     Concat<Dtype>  // NOLINT_NEXT_LINE(whitespace/operators)
@@ -56,8 +59,11 @@ void ConcatLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   for (int i = 0; i < bottom.size(); ++i) {
     const int bottom_concat_axis = bottom[i]->shape(concat_axis_);
     if (propagate_down[i]) {
-      Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
+      if (bottom_concat_axis == 0) {
+          continue;
+      }
       const int bottom_concat_size = bottom_concat_axis * concat_input_size_;
+      Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
       const int nthreads = bottom_concat_size * num_concats_;
       Concat<Dtype>  // NOLINT_NEXT_LINE(whitespace/operators)
           <<<CAFFE_GET_BLOCKS(nthreads), CAFFE_CUDA_NUM_THREADS>>>(

--- a/src/caffe/test/test_concat_layer.cpp
+++ b/src/caffe/test/test_concat_layer.cpp
@@ -21,6 +21,8 @@ class ConcatLayerTest : public MultiDeviceTest<TypeParam> {
       : blob_bottom_0_(new Blob<Dtype>(2, 3, 6, 5)),
         blob_bottom_1_(new Blob<Dtype>(2, 5, 6, 5)),
         blob_bottom_2_(new Blob<Dtype>(5, 3, 6, 5)),
+        blob_bottom_3_(new Blob<Dtype>(0, 3, 6, 5)),
+        blob_bottom_4_(new Blob<Dtype>(2, 0, 6, 5)),
         blob_top_(new Blob<Dtype>()) {}
   virtual void SetUp() {
     // fill the values
@@ -37,19 +39,26 @@ class ConcatLayerTest : public MultiDeviceTest<TypeParam> {
     filler->Fill(this->blob_bottom_2_);
     blob_bottom_vec_0_.push_back(blob_bottom_0_);
     blob_bottom_vec_0_.push_back(blob_bottom_1_);
+    blob_bottom_vec_0_.push_back(blob_bottom_4_);
+
     blob_bottom_vec_1_.push_back(blob_bottom_0_);
     blob_bottom_vec_1_.push_back(blob_bottom_2_);
+    blob_bottom_vec_1_.push_back(blob_bottom_3_);
+
     blob_top_vec_.push_back(blob_top_);
   }
 
   virtual ~ConcatLayerTest() {
     delete blob_bottom_0_; delete blob_bottom_1_;
     delete blob_bottom_2_; delete blob_top_;
+    delete blob_bottom_3_; delete blob_bottom_4_;
   }
 
   Blob<Dtype>* const blob_bottom_0_;
   Blob<Dtype>* const blob_bottom_1_;
   Blob<Dtype>* const blob_bottom_2_;
+  Blob<Dtype>* const blob_bottom_3_;
+  Blob<Dtype>* const blob_bottom_4_;
   Blob<Dtype>* const blob_top_;
   vector<Blob<Dtype>*> blob_bottom_vec_0_, blob_bottom_vec_1_;
   vector<Blob<Dtype>*> blob_top_vec_;


### PR DESCRIPTION
It's necessary that Concat layers should be able to deal with empty blobs where the `concat_axis` is zero.

For example, when concat `blob(2, 5)` and `blob(0, 5)`, it should produce `blob(2,5)`. And it should never back-propagate the empty blob.

it's possible that the input blob is empty, for example, when implementing FPN (https://arxiv.org/abs/1612.03144), some of the roi pooling layers may produce empty rois. And caffe should be able to concat all of the rois to feed into the next fully connected layers.