### PR TITLE
Remove unused codes

### DIFF
--- a/include/caffe/layers/cudnn_lcn_layer.hpp
+++ b/include/caffe/layers/cudnn_lcn_layer.hpp
@@ -36,9 +36,6 @@ class CuDNNLCNLayer : public LRNLayer<Dtype> {
   cudnnLRNDescriptor_t norm_desc_;
   cudnnTensorDescriptor_t bottom_desc_, top_desc_;
 
-  int size_, pre_pad_;
-  Dtype alpha_, beta_, k_;
-
   size_t tempDataSize;
   void *tempData1, *tempData2;
 };

--- a/src/caffe/layers/cudnn_lcn_layer.cpp
+++ b/src/caffe/layers/cudnn_lcn_layer.cpp
@@ -17,12 +17,6 @@ void CuDNNLCNLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
 
   // create a LRN handle
   handles_setup_ = true;
-
-  size_ = this->layer_param().lrn_param().local_size();
-  pre_pad_ = (size_ - 1) / 2;
-  alpha_ = this->layer_param().lrn_param().alpha();
-  beta_ = this->layer_param().lrn_param().beta();
-  k_ = this->layer_param().lrn_param().k();
 }
 
 template <typename Dtype>
@@ -33,7 +27,8 @@ void CuDNNLCNLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
       this->channels_, this->height_, this->width_);
   cudnn::setTensor4dDesc<Dtype>(&top_desc_, bottom[0]->num(),
       this->channels_, this->height_, this->width_);
-  CUDNN_CHECK(cudnnSetLRNDescriptor(norm_desc_, size_, alpha_, beta_, k_));
+  CUDNN_CHECK(cudnnSetLRNDescriptor(norm_desc_, this->size_, this->alpha_,
+                                    this->beta_, this->k_));
 
   // allocate / reallocate tempData buffers
   size_t totalSizeInBytes = sizeof(Dtype)*bottom[0]->num()* \


### PR DESCRIPTION
size_, pre_pad_, alpha_, beta_, k_ is defined in the base LRNLayer class.