### PR TITLE
Makefile Xcode version check fails for version 10+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ else
 		# OS X packages atlas as the vecLib framework
 		LIBRARIES += cblas
 		# 10.10 has accelerate while 10.9 has veclib
-		XCODE_CLT_VER := $(shell pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | grep 'version' | sed 's/[^0-9]*\([0-9]\).*/\1/')
+		XCODE_CLT_VER := $(shell pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | grep 'version' | sed 's/[^0-9]*\([0-9]*\).*/\1/')
 		XCODE_CLT_GEQ_7 := $(shell [ $(XCODE_CLT_VER) -gt 6 ] && echo 1)
 		XCODE_CLT_GEQ_6 := $(shell [ $(XCODE_CLT_VER) -gt 5 ] && echo 1)
 		ifeq ($(XCODE_CLT_GEQ_7), 1)


### PR DESCRIPTION
The regular expression at line 400 that checks the Xcode major version will return only 1 digit. This causes incorrect branching in the makefile for Xcode version 10 and above. The end result is the wrong linker flags are set leading to build failures on Mac OS X.