### PR TITLE
Improve Vector Performance - Save Reallocation Cost

### DIFF
--- a/src/caffe/layers/batch_reindex_layer.cpp
+++ b/src/caffe/layers/batch_reindex_layer.cpp
@@ -10,6 +10,7 @@ void BatchReindexLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
                                        const vector<Blob<Dtype>*>& top) {
   CHECK_EQ(1, bottom[1]->num_axes());
   vector<int> newshape;
+  newshape.reserve(bottom[0]->shape().size() + 1);
   newshape.push_back(bottom[1]->shape(0));
   for (int i = 1; i < bottom[0]->shape().size(); ++i) {
     newshape.push_back(bottom[0]->shape()[i]);


### PR DESCRIPTION
We know the number of elements pushed into the vector will be (1 + bottom[0]->shape().size()). 
So reserve it, to save on reallocation costs.