### PR TITLE
enable C++11 build to avoid make error on macos.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include(cmake/Dependencies.cmake)
 
 # ---[ Flags
 if(UNIX OR APPLE)
+  set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall")
 endif()
 


### PR DESCRIPTION
make error with opencv4 and fixed it by adding "set (CMAKE_CXX_STANDARD 11)" in CMakeLists.txt.