### PR TITLE
Replace math_functions.h with cuda_runtime.h to remove CUDA compile w…

### DIFF
--- a/src/caffe/util/math_functions.cu
+++ b/src/caffe/util/math_functions.cu
@@ -1,4 +1,4 @@
-#include <math_functions.h>  // CUDA's, not caffe's, for fabs, signbit
+#include <cuda_runtime.h>  // CUDA's, not caffe's, for fabs, signbit
 #include <thrust/device_vector.h>
 #include <thrust/functional.h>  // thrust::plus
 #include <thrust/reduce.h>


### PR DESCRIPTION
When compile with CUDA10, there's a warning like this.
In file included from src/caffe/util/math_functions.cu:1:0:
/usr/local/cuda/include/math_functions.h:54:2: warning: #warning "math_functions.h is an internal header file and must not be used directly.  This file will be removed in a future CUDA release.  Please use cuda_runtime_api.h or cuda_runtime.h instead." [-Wcpp]
 #warning "math_functions.h is an internal header file and must not be used directly.  This file will be removed in a future CUDA release.  Please use cuda_runtime_api.h or cuda_runtime.h instead."
This PR aims to remove the deprecated header file.