### PR TITLE
Little enhancement to the plot_training_log.py.example -- unblocking execution

### DIFF
--- a/tools/extra/plot_training_log.py.example
+++ b/tools/extra/plot_training_log.py.example
@@ -135,7 +135,12 @@ def plot_chart(chart_type, path_to_png, path_to_log_list):
     plt.xlabel(x_axis_field)
     plt.ylabel(y_axis_field)
     plt.savefig(path_to_png)
-    plt.show()
+    # plt.show() # Blocks the execution of the program and prevents script from completion
+    plt.show(block=False) # Do not block, override the blocking behavior
+    # OR
+    # plt.ion() # Turn interactive mode on.
+    # plt.show()
+    # plt.pause(seconds) # Pause for *interval* seconds
 
 def print_help():
     print """This script mainly serves as the basis of your customizations.


### PR DESCRIPTION
## Background
* Currently, in the `caffe/tools/extra/plot_training_log.py.example` there is a call to [`plt.show()`](https://github.com/BVLC/caffe/blob/master/tools/extra/plot_training_log.py.example#L138). 
* This is the last call that gets invoked in this script, and since it is made in a non-interactive mode; it blocks until the figures have been closed. [Reference](https://matplotlib.org/api/_as_gen/matplotlib.pyplot.show.html#matplotlib.pyplot.show)
> In non-interactive mode, display all figures and block until the figures have been closed;
* I tested this behaviour in my Mac OS X and `plt.show()` does not open up an image preview for the user to close unless the interactive mode is on with `plt.pause()`.

## What does this PR do?
* I'm proposing two alternatives to fix this issue so it would work across different platforms:
a. Add the `(block=False)` to override the blocking behavior. Or, 
b. Make the plot interactive using `plt.ion()` and add certain `pause()` for the user to react to the plot frame within a certain limit, so the script won't keep on running forever. 

## Why is it necessary?
I know that [plot_training_log.py.example](https://github.com/BVLC/caffe/blob/master/tools/extra/plot_training_log.py.example#L141-L151) is supposed to be an example and customization is a must. 

But, I still believe including/introducing this non-blocking execution approach to the end user would be beneficial and could save some time investigating this problem, especially on the OS X machines.   

## System configuration
Operating system: **mac OS X Sierra 10.12.6**
BLAS: **open**
Python version (if using pycaffe): **Python 2.7.15 :: Anaconda, Inc**.

