### PR TITLE
Hdf5DataLayer: Fix support for multi-gpu training

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ include(cmake/Dependencies.cmake)
 
 # ---[ Flags
 if(UNIX OR APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall --std=c++11")
 endif()
 
 caffe_set_caffe_link()
@@ -83,7 +83,7 @@ if(HAVE_CUDA)
   # add definitions to nvcc flags directly
   set(Caffe_ALL_DEFINITIONS ${Caffe_DEFINITIONS})
   list(REMOVE_ITEM Caffe_ALL_DEFINITIONS PRIVATE PUBLIC)
-  list(APPEND CUDA_NVCC_FLAGS ${Caffe_ALL_DEFINITIONS})
+  list(APPEND CUDA_NVCC_FLAGS ${Caffe_ALL_DEFINITIONS} --std=c++11)
 endif()
 
 # ---[ Subdirectories

--- a/include/caffe/layers/hdf5_data_layer.hpp
+++ b/include/caffe/layers/hdf5_data_layer.hpp
@@ -5,6 +5,9 @@
 
 #include <string>
 #include <vector>
+#include <mutex>
+#include <unordered_set>
+#include <memory>
 
 #include "caffe/blob.hpp"
 #include "caffe/layer.hpp"
@@ -13,6 +16,75 @@
 #include "caffe/layers/base_data_layer.hpp"
 
 namespace caffe {
+
+namespace hdf5DataLayerDetail {
+
+  template <typename Dtype>
+  class HDF5FileDataBuffer
+  {
+    unsigned int file_idx_;
+    std::vector<shared_ptr<Blob<Dtype> > > hdf_blobs_;
+    std::vector<unsigned int> data_permutation_;
+    public:
+
+      HDF5FileDataBuffer(unsigned int idx, const std::string& file, LayerParameter& layer_param);
+
+    unsigned int file_idx() const {return file_idx_;}
+    const std::vector<shared_ptr<Blob<Dtype> > >& hdf_blobs() const {return hdf_blobs_;}
+    const std::vector<unsigned int>& data_permutation() const {return data_permutation_;}
+  };
+
+  template <typename Dtype>
+  class HDF5FileDataHandler
+  {
+    int current_file_ = 0;
+    std::vector<std::string> hdf_filenames_;
+    std::vector<unsigned int> file_permutation_;
+    std::weak_ptr<HDF5FileDataBuffer<Dtype>> current_buffer_;
+
+    std::mutex loadDataMutex_;
+
+    LayerParameter& layer_param_;
+
+    public:
+      HDF5FileDataHandler(const std::vector<std::string>& files, LayerParameter& layer_param);
+
+    const std::vector<std::string>& files() const {return hdf_filenames_;}
+
+    /*!
+     * @param prev last buffer the caller went through
+     * */
+    std::shared_ptr<HDF5FileDataBuffer<Dtype>> getBuffer(std::shared_ptr<HDF5FileDataBuffer<Dtype>> prev);
+  };
+
+  template <typename Dtype>
+  class HDF5DataManager
+  {
+    static void createInstance();
+    static std::unique_ptr<HDF5DataManager<Dtype>> _instance;
+    static std::mutex _createInstanceMutex;
+
+    public:
+
+    inline static HDF5DataManager& instance() {
+      if (!_instance)
+        createInstance();
+      return *_instance;
+    }
+
+    HDF5FileDataHandler<Dtype>* registerFileSet(const std::vector<std::string>& files, LayerParameter& layer_param);
+
+    protected:
+
+    std::unordered_set<std::unique_ptr<HDF5FileDataHandler<Dtype>>> handlers_;
+    std::mutex instanceMutex_;
+  };
+
+  template<class Dtype>
+  std::unique_ptr<HDF5DataManager<Dtype>> HDF5DataManager<Dtype>::_instance;
+  template<class Dtype>
+  std::mutex HDF5DataManager<Dtype>::_createInstanceMutex;
+}
 
 /**
  * @brief Provides data to the Net from HDF5 files.
@@ -47,17 +119,13 @@ class HDF5DataLayer : public Layer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {}
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {}
-  virtual void LoadHDF5FileData(const char* filename);
 
-  std::vector<std::string> hdf_filenames_;
-  unsigned int num_files_;
-  unsigned int current_file_;
+  hdf5DataLayerDetail::HDF5FileDataHandler<Dtype>* data_handler_;
+  std::shared_ptr<hdf5DataLayerDetail::HDF5FileDataBuffer<Dtype>> current_buffer_;
   hsize_t current_row_;
-  std::vector<shared_ptr<Blob<Dtype> > > hdf_blobs_;
-  std::vector<unsigned int> data_permutation_;
-  std::vector<unsigned int> file_permutation_;
   uint64_t offset_;
 };
+
 
 }  // namespace caffe
 

--- a/src/caffe/layers/hdf5_data_layer.cpp
+++ b/src/caffe/layers/hdf5_data_layer.cpp
@@ -9,6 +9,7 @@ TODO:
 #include <fstream>  // NOLINT(readability/streams)
 #include <string>
 #include <vector>
+#include <utility>
 
 #include "hdf5.h"
 #include "hdf5_hl.h"
@@ -17,21 +18,113 @@ TODO:
 #include "caffe/layers/hdf5_data_layer.hpp"
 #include "caffe/util/hdf5.hpp"
 
+namespace std
+{
+  template<class Dtype> struct hash<std::unique_ptr<caffe::hdf5DataLayerDetail::HDF5FileDataHandler<Dtype>>>
+  {
+    typedef std::unique_ptr<caffe::hdf5DataLayerDetail::HDF5FileDataHandler<Dtype>> argument_type;
+    typedef std::size_t result_type;
+    result_type operator()(argument_type const& s) const noexcept
+    {
+      result_type h = 0;
+      for(const auto& a: s->files())
+          h ^= (std::hash<std::string>{}(a) << 1);
+      return h;
+    }
+  };
+
+  template<class Dtype> struct equal_to<std::unique_ptr<caffe::hdf5DataLayerDetail::HDF5FileDataHandler<Dtype>>>
+  {
+    typedef std::unique_ptr<caffe::hdf5DataLayerDetail::HDF5FileDataHandler<Dtype>> first_argument_type;
+    typedef first_argument_type second_argument_type;
+    typedef bool result_type;
+
+    result_type operator()(first_argument_type const& a, second_argument_type const& b) const noexcept
+    {
+      return std::equal_to<std::vector<std::string>>{}(a->files(),b->files());
+    }
+  };
+}
+
 namespace caffe {
 
+namespace hdf5DataLayerDetail {
+
 template <typename Dtype>
-HDF5DataLayer<Dtype>::~HDF5DataLayer<Dtype>() { }
+HDF5FileDataHandler<Dtype>::HDF5FileDataHandler(const std::vector<std::string>& files, LayerParameter& layer_param)
+  : hdf_filenames_(files), file_permutation_(files.size()), layer_param_(layer_param) {
+  // Default to identity permutation.
+  for (int i = 0; i < file_permutation_.size(); i++) {
+    file_permutation_[i] = i;
+  }
+
+  // Shuffle if needed.
+  if (this->layer_param_.hdf5_data_param().shuffle()) {
+    std::random_shuffle(file_permutation_.begin(), file_permutation_.end());
+  }
+}
+
+template <typename Dtype>
+void HDF5DataManager<Dtype>::createInstance() {
+  std::unique_lock<std::mutex> lock(_createInstanceMutex, std::try_to_lock);
+  if(lock) {
+    _instance.reset(new HDF5DataManager);
+  }
+}
+
+template <typename Dtype>
+HDF5FileDataHandler<Dtype>* HDF5DataManager<Dtype>::registerFileSet
+  (const std::vector<std::string>& files, LayerParameter& layer_param) {
+  auto handler = std::unique_ptr<HDF5FileDataHandler<Dtype>>(new HDF5FileDataHandler<Dtype>(files, layer_param));
+  std::unique_lock<std::mutex> lock(instanceMutex_);
+  auto ins = handlers_.insert(std::move(handler));
+  return ins.first->get(); // we do not care if insertion was blocked, if it was we use the present instance
+}
+
+template <typename Dtype>
+std::shared_ptr<HDF5FileDataBuffer<Dtype>> HDF5FileDataHandler<Dtype>::getBuffer
+  (std::shared_ptr<HDF5FileDataBuffer<Dtype>> prev) {
+  if(!current_buffer_.expired())
+  {
+    auto tmp = current_buffer_.lock();
+    if(prev != tmp)
+      return tmp;
+  }
+  std::unique_lock<std::mutex> loadDataLock(loadDataMutex_, std::try_to_lock);
+  if(loadDataLock)
+  {
+    ++current_file_;
+    if(current_file_ == file_permutation_.size())
+    {
+      current_file_ = 0;
+      DLOG(INFO) << "Looping around to first file.";
+    }
+    auto tmp = std::make_shared<HDF5FileDataBuffer<Dtype>>
+      (current_file_, hdf_filenames_[file_permutation_[current_file_]], layer_param_);
+    current_buffer_ = tmp;
+    return tmp;
+  }
+  else
+  {
+    loadDataLock.lock();
+    return current_buffer_.lock();
+  }
+}
 
 // Load data and label from HDF5 filename into the class property blobs.
+// template <typename Dtype>
+// void HDF5DataLayer<Dtype>::LoadHDF5FileData(const char* filename) {
 template <typename Dtype>
-void HDF5DataLayer<Dtype>::LoadHDF5FileData(const char* filename) {
+HDF5FileDataBuffer<Dtype>::HDF5FileDataBuffer
+  (unsigned int idx, const std::string& filename, LayerParameter& layer_param) {
   DLOG(INFO) << "Loading HDF5 file: " << filename;
-  hid_t file_id = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+
+  hid_t file_id = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
   if (file_id < 0) {
     LOG(FATAL) << "Failed opening HDF5 file: " << filename;
   }
 
-  int top_size = this->layer_param_.top_size();
+  int top_size = layer_param.top_size();
   hdf_blobs_.resize(top_size);
 
   const int MIN_DATA_DIM = 1;
@@ -40,7 +133,7 @@ void HDF5DataLayer<Dtype>::LoadHDF5FileData(const char* filename) {
   for (int i = 0; i < top_size; ++i) {
     hdf_blobs_[i] = shared_ptr<Blob<Dtype> >(new Blob<Dtype>());
     // Allow reshape here, as we are loading data not params
-    hdf5_load_nd_dataset(file_id, this->layer_param_.top(i).c_str(),
+    hdf5_load_nd_dataset(file_id, layer_param.top(i).c_str(),
         MIN_DATA_DIM, MAX_DATA_DIM, hdf_blobs_[i].get(), true);
   }
 
@@ -54,13 +147,12 @@ void HDF5DataLayer<Dtype>::LoadHDF5FileData(const char* filename) {
     CHECK_EQ(hdf_blobs_[i]->shape(0), num);
   }
   // Default to identity permutation.
-  data_permutation_.clear();
   data_permutation_.resize(hdf_blobs_[0]->shape(0));
   for (int i = 0; i < hdf_blobs_[0]->shape(0); i++)
     data_permutation_[i] = i;
 
   // Shuffle if needed.
-  if (this->layer_param_.hdf5_data_param().shuffle()) {
+  if (layer_param.hdf5_data_param().shuffle()) {
     std::random_shuffle(data_permutation_.begin(), data_permutation_.end());
     DLOG(INFO) << "Successfully loaded " << hdf_blobs_[0]->shape(0)
                << " rows (shuffled)";
@@ -68,6 +160,11 @@ void HDF5DataLayer<Dtype>::LoadHDF5FileData(const char* filename) {
     DLOG(INFO) << "Successfully loaded " << hdf_blobs_[0]->shape(0) << " rows";
   }
 }
+
+}
+
+template <typename Dtype>
+HDF5DataLayer<Dtype>::~HDF5DataLayer<Dtype>() { }
 
 template <typename Dtype>
 void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
@@ -78,48 +175,37 @@ void HDF5DataLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   // Read the source to parse the filenames.
   const string& source = this->layer_param_.hdf5_data_param().source();
   LOG(INFO) << "Loading list of HDF5 filenames from: " << source;
-  hdf_filenames_.clear();
+  std::vector<std::string> hdf_filenames;
   std::ifstream source_file(source.c_str());
   if (source_file.is_open()) {
     std::string line;
     while (source_file >> line) {
-      hdf_filenames_.push_back(line);
+      hdf_filenames.push_back(line);
     }
   } else {
     LOG(FATAL) << "Failed to open source file: " << source;
   }
   source_file.close();
-  num_files_ = hdf_filenames_.size();
-  current_file_ = 0;
-  LOG(INFO) << "Number of HDF5 files: " << num_files_;
-  CHECK_GE(num_files_, 1) << "Must have at least 1 HDF5 filename listed in "
+  LOG(INFO) << "Number of HDF5 files: " << hdf_filenames.size();
+  CHECK_GE(hdf_filenames.size(), 1) << "Must have at least 1 HDF5 filename listed in "
     << source;
 
-  file_permutation_.clear();
-  file_permutation_.resize(num_files_);
-  // Default to identity permutation.
-  for (int i = 0; i < num_files_; i++) {
-    file_permutation_[i] = i;
-  }
+  const int top_size = this->layer_param_.top_size();
+  data_handler_ = hdf5DataLayerDetail::HDF5DataManager<Dtype>::instance().registerFileSet
+    (hdf_filenames, this->layer_param_);
 
-  // Shuffle if needed.
-  if (this->layer_param_.hdf5_data_param().shuffle()) {
-    std::random_shuffle(file_permutation_.begin(), file_permutation_.end());
-  }
 
-  // Load the first HDF5 file and initialize the line counter.
-  LoadHDF5FileData(hdf_filenames_[file_permutation_[current_file_]].c_str());
+  current_buffer_ = data_handler_->getBuffer(nullptr);
   current_row_ = 0;
 
   // Reshape blobs.
   const int batch_size = this->layer_param_.hdf5_data_param().batch_size();
-  const int top_size = this->layer_param_.top_size();
   vector<int> top_shape;
   for (int i = 0; i < top_size; ++i) {
-    top_shape.resize(hdf_blobs_[i]->num_axes());
+    top_shape.resize(current_buffer_->hdf_blobs()[i]->num_axes());
     top_shape[0] = batch_size;
     for (int j = 1; j < top_shape.size(); ++j) {
-      top_shape[j] = hdf_blobs_[i]->shape(j);
+      top_shape[j] = current_buffer_->hdf_blobs()[i]->shape(j);
     }
     top[i]->Reshape(top_shape);
   }
@@ -137,23 +223,9 @@ bool HDF5DataLayer<Dtype>::Skip() {
 
 template<typename Dtype>
 void HDF5DataLayer<Dtype>::Next() {
-  if (++current_row_ == hdf_blobs_[0]->shape(0)) {
-    if (num_files_ > 1) {
-      ++current_file_;
-      if (current_file_ == num_files_) {
-        current_file_ = 0;
-        if (this->layer_param_.hdf5_data_param().shuffle()) {
-          std::random_shuffle(file_permutation_.begin(),
-                              file_permutation_.end());
-        }
-        DLOG(INFO) << "Looping around to first file.";
-      }
-      LoadHDF5FileData(
-        hdf_filenames_[file_permutation_[current_file_]].c_str());
-    }
+  if (++current_row_ == current_buffer_->hdf_blobs()[0]->shape(0)) {
+    current_buffer_ = data_handler_->getBuffer(current_buffer_);
     current_row_ = 0;
-    if (this->layer_param_.hdf5_data_param().shuffle())
-      std::random_shuffle(data_permutation_.begin(), data_permutation_.end());
   }
   offset_++;
 }
@@ -169,7 +241,7 @@ void HDF5DataLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     for (int j = 0; j < this->layer_param_.top_size(); ++j) {
       int data_dim = top[j]->count() / top[j]->shape(0);
       caffe_copy(data_dim,
-          &hdf_blobs_[j]->cpu_data()[data_permutation_[current_row_]
+          &current_buffer_->hdf_blobs()[j]->cpu_data()[current_buffer_->data_permutation()[current_row_]
             * data_dim], &top[j]->mutable_cpu_data()[i * data_dim]);
     }
     Next();

--- a/src/caffe/layers/hdf5_data_layer.cu
+++ b/src/caffe/layers/hdf5_data_layer.cu
@@ -24,7 +24,7 @@ void HDF5DataLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     for (int j = 0; j < this->layer_param_.top_size(); ++j) {
       int data_dim = top[j]->count() / top[j]->shape(0);
       caffe_copy(data_dim,
-          &hdf_blobs_[j]->cpu_data()[data_permutation_[current_row_]
+          &current_buffer_->hdf_blobs()[j]->cpu_data()[current_buffer_->data_permutation()[current_row_]
             * data_dim], &top[j]->mutable_gpu_data()[i * data_dim]);
     }
     Next();


### PR DESCRIPTION
Add synchronous datamanagement
uses c++11 threads, unordered_map: set CXX_STANDARD to 11

In its current implementation the hdf5 layer opens one hdf5 file in each Caffe rank  and copies it into memory completely, exceeding memory capacity in multi-GPU systems. In addition, each threads only uses a subset of the loaded data, the same way the database layer handles multi-GPU training.

This patch solves these problems by introducing a synchronized data handling scheme, which allows all threads to share one resident hdf5 file.

This patch uses C++11 and changes the CMakeLists.txt for this reason. So I am not sure if it is welcome at this time. Will Caffe at some point be transitioned to C++11? I am aware, that the important C++11 STL features can only be replaced stuff provided by boost, but I am not very familiar with these parts of it.