### PR TITLE
Support OpenCV 4 compatible with older versions

### DIFF
--- a/src/caffe/layers/window_data_layer.cpp
+++ b/src/caffe/layers/window_data_layer.cpp
@@ -11,6 +11,9 @@
 #include "opencv2/core/core.hpp"
 #include "opencv2/highgui/highgui.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
+#if CV_VERSION_MAJOR >= 4
+#include "opencv2/imgcodecs/legacy/constants_c.h"
+#endif 
 
 #include "caffe/data_transformer.hpp"
 #include "caffe/internal_thread.hpp"

--- a/src/caffe/test/test_io.cpp
+++ b/src/caffe/test/test_io.cpp
@@ -3,6 +3,9 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/highgui/highgui_c.h>
 #include <opencv2/imgproc/imgproc.hpp>
+#if CV_VERSION_MAJOR >= 4
+#include "opencv2/imgcodecs/legacy/constants_c.h"
+#endif 
 
 #include <string>
 

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -7,6 +7,9 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/highgui/highgui_c.h>
 #include <opencv2/imgproc/imgproc.hpp>
+#if CV_VERSION_MAJOR >= 4
+#include "opencv2/imgcodecs/legacy/constants_c.h"
+#endif 
 #endif  // USE_OPENCV
 #include <stdint.h>
 


### PR DESCRIPTION
Consider deprecated cv_constants (need to include legacy header since opencv 4.0)