### PR TITLE
update `as_grey` argument of `skimage.io.imread` to `as_gray`

### DIFF
--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -299,7 +299,7 @@ def load_image(filename, color=True):
         of size (H x W x 3) in RGB or
         of size (H x W x 1) in grayscale.
     """
-    img = skimage.img_as_float(skimage.io.imread(filename, as_grey=not color)).astype(np.float32)
+    img = skimage.img_as_float(skimage.io.imread(filename, as_gray=not color)).astype(np.float32)
     if img.ndim == 2:
         img = img[:, :, np.newaxis]
         if color:


### PR DESCRIPTION
###  Summary
Due to https://github.com/scikit-image/scikit-image/pull/2652 changes, using `as_grey` when calling `skimage.io.imread` at 
https://github.com/BVLC/caffe/blob/04ab089db018a292ae48d51732dd6c66766b36b6/python/caffe/io.py#L302
causes the following error 
```
TypeError: _open() got an unexpected keyword argument 'as_grey'*
```

### Steps to reproduce
```python
import caffe
caffe.io.load_image('./imgs/example.jpg')
```

###  Solution
use `use_gray` instead of `use_grey`

### System configuration

* Operating system: Ubuntu 18.04
* Compiler: g++
* CUDA version (if applicable): 9.2
* Python version (if using pycaffe): 3.6
* skimage.__version__ : 0.16.2
