### PR TITLE
bug fix: cifar10's full train steps need hdf5 file

### DIFF
--- a/examples/cifar10/train_full.sh
+++ b/examples/cifar10/train_full.sh
@@ -9,9 +9,9 @@ $TOOLS/caffe train \
 # reduce learning rate by factor of 10
 $TOOLS/caffe train \
     --solver=examples/cifar10/cifar10_full_solver_lr1.prototxt \
-    --snapshot=examples/cifar10/cifar10_full_iter_60000.solverstate $@
+    --snapshot=examples/cifar10/cifar10_full_iter_60000.solverstate.h5 $@
 
 # reduce learning rate by factor of 10
 $TOOLS/caffe train \
     --solver=examples/cifar10/cifar10_full_solver_lr2.prototxt \
-    --snapshot=examples/cifar10/cifar10_full_iter_65000.solverstate $@
+    --snapshot=examples/cifar10/cifar10_full_iter_65000.solverstate.h5 $@


### PR DESCRIPTION
```
examples/cifar10/cifar10_full_solver.prototxt
examples/cifar10/cifar10_full_solver_lr1.prototxt
examples/cifar10/cifar10_full_solver_lr2.prototxt
```
These three solvers all produce `hdf5` file, that is `solverstate.h5` and `caffemodel.h5`.
So, if you feed `--snapshot` with `solverstate` file, it cannot be found.