### PR TITLE
add CUDA block limitation for CAFFE_GET_BLOCKS

### DIFF
--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -83,10 +83,13 @@ const char* curandGetErrorString(curandStatus_t error);
 
 // CUDA: use 512 threads per block
 const int CAFFE_CUDA_NUM_THREADS = 512;
+// CUDA: The maximum number of CUDA Block x
+const int CAFFE_CUDA_MAX_BLOCK_NUM = 65535;
 
 // CUDA: number of blocks for threads.
 inline int CAFFE_GET_BLOCKS(const int N) {
-  return (N + CAFFE_CUDA_NUM_THREADS - 1) / CAFFE_CUDA_NUM_THREADS;
+  const int num_blocks = (N + CAFFE_CUDA_NUM_THREADS - 1) / CAFFE_CUDA_NUM_THREADS;
+  return num_blocks < CAFFE_CUDA_MAX_BLOCK_NUM ? num_blocks : CAFFE_CUDA_MAX_BLOCK_NUM;
 }
 
 }  // namespace caffe

--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -90,7 +90,8 @@ const int CAFFE_CUDA_MAX_BLOCK_NUM = 65535;
 
 // CUDA: number of blocks for threads.
 inline int CAFFE_GET_BLOCKS(const int N) {
-  const int num_blocks = (N + CAFFE_CUDA_NUM_THREADS - 1) / CAFFE_CUDA_NUM_THREADS;
+  const int num_blocks =
+      (N + CAFFE_CUDA_NUM_THREADS - 1) / CAFFE_CUDA_NUM_THREADS;
   return std::min(num_blocks, CAFFE_CUDA_MAX_BLOCK_NUM);
 }
 

--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -77,6 +77,8 @@ void classname<Dtype>::funcname##_##gpu(const vector<Blob<Dtype>*>& top, \
 
 namespace caffe {
 
+#include <algorithm>
+
 // CUDA: library error reporting.
 const char* cublasGetErrorString(cublasStatus_t error);
 const char* curandGetErrorString(curandStatus_t error);
@@ -89,7 +91,7 @@ const int CAFFE_CUDA_MAX_BLOCK_NUM = 65535;
 // CUDA: number of blocks for threads.
 inline int CAFFE_GET_BLOCKS(const int N) {
   const int num_blocks = (N + CAFFE_CUDA_NUM_THREADS - 1) / CAFFE_CUDA_NUM_THREADS;
-  return num_blocks < CAFFE_CUDA_MAX_BLOCK_NUM ? num_blocks : CAFFE_CUDA_MAX_BLOCK_NUM;
+  return std::min(num_blocks, CAFFE_CUDA_MAX_BLOCK_NUM);
 }
 
 }  // namespace caffe


### PR DESCRIPTION
There is a limitation for the number of CUDA blocks `KERNEL<<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>`.
In the previous implementation, when N is extremely larger than the limitation (e.g. N > 65535 * 512), the kernel will not launch.

So I add a limitation for the number of CUDA block,