### PR TITLE
Fixed CMake compiling error if no options enabled

### DIFF
--- a/src/caffe/CMakeLists.txt
+++ b/src/caffe/CMakeLists.txt
@@ -27,7 +27,9 @@ target_include_directories(caffe ${Caffe_INCLUDE_DIRS}
                                  PUBLIC
                                  $<BUILD_INTERFACE:${Caffe_INCLUDE_DIR}>
                                  $<INSTALL_INTERFACE:include>)
-target_compile_definitions(caffe ${Caffe_DEFINITIONS})
+if(Caffe_DEFINITIONS)
+  target_compile_definitions(caffe ${Caffe_DEFINITIONS})
+endif()
 if(Caffe_COMPILE_OPTIONS)
   target_compile_options(caffe ${Caffe_COMPILE_OPTIONS})
 endif()


### PR DESCRIPTION
This error occurs when no options are enabled, as ${Caffe_DEFINITIONS} will be empty. E.g., if using CUDA version with no cuDNN enabled (and disabling OpenCV and all other variables).