### PR TITLE
Implement ResizeBilinear layer in caffe(equal to tf.image.resize_bilinear operation)

### DIFF
--- a/include/caffe/layers/resizebilinear_layer.hpp
+++ b/include/caffe/layers/resizebilinear_layer.hpp
@@ -1,0 +1,40 @@
+#ifndef CAFFE_RESIZEBILINEAR_LAYER_HPP_
+#define CAFFE_RESIZEBILINEAR_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+template <typename Dtype>
+class ResizeBilinearLayer : public Layer<Dtype> {
+  public:
+	explicit ResizeBilinearLayer(const LayerParameter& param)
+		: Layer<Dtype>(param) {}
+	virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top);
+  	virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      	const vector<Blob<Dtype>*>& top);
+
+	virtual inline const char* type() const { return "ResizeBilinear"; }
+	virtual inline int ExactNumBottomBlobs() const { return 1; }
+	virtual inline int ExactNumTopBlobs() const { return 1; }
+
+  protected:
+	virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top);
+	virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+	int input_height_, input_width_;	
+	int output_height_,output_width_;
+	int num_, channels_;
+	int factor_;
+	
+};
+
+} // namespace caffe
+
+#endif // CAFFE_BILINEAR_LAYER_HPP

--- a/include/caffe/layers/resizebilinear_layer.hpp
+++ b/include/caffe/layers/resizebilinear_layer.hpp
@@ -14,33 +14,30 @@ namespace caffe {
  * formula: f(i+u, j+v) = (1-u)(1-v)*f(i,j) + (1-u)v*f(i,j+1)
  *                        + u(1-v)*f(i+1,j) + uv*f(i+1,j+1)               
  */
-
 template <typename Dtype>
 class ResizeBilinearLayer : public Layer<Dtype> {
  public:
   explicit ResizeBilinearLayer(const LayerParameter& param)
-		  : Layer<Dtype>(param) {}
-
+      : Layer<Dtype>(param) {}
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-		  const vector<Blob<Dtype>*>& top);
+      const vector<Blob<Dtype>*>& top);
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
 
-	virtual inline const char* type() const { return "ResizeBilinear"; }
-	virtual inline int ExactNumBottomBlobs() const { return 1; }
-	virtual inline int ExactNumTopBlobs() const { return 1; }
+  virtual inline const char* type() const { return "ResizeBilinear"; }
+  virtual inline int ExactNumBottomBlobs() const { return 1; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
 
  protected:
-	virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-		  const vector<Blob<Dtype>*>& top);
-	virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
-	    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
-	int input_height_, input_width_;	
-	int output_height_,output_width_;
-	int num_, channels_;
-	int factor_;
-	
+  int input_height_, input_width_;	
+  int output_height_,output_width_;
+  int num_, channels_;
+  int factor_;	
 };
 
 } // namespace caffe

--- a/include/caffe/layers/resizebilinear_layer.hpp
+++ b/include/caffe/layers/resizebilinear_layer.hpp
@@ -35,11 +35,11 @@ class ResizeBilinearLayer : public Layer<Dtype> {
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
   int input_height_, input_width_;	
-  int output_height_,output_width_;
+  int output_height_, output_width_;
   int num_, channels_;
   int factor_;	
 };
 
 } // namespace caffe
 
-#endif // CAFFE_BILINEAR_LAYER_HPP
+#endif // CAFFE_RESIZEBILINEAR_LAYER_HPP

--- a/include/caffe/layers/resizebilinear_layer.hpp
+++ b/include/caffe/layers/resizebilinear_layer.hpp
@@ -8,25 +8,33 @@
 #include "caffe/proto/caffe.pb.h"
 
 namespace caffe {
+/**
+ * @brief implement tf.image.resize_bilinear operation, in the way of ResizeBilinear
+ * layer
+ * formula: f(i+u, j+v) = (1-u)(1-v)*f(i,j) + (1-u)v*f(i,j+1)
+ *                        + u(1-v)*f(i+1,j) + uv*f(i+1,j+1)               
+ */
+
 template <typename Dtype>
 class ResizeBilinearLayer : public Layer<Dtype> {
-  public:
-	explicit ResizeBilinearLayer(const LayerParameter& param)
-		: Layer<Dtype>(param) {}
-	virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top);
-  	virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
-      	const vector<Blob<Dtype>*>& top);
+ public:
+  explicit ResizeBilinearLayer(const LayerParameter& param)
+		  : Layer<Dtype>(param) {}
+
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+		  const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
 
 	virtual inline const char* type() const { return "ResizeBilinear"; }
 	virtual inline int ExactNumBottomBlobs() const { return 1; }
 	virtual inline int ExactNumTopBlobs() const { return 1; }
 
-  protected:
+ protected:
 	virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top);
+		  const vector<Blob<Dtype>*>& top);
 	virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
-		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+	    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
 	int input_height_, input_width_;	
 	int output_height_,output_width_;

--- a/src/caffe/layers/resizebilinear_layer.cpp
+++ b/src/caffe/layers/resizebilinear_layer.cpp
@@ -20,10 +20,6 @@ void ResizeBilinearLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 void ResizeBilinearLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
 		const vector<Blob<Dtype>*>& top) {
-  // 	int input_height_, input_width_;	
-  //	int output_height_,output_width_;
-  //	int num_, channels_;
-  //	int factor_;
   num_ = bottom[0]->num();
   channels_ = bottom[0]->channels();
   input_height_ = bottom[0]->height();
@@ -31,11 +27,11 @@ void ResizeBilinearLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   ResizeBilinearParameter rebilinear_param = this->layer_param_.resize_bilinear_param();
   if (rebilinear_param.has_factor()) {
     factor_ = rebilinear_param.factor();
-	output_height_ = static_cast<int>(input_height_ * factor_);
-	output_width_ = static_cast<int>(input_width_ * factor_);	
+	  output_height_ = static_cast<int>(input_height_ * factor_);
+	  output_width_ = static_cast<int>(input_width_ * factor_);	
   } else if (rebilinear_param.has_height() && rebilinear_param.has_width()) {
-	output_height_ = rebilinear_param.height();
-	output_width_ = rebilinear_param.width();
+	  output_height_ = rebilinear_param.height();
+	  output_width_ = rebilinear_param.width();
   } else {
 	LOG(FATAL);
   }
@@ -44,7 +40,6 @@ void ResizeBilinearLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   CHECK_GT(output_height_, 0) << "output height shoule be positive";
   CHECK_GT(output_width_, 0) << "output width shoule be positive";
   top[0]->Reshape(num_, channels_, output_height_, output_width_);
-  
 }
 
 template <typename Dtype>
@@ -65,14 +60,14 @@ void ResizeBilinearLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
         int x1 = std::min(x0 + 1, input_width_ - 1);
         for (int c = 0; c < channels_; ++c) {
           Dtype interpolation = static_cast<Dtype>(input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y0 * input_width_ + x0] *
-								                    (1 - (input_y - y0)) * (1 - (input_x - x0)) +
-							                   input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y1 * input_width_ + x0] *
+                                    (1 - (input_y - y0)) * (1 - (input_x - x0)) +
+                                 input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y1 * input_width_ + x0] *
                                     (input_y - y0) * (1 - (input_x - x0)) +
                                  input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y0 * input_width_ + x1] *
                                     (1 - (input_y - y0)) * (input_x - x0) +
-							                   input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y1 * input_width_ + x1] *
+                                 input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y1 * input_width_ + x1] *
                                     (input_y - y0) * (input_x - x0));
-		      output_data[b * channels_ * output_height_ * output_width_ + c * output_height_ * output_width_ + y * output_width_ + x] = interpolation;
+          output_data[b * channels_ * output_height_ * output_width_ + c * output_height_ * output_width_ + y * output_width_ + x] = interpolation;
         }
       }
     }

--- a/src/caffe/layers/resizebilinear_layer.cpp
+++ b/src/caffe/layers/resizebilinear_layer.cpp
@@ -10,7 +10,7 @@ namespace caffe {
 
 template <typename Dtype>
 void ResizeBilinearLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top) {
+    const vector<Blob<Dtype>*>& top) {
   // class ResizeBilinearParameter
   ResizeBilinearParameter rebilinear_param = this->layer_param_.resize_bilinear_param();
   factor_ = rebilinear_param.factor();
@@ -19,7 +19,7 @@ void ResizeBilinearLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
 
 template <typename Dtype>
 void ResizeBilinearLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top) {
+    const vector<Blob<Dtype>*>& top) {
   num_ = bottom[0]->num();
   channels_ = bottom[0]->channels();
   input_height_ = bottom[0]->height();
@@ -27,13 +27,13 @@ void ResizeBilinearLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   ResizeBilinearParameter rebilinear_param = this->layer_param_.resize_bilinear_param();
   if (rebilinear_param.has_factor()) {
     factor_ = rebilinear_param.factor();
-	  output_height_ = static_cast<int>(input_height_ * factor_);
-	  output_width_ = static_cast<int>(input_width_ * factor_);	
+    output_height_ = static_cast<int>(input_height_ * factor_);
+    output_width_ = static_cast<int>(input_width_ * factor_);	
   } else if (rebilinear_param.has_height() && rebilinear_param.has_width()) {
-	  output_height_ = rebilinear_param.height();
-	  output_width_ = rebilinear_param.width();
+    output_height_ = rebilinear_param.height();
+    output_width_ = rebilinear_param.width();
   } else {
-	LOG(FATAL);
+    LOG(FATAL);
   }
   CHECK_GT(input_height_, 0) << "input height shoule be positive";
   CHECK_GT(input_width_, 0) << "input width shoule be positive";
@@ -44,7 +44,7 @@ void ResizeBilinearLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
 
 template <typename Dtype>
 void ResizeBilinearLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
-		const vector<Blob<Dtype>*>& top) {
+    const vector<Blob<Dtype>*>& top) {
   float height_scale = static_cast<float>(input_height_) / output_height_;
   float width_scale = static_cast<float>(input_width_) / output_width_;
   const Dtype *input_data = bottom[0]->cpu_data();
@@ -76,8 +76,8 @@ void ResizeBilinearLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
 
 template <typename Dtype>
 void ResizeBilinearLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
-		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-	NOT_IMPLEMENTED;
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  NOT_IMPLEMENTED;
 }
 
 

--- a/src/caffe/layers/resizebilinear_layer.cpp
+++ b/src/caffe/layers/resizebilinear_layer.cpp
@@ -80,7 +80,6 @@ void ResizeBilinearLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
   NOT_IMPLEMENTED;
 }
 
-
 INSTANTIATE_CLASS(ResizeBilinearLayer);
 REGISTER_LAYER_CLASS(ResizeBilinear);
 

--- a/src/caffe/layers/resizebilinear_layer.cpp
+++ b/src/caffe/layers/resizebilinear_layer.cpp
@@ -1,0 +1,92 @@
+#include <algorithm>
+#include <cfloat>
+#include <vector>
+
+#include "caffe/layers/resizebilinear_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+#include "caffe/layer.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void ResizeBilinearLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top) {
+  // class ResizeBilinearParameter
+  ResizeBilinearParameter rebilinear_param = this->layer_param_.resize_bilinear_param();
+  factor_ = rebilinear_param.factor();
+  CHECK_GT(factor_, 0) << "Only supports factor greater than 0";
+} 
+
+template <typename Dtype>
+void ResizeBilinearLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top) {
+  // 	int input_height_, input_width_;	
+  //	int output_height_,output_width_;
+  //	int num_, channels_;
+  //	int factor_;
+  num_ = bottom[0]->num();
+  channels_ = bottom[0]->channels();
+  input_height_ = bottom[0]->height();
+  input_width_ = bottom[0]->width();
+  ResizeBilinearParameter rebilinear_param = this->layer_param_.resize_bilinear_param();
+  if (rebilinear_param.has_factor()) {
+    factor_ = rebilinear_param.factor();
+	output_height_ = static_cast<int>(input_height_ * factor_);
+	output_width_ = static_cast<int>(input_width_ * factor_);	
+  } else if (rebilinear_param.has_height() && rebilinear_param.has_width()) {
+	output_height_ = rebilinear_param.height();
+	output_width_ = rebilinear_param.width();
+  } else {
+	LOG(FATAL);
+  }
+  CHECK_GT(input_height_, 0) << "input height shoule be positive";
+  CHECK_GT(input_width_, 0) << "input width shoule be positive";
+  CHECK_GT(output_height_, 0) << "output height shoule be positive";
+  CHECK_GT(output_width_, 0) << "output width shoule be positive";
+  top[0]->Reshape(num_, channels_, output_height_, output_width_);
+  
+}
+
+template <typename Dtype>
+void ResizeBilinearLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+		const vector<Blob<Dtype>*>& top) {
+  float height_scale = static_cast<float>(input_height_) / output_height_;
+  float width_scale = static_cast<float>(input_width_) / output_width_;
+  const Dtype *input_data = bottom[0]->cpu_data();
+  Dtype *output_data = top[0]->mutable_cpu_data();
+  for (int b = 0; b < num_; ++b) {
+    for (int y = 0; y < output_height_; ++y) {
+      float input_y = y * height_scale;
+      int y0 = static_cast<int>(std::floor(input_y));
+      int y1 = std::min(y0 + 1, input_height_ - 1);
+      for (int x = 0; x < output_width_; ++x) {
+        float input_x = x * width_scale;
+        int x0 = static_cast<int>(std::floor(input_x));
+        int x1 = std::min(x0 + 1, input_width_ - 1);
+        for (int c = 0; c < channels_; ++c) {
+          Dtype interpolation = static_cast<Dtype>(input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y0 * input_width_ + x0] *
+								                    (1 - (input_y - y0)) * (1 - (input_x - x0)) +
+							                   input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y1 * input_width_ + x0] *
+                                    (input_y - y0) * (1 - (input_x - x0)) +
+                                 input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y0 * input_width_ + x1] *
+                                    (1 - (input_y - y0)) * (input_x - x0) +
+							                   input_data[b * channels_ * input_height_ * input_width_ + c * input_height_ * input_width_ + y1 * input_width_ + x1] *
+                                    (input_y - y0) * (input_x - x0));
+		      output_data[b * channels_ * output_height_ * output_width_ + c * output_height_ * output_width_ + y * output_width_ + x] = interpolation;
+        }
+      }
+    }
+  }
+}
+
+template <typename Dtype>
+void ResizeBilinearLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+		const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+	NOT_IMPLEMENTED;
+}
+
+
+INSTANTIATE_CLASS(ResizeBilinearLayer);
+REGISTER_LAYER_CLASS(ResizeBilinear);
+
+} // namespace caffe

--- a/src/caffe/test/test_resizebilinear_layer.cpp
+++ b/src/caffe/test/test_resizebilinear_layer.cpp
@@ -40,7 +40,7 @@ class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
   Blob<Dtype>* const blob_top_;
   vector<Blob<Dtype>*> blob_bottom_vec_;
   vector<Blob<Dtype>*> blob_top_vec_;
-  // Test for 2x2x5x5 resizebilinear layer
+
   void TestForward() {
     LayerParameter layer_param;
     ResizeBilinearParameter* rebilinear_param = layer_param.mutable_resize_bilinear_param();
@@ -91,7 +91,6 @@ class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
     //   [5.    4.      3.      2.75    2.5     2.75    3.       4.25    5.5     5.5  ] 
     //   [1.    1.5     2.      3.      4.      3.      2.       2.5     3.      3.   ]
     //   [1.    1.5     2.      3.      4.      3.      2.       2.5     3.      3.   ]
-    //
     Dtype epsilon = 1e-8;
     for (int i = 0; i < 16 * num * channels; i += 16) { 
       EXPECT_NEAR(blob_top_->cpu_data()[i + 0], 1., epsilon); 
@@ -111,50 +110,50 @@ class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
       EXPECT_NEAR(blob_top_->cpu_data()[i + 14], 9., epsilon);
       EXPECT_NEAR(blob_top_->cpu_data()[i + 15], 9., epsilon); 
 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 16], 3., epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 17], 4.25, epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 18], 5.5, epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 19], 5.5, epsilon);  
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 20], 9., epsilon); 
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 21], 6.5, epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 22], 4., epsilon);
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 23], 2.5, epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 24], 1., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 25], 2.5, epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 26], 4., epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 27], 6., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 28], 8., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 29], 8., epsilon);
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 30], 5., epsilon); 
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 31], 4., epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 32], 3., epsilon);
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 33], 2.75, epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 34], 2.5, epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 35], 2.75, epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 36], 3., epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 37], 4.25, epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 38], 5.5, epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 39], 5.5, epsilon);
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 40], 1., epsilon); 
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 41], 1.5, epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 42], 2., epsilon);
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 43], 3., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 44], 4., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 45], 3., epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 46], 2., epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 47], 2.5, epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 48], 3., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 49], 3., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 50], 1., epsilon); 
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 51], 1.5, epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 52], 2., epsilon);
-//      EXPECT_NEAR(blob_top_->cpu_data()[i + 53], 3., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 54], 4., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 55], 3., epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 56], 2., epsilon); 
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 57], 2.5, epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 58], 3., epsilon);
-//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 59], 3., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 16], 3., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 17], 4.25, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 18], 5.5, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 19], 5.5, epsilon);  
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 20], 9., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 21], 6.5, epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 22], 4., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 23], 2.5, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 24], 1., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 25], 2.5, epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 26], 4., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 27], 6., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 28], 8., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 29], 8., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 30], 5., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 31], 4., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 32], 3., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 33], 2.75, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 34], 2.5, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 35], 2.75, epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 36], 3., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 37], 4.25, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 38], 5.5, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 39], 5.5, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 40], 1., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 41], 1.5, epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 42], 2., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 43], 3., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 44], 4., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 45], 3., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 46], 2., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 47], 2.5, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 48], 3., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 49], 3., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 50], 1., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 51], 1.5, epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 52], 2., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 53], 3., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 54], 4., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 55], 3., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 56], 2., epsilon); 
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 57], 2.5, epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 58], 3., epsilon);
+//    EXPECT_NEAR(blob_top_->cpu_data()[i + 59], 3., epsilon);
     }
   }
 };
@@ -164,7 +163,6 @@ TYPED_TEST_CASE(ResizeBilinearLayerTest, TestDtypesAndDevices);
 TYPED_TEST(ResizeBilinearLayerTest, TestResizeBilinear) {
   this->TestForward();
 }
-
 
 } // namespace caffe
 

--- a/src/caffe/test/test_resizebilinear_layer.cpp
+++ b/src/caffe/test/test_resizebilinear_layer.cpp
@@ -109,7 +109,6 @@ class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
       EXPECT_NEAR(blob_top_->cpu_data()[i + 13], 6.5, epsilon);
       EXPECT_NEAR(blob_top_->cpu_data()[i + 14], 9., epsilon);
       EXPECT_NEAR(blob_top_->cpu_data()[i + 15], 9., epsilon); 
-
 //    EXPECT_NEAR(blob_top_->cpu_data()[i + 16], 3., epsilon); 
 //    EXPECT_NEAR(blob_top_->cpu_data()[i + 17], 4.25, epsilon);
 //    EXPECT_NEAR(blob_top_->cpu_data()[i + 18], 5.5, epsilon);

--- a/src/caffe/test/test_resizebilinear_layer.cpp
+++ b/src/caffe/test/test_resizebilinear_layer.cpp
@@ -15,14 +15,14 @@ namespace caffe {
 template <typename TypeParam>
 class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
   typedef typename TypeParam::Dtype Dtype;
-
  protected:
   ResizeBilinearLayerTest()
     : blob_bottom_(new Blob<Dtype>()),
       blob_top_(new Blob<Dtype>()) {}
+  
   virtual void SetUp() {
     Caffe::set_random_seed(1701);
-    blob_bottom_ -> Reshape(2, 3, 6, 5);
+    blob_bottom_->Reshape(2, 3, 6, 5);
     // fill the values;
     FillerParameter filler_param;
     GaussianFiller<Dtype> filler(filler_param);
@@ -30,10 +30,12 @@ class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
     blob_bottom_vec_.push_back(blob_bottom_);
     blob_top_vec_.push_back(blob_top_);
   }
+
   virtual ~ResizeBilinearLayerTest() {
     delete blob_bottom_;
     delete blob_top_;
   }
+
   Blob<Dtype>* const blob_bottom_;
   Blob<Dtype>* const blob_top_;
   vector<Blob<Dtype>*> blob_bottom_vec_;
@@ -46,28 +48,29 @@ class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
     const int num = 2;
     const int channels = 2;
     blob_bottom_->Reshape(num, channels, 2, 2);
-    // Input: 2x 2 channels of:
+    // test case 1: NCHW(2, 2, 2, 2)
+    //   [1 3]
+    //   [4 9]
+    // test case 2: NCHW(2, 2, 3, 5)
     //   [1 2 5 2 3]
     //   [9 4 1 4 8]
     //   [1 2 4 2 3]
-    //   [1 3]
-    //   [4 9]
     for (int i = 0; i < 4 * num * channels; i += 4) {
       blob_bottom_->mutable_cpu_data()[i + 0] = 1;
       blob_bottom_->mutable_cpu_data()[i + 1] = 3;
       blob_bottom_->mutable_cpu_data()[i + 2] = 4;
       blob_bottom_->mutable_cpu_data()[i + 3] = 9;
-      /*blob_bottom_->mutable_cpu_data()[i + 4] = 3;
-      blob_bottom_->mutable_cpu_data()[i + 5] = 9;
-      blob_bottom_->mutable_cpu_data()[i + 6] = 4;
-      blob_bottom_->mutable_cpu_data()[i + 7] = 1;
-      blob_bottom_->mutable_cpu_data()[i + 8] = 4;
-      blob_bottom_->mutable_cpu_data()[i + 9] = 8;
-      blob_bottom_->mutable_cpu_data()[i + 10] = 1;
-      blob_bottom_->mutable_cpu_data()[i + 11] = 2;
-      blob_bottom_->mutable_cpu_data()[i + 12] = 4;
-      blob_bottom_->mutable_cpu_data()[i + 13] = 2;
-      blob_bottom_->mutable_cpu_data()[i + 14] = 3;*/ 
+  //  blob_bottom_->mutable_cpu_data()[i + 4] = 3;
+  //  blob_bottom_->mutable_cpu_data()[i + 5] = 9;
+  //  blob_bottom_->mutable_cpu_data()[i + 6] = 4;
+  //  blob_bottom_->mutable_cpu_data()[i + 7] = 1;
+  //  blob_bottom_->mutable_cpu_data()[i + 8] = 4;
+  //  blob_bottom_->mutable_cpu_data()[i + 9] = 8;
+  //  blob_bottom_->mutable_cpu_data()[i + 10] = 1;
+  //  blob_bottom_->mutable_cpu_data()[i + 11] = 2;
+  //  blob_bottom_->mutable_cpu_data()[i + 12] = 4;
+  //  blob_bottom_->mutable_cpu_data()[i + 13] = 2;
+  //  blob_bottom_->mutable_cpu_data()[i + 14] = 3;
     }
     ResizeBilinearLayer<Dtype> layer(layer_param);
     layer.SetUp(blob_bottom_vec_, blob_top_vec_);
@@ -76,7 +79,12 @@ class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
     EXPECT_EQ(blob_top_->height(), 4);
     EXPECT_EQ(blob_top_->width(), 4);
     layer.Forward(blob_bottom_vec_, blob_top_vec_);
-    // Expected output: 2x 2 channels of:
+    // test case 1 expected output: NCHW(2, 2, 4, 4)
+    //   [1.    2.      3.      3.]
+    //   [2.5   4.25    6.      6.]
+    //   [4.    6.5     9.      9.]
+    //   [4.    6.5     9.      9.]
+    // test case 2 expected output: NCHW(2, 2, 6, 10)
     //   [1.    1.5     2.      3.5     5.      3.5     2.       2.5     3.      3.   ]
     //   [5.    4.      3.      3.      3.      3.      3.       4.25    5.5     5.5  ]
     //   [9.    6.5     4.      2.5     1.      2.5     4.       6.      8.      8.   ]
@@ -88,64 +96,65 @@ class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
     for (int i = 0; i < 16 * num * channels; i += 16) { 
       EXPECT_NEAR(blob_top_->cpu_data()[i + 0], 1., epsilon); 
       EXPECT_NEAR(blob_top_->cpu_data()[i + 1], 2., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 2], 3., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 2], 3., epsilon);
       EXPECT_NEAR(blob_top_->cpu_data()[i + 3], 3., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 4], 2.5, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 5], 4.25, epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 6], 6., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 7], 6., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 8], 4., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 9], 6.5, epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 4], 2.5, epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 5], 4.25, epsilon); 
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 6], 6., epsilon); 
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 7], 6., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 8], 4., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 9], 6.5, epsilon);
       EXPECT_NEAR(blob_top_->cpu_data()[i + 10], 9., epsilon); 
       EXPECT_NEAR(blob_top_->cpu_data()[i + 11], 9., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 12], 4., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 12], 4., epsilon);
       EXPECT_NEAR(blob_top_->cpu_data()[i + 13], 6.5, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 14], 9., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 15], 9., epsilon); 
-	    /*EXPECT_NEAR(blob_top_->cpu_data()[i + 16], 3., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 17], 4.25, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 18], 5.5, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 19], 5.5, epsilon);  
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 20], 9., epsilon); 
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 21], 6.5, epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 22], 4., epsilon);
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 23], 2.5, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 24], 1., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 25], 2.5, epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 26], 4., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 27], 6., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 28], 8., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 29], 8., epsilon);
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 30], 5., epsilon); 
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 31], 4., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 32], 3., epsilon);
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 33], 2.75, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 34], 2.5, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 35], 2.75, epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 36], 3., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 37], 4.25, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 38], 5.5, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 39], 5.5, epsilon);
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 40], 1., epsilon); 
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 41], 1.5, epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 42], 2., epsilon);
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 43], 3., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 44], 4., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 45], 3., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 46], 2., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 47], 2.5, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 48], 3., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 49], 3., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 50], 1., epsilon); 
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 51], 1.5, epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 52], 2., epsilon);
-      EXPECT_NEAR(blob_top_->cpu_data()[i + 53], 3., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 54], 4., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 55], 3., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 56], 2., epsilon); 
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 57], 2.5, epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 58], 3., epsilon);
-	    EXPECT_NEAR(blob_top_->cpu_data()[i + 59], 3., epsilon);*/
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 14], 9., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 15], 9., epsilon); 
+
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 16], 3., epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 17], 4.25, epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 18], 5.5, epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 19], 5.5, epsilon);  
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 20], 9., epsilon); 
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 21], 6.5, epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 22], 4., epsilon);
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 23], 2.5, epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 24], 1., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 25], 2.5, epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 26], 4., epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 27], 6., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 28], 8., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 29], 8., epsilon);
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 30], 5., epsilon); 
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 31], 4., epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 32], 3., epsilon);
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 33], 2.75, epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 34], 2.5, epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 35], 2.75, epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 36], 3., epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 37], 4.25, epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 38], 5.5, epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 39], 5.5, epsilon);
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 40], 1., epsilon); 
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 41], 1.5, epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 42], 2., epsilon);
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 43], 3., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 44], 4., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 45], 3., epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 46], 2., epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 47], 2.5, epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 48], 3., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 49], 3., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 50], 1., epsilon); 
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 51], 1.5, epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 52], 2., epsilon);
+//      EXPECT_NEAR(blob_top_->cpu_data()[i + 53], 3., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 54], 4., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 55], 3., epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 56], 2., epsilon); 
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 57], 2.5, epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 58], 3., epsilon);
+//	    EXPECT_NEAR(blob_top_->cpu_data()[i + 59], 3., epsilon);
     }
   }
 };

--- a/src/caffe/test/test_resizebilinear_layer.cpp
+++ b/src/caffe/test/test_resizebilinear_layer.cpp
@@ -1,0 +1,161 @@
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/resizebilinear_layer.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+namespace caffe {
+
+template <typename TypeParam>
+class ResizeBilinearLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  ResizeBilinearLayerTest()
+    : blob_bottom_(new Blob<Dtype>()),
+      blob_top_(new Blob<Dtype>()) {}
+  virtual void SetUp() {
+    Caffe::set_random_seed(1701);
+    blob_bottom_ -> Reshape(2, 3, 6, 5);
+    // fill the values;
+    FillerParameter filler_param;
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_);
+    blob_bottom_vec_.push_back(blob_bottom_);
+    blob_top_vec_.push_back(blob_top_);
+  }
+  virtual ~ResizeBilinearLayerTest() {
+    delete blob_bottom_;
+    delete blob_top_;
+  }
+  Blob<Dtype>* const blob_bottom_;
+  Blob<Dtype>* const blob_top_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+  // Test for 2x2x5x5 resizebilinear layer
+  void TestForward() {
+    LayerParameter layer_param;
+    ResizeBilinearParameter* rebilinear_param = layer_param.mutable_resize_bilinear_param();
+    rebilinear_param->set_factor(2);
+    const int num = 2;
+    const int channels = 2;
+    blob_bottom_->Reshape(num, channels, 2, 2);
+    // Input: 2x 2 channels of:
+    //   [1 2 5 2 3]
+    //   [9 4 1 4 8]
+    //   [1 2 4 2 3]
+    //   [1 3]
+    //   [4 9]
+    for (int i = 0; i < 4 * num * channels; i += 4) {
+      blob_bottom_->mutable_cpu_data()[i + 0] = 1;
+      blob_bottom_->mutable_cpu_data()[i + 1] = 3;
+      blob_bottom_->mutable_cpu_data()[i + 2] = 4;
+      blob_bottom_->mutable_cpu_data()[i + 3] = 9;
+      /*blob_bottom_->mutable_cpu_data()[i + 4] = 3;
+      blob_bottom_->mutable_cpu_data()[i + 5] = 9;
+      blob_bottom_->mutable_cpu_data()[i + 6] = 4;
+      blob_bottom_->mutable_cpu_data()[i + 7] = 1;
+      blob_bottom_->mutable_cpu_data()[i + 8] = 4;
+      blob_bottom_->mutable_cpu_data()[i + 9] = 8;
+      blob_bottom_->mutable_cpu_data()[i + 10] = 1;
+      blob_bottom_->mutable_cpu_data()[i + 11] = 2;
+      blob_bottom_->mutable_cpu_data()[i + 12] = 4;
+      blob_bottom_->mutable_cpu_data()[i + 13] = 2;
+      blob_bottom_->mutable_cpu_data()[i + 14] = 3;*/ 
+    }
+    ResizeBilinearLayer<Dtype> layer(layer_param);
+    layer.SetUp(blob_bottom_vec_, blob_top_vec_);
+    EXPECT_EQ(blob_top_->num(), num);
+    EXPECT_EQ(blob_top_->channels(), channels);
+    EXPECT_EQ(blob_top_->height(), 4);
+    EXPECT_EQ(blob_top_->width(), 4);
+    layer.Forward(blob_bottom_vec_, blob_top_vec_);
+    // Expected output: 2x 2 channels of:
+    //   [1.    1.5     2.      3.5     5.      3.5     2.       2.5     3.      3.   ]
+    //   [5.    4.      3.      3.      3.      3.      3.       4.25    5.5     5.5  ]
+    //   [9.    6.5     4.      2.5     1.      2.5     4.       6.      8.      8.   ]
+    //   [5.    4.      3.      2.75    2.5     2.75    3.       4.25    5.5     5.5  ] 
+    //   [1.    1.5     2.      3.      4.      3.      2.       2.5     3.      3.   ]
+    //   [1.    1.5     2.      3.      4.      3.      2.       2.5     3.      3.   ]
+    //
+    Dtype epsilon = 1e-8;
+    for (int i = 0; i < 16 * num * channels; i += 16) { 
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 0], 1., epsilon); 
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 1], 2., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 2], 3., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 3], 3., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 4], 2.5, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 5], 4.25, epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 6], 6., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 7], 6., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 8], 4., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 9], 6.5, epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 10], 9., epsilon); 
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 11], 9., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 12], 4., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 13], 6.5, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 14], 9., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 15], 9., epsilon); 
+	    /*EXPECT_NEAR(blob_top_->cpu_data()[i + 16], 3., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 17], 4.25, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 18], 5.5, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 19], 5.5, epsilon);  
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 20], 9., epsilon); 
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 21], 6.5, epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 22], 4., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 23], 2.5, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 24], 1., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 25], 2.5, epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 26], 4., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 27], 6., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 28], 8., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 29], 8., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 30], 5., epsilon); 
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 31], 4., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 32], 3., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 33], 2.75, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 34], 2.5, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 35], 2.75, epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 36], 3., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 37], 4.25, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 38], 5.5, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 39], 5.5, epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 40], 1., epsilon); 
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 41], 1.5, epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 42], 2., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 43], 3., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 44], 4., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 45], 3., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 46], 2., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 47], 2.5, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 48], 3., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 49], 3., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 50], 1., epsilon); 
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 51], 1.5, epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 52], 2., epsilon);
+      EXPECT_NEAR(blob_top_->cpu_data()[i + 53], 3., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 54], 4., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 55], 3., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 56], 2., epsilon); 
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 57], 2.5, epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 58], 3., epsilon);
+	    EXPECT_NEAR(blob_top_->cpu_data()[i + 59], 3., epsilon);*/
+    }
+  }
+};
+
+TYPED_TEST_CASE(ResizeBilinearLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(ResizeBilinearLayerTest, TestResizeBilinear) {
+  this->TestForward();
+}
+
+
+} // namespace caffe
+


### PR DESCRIPTION
Hi, when I convert mobilenet/mobilenet v2 tensorflow model to caffe model, it has the error that caffe does not support the Resize_Bilinear operation, so I implement it and test it successfully. 
However, the ResizeBilinear layer now not supports for backpropagation, I will implement it if anyone thinks it is necessary.