### PR TITLE
Fixed running Caffe build with CUDA and CUDNN on hardware without GPU

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -53,7 +53,7 @@ shared_ptr<Layer<Dtype> > GetConvolutionLayer(
   if (engine == ConvolutionParameter_Engine_DEFAULT) {
     engine = ConvolutionParameter_Engine_CAFFE;
 #ifdef USE_CUDNN
-    if (!use_dilation) {
+    if (!use_dilation && Caffe::mode() == Caffe::GPU) {
       engine = ConvolutionParameter_Engine_CUDNN;
     }
 #endif
@@ -92,7 +92,7 @@ shared_ptr<Layer<Dtype> > GetDeconvolutionLayer(const LayerParameter& param) {
   if (engine == ConvolutionParameter_Engine_DEFAULT) {
     engine = ConvolutionParameter_Engine_CAFFE;
 #ifdef USE_CUDNN
-    if (!use_dilation) {
+    if (!use_dilation && Caffe::mode() == Caffe::GPU) {
       engine = ConvolutionParameter_Engine_CUDNN;
     }
 #endif
@@ -122,7 +122,9 @@ shared_ptr<Layer<Dtype> > GetPoolingLayer(const LayerParameter& param) {
   if (engine == PoolingParameter_Engine_DEFAULT) {
     engine = PoolingParameter_Engine_CAFFE;
 #ifdef USE_CUDNN
-    engine = PoolingParameter_Engine_CUDNN;
+    if (Caffe::mode() == Caffe::GPU) {
+        engine = PoolingParameter_Engine_CUDNN;
+    }
 #endif
   }
   if (engine == PoolingParameter_Engine_CAFFE) {
@@ -160,7 +162,9 @@ shared_ptr<Layer<Dtype> > GetLRNLayer(const LayerParameter& param) {
 
   if (engine == LRNParameter_Engine_DEFAULT) {
 #ifdef USE_CUDNN
-    engine = LRNParameter_Engine_CUDNN;
+    if (Caffe::mode() == Caffe::GPU) {
+        engine = LRNParameter_Engine_CUDNN;
+    }
 #else
     engine = LRNParameter_Engine_CAFFE;
 #endif
@@ -198,7 +202,9 @@ shared_ptr<Layer<Dtype> > GetReLULayer(const LayerParameter& param) {
   if (engine == ReLUParameter_Engine_DEFAULT) {
     engine = ReLUParameter_Engine_CAFFE;
 #ifdef USE_CUDNN
-    engine = ReLUParameter_Engine_CUDNN;
+    if (Caffe::mode() == Caffe::GPU) {
+        engine = ReLUParameter_Engine_CUDNN;
+    }
 #endif
   }
   if (engine == ReLUParameter_Engine_CAFFE) {
@@ -222,7 +228,9 @@ shared_ptr<Layer<Dtype> > GetSigmoidLayer(const LayerParameter& param) {
   if (engine == SigmoidParameter_Engine_DEFAULT) {
     engine = SigmoidParameter_Engine_CAFFE;
 #ifdef USE_CUDNN
-    engine = SigmoidParameter_Engine_CUDNN;
+    if (Caffe::mode() == Caffe::GPU) {
+        engine = SigmoidParameter_Engine_CUDNN;
+    }
 #endif
   }
   if (engine == SigmoidParameter_Engine_CAFFE) {
@@ -246,7 +254,9 @@ shared_ptr<Layer<Dtype> > GetSoftmaxLayer(const LayerParameter& param) {
   if (engine == SoftmaxParameter_Engine_DEFAULT) {
     engine = SoftmaxParameter_Engine_CAFFE;
 #ifdef USE_CUDNN
-    engine = SoftmaxParameter_Engine_CUDNN;
+    if (Caffe::mode() == Caffe::GPU) {
+        engine = SoftmaxParameter_Engine_CUDNN;
+    }
 #endif
   }
   if (engine == SoftmaxParameter_Engine_CAFFE) {
@@ -270,7 +280,9 @@ shared_ptr<Layer<Dtype> > GetTanHLayer(const LayerParameter& param) {
   if (engine == TanHParameter_Engine_DEFAULT) {
     engine = TanHParameter_Engine_CAFFE;
 #ifdef USE_CUDNN
-    engine = TanHParameter_Engine_CUDNN;
+    if (Caffe::mode() == Caffe::GPU) {
+        engine = TanHParameter_Engine_CUDNN;
+    }
 #endif
   }
   if (engine == TanHParameter_Engine_CAFFE) {


### PR DESCRIPTION
There is a selection to run caffe with CPU or GPU mode in the API.

It makes it very useful to deploy the library on different hardware allowing user to enable GPU support if available by simple setting CPU or GPU caffe mode.

However in the current version if the library is compiled with CUDNN it would fail to run if Caffe::mode(CPU) is selected. This patch fixes this issue allowing to select GPU or CPU in runtime without requiring the library to be compiled in CPU only mode.

The root cause of the issue is that CUDNN layers allocate different GPU resources on start even if they run in CPU mode. This fix disables CUDNN based layer and switches them to native Caffe layers when working in CPU mode.