### PR TITLE
Fix for the failings continuous Windows branch (when using WITH_NINJA=1 and Visual Studio Compiler)

### DIFF
--- a/cmake/Templates/export.hpp.in
+++ b/cmake/Templates/export.hpp.in
@@ -4,7 +4,7 @@
 // CAFFE_BUILDING_STATIC_LIB should be defined 
 // only by the caffe target
 #if defined(_MSC_VER) && !defined(CAFFE_BUILDING_STATIC_LIB) 
-    ${CAFFE_INCLUDE_SYMBOLS}
+//    ${CAFFE_INCLUDE_SYMBOLS}
 #endif
 
 #endif  // CAFFE_EXPORT_HPP_


### PR DESCRIPTION
This is related to issues https://github.com/BVLC/caffe/issues/6215 and https://github.com/BVLC/caffe/issues/6235 .

When compiling with 'Ninja' + 'Windows' + 'Visual Studio', we have the error:
 "fatal error C1083: Cannot open include file: 'caffe/include_symbols.hpp': No such file or directory"

As described in [this comment](https://github.com/BVLC/caffe/issues/6215#issuecomment-542659481):
using an empty 'include_symbols.hpp' works.

So this PR only removes the dependecy to the file 'include_symbols.hpp'