### PR TITLE
fix glog finder

### DIFF
--- a/cmake/Modules/FindGlog.cmake
+++ b/cmake/Modules/FindGlog.cmake
@@ -18,7 +18,8 @@ if(WIN32)
         PATHS ${GLOG_ROOT_DIR}/src/windows)
 else()
     find_path(GLOG_INCLUDE_DIR glog/logging.h
-        PATHS ${GLOG_ROOT_DIR})
+        PATHS ${GLOG_ROOT_DIR}
+        PATH_SUFFIXES include)
 endif()
 
 if(MSVC)


### PR DESCRIPTION
I couldn't build with 'glog' being installed non-systemwide. It seems that you aim that a user can supply GLOG_ROOT_DIR in such case, but you missed an "include"-suffix to resolve headers.

* I built on Linux only