### PR TITLE
switch UID conversion from PyBytes_FromString to PyBytes_FromStringAn…

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -367,7 +367,7 @@ bp::object NCCL_New_Uid() {
   // force a bytes object to be returned. When this object
   // is passed back to the NCCL constructor boost.python will
   // correctly convert the bytes to std::string automatically
-  PyObject* py_uid = PyBytes_FromString(uid.c_str());
+  PyObject* py_uid = PyBytes_FromStringAndSize(uid.data(), uid.size());
   return bp::object(bp::handle<>(py_uid));
 #else
   // automatic conversion is correct for python 2.


### PR DESCRIPTION
Proposed patch for https://github.com/BVLC/caffe/issues/6600

A one-liner.
This addresses the case of a null-truncated UID.