### PR TITLE
Fixed alingment issue "cudaSuccess (74 vs. 0) misaligned address"

### DIFF
--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -185,6 +185,10 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
   size_t max_workspace = std::max(total_workspace_fwd,
                              total_workspace_bwd_data);
   max_workspace = std::max(max_workspace, total_workspace_bwd_filter);
+
+  // make sure max_workspace is multiplies of 16
+  max_workspace = (max_workspace + 15) & size_t(-16);
+
   // ensure all groups have enough workspace
   size_t total_max_workspace = max_workspace *
                                (this->group_ * CUDNN_STREAMS_PER_GROUP);
@@ -216,10 +220,14 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
       // NULL out underlying data
       workspaceData = NULL;
       workspaceSizeInBytes = 0;
+
+      // return here as in case of this error rest of the function does not make sense
+      return;
     }
 
     // if we succeed in the allocation, set pointer aliases for workspaces
     for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
+      // NOTE these pointers must be aligned. As result max_workspace must be mutiplies of 16
       workspace[g] = reinterpret_cast<char *>(workspaceData) + g*max_workspace;
     }
   }

--- a/src/caffe/layers/cudnn_deconv_layer.cpp
+++ b/src/caffe/layers/cudnn_deconv_layer.cpp
@@ -243,6 +243,10 @@ void CuDNNDeconvolutionLayer<Dtype>::Reshape(
   size_t max_workspace = std::max(total_workspace_fwd,
                              total_workspace_bwd_data);
   max_workspace = std::max(max_workspace, total_workspace_bwd_filter);
+
+  // make sure max_workspace is multiplies of 16
+  max_workspace = (max_workspace + 15) & size_t(-16);
+
   // ensure all groups have enough workspace
   size_t total_max_workspace = max_workspace *
                                (this->group_ * CUDNN_STREAMS_PER_GROUP);
@@ -274,10 +278,14 @@ void CuDNNDeconvolutionLayer<Dtype>::Reshape(
       // NULL out underlying data
       workspaceData = NULL;
       workspaceSizeInBytes = 0;
+
+      // return here as in case of this error rest of the function does not make sense
+      return;
     }
 
     // if we succeed in the allocation, set pointer aliases for workspaces
     for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
+      // NOTE these pointers must be aligned. As result max_workspace must be mutiplies of 16
       workspace[g] = reinterpret_cast<char *>(workspaceData) + g*max_workspace;
     }
   }


### PR DESCRIPTION
In some situations it is possible to have max_workspace to be not multiple of 16. This will lead to at least workspace[1] to be unaligned. Resulting later in "cudaSuccess (74 vs. 0) misaligned address" error.

I am not sure if we must have alignment to 16 bytes (in my case the fix works with alignment to 8 bytes). But I believe using extra 8 bytes in this rare case to be a bit future proof is justified.