### PR TITLE
Removed memory leak in layer factory

### DIFF
--- a/include/caffe/layer_factory.hpp
+++ b/include/caffe/layer_factory.hpp
@@ -59,8 +59,8 @@ class LayerRegistry {
   typedef std::map<string, Creator> CreatorRegistry;
 
   static CreatorRegistry& Registry() {
-    static CreatorRegistry* g_registry_ = new CreatorRegistry();
-    return *g_registry_;
+    static CreatorRegistry g_registry_;
+    return g_registry_;
   }
 
   // Adds a creator.


### PR DESCRIPTION
This PR addresses the following:

1.  Using `new` for allocating a `std::map` is redundant and less idiomatic than allocating it directly on stack. The actual memory required for `std::map` will be allocated as per need basis from heap automatically.
2. Using `new` for a static pointer technically causes a memory leak here  since `delete` is never really called for this.
This change will address both these problems as stack objects are guaranteed to be freed on program termination. 