### PR TITLE
dataframe sort api is not available

### DIFF
--- a/examples/web_demo/app.py
+++ b/examples/web_demo/app.py
@@ -137,7 +137,7 @@ class ImagenetClassifier(object):
                 }
                 for l in f.readlines()
             ])
-        self.labels = labels_df.sort('synset_id')['name'].values
+        self.labels = labels_df.sort_values('synset_id')['name'].values
 
         self.bet = cPickle.load(open(bet_file))
         # A bias to prefer children nodes in single-chain paths


### PR DESCRIPTION
dataframe sort api is not available, should use the sort_values to replace. Previously, sort and sort_values are all supported by dataframe, but in the recent several versions, sort is not provided anymore.